### PR TITLE
Use DAO-configured RPCs for wagmi and viem

### DIFF
--- a/packages/web/src/config/wagmi.ts
+++ b/packages/web/src/config/wagmi.ts
@@ -8,12 +8,14 @@ import {
   subWallet,
 } from "@rainbow-me/rainbowkit/wallets";
 import { QueryClient } from "@tanstack/react-query";
+import { fallback, http, type Transport } from "viem";
 import { cookieStorage, createStorage, type Storage } from "wagmi";
 import { mainnet } from "wagmi/chains";
 
+import type { Chain as DaoChainConfig } from "@/types/config";
 import { createWagmiQueryConfig } from "@/utils/query-config";
 
-import type { Chain } from "@rainbow-me/rainbowkit";
+import type { Chain as RainbowKitChain } from "@rainbow-me/rainbowkit";
 
 const { wallets } = getDefaultWallets();
 
@@ -25,7 +27,47 @@ type WagmiConfig = ReturnType<typeof getDefaultConfig>;
 
 const configCache = new Map<string, WagmiConfig>();
 
-function chainFingerprint(chain: Chain) {
+function getRpcUrls(rpcUrls: readonly string[] | undefined) {
+  return Array.from(
+    new Set((rpcUrls ?? []).map((rpcUrl) => rpcUrl.trim()).filter(Boolean))
+  );
+}
+
+function getChainRpcUrls(chain: RainbowKitChain) {
+  return getRpcUrls([
+    ...(chain.rpcUrls?.default?.http ?? []),
+    ...(chain.rpcUrls?.public?.http ?? []),
+  ]);
+}
+
+function createChainTransport(chain: RainbowKitChain): Transport {
+  const rpcUrls = getChainRpcUrls(chain);
+
+  if (rpcUrls.length === 0) {
+    return http();
+  }
+
+  if (rpcUrls.length === 1) {
+    return http(rpcUrls[0]);
+  }
+
+  return fallback(
+    rpcUrls.map((rpcUrl) => http(rpcUrl)),
+    {
+      rank: false,
+    }
+  );
+}
+
+function getConfiguredChains(chain: RainbowKitChain) {
+  if (chain.id === mainnet.id) {
+    return [chain] as const;
+  }
+
+  return [mainnet as RainbowKitChain, chain] as const;
+}
+
+function chainFingerprint(chain: RainbowKitChain) {
   // Stable, order-defined subset of chain metadata that affects wagmi config
   return JSON.stringify({
     id: chain.id,
@@ -38,12 +80,43 @@ function chainFingerprint(chain: Chain) {
   });
 }
 
+export function createDaoChain(
+  chain: DaoChainConfig | null | undefined
+): RainbowKitChain {
+  const rpcUrls = getRpcUrls(chain?.rpcs);
+
+  return {
+    id: Number(chain?.id ?? 0),
+    name: chain?.name ?? "",
+    nativeCurrency: {
+      name: chain?.nativeToken?.symbol ?? "",
+      symbol: chain?.nativeToken?.symbol ?? "",
+      decimals: chain?.nativeToken?.decimals ?? 18,
+    },
+    rpcUrls: {
+      default: {
+        http: rpcUrls,
+      },
+      public: {
+        http: rpcUrls,
+      },
+    },
+    blockExplorers: {
+      default: {
+        name: "Explorer",
+        url: chain?.explorers?.[0] ?? "",
+      },
+    },
+    contracts: chain?.contracts ?? undefined,
+  };
+}
+
 export function createConfig({
   appName,
   projectId,
   chain,
 }: {
-  chain: Chain;
+  chain: RainbowKitChain;
   appName: string;
   projectId: string;
 }) {
@@ -53,7 +126,13 @@ export function createConfig({
     return cachedConfig;
   }
 
-  const chains = [mainnet as Chain, chain];
+  const chains = getConfiguredChains(chain);
+  const transports = Object.fromEntries(
+    chains.map((configuredChain) => [
+      configuredChain.id,
+      createChainTransport(configuredChain),
+    ])
+  ) as Record<(typeof chains)[number]["id"], Transport>;
   const storage: Storage = createStorage({
     storage: cookieStorage,
   });
@@ -61,7 +140,11 @@ export function createConfig({
   const config = getDefaultConfig({
     appName,
     projectId,
-    chains: chains as unknown as readonly [Chain, ...Chain[]],
+    chains: chains as unknown as readonly [
+      RainbowKitChain,
+      ...RainbowKitChain[],
+    ],
+    transports,
     wallets: [
       ...wallets,
       {

--- a/packages/web/src/providers/dapp.provider.tsx
+++ b/packages/web/src/providers/dapp.provider.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { WagmiProvider } from "wagmi";
 
 import { LoadingState } from "@/components/ui/loading-spinner";
-import { createConfig, createQueryClient } from "@/config/wagmi";
+import { createConfig, createDaoChain, createQueryClient } from "@/config/wagmi";
 import { useAuthStatus } from "@/hooks/useAuthStatus";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useMounted } from "@/hooks/useMounted";
@@ -23,29 +23,10 @@ function RainbowKitProviders({ children }: React.PropsWithChildren<unknown>) {
   const authStatus = useAuthStatus();
   const dappConfig = useDaoConfig();
 
-  const currentChain: Chain = React.useMemo(() => {
-    return {
-      id: Number(dappConfig?.chain?.id),
-      name: dappConfig?.chain?.name ?? "",
-      nativeCurrency: {
-        name: dappConfig?.chain?.nativeToken?.symbol ?? "",
-        symbol: dappConfig?.chain?.nativeToken?.symbol ?? "",
-        decimals: dappConfig?.chain?.nativeToken?.decimals ?? 18,
-      },
-      rpcUrls: {
-        default: {
-          http: dappConfig?.chain?.rpcs ?? [],
-        },
-      },
-      blockExplorers: {
-        default: {
-          name: "Explorer",
-          url: dappConfig?.chain?.explorers?.[0] ?? "",
-        },
-      },
-      contracts: dappConfig?.chain?.contracts ?? undefined,
-    };
-  }, [dappConfig]);
+  const currentChain: Chain = React.useMemo(
+    () => createDaoChain(dappConfig?.chain),
+    [dappConfig?.chain]
+  );
 
   return (
     <RainbowKitAuthenticationProvider
@@ -74,29 +55,10 @@ export function DAppProvider({ children }: React.PropsWithChildren<unknown>) {
     typeof createConfig
   > | null>(null);
 
-  const currentChain: Chain = React.useMemo(() => {
-    return {
-      id: Number(dappConfig?.chain?.id),
-      name: dappConfig?.chain?.name ?? "",
-      nativeCurrency: {
-        name: dappConfig?.chain?.nativeToken?.symbol ?? "",
-        symbol: dappConfig?.chain?.nativeToken?.symbol ?? "",
-        decimals: dappConfig?.chain?.nativeToken?.decimals ?? 18,
-      },
-      rpcUrls: {
-        default: {
-          http: dappConfig?.chain?.rpcs ?? [],
-        },
-      },
-      blockExplorers: {
-        default: {
-          name: "Explorer",
-          url: dappConfig?.chain?.explorers?.[0] ?? "",
-        },
-      },
-      contracts: dappConfig?.chain?.contracts ?? undefined,
-    };
-  }, [dappConfig]);
+  const currentChain: Chain = React.useMemo(
+    () => createDaoChain(dappConfig?.chain),
+    [dappConfig?.chain]
+  );
 
   React.useEffect(() => {
     if (!mounted || !dappConfig) return;


### PR DESCRIPTION
## Summary
- normalize DAO chain metadata in one place before building the wagmi config
- use DAO-configured RPC URLs as explicit viem transports with ordered fallback
- avoid duplicating `mainnet` when the DAO itself is on Ethereum mainnet so built-in RPCs cannot shadow `chain.rpcs`

## Testing
- `pnpm exec eslint src/config/wagmi.ts src/providers/dapp.provider.tsx src/components/members-table/hooks/useMembersData.ts`
- `pnpm exec tsc --noEmit`
- `node --input-type=module` viem fallback transport probe

## Manual QA
- load a DAO whose config has `chain.id = 1` and multiple `chain.rpcs`
- confirm on-chain reads use the configured RPC order instead of the built-in wagmi/viem default mainnet RPC
- make the first configured RPC unavailable and confirm reads fall through to the next configured RPC
