### PR TITLE
feat(indexer): add additive multichain identity fields

### DIFF
--- a/packages/indexer/__tests__/helpers.test.ts
+++ b/packages/indexer/__tests__/helpers.test.ts
@@ -1,0 +1,47 @@
+import { DegovIndexerHelpers } from "../src/internal/helpers";
+
+describe("DegovIndexerHelpers", () => {
+  it("normalizes addresses to lowercase", () => {
+    expect(
+      DegovIndexerHelpers.normalizeAddress(
+        "0xABCdefABCdefABCdefABCdefABCdefABCdefABCD"
+      )
+    ).toBe("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+    expect(DegovIndexerHelpers.normalizeAddress()).toBeUndefined();
+  });
+
+  it("finds normalized contract addresses by contract name", () => {
+    expect(
+      DegovIndexerHelpers.findContractAddress(
+        {
+          daoCode: "unlock-dao",
+          contracts: [
+            {
+              name: "governor",
+              address: "0xABCdefABCdefABCdefABCdefABCdefABCdefABCD",
+            },
+            {
+              name: "governorToken",
+              address: "0x1234512345123451234512345123451234512345",
+            },
+          ],
+        },
+        "governor"
+      )
+    ).toBe("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+  });
+
+  it("builds a composite proposal scope lookup", () => {
+    expect(
+      DegovIndexerHelpers.proposalScopeWhere({
+        chainId: 8453,
+        governorAddress: "0xABCdefABCdefABCdefABCdefABCdefABCdefABCD",
+        proposalId: "0x01",
+      })
+    ).toEqual({
+      chainId: 8453,
+      governorAddress: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      proposalId: "0x01",
+    });
+  });
+});

--- a/packages/indexer/db/migrations/1774369502838-AddScopeFields.js
+++ b/packages/indexer/db/migrations/1774369502838-AddScopeFields.js
@@ -1,0 +1,311 @@
+module.exports = class AddScopeFields1774369502838 {
+    name = 'AddScopeFields1774369502838'
+
+    async up(db) {
+        await db.query(`ALTER TABLE "delegate_changed"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "token_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_0fed007c6b7b9a0d5db284a1ad" ON "delegate_changed" ("chain_id", "governor_address", "delegator") `)
+
+        await db.query(`ALTER TABLE "delegate_votes_changed"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "token_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_8b36c6f37c8e64f25dd9e5264d" ON "delegate_votes_changed" ("chain_id", "governor_address", "delegate") `)
+
+        await db.query(`ALTER TABLE "token_transfer"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "token_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_e3fe323128cc8da72b2d7b5d6a" ON "token_transfer" ("chain_id", "governor_address", "token_address") `)
+
+        await db.query(`ALTER TABLE "proposal_canceled"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_ce8974da5dced94a5a3fb7849f" ON "proposal_canceled" ("chain_id", "governor_address", "proposal_id") `)
+
+        await db.query(`ALTER TABLE "proposal_created"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_0baf06a475c01030f465b563e6" ON "proposal_created" ("chain_id", "governor_address", "proposal_id") `)
+
+        await db.query(`ALTER TABLE "proposal_executed"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_236183a9fbc8bab05c572325b0" ON "proposal_executed" ("chain_id", "governor_address", "proposal_id") `)
+
+        await db.query(`ALTER TABLE "proposal_queued"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_58acbeb4d04c455acbc8b18617" ON "proposal_queued" ("chain_id", "governor_address", "proposal_id") `)
+
+        await db.query(`ALTER TABLE "vote_cast"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_51a29cfd1e5f71932317a66133" ON "vote_cast" ("chain_id", "governor_address", "proposal_id") `)
+
+        await db.query(`ALTER TABLE "vote_cast_with_params"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_74f9e8ec92107a0e3e0e9011e8" ON "vote_cast_with_params" ("chain_id", "governor_address", "proposal_id") `)
+
+        await db.query(`ALTER TABLE "proposal"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_c2956b263206187757df55ad45" ON "proposal" ("chain_id", "governor_address", "proposal_id") `)
+
+        await db.query(`ALTER TABLE "vote_cast_group"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_35b8709ea26d346c86d9ee76e3" ON "vote_cast_group" ("chain_id", "governor_address", "ref_proposal_id") `)
+
+        await db.query(`ALTER TABLE "data_metric"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "token_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_95c80384fafd3caf17631ee3a4" ON "data_metric" ("chain_id", "governor_address", "dao_code") `)
+
+        await db.query(`ALTER TABLE "delegate_rolling"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "token_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_f68da56408b641c4ed4d4e1a96" ON "delegate_rolling" ("chain_id", "governor_address", "delegator") `)
+
+        await db.query(`ALTER TABLE "delegate"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "token_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_3ff4b3a851b38f29afb15bafcc" ON "delegate" ("chain_id", "governor_address", "from_delegate", "to_delegate") `)
+
+        await db.query(`ALTER TABLE "contributor"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "token_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_34d8a39d812fd6841f0cd49238" ON "contributor" ("chain_id", "governor_address", "id") `)
+
+        await db.query(`ALTER TABLE "delegate_mapping"
+            ADD COLUMN IF NOT EXISTS "chain_id" integer,
+            ADD COLUMN IF NOT EXISTS "dao_code" text,
+            ADD COLUMN IF NOT EXISTS "governor_address" text,
+            ADD COLUMN IF NOT EXISTS "token_address" text,
+            ADD COLUMN IF NOT EXISTS "contract_address" text,
+            ADD COLUMN IF NOT EXISTS "log_index" integer,
+            ADD COLUMN IF NOT EXISTS "transaction_index" integer`)
+        await db.query(`CREATE INDEX IF NOT EXISTS "IDX_b593bc2d019039d306e64c5128" ON "delegate_mapping" ("chain_id", "governor_address", "from") `)
+    }
+
+    async down(db) {
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_0fed007c6b7b9a0d5db284a1ad"`)
+        await db.query(`ALTER TABLE "delegate_changed"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "token_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_8b36c6f37c8e64f25dd9e5264d"`)
+        await db.query(`ALTER TABLE "delegate_votes_changed"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "token_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_e3fe323128cc8da72b2d7b5d6a"`)
+        await db.query(`ALTER TABLE "token_transfer"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "token_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_ce8974da5dced94a5a3fb7849f"`)
+        await db.query(`ALTER TABLE "proposal_canceled"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_0baf06a475c01030f465b563e6"`)
+        await db.query(`ALTER TABLE "proposal_created"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_236183a9fbc8bab05c572325b0"`)
+        await db.query(`ALTER TABLE "proposal_executed"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_58acbeb4d04c455acbc8b18617"`)
+        await db.query(`ALTER TABLE "proposal_queued"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_51a29cfd1e5f71932317a66133"`)
+        await db.query(`ALTER TABLE "vote_cast"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_74f9e8ec92107a0e3e0e9011e8"`)
+        await db.query(`ALTER TABLE "vote_cast_with_params"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_c2956b263206187757df55ad45"`)
+        await db.query(`ALTER TABLE "proposal"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_35b8709ea26d346c86d9ee76e3"`)
+        await db.query(`ALTER TABLE "vote_cast_group"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_95c80384fafd3caf17631ee3a4"`)
+        await db.query(`ALTER TABLE "data_metric"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "token_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_f68da56408b641c4ed4d4e1a96"`)
+        await db.query(`ALTER TABLE "delegate_rolling"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "token_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_3ff4b3a851b38f29afb15bafcc"`)
+        await db.query(`ALTER TABLE "delegate"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "token_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_34d8a39d812fd6841f0cd49238"`)
+        await db.query(`ALTER TABLE "contributor"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "token_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+
+        await db.query(`DROP INDEX IF EXISTS "public"."IDX_b593bc2d019039d306e64c5128"`)
+        await db.query(`ALTER TABLE "delegate_mapping"
+            DROP COLUMN IF EXISTS "chain_id",
+            DROP COLUMN IF EXISTS "dao_code",
+            DROP COLUMN IF EXISTS "governor_address",
+            DROP COLUMN IF EXISTS "token_address",
+            DROP COLUMN IF EXISTS "contract_address",
+            DROP COLUMN IF EXISTS "log_index",
+            DROP COLUMN IF EXISTS "transaction_index"`)
+    }
+}

--- a/packages/indexer/schema.graphql
+++ b/packages/indexer/schema.graphql
@@ -2,8 +2,15 @@
 
 ### === ivotes
 
-type DelegateChanged @entity {
+type DelegateChanged @entity @index(fields: ["chainId", "governorAddress", "delegator"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   delegator: String! # address
   fromDelegate: String! # address
   toDelegate: String! # address
@@ -12,8 +19,15 @@ type DelegateChanged @entity {
   transactionHash: String!
 }
 
-type DelegateVotesChanged @entity {
+type DelegateVotesChanged @entity @index(fields: ["chainId", "governorAddress", "delegate"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   delegate: String! # address
   previousVotes: BigInt! # uint256
   newVotes: BigInt! # uint256
@@ -22,8 +36,15 @@ type DelegateVotesChanged @entity {
   transactionHash: String!
 }
 
-type TokenTransfer @entity {
+type TokenTransfer @entity @index(fields: ["chainId", "governorAddress", "tokenAddress"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   from: String!
   to: String!
   value: BigInt!
@@ -35,16 +56,28 @@ type TokenTransfer @entity {
 
 ### === igovernor
 
-type ProposalCanceled @entity {
+type ProposalCanceled @entity @index(fields: ["chainId", "governorAddress", "proposalId"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   proposalId: String! # uint256
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: String!
 }
 
-type ProposalCreated @entity {
+type ProposalCreated @entity @index(fields: ["chainId", "governorAddress", "proposalId"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   proposalId: String! # uint256
   proposer: String! # address
   targets: [String!]! # address[]
@@ -59,16 +92,28 @@ type ProposalCreated @entity {
   transactionHash: String!
 }
 
-type ProposalExecuted @entity {
+type ProposalExecuted @entity @index(fields: ["chainId", "governorAddress", "proposalId"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   proposalId: String! # uint256
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: String!
 }
 
-type ProposalQueued @entity {
+type ProposalQueued @entity @index(fields: ["chainId", "governorAddress", "proposalId"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   proposalId: String! # uint256
   etaSeconds: BigInt! # uint256
   blockNumber: BigInt!
@@ -76,8 +121,14 @@ type ProposalQueued @entity {
   transactionHash: String!
 }
 
-type VoteCast @entity {
+type VoteCast @entity @index(fields: ["chainId", "governorAddress", "proposalId"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   voter: String! # address
   proposalId: String! # uint256
   support: Int! # uint8
@@ -88,8 +139,14 @@ type VoteCast @entity {
   transactionHash: String!
 }
 
-type VoteCastWithParams @entity {
+type VoteCastWithParams @entity @index(fields: ["chainId", "governorAddress", "proposalId"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   voter: String! # address
   proposalId: String! # uint256
   support: Int! # uint8
@@ -104,8 +161,14 @@ type VoteCastWithParams @entity {
 
 ### ====== custom
 
-type VoteCastGroup @entity {
+type VoteCastGroup @entity @index(fields: ["chainId", "governorAddress", "refProposalId"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   proposal: Proposal!
   type: String!
   voter: String! # address
@@ -119,8 +182,14 @@ type VoteCastGroup @entity {
   transactionHash: String!
 }
 
-type Proposal @entity {
+type Proposal @entity @index(fields: ["chainId", "governorAddress", "proposalId"]) {
   id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   proposalId: String! # uint256
   proposer: String! # address
   targets: [String!]! # address[]
@@ -152,8 +221,15 @@ type Proposal @entity {
 }
 
 
-type DataMetric @entity {
+type DataMetric @entity @index(fields: ["chainId", "governorAddress", "daoCode"]) {
   id: ID! # global (or chain id?)
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   proposalsCount: Int
   votesCount: Int
   votesWithParamsCount: Int
@@ -166,8 +242,15 @@ type DataMetric @entity {
 }
 
 
-type DelegateRolling @entity {
+type DelegateRolling @entity @index(fields: ["chainId", "governorAddress", "delegator"]) {
   id: ID! # tx hash
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   delegator: String! # address
   fromDelegate: String! # address
   toDelegate: String! # address
@@ -182,8 +265,15 @@ type DelegateRolling @entity {
   toNewVotes: BigInt # uint256
 }
 
-type Delegate @entity {
+type Delegate @entity @index(fields: ["chainId", "governorAddress", "fromDelegate", "toDelegate"]) {
   id: ID! # tx hash
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   fromDelegate: String! # address
   toDelegate: String!
   blockNumber: BigInt!
@@ -193,8 +283,15 @@ type Delegate @entity {
   power: BigInt!
 }
 
-type Contributor @entity {
+type Contributor @entity @index(fields: ["chainId", "governorAddress", "id"]) {
   id: ID! # tx hash
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
 
   blockNumber: BigInt!
   blockTimestamp: BigInt!
@@ -209,8 +306,15 @@ type Contributor @entity {
   delegatesCountEffective: Int!
 }
 
-type DelegateMapping @entity {
+type DelegateMapping @entity @index(fields: ["chainId", "governorAddress", "from"]) {
   id: ID! # from
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
   from: String! # address
   to: String! # address
 

--- a/packages/indexer/src/handler/governor.ts
+++ b/packages/indexer/src/handler/governor.ts
@@ -32,11 +32,51 @@ export interface GovernorHandlerOptions {
   textPlus: TextPlus;
 }
 
+interface GovernanceScopeFields {
+  chainId?: number | null;
+  daoCode?: string | null;
+  governorAddress?: string | null;
+  contractAddress?: string | null;
+  logIndex?: number | null;
+  transactionIndex?: number | null;
+}
+
 export class GovernorHandler {
   constructor(
     private readonly ctx: DataHandlerContext<Store, EvmFieldSelection>,
     private readonly options: GovernorHandlerOptions
   ) {}
+
+  private governorAddress(): string {
+    return DegovIndexerHelpers.normalizeAddress(this.options.indexContract.address)!;
+  }
+
+  private scopeFields(): GovernanceScopeFields {
+    return {
+      chainId: this.options.chainId,
+      daoCode: this.options.work.daoCode,
+      governorAddress: this.governorAddress(),
+    };
+  }
+
+  private eventFields(
+    eventLog: EvmLog<EvmFieldSelection>
+  ): GovernanceScopeFields {
+    return {
+      ...this.scopeFields(),
+      contractAddress: DegovIndexerHelpers.normalizeAddress(eventLog.address),
+      logIndex: eventLog.logIndex,
+      transactionIndex: eventLog.transactionIndex,
+    };
+  }
+
+  private applyScopeFields<T extends object>(
+    target: T,
+    scope: GovernanceScopeFields
+  ): T {
+    Object.assign(target, scope);
+    return target;
+  }
 
   async handle(eventLog: EvmLog<EvmFieldSelection>) {
     const isProposalCreated =
@@ -97,6 +137,7 @@ export class GovernorHandler {
     const proposalId = this.stdProposalId(event.proposalId);
     const entity = new ProposalCreated({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       proposalId,
       proposer: event.proposer,
       targets: event.targets,
@@ -163,6 +204,7 @@ export class GovernorHandler {
 
     const proposal = new Proposal({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       proposalId,
       proposer: event.proposer,
       targets: event.targets,
@@ -188,13 +230,14 @@ export class GovernorHandler {
 
     await this.storeGlobalDataMetric({
       proposalsCount: 1,
-    });
+    }, proposal);
   }
 
   private async storeProposalQueued(eventLog: EvmLog<EvmFieldSelection>) {
     const event = igovernorAbi.events.ProposalQueued.decode(eventLog);
     const entity = new ProposalQueued({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       proposalId: this.stdProposalId(event.proposalId),
       etaSeconds: event.etaSeconds,
       blockNumber: BigInt(eventLog.block.height),
@@ -208,6 +251,7 @@ export class GovernorHandler {
     const event = igovernorAbi.events.ProposalExecuted.decode(eventLog);
     const entity = new ProposalExecuted({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       proposalId: this.stdProposalId(event.proposalId),
       blockNumber: BigInt(eventLog.block.height),
       blockTimestamp: BigInt(eventLog.block.timestamp),
@@ -220,6 +264,7 @@ export class GovernorHandler {
     const event = igovernorAbi.events.ProposalCanceled.decode(eventLog);
     const entity = new ProposalCanceled({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       proposalId: this.stdProposalId(event.proposalId),
       blockNumber: BigInt(eventLog.block.height),
       blockTimestamp: BigInt(eventLog.block.timestamp),
@@ -232,6 +277,7 @@ export class GovernorHandler {
     const event = igovernorAbi.events.VoteCast.decode(eventLog);
     const entity = new VoteCast({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       voter: event.voter,
       proposalId: this.stdProposalId(event.proposalId),
       support: event.support,
@@ -245,6 +291,7 @@ export class GovernorHandler {
 
     const vcg = new VoteCastGroup({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       type: "vote-cast-without-params",
       voter: event.voter,
       refProposalId: this.stdProposalId(event.proposalId),
@@ -262,6 +309,7 @@ export class GovernorHandler {
     const event = igovernorAbi.events.VoteCastWithParams.decode(eventLog);
     const entity = new VoteCastWithParams({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       voter: event.voter,
       proposalId: this.stdProposalId(event.proposalId),
       support: event.support,
@@ -276,6 +324,7 @@ export class GovernorHandler {
 
     const vcg = new VoteCastGroup({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       type: "vote-cast-with-params",
       voter: event.voter,
       refProposalId: this.stdProposalId(event.proposalId),
@@ -294,9 +343,11 @@ export class GovernorHandler {
     const proposal: Proposal | undefined = await this.ctx.store.findOne(
       Proposal,
       {
-        where: {
+        where: DegovIndexerHelpers.proposalScopeWhere({
+          chainId: vcg.chainId ?? this.options.chainId,
+          governorAddress: vcg.governorAddress ?? this.governorAddress(),
           proposalId: vcg.refProposalId,
-        },
+        }),
       }
     );
 
@@ -352,6 +403,14 @@ export class GovernorHandler {
     if (storedContributor) {
       storedContributor.lastVoteBlockNumber = BigInt(vcg.blockNumber);
       storedContributor.lastVoteTimestamp = BigInt(vcg.blockTimestamp);
+      this.applyScopeFields(storedContributor, {
+        chainId: vcg.chainId,
+        daoCode: vcg.daoCode,
+        governorAddress: vcg.governorAddress,
+        contractAddress: vcg.contractAddress,
+        logIndex: vcg.logIndex,
+        transactionIndex: vcg.transactionIndex,
+      });
       await this.ctx.store.save(storedContributor);
     }
 
@@ -363,10 +422,13 @@ export class GovernorHandler {
       votesWeightForSum,
       votesWeightAgainstSum,
       votesWeightAbstainSum,
-    });
+    }, vcg);
   }
 
-  private async storeGlobalDataMetric(options: DataMetricOptions) {
+  private async storeGlobalDataMetric(
+    options: DataMetricOptions,
+    source: GovernanceScopeFields
+  ) {
     const storedDataMetric: DataMetric | undefined =
       await this.ctx.store.findOne(DataMetric, {
         where: {
@@ -381,6 +443,7 @@ export class GovernorHandler {
     if (!storedDataMetric) {
       await this.ctx.store.insert(dm);
     }
+    this.applyScopeFields(dm, source);
     dm.proposalsCount =
       (dm.proposalsCount ?? 0) + (options.proposalsCount ?? 0);
     dm.votesCount = (dm.votesCount ?? 0) + (options.votesCount ?? 0);

--- a/packages/indexer/src/handler/token.ts
+++ b/packages/indexer/src/handler/token.ts
@@ -28,11 +28,64 @@ export interface TokenhandlerOptions {
   indexContract: IndexerContract;
 }
 
+interface TokenScopeFields {
+  chainId?: number | null;
+  daoCode?: string | null;
+  governorAddress?: string | null;
+  tokenAddress?: string | null;
+  contractAddress?: string | null;
+  logIndex?: number | null;
+  transactionIndex?: number | null;
+}
+
 export class TokenHandler {
   constructor(
     private readonly ctx: DataHandlerContext<Store, EvmFieldSelection>,
     private readonly options: TokenhandlerOptions
   ) {}
+
+  private governorAddress(): string {
+    const governorAddress = DegovIndexerHelpers.findContractAddress(
+      this.options.work,
+      "governor"
+    );
+    if (!governorAddress) {
+      throw new Error(
+        `governor contract not found in work daoCode: ${this.options.work.daoCode}`
+      );
+    }
+    return governorAddress;
+  }
+
+  private tokenAddress(): string {
+    return DegovIndexerHelpers.normalizeAddress(this.options.indexContract.address)!;
+  }
+
+  private scopeFields(): TokenScopeFields {
+    return {
+      chainId: this.options.chainId,
+      daoCode: this.options.work.daoCode,
+      governorAddress: this.governorAddress(),
+      tokenAddress: this.tokenAddress(),
+    };
+  }
+
+  private eventFields(eventLog: EvmLog<EvmFieldSelection>): TokenScopeFields {
+    return {
+      ...this.scopeFields(),
+      contractAddress: DegovIndexerHelpers.normalizeAddress(eventLog.address),
+      logIndex: eventLog.logIndex,
+      transactionIndex: eventLog.transactionIndex,
+    };
+  }
+
+  private applyScopeFields<T extends object>(
+    target: T,
+    scope: TokenScopeFields
+  ): T {
+    Object.assign(target, scope);
+    return target;
+  }
 
   private contractStandard() {
     const contractStandard = (
@@ -84,6 +137,7 @@ export class TokenHandler {
     );
     const entity = new DelegateChanged({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       delegator: event.delegator,
       fromDelegate: event.fromDelegate,
       toDelegate: event.toDelegate,
@@ -116,6 +170,7 @@ export class TokenHandler {
         oldDelegateContributor.delegatesCountAll > 0
       ) {
         oldDelegateContributor.delegatesCountAll -= 1;
+        this.applyScopeFields(oldDelegateContributor, this.eventFields(eventLog));
         await this.ctx.store.save(oldDelegateContributor);
       }
     }
@@ -130,10 +185,12 @@ export class TokenHandler {
 
     if (newDelegateContributor) {
       newDelegateContributor.delegatesCountAll += 1;
+      this.applyScopeFields(newDelegateContributor, this.eventFields(eventLog));
       await this.ctx.store.save(newDelegateContributor);
     } else {
       const contributor = new Contributor({
         id: entity.toDelegate,
+        ...this.eventFields(eventLog),
         blockNumber: entity.blockNumber,
         blockTimestamp: entity.blockTimestamp,
         transactionHash: entity.transactionHash,
@@ -142,13 +199,14 @@ export class TokenHandler {
         delegatesCountEffective: 0,
       });
       await this.ctx.store.insert(contributor);
-      await this.increaseMetricsContributorCount();
+      await this.increaseMetricsContributorCount(contributor);
     }
 
     // store delegate mapping
     await this.ctx.store.remove(DelegateMapping, entity.delegator);
     const currentDelegateMapping = new DelegateMapping({
       id: entity.delegator,
+      ...this.eventFields(eventLog),
       from: entity.delegator,
       to: entity.toDelegate,
       power: 0n,
@@ -161,6 +219,7 @@ export class TokenHandler {
     // store delegate rolling
     const delegateRolling = new DelegateRolling({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       delegator: event.delegator,
       fromDelegate: event.fromDelegate,
       toDelegate: event.toDelegate,
@@ -176,6 +235,7 @@ export class TokenHandler {
       entity.delegator === entity.toDelegate
     ) {
       const selfDelegate = new Delegate({
+        ...this.eventFields(eventLog),
         fromDelegate: entity.delegator,
         toDelegate: entity.toDelegate,
         blockNumber: entity.blockNumber,
@@ -197,6 +257,7 @@ export class TokenHandler {
     );
     const entity = new DelegateVotesChanged({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       delegate: event.delegate,
       previousVotes:
         "previousVotes" in event ? event.previousVotes : event.previousBalance,
@@ -284,6 +345,13 @@ export class TokenHandler {
     }
 
     const delegate = new Delegate({
+      chainId: delegateRolling.chainId,
+      daoCode: delegateRolling.daoCode,
+      governorAddress: delegateRolling.governorAddress,
+      tokenAddress: delegateRolling.tokenAddress,
+      contractAddress: options.contractAddress,
+      logIndex: options.logIndex,
+      transactionIndex: options.transactionIndex,
       fromDelegate,
       toDelegate,
       blockNumber: delegateRolling.blockNumber,
@@ -292,6 +360,15 @@ export class TokenHandler {
       power: options.newVotes - options.previousVotes,
     });
 
+    this.applyScopeFields(delegateRolling, {
+      chainId: options.chainId,
+      daoCode: options.daoCode,
+      governorAddress: options.governorAddress,
+      tokenAddress: options.tokenAddress,
+      contractAddress: options.contractAddress,
+      logIndex: options.logIndex,
+      transactionIndex: options.transactionIndex,
+    });
     await this.ctx.store.save(delegateRolling);
     await this.storeDelegate(delegate);
   }
@@ -309,6 +386,7 @@ export class TokenHandler {
     );
     const entity = new TokenTransfer({
       id: eventLog.id,
+      ...this.eventFields(eventLog),
       from: event.from,
       to: event.to,
       value: "value" in event ? event.value : event.tokenId,
@@ -336,6 +414,7 @@ export class TokenHandler {
 
     if (storedFromDelegate) {
       const fromDelegate = new Delegate({
+        ...this.eventFields(eventLog),
         fromDelegate: storedFromDelegate.from,
         toDelegate: storedFromDelegate.to,
         blockNumber: entity.blockNumber,
@@ -347,6 +426,7 @@ export class TokenHandler {
     }
     if (storedToDelegate) {
       const toDelegate = new Delegate({
+        ...this.eventFields(eventLog),
         fromDelegate: storedToDelegate.from,
         toDelegate: storedToDelegate.to,
         blockNumber: entity.blockNumber,
@@ -391,6 +471,15 @@ export class TokenHandler {
       storedDelegateFromWithTo.blockTimestamp = currentDelegate.blockTimestamp;
       storedDelegateFromWithTo.transactionHash =
         currentDelegate.transactionHash;
+      this.applyScopeFields(storedDelegateFromWithTo, {
+        chainId: currentDelegate.chainId,
+        daoCode: currentDelegate.daoCode,
+        governorAddress: currentDelegate.governorAddress,
+        tokenAddress: currentDelegate.tokenAddress,
+        contractAddress: currentDelegate.contractAddress,
+        logIndex: currentDelegate.logIndex,
+        transactionIndex: currentDelegate.transactionIndex,
+      });
       // Remove delegate record if power is zero
       if (storedDelegateFromWithTo.power === 0n) {
         await this.ctx.store.remove(Delegate, storedDelegateFromWithTo.id);
@@ -412,12 +501,28 @@ export class TokenHandler {
       });
     if (storedFromDelegate) {
       storedFromDelegate.power = newDelegatePowerOfFromTo;
+      this.applyScopeFields(storedFromDelegate, {
+        chainId: currentDelegate.chainId,
+        daoCode: currentDelegate.daoCode,
+        governorAddress: currentDelegate.governorAddress,
+        tokenAddress: currentDelegate.tokenAddress,
+        contractAddress: currentDelegate.contractAddress,
+        logIndex: currentDelegate.logIndex,
+        transactionIndex: currentDelegate.transactionIndex,
+      });
       await this.ctx.store.save(storedFromDelegate);
     }
 
     // store contributor
     const contributor = new Contributor({
       id: currentDelegate.toDelegate,
+      chainId: currentDelegate.chainId,
+      daoCode: currentDelegate.daoCode,
+      governorAddress: currentDelegate.governorAddress,
+      tokenAddress: currentDelegate.tokenAddress,
+      contractAddress: currentDelegate.contractAddress,
+      logIndex: currentDelegate.logIndex,
+      transactionIndex: currentDelegate.transactionIndex,
       blockNumber: currentDelegate.blockNumber,
       blockTimestamp: currentDelegate.blockTimestamp,
       transactionHash: currentDelegate.transactionHash,
@@ -442,6 +547,15 @@ export class TokenHandler {
     if (!storedDataMetric) {
       await this.ctx.store.insert(dm);
     }
+    this.applyScopeFields(dm, {
+      chainId: currentDelegate.chainId,
+      daoCode: currentDelegate.daoCode,
+      governorAddress: currentDelegate.governorAddress,
+      tokenAddress: currentDelegate.tokenAddress,
+      contractAddress: currentDelegate.contractAddress,
+      logIndex: currentDelegate.logIndex,
+      transactionIndex: currentDelegate.transactionIndex,
+    });
     dm.powerSum = (dm.powerSum ?? 0n) + currentDelegate.power;
     await this.ctx.store.save(dm);
   }
@@ -460,6 +574,15 @@ export class TokenHandler {
       storedContributor.blockNumber = contributor.blockNumber;
       storedContributor.blockTimestamp = contributor.blockTimestamp;
       storedContributor.transactionHash = contributor.transactionHash;
+      this.applyScopeFields(storedContributor, {
+        chainId: contributor.chainId,
+        daoCode: contributor.daoCode,
+        governorAddress: contributor.governorAddress,
+        tokenAddress: contributor.tokenAddress,
+        contractAddress: contributor.contractAddress,
+        logIndex: contributor.logIndex,
+        transactionIndex: contributor.transactionIndex,
+      });
 
       storedContributor.power = storedContributor.power + contributor.power;
       storedContributor.delegatesCountEffective =
@@ -510,10 +633,10 @@ export class TokenHandler {
     if (!storeMemberMetrics) {
       return;
     }
-    await this.increaseMetricsContributorCount();
+    await this.increaseMetricsContributorCount(contributor);
   }
 
-  private async increaseMetricsContributorCount() {
+  private async increaseMetricsContributorCount(source: TokenScopeFields) {
     // increase metrics for memberCount
     const storedDataMetric: DataMetric | undefined =
       await this.ctx.store.findOne(DataMetric, {
@@ -526,6 +649,7 @@ export class TokenHandler {
       : new DataMetric({
           id: MetricsId.global,
         });
+    this.applyScopeFields(dm, source);
     dm.memberCount = (dm.memberCount ?? 0) + 1;
     await this.ctx.store.save(dm);
   }

--- a/packages/indexer/src/internal/helpers.ts
+++ b/packages/indexer/src/internal/helpers.ts
@@ -1,3 +1,11 @@
+import { ContractName, IndexerWork } from "../types";
+
+export interface ProposalScopeWhereOptions {
+  chainId: number;
+  governorAddress: string;
+  proposalId: string;
+}
+
 export class DegovIndexerHelpers {
   static safeJsonStringify(
     value: any,
@@ -9,5 +17,26 @@ export class DegovIndexerHelpers {
       }
       return v;
     });
+  }
+
+  static normalizeAddress(value?: string | null): string | undefined {
+    return value?.toLowerCase();
+  }
+
+  static findContractAddress(
+    work: IndexerWork,
+    contractName: ContractName
+  ): string | undefined {
+    return this.normalizeAddress(
+      work.contracts.find((item) => item.name === contractName)?.address
+    );
+  }
+
+  static proposalScopeWhere(options: ProposalScopeWhereOptions) {
+    return {
+      chainId: options.chainId,
+      governorAddress: this.normalizeAddress(options.governorAddress),
+      proposalId: options.proposalId,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- add additive scope fields (`chainId`, `daoCode`, `governorAddress`, `tokenAddress`) plus `contractAddress`, `logIndex`, and `transactionIndex` across the indexer schema
- populate the new identity fields in governor and token handlers and scope proposal lookups by `chainId + governorAddress + proposalId`
- add a manual additive migration and regression tests for normalized scope helpers

## Testing
- `cd packages/indexer && npx -y yarn@1.22.22 build`
- `cd packages/indexer && npx -y yarn@1.22.22 test`
- `cd packages/indexer && DB_PORT=55432 DB_PASS=postgres DB_HOST=127.0.0.1 DB_NAME=squid DB_USER=postgres npx sqd migration:apply`
- verified `db/migrations/1774369502838-AddScopeFields.js` `up` section contains only `ALTER TABLE` and `CREATE INDEX`

## Notes
- Related issue: `OHH-33`
- Base branch: `ohh-32-indexer-baseline-upgrade`
- The new migration is manual because the generated migration path rewrote the baseline into a full schema create, which would violate the additive-only requirement.
