### PR TITLE
fix: restore multicall batching for DAO RPC reads

### DIFF
--- a/packages/web/src/config/base.ts
+++ b/packages/web/src/config/base.ts
@@ -3,4 +3,5 @@ export const DEFAULT_PAGE_SIZE = 10;
 export const INITIAL_LIST_PAGE_SIZE = DEFAULT_PAGE_SIZE * 3;
 export const DEFAULT_ANIMATION_DURATION = 0.1;
 export const DEGOV_APPS_URL = "https://square.degov.ai";
-export const DEFAULT_MULTICALL_BATCH_SIZE = 10;
+// viem interprets multicall batchSize as calldata bytes, not "number of calls".
+export const DEFAULT_MULTICALL_BATCH_SIZE = 1024;

--- a/packages/web/src/config/wagmi.ts
+++ b/packages/web/src/config/wagmi.ts
@@ -8,9 +8,11 @@ import {
   subWallet,
 } from "@rainbow-me/rainbowkit/wallets";
 import { QueryClient } from "@tanstack/react-query";
+import { fallback, http } from "viem";
 import { cookieStorage, createStorage, type Storage } from "wagmi";
 import { mainnet } from "wagmi/chains";
 
+import { DEFAULT_MULTICALL_BATCH_SIZE } from "@/config/base";
 import { createWagmiQueryConfig } from "@/utils/query-config";
 
 import type { Chain } from "@rainbow-me/rainbowkit";
@@ -38,6 +40,36 @@ function chainFingerprint(chain: Chain) {
   });
 }
 
+function createChainTransport(chain: Chain) {
+  const rpcUrls = [...new Set(chain.rpcUrls.default.http.filter(Boolean))];
+
+  if (rpcUrls.length === 0) {
+    return http(undefined, {
+      batch: true,
+      retryCount: 0,
+    });
+  }
+
+  if (rpcUrls.length === 1) {
+    return http(rpcUrls[0], {
+      batch: true,
+      retryCount: 0,
+    });
+  }
+
+  return fallback(
+    rpcUrls.map((rpcUrl) =>
+      http(rpcUrl, {
+        batch: true,
+        retryCount: 0,
+      })
+    ),
+    {
+      retryCount: 0,
+    }
+  );
+}
+
 export function createConfig({
   appName,
   projectId,
@@ -58,10 +90,21 @@ export function createConfig({
     storage: cookieStorage,
   });
 
+  const transports = {
+    [mainnet.id]: createChainTransport(mainnet as Chain),
+    [chain.id]: createChainTransport(chain),
+  } as const;
+
   const config = getDefaultConfig({
     appName,
     projectId,
     chains: chains as unknown as readonly [Chain, ...Chain[]],
+    transports,
+    batch: {
+      multicall: {
+        batchSize: DEFAULT_MULTICALL_BATCH_SIZE,
+      },
+    },
     wallets: [
       ...wallets,
       {


### PR DESCRIPTION
## Summary
- fix the web multicall batch size so viem stops splitting batched reads into near-single-call requests
- configure the shared wagmi client to build transports from each chain's DAO RPC list instead of RainbowKit's single default `http()` transport
- make multicall batching explicit in the shared wagmi config so public read traffic fans out less under normal renders/refetches

## Testing
- cd packages/web && pnpm lint
- cd packages/web && pnpm exec tsc --noEmit

## Context
- Linear: OHH-12
- Reproduction before fix: `DEFAULT_MULTICALL_BATCH_SIZE` was `10`, but viem interprets that value as calldata bytes, which effectively disabled existing multicall usage.
