### PR TITLE
Fix delegates default sort order

### DIFF
--- a/packages/web/scripts/delegates-default-sort.test.ts
+++ b/packages/web/scripts/delegates-default-sort.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_ORDER_BY,
+  DEFAULT_SORT_STATE,
+} from "../src/components/members-table/types.ts";
+
+test("delegates page defaults to voting power descending", () => {
+  assert.deepEqual(DEFAULT_SORT_STATE, {
+    field: "power",
+    direction: "desc",
+  });
+  assert.equal(DEFAULT_ORDER_BY, "power_DESC");
+});

--- a/packages/web/src/components/members-table/hooks/useMembersData.ts
+++ b/packages/web/src/components/members-table/hooks/useMembersData.ts
@@ -12,6 +12,8 @@ import { normalizeAddress } from "@/hooks/useProfileQuery";
 import { contributorService } from "@/services/graphql";
 import type { ContributorItem } from "@/services/graphql/types";
 
+import { DEFAULT_ORDER_BY } from "../types";
+
 type PageParam = {
   offset: number;
   limit: number;
@@ -24,7 +26,6 @@ export function useMembersData(
   orderBy?: string,
   includeBotInQuery = false
 ) {
-  const DEFAULT_ORDER_BY = "lastVoteTimestamp_DESC_NULLS_LAST";
   const daoConfig = useDaoConfig();
   const { botAddress } = useAiBotAddress();
   const isSearching = searchTerm.trim().length > 0;

--- a/packages/web/src/components/members-table/types.ts
+++ b/packages/web/src/components/members-table/types.ts
@@ -6,7 +6,9 @@ export interface MemberSortState {
   direction: MemberSortDirection;
 }
 
+export const DEFAULT_ORDER_BY = "power_DESC";
+
 export const DEFAULT_SORT_STATE: MemberSortState = {
-  field: "lastVoted",
+  field: "power",
   direction: "desc",
 };


### PR DESCRIPTION
## Summary
- default the delegates page sort state to Voting Power descending
- reuse a shared default order in the members data hook so the initial query matches the page default
- add a targeted node:test regression for the delegates default sort contract

## Testing
- node --experimental-strip-types --test packages/web/scripts/delegates-default-sort.test.ts
- pnpm lint

Closes #564
