### PR TITLE
OHH-35 fix(indexer): materialize snapshot vote power checkpoints

### DIFF
--- a/packages/indexer/__tests__/token-vote-power.test.ts
+++ b/packages/indexer/__tests__/token-vote-power.test.ts
@@ -1,0 +1,180 @@
+import {
+  classifyVotePowerCheckpointCause,
+  TokenHandler,
+  votePowerTimepointForLog,
+} from "../src/handler/token";
+import { ChainTool, ClockMode } from "../src/internal/chaintool";
+import {
+  DelegateRolling,
+  DelegateVotesChanged,
+  TokenTransfer,
+  VotePowerCheckpoint,
+} from "../src/model";
+
+describe("token vote power checkpoints", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses proposal-compatible block timepoints for blocknumber mode", () => {
+    expect(
+      votePowerTimepointForLog({
+        clockMode: ClockMode.BlockNumber,
+        blockHeight: 123,
+        blockTimestampMs: 1_700_000_000_000,
+      })
+    ).toBe(123n);
+  });
+
+  it("uses proposal-compatible timestamp timepoints for timestamp mode", () => {
+    expect(
+      votePowerTimepointForLog({
+        clockMode: ClockMode.Timestamp,
+        blockHeight: 123,
+        blockTimestampMs: 1_700_000_123_987,
+      })
+    ).toBe(1_700_000_123n);
+  });
+
+  it("classifies checkpoint causes from sibling token/governance events", () => {
+    expect(
+      classifyVotePowerCheckpointCause({
+        hasDelegateChange: true,
+        hasTransfer: true,
+      })
+    ).toBe("delegate-change+transfer");
+    expect(
+      classifyVotePowerCheckpointCause({
+        hasDelegateChange: true,
+        hasTransfer: false,
+      })
+    ).toBe("delegate-change");
+    expect(
+      classifyVotePowerCheckpointCause({
+        hasDelegateChange: false,
+        hasTransfer: true,
+      })
+    ).toBe("transfer");
+    expect(
+      classifyVotePowerCheckpointCause({
+        hasDelegateChange: false,
+        hasTransfer: false,
+      })
+    ).toBe("delegate-votes-changed");
+  });
+
+  it("materializes vote power checkpoints from delegate vote changes", async () => {
+    const inserted: unknown[] = [];
+    const store = {
+      findOne: jest.fn(async (entity, options: any) => {
+        if (entity === DelegateRolling) {
+          return new DelegateRolling({
+            id: "rolling",
+            delegator: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+            fromDelegate: "0x0000000000000000000000000000000000000000",
+            toDelegate: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+            transactionHash: options.where.transactionHash,
+          });
+        }
+        if (entity === TokenTransfer) {
+          return new TokenTransfer({
+            id: "transfer",
+            transactionHash: options.where.transactionHash,
+          });
+        }
+        return undefined;
+      }),
+      insert: jest.fn(async (entity) => {
+        inserted.push(entity);
+      }),
+    };
+
+    const handler = new TokenHandler(
+      {
+        store,
+        log: {
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
+      } as any,
+      {
+        chainId: 1,
+        rpcs: ["https://rpc.example.invalid"],
+        work: {
+          daoCode: "demo",
+          contracts: [
+            {
+              name: "governor",
+              address: "0x9999999999999999999999999999999999999999",
+            },
+            {
+              name: "governorToken",
+              address: "0x8888888888888888888888888888888888888888",
+              standard: "ERC20",
+            },
+          ],
+        },
+        indexContract: {
+          name: "governorToken",
+          address: "0x8888888888888888888888888888888888888888",
+          standard: "ERC20",
+        },
+        chainTool: new ChainTool(),
+      }
+    );
+
+    jest
+      .spyOn(handler as any, "voteClockMode")
+      .mockResolvedValue(ClockMode.BlockNumber);
+
+    const delegateVotesChanged = new DelegateVotesChanged({
+      id: "log-1",
+      chainId: 1,
+      daoCode: "demo",
+      governorAddress: "0x9999999999999999999999999999999999999999",
+      tokenAddress: "0x8888888888888888888888888888888888888888",
+      contractAddress: "0x8888888888888888888888888888888888888888",
+      logIndex: 7,
+      transactionIndex: 3,
+      delegate: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+      previousVotes: 12n,
+      newVotes: 42n,
+      blockNumber: 123n,
+      blockTimestamp: 1_700_000_000_000n,
+      transactionHash: "0xdeadbeef",
+    });
+
+    const eventLog = {
+      id: "log-1",
+      address: "0x8888888888888888888888888888888888888888",
+      logIndex: 7,
+      transactionIndex: 3,
+      block: {
+        height: 123,
+        timestamp: 1_700_000_000_000,
+      },
+      transactionHash: "0xdeadbeef",
+    } as any;
+
+    await (handler as any).storeVotePowerCheckpoint(delegateVotesChanged, eventLog);
+
+    expect(store.insert).toHaveBeenCalledTimes(1);
+    expect(inserted[0]).toBeInstanceOf(VotePowerCheckpoint);
+    expect(inserted[0]).toMatchObject({
+      id: "log-1",
+      account: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      clockMode: ClockMode.BlockNumber,
+      timepoint: 123n,
+      previousPower: 12n,
+      newPower: 42n,
+      delta: 30n,
+      cause: "delegate-change+transfer",
+      delegator: "0xcccccccccccccccccccccccccccccccccccccccc",
+      fromDelegate: "0x0000000000000000000000000000000000000000",
+      toDelegate: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      blockNumber: 123n,
+      transactionHash: "0xdeadbeef",
+    });
+  });
+});

--- a/packages/indexer/db/migrations/1774407579836-Data.js
+++ b/packages/indexer/db/migrations/1774407579836-Data.js
@@ -1,0 +1,13 @@
+module.exports = class Data1774407579836 {
+    name = 'Data1774407579836'
+
+    async up(db) {
+        await db.query(`CREATE TABLE "vote_power_checkpoint" ("id" character varying NOT NULL, "chain_id" integer, "dao_code" text, "governor_address" text, "token_address" text, "contract_address" text, "log_index" integer, "transaction_index" integer, "account" text NOT NULL, "clock_mode" text NOT NULL, "timepoint" numeric NOT NULL, "previous_power" numeric NOT NULL, "new_power" numeric NOT NULL, "delta" numeric NOT NULL, "cause" text NOT NULL, "delegator" text, "from_delegate" text, "to_delegate" text, "block_number" numeric NOT NULL, "block_timestamp" numeric NOT NULL, "transaction_hash" text NOT NULL, CONSTRAINT "PK_a7046c290a7a7d881283853f3f7" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE INDEX "IDX_08c8f53fdccf02212a8da0ee1e" ON "vote_power_checkpoint" ("chain_id", "governor_address", "token_address", "account", "clock_mode", "timepoint") `)
+    }
+
+    async down(db) {
+        await db.query(`DROP TABLE "vote_power_checkpoint"`)
+        await db.query(`DROP INDEX "public"."IDX_08c8f53fdccf02212a8da0ee1e"`)
+    }
+}

--- a/packages/indexer/schema.graphql
+++ b/packages/indexer/schema.graphql
@@ -54,6 +54,30 @@ type TokenTransfer @entity @index(fields: ["chainId", "governorAddress", "tokenA
   transactionHash: String!
 }
 
+type VotePowerCheckpoint @entity @index(fields: ["chainId", "governorAddress", "tokenAddress", "account", "clockMode", "timepoint"]) {
+  id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  tokenAddress: String # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
+  account: String! # address
+  clockMode: String!
+  timepoint: BigInt!
+  previousPower: BigInt!
+  newPower: BigInt!
+  delta: BigInt!
+  cause: String!
+  delegator: String # address
+  fromDelegate: String # address
+  toDelegate: String # address
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: String!
+}
+
 ### === igovernor
 
 type ProposalCanceled @entity @index(fields: ["chainId", "governorAddress", "proposalId"]) {

--- a/packages/indexer/src/handler/token.ts
+++ b/packages/indexer/src/handler/token.ts
@@ -11,6 +11,7 @@ import {
   DelegateRolling,
   DelegateVotesChanged,
   TokenTransfer,
+  VotePowerCheckpoint,
 } from "../model";
 import {
   MetricsId,
@@ -19,13 +20,16 @@ import {
   IndexerWork,
 } from "../types";
 import { DegovIndexerHelpers } from "../internal/helpers";
+import { ChainTool, ClockMode } from "../internal/chaintool";
 
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 
 export interface TokenhandlerOptions {
   chainId: number;
+  rpcs: string[];
   work: IndexerWork;
   indexContract: IndexerContract;
+  chainTool: ChainTool;
 }
 
 interface TokenScopeFields {
@@ -36,6 +40,32 @@ interface TokenScopeFields {
   contractAddress?: string | null;
   logIndex?: number | null;
   transactionIndex?: number | null;
+}
+
+export function votePowerTimepointForLog(options: {
+  clockMode: ClockMode;
+  blockHeight: number;
+  blockTimestampMs: number;
+}): bigint {
+  return options.clockMode === ClockMode.Timestamp
+    ? BigInt(Math.floor(options.blockTimestampMs / 1000))
+    : BigInt(options.blockHeight);
+}
+
+export function classifyVotePowerCheckpointCause(options: {
+  hasDelegateChange: boolean;
+  hasTransfer: boolean;
+}): string {
+  if (options.hasDelegateChange && options.hasTransfer) {
+    return "delegate-change+transfer";
+  }
+  if (options.hasDelegateChange) {
+    return "delegate-change";
+  }
+  if (options.hasTransfer) {
+    return "transfer";
+  }
+  return "delegate-votes-changed";
 }
 
 export class TokenHandler {
@@ -59,6 +89,14 @@ export class TokenHandler {
 
   private tokenAddress(): string {
     return DegovIndexerHelpers.normalizeAddress(this.options.indexContract.address)!;
+  }
+
+  private async voteClockMode(): Promise<ClockMode> {
+    return this.options.chainTool.clockMode({
+      chainId: this.options.chainId,
+      contractAddress: this.governorAddress() as `0x${string}`,
+      rpcs: this.options.rpcs,
+    });
   }
 
   private scopeFields(): TokenScopeFields {
@@ -267,8 +305,61 @@ export class TokenHandler {
       transactionHash: eventLog.transactionHash,
     });
     await this.ctx.store.insert(entity);
+    await this.storeVotePowerCheckpoint(entity, eventLog);
     // store rolling
     await this.updateDelegateRolling(entity);
+  }
+
+  private async storeVotePowerCheckpoint(
+    delegateVotesChanged: DelegateVotesChanged,
+    eventLog: EvmLog<EvmFieldSelection>
+  ) {
+    const [clockMode, delegateRolling, tokenTransfer] = await Promise.all([
+      this.voteClockMode(),
+      this.ctx.store.findOne(DelegateRolling, {
+        where: {
+          transactionHash: delegateVotesChanged.transactionHash,
+        },
+      }),
+      this.ctx.store.findOne(TokenTransfer, {
+        where: {
+          transactionHash: delegateVotesChanged.transactionHash,
+        },
+      }),
+    ]);
+
+    const checkpoint = new VotePowerCheckpoint({
+      id: eventLog.id,
+      ...this.eventFields(eventLog),
+      account:
+        DegovIndexerHelpers.normalizeAddress(delegateVotesChanged.delegate) ??
+        delegateVotesChanged.delegate,
+      clockMode,
+      timepoint: votePowerTimepointForLog({
+        clockMode,
+        blockHeight: eventLog.block.height,
+        blockTimestampMs: eventLog.block.timestamp,
+      }),
+      previousPower: BigInt(delegateVotesChanged.previousVotes),
+      newPower: BigInt(delegateVotesChanged.newVotes),
+      delta:
+        BigInt(delegateVotesChanged.newVotes) -
+        BigInt(delegateVotesChanged.previousVotes),
+      cause: classifyVotePowerCheckpointCause({
+        hasDelegateChange: Boolean(delegateRolling),
+        hasTransfer: Boolean(tokenTransfer),
+      }),
+      delegator: DegovIndexerHelpers.normalizeAddress(delegateRolling?.delegator),
+      fromDelegate: DegovIndexerHelpers.normalizeAddress(
+        delegateRolling?.fromDelegate
+      ),
+      toDelegate: DegovIndexerHelpers.normalizeAddress(delegateRolling?.toDelegate),
+      blockNumber: BigInt(eventLog.block.height),
+      blockTimestamp: BigInt(eventLog.block.timestamp),
+      transactionHash: eventLog.transactionHash,
+    });
+
+    await this.ctx.store.insert(checkpoint);
   }
 
   private async updateDelegateRolling(options: DelegateVotesChanged) {

--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -126,8 +126,10 @@ async function runProcessorEvm(config: IndexerProcessorConfig) {
                 case "governorToken":
                   await new TokenHandler(ctx, {
                     chainId: config.chainId,
+                    rpcs: [...new Set([...configRpcs, ...envRpcs])],
                     work,
                     indexContract,
+                    chainTool,
                   }).handle(event);
                   break;
               }


### PR DESCRIPTION
## Summary
- add `VotePowerCheckpoint` as an additive snapshot-truth layer for governor token vote power
- materialize checkpoints from `DelegateVotesChanged` using governor-compatible timepoints and transaction context from `DelegateChanged` / `Transfer`
- keep live `Contributor.power` / `Delegate.power` behavior intact and cover the new checkpoint helpers with unit tests

## Validation
- `cd packages/indexer && npx -y yarn@1.22.22 install --ignore-scripts`
- `cd packages/indexer && npx -y yarn@1.22.22 codegen`
- `cd packages/indexer && npx -y yarn@1.22.22 build`
- `cd packages/indexer && npx -y yarn@1.22.22 test`
- `cd packages/indexer && DB_HOST=127.0.0.1 DB_PORT=55432 DB_PASS=postgres DB_NAME=indexer DB_USER=postgres npx sqd migration:apply`

Refs: OHH-35