### PR TITLE
fix(indexer): index timelock lifecycle and role history

### DIFF
--- a/packages/indexer/__tests__/datasource.test.ts
+++ b/packages/indexer/__tests__/datasource.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, writeFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { DegovDataSource } from "../src/datasource";
+
+describe("DegovDataSource", () => {
+  it("includes timeLock in indexed contracts", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "degov-datasource-"));
+    const configPath = join(tempDir, "degov.yml");
+
+    try {
+      await writeFile(
+        configPath,
+        `
+code: demo
+chain:
+  id: 46
+  rpcs:
+    - https://rpc.darwinia.network
+indexer:
+  startBlock: 1
+contracts:
+  governor: "0x1111111111111111111111111111111111111111"
+  governorToken:
+    address: "0x2222222222222222222222222222222222222222"
+    standard: ERC20
+  timeLock: "0x3333333333333333333333333333333333333333"
+`
+      );
+
+      const config = await DegovDataSource.fromDegovConfigPath(configPath);
+
+      expect(config.works[0].contracts).toEqual([
+        {
+          name: "governor",
+          address: "0x1111111111111111111111111111111111111111",
+          standard: undefined,
+        },
+        {
+          name: "governorToken",
+          address: "0x2222222222222222222222222222222222222222",
+          standard: "ERC20",
+        },
+        {
+          name: "timeLock",
+          address: "0x3333333333333333333333333333333333333333",
+          standard: undefined,
+        },
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/indexer/__tests__/governor.test.ts
+++ b/packages/indexer/__tests__/governor.test.ts
@@ -1,7 +1,9 @@
 import {
   calculateProposalVoteTimestamp,
+  GovernorHandler,
 } from "../src/handler/governor";
 import { ClockMode } from "../src/internal/chaintool";
+import { Proposal, TimelockCall, TimelockOperation } from "../src/model";
 
 describe("calculateProposalVoteTimestamp", () => {
   it("derives vote timestamps from block-based proposal timepoints", () => {
@@ -33,6 +35,125 @@ describe("calculateProposalVoteTimestamp", () => {
     ).toEqual({
       voteStart: 1_700_000_000_000,
       voteEnd: 1_700_086_400_000,
+    });
+  });
+});
+
+describe("GovernorHandler timelock queue materialization", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("links queued proposals to a timelock operation and calls", async () => {
+    const saved: unknown[] = [];
+    const store = {
+      findOne: jest.fn(async () => undefined),
+      save: jest.fn(async (entity) => {
+        saved.push(entity);
+        return entity;
+      }),
+    };
+
+    const handler = new GovernorHandler(
+      {
+        store,
+        log: {
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
+      } as any,
+      {
+        chainId: 46,
+        rpcs: ["https://rpc.example.invalid"],
+        work: {
+          daoCode: "demo",
+          contracts: [
+            {
+              name: "governor",
+              address: "0x9999999999999999999999999999999999999999",
+            },
+            {
+              name: "timeLock",
+              address: "0x7777777777777777777777777777777777777777",
+            },
+          ],
+        },
+        indexContract: {
+          name: "governor",
+          address: "0x9999999999999999999999999999999999999999",
+        },
+        chainTool: new (class {} as any)(),
+        textPlus: new (class {} as any)(),
+      }
+    );
+
+    const proposal = new Proposal({
+      id: "proposal-log",
+      chainId: 46,
+      daoCode: "demo",
+      governorAddress: "0x9999999999999999999999999999999999999999",
+      proposalId: "0x1",
+      descriptionHash:
+        "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      targets: [
+        "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+      ],
+      values: ["1", "2"],
+      calldatas: ["0x1234", "0xabcd"],
+      timelockAddress: "0x7777777777777777777777777777777777777777",
+      clockMode: ClockMode.BlockNumber,
+    });
+
+    await (handler as any).syncTimelockOperationForProposalQueue(
+      proposal,
+      {
+        id: "queue-log",
+        logIndex: 3,
+        transactionIndex: 2,
+        block: {
+          height: 100,
+          timestamp: 900_000,
+        },
+        transactionHash: "0xdeadbeef",
+      },
+      1_000n
+    );
+
+    expect(store.save).toHaveBeenCalledTimes(3);
+    expect(saved[0]).toBeInstanceOf(TimelockOperation);
+    expect(saved[1]).toBeInstanceOf(TimelockCall);
+    expect(saved[2]).toBeInstanceOf(TimelockCall);
+    expect(saved[0]).toMatchObject({
+      proposalId: "0x1",
+      timelockType: "GovernorTimelockControl",
+      state: "Waiting",
+      callCount: 2,
+      executedCallCount: 0,
+      delaySeconds: 100n,
+      readyAt: 1_000_000n,
+      queuedTransactionHash: "0xdeadbeef",
+    });
+    expect(saved[1]).toMatchObject({
+      proposalId: "0x1",
+      proposalActionIndex: 0,
+      proposalActionId: "proposal-log:action:0",
+      actionIndex: 0,
+      target: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+      value: "1",
+      data: "0x1234",
+      state: "Waiting",
+    });
+    expect(saved[2]).toMatchObject({
+      proposalId: "0x1",
+      proposalActionIndex: 1,
+      proposalActionId: "proposal-log:action:1",
+      actionIndex: 1,
+      target: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+      value: "2",
+      data: "0xabcd",
+      state: "Waiting",
     });
   });
 });

--- a/packages/indexer/abi/itimelockcontroller.json
+++ b/packages/indexer/abi/itimelockcontroller.json
@@ -1,0 +1,240 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "predecessor",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "delay",
+        "type": "uint256"
+      }
+    ],
+    "name": "CallScheduled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "CallExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      }
+    ],
+    "name": "CallSalt",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "Cancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "MinDelayChange",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "getMinDelay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "GRACE_PERIOD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/indexer/db/migrations/1774409157559-Data.js
+++ b/packages/indexer/db/migrations/1774409157559-Data.js
@@ -1,0 +1,43 @@
+module.exports = class Data1774409157559 {
+    name = 'Data1774409157559'
+
+    async up(db) {
+        await db.query(`CREATE TABLE "timelock_call" ("id" character varying NOT NULL, "chain_id" integer, "dao_code" text, "governor_address" text, "timelock_address" text NOT NULL, "contract_address" text, "log_index" integer, "transaction_index" integer, "operation_id" character varying NOT NULL, "proposal_id" character varying, "proposal_action_id" text, "proposal_action_index" integer, "action_index" integer NOT NULL, "target" text NOT NULL, "value" text NOT NULL, "data" text NOT NULL, "predecessor" text, "delay_seconds" numeric, "state" text NOT NULL, "scheduled_block_number" numeric, "scheduled_block_timestamp" numeric, "scheduled_transaction_hash" text, "executed_block_number" numeric, "executed_block_timestamp" numeric, "executed_transaction_hash" text, CONSTRAINT "PK_dae843ead23b71257e61fae484e" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE INDEX "IDX_5a89e85fcddd1c5120a66ddff3" ON "timelock_call" ("operation_id") `)
+        await db.query(`CREATE INDEX "IDX_02e9680cc4905d667deaec230b" ON "timelock_call" ("proposal_id") `)
+        await db.query(`CREATE INDEX "IDX_d2c4c75619b38113cc07d29be2" ON "timelock_call" ("chain_id", "governor_address", "timelock_address", "operation_id", "action_index") `)
+        await db.query(`CREATE TABLE "timelock_operation" ("id" character varying NOT NULL, "chain_id" integer, "dao_code" text, "governor_address" text, "timelock_address" text NOT NULL, "contract_address" text, "log_index" integer, "transaction_index" integer, "proposal_id" character varying, "operation_id" text NOT NULL, "timelock_type" text NOT NULL, "predecessor" text, "salt" text, "state" text NOT NULL, "call_count" integer, "executed_call_count" integer, "delay_seconds" numeric, "ready_at" numeric, "expires_at" numeric, "queued_block_number" numeric, "queued_block_timestamp" numeric, "queued_transaction_hash" text, "cancelled_block_number" numeric, "cancelled_block_timestamp" numeric, "cancelled_transaction_hash" text, "executed_block_number" numeric, "executed_block_timestamp" numeric, "executed_transaction_hash" text, CONSTRAINT "PK_80f1a4c38f9180ca2af3328a2b8" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE INDEX "IDX_4f85eaf0fa034e10124101ad01" ON "timelock_operation" ("proposal_id") `)
+        await db.query(`CREATE INDEX "IDX_1d57ae87a833af26036523041b" ON "timelock_operation" ("chain_id", "governor_address", "timelock_address", "proposal_id", "operation_id") `)
+        await db.query(`CREATE TABLE "timelock_role_event" ("id" character varying NOT NULL, "chain_id" integer, "dao_code" text, "governor_address" text, "timelock_address" text NOT NULL, "contract_address" text, "log_index" integer, "transaction_index" integer, "event_name" text NOT NULL, "role" text NOT NULL, "role_label" text, "account" text, "sender" text, "previous_admin_role" text, "previous_admin_role_label" text, "new_admin_role" text, "new_admin_role_label" text, "block_number" numeric NOT NULL, "block_timestamp" numeric NOT NULL, "transaction_hash" text NOT NULL, CONSTRAINT "PK_9ca37fd5648a81b8799cd7307d4" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE INDEX "IDX_5ff9c27463cdecb92a4b7ccff9" ON "timelock_role_event" ("chain_id", "governor_address", "timelock_address", "role", "event_name") `)
+        await db.query(`CREATE TABLE "timelock_min_delay_change" ("id" character varying NOT NULL, "chain_id" integer, "dao_code" text, "governor_address" text, "timelock_address" text NOT NULL, "contract_address" text, "log_index" integer, "transaction_index" integer, "old_duration" numeric NOT NULL, "new_duration" numeric NOT NULL, "block_number" numeric NOT NULL, "block_timestamp" numeric NOT NULL, "transaction_hash" text NOT NULL, CONSTRAINT "PK_116a972c9389a86114c0f676c84" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE INDEX "IDX_b98caad15a83928f8b5fa657b2" ON "timelock_min_delay_change" ("chain_id", "governor_address", "timelock_address", "block_number") `)
+        await db.query(`ALTER TABLE "proposal" ADD "queue_ready_at" numeric`)
+        await db.query(`ALTER TABLE "proposal" ADD "queue_expires_at" numeric`)
+        await db.query(`ALTER TABLE "proposal" ADD "timelock_grace_period" numeric`)
+        await db.query(`ALTER TABLE "timelock_call" ADD CONSTRAINT "FK_5a89e85fcddd1c5120a66ddff3e" FOREIGN KEY ("operation_id") REFERENCES "timelock_operation"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)
+        await db.query(`ALTER TABLE "timelock_call" ADD CONSTRAINT "FK_02e9680cc4905d667deaec230b5" FOREIGN KEY ("proposal_id") REFERENCES "proposal"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)
+        await db.query(`ALTER TABLE "timelock_operation" ADD CONSTRAINT "FK_4f85eaf0fa034e10124101ad013" FOREIGN KEY ("proposal_id") REFERENCES "proposal"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)
+    }
+
+    async down(db) {
+        await db.query(`DROP TABLE "timelock_call"`)
+        await db.query(`DROP INDEX "public"."IDX_5a89e85fcddd1c5120a66ddff3"`)
+        await db.query(`DROP INDEX "public"."IDX_02e9680cc4905d667deaec230b"`)
+        await db.query(`DROP INDEX "public"."IDX_d2c4c75619b38113cc07d29be2"`)
+        await db.query(`DROP TABLE "timelock_operation"`)
+        await db.query(`DROP INDEX "public"."IDX_4f85eaf0fa034e10124101ad01"`)
+        await db.query(`DROP INDEX "public"."IDX_1d57ae87a833af26036523041b"`)
+        await db.query(`DROP TABLE "timelock_role_event"`)
+        await db.query(`DROP INDEX "public"."IDX_5ff9c27463cdecb92a4b7ccff9"`)
+        await db.query(`DROP TABLE "timelock_min_delay_change"`)
+        await db.query(`DROP INDEX "public"."IDX_b98caad15a83928f8b5fa657b2"`)
+        await db.query(`ALTER TABLE "proposal" DROP COLUMN "queue_ready_at"`)
+        await db.query(`ALTER TABLE "proposal" DROP COLUMN "queue_expires_at"`)
+        await db.query(`ALTER TABLE "proposal" DROP COLUMN "timelock_grace_period"`)
+        await db.query(`ALTER TABLE "timelock_call" DROP CONSTRAINT "FK_5a89e85fcddd1c5120a66ddff3e"`)
+        await db.query(`ALTER TABLE "timelock_call" DROP CONSTRAINT "FK_02e9680cc4905d667deaec230b5"`)
+        await db.query(`ALTER TABLE "timelock_operation" DROP CONSTRAINT "FK_4f85eaf0fa034e10124101ad013"`)
+    }
+}

--- a/packages/indexer/schema.graphql
+++ b/packages/indexer/schema.graphql
@@ -335,6 +335,7 @@ type Proposal @entity @index(fields: ["chainId", "governorAddress", "proposalId"
   actions: [ProposalAction!] @derivedFrom(field: "proposal")
   stateEpochs: [ProposalStateEpoch!] @derivedFrom(field: "proposal")
   deadlineExtensions: [ProposalDeadlineExtension!] @derivedFrom(field: "proposal")
+  timelockOperations: [TimelockOperation!] @derivedFrom(field: "proposal")
 
   metricsVotesCount: Int
   metricsVotesWithParamsCount: Int
@@ -351,8 +352,11 @@ type Proposal @entity @index(fields: ["chainId", "governorAddress", "proposalId"
   proposalSnapshot: BigInt
   proposalDeadline: BigInt
   proposalEta: BigInt
+  queueReadyAt: BigInt
+  queueExpiresAt: BigInt
   countingMode: String
   timelockAddress: String # address
+  timelockGracePeriod: BigInt
   clockMode: String!
   quorum: BigInt!
   decimals: BigInt!
@@ -428,6 +432,108 @@ type ProposalDeadlineExtension @entity @index(fields: ["chainId", "governorAddre
   proposalId: String! # uint256
   previousDeadline: BigInt
   newDeadline: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: String!
+}
+
+type TimelockOperation @entity @index(fields: ["chainId", "governorAddress", "timelockAddress", "proposalId", "operationId"]) {
+  id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  timelockAddress: String! # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
+  proposal: Proposal
+  proposalId: String # uint256
+  operationId: String! # bytes32
+  timelockType: String!
+  predecessor: String # bytes32
+  salt: String # bytes32
+  state: String!
+  callCount: Int
+  executedCallCount: Int
+  delaySeconds: BigInt
+  readyAt: BigInt
+  expiresAt: BigInt
+  queuedBlockNumber: BigInt
+  queuedBlockTimestamp: BigInt
+  queuedTransactionHash: String
+  cancelledBlockNumber: BigInt
+  cancelledBlockTimestamp: BigInt
+  cancelledTransactionHash: String
+  executedBlockNumber: BigInt
+  executedBlockTimestamp: BigInt
+  executedTransactionHash: String
+  calls: [TimelockCall!] @derivedFrom(field: "operation")
+}
+
+type TimelockCall @entity @index(fields: ["chainId", "governorAddress", "timelockAddress", "operationId", "actionIndex"]) {
+  id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  timelockAddress: String! # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
+  operation: TimelockOperation!
+  operationId: String! # bytes32
+  proposal: Proposal
+  proposalId: String # uint256
+  proposalActionId: String
+  proposalActionIndex: Int
+  actionIndex: Int!
+  target: String! # address
+  value: String! # uint256
+  data: String! # bytes
+  predecessor: String # bytes32
+  delaySeconds: BigInt
+  state: String!
+  scheduledBlockNumber: BigInt
+  scheduledBlockTimestamp: BigInt
+  scheduledTransactionHash: String
+  executedBlockNumber: BigInt
+  executedBlockTimestamp: BigInt
+  executedTransactionHash: String
+}
+
+type TimelockRoleEvent @entity @index(fields: ["chainId", "governorAddress", "timelockAddress", "role", "eventName"]) {
+  id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  timelockAddress: String! # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
+  eventName: String!
+  role: String! # bytes32
+  roleLabel: String
+  account: String # address
+  sender: String # address
+  previousAdminRole: String # bytes32
+  previousAdminRoleLabel: String
+  newAdminRole: String # bytes32
+  newAdminRoleLabel: String
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: String!
+}
+
+type TimelockMinDelayChange @entity @index(fields: ["chainId", "governorAddress", "timelockAddress", "blockNumber"]) {
+  id: ID!
+  chainId: Int
+  daoCode: String
+  governorAddress: String # address
+  timelockAddress: String! # address
+  contractAddress: String # address
+  logIndex: Int
+  transactionIndex: Int
+  oldDuration: BigInt!
+  newDuration: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: String!

--- a/packages/indexer/src/abi/itimelockcontroller.ts
+++ b/packages/indexer/src/abi/itimelockcontroller.ts
@@ -1,0 +1,48 @@
+import * as p from '@subsquid/evm-codec'
+import { event, fun, viewFun, indexed, ContractBase } from '@subsquid/evm-abi'
+import type { EventParams as EParams, FunctionArguments, FunctionReturn } from '@subsquid/evm-abi'
+
+export const events = {
+    CallScheduled: event("0x4cf4410cc57040e44862ef0f45f3dd5a5e02db8eb8add648d4b0e236f1d07dca", "CallScheduled(bytes32,uint256,address,uint256,bytes,bytes32,uint256)", {"id": indexed(p.bytes32), "index": indexed(p.uint256), "target": p.address, "value": p.uint256, "data": p.bytes, "predecessor": p.bytes32, "delay": p.uint256}),
+    CallExecuted: event("0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58", "CallExecuted(bytes32,uint256,address,uint256,bytes)", {"id": indexed(p.bytes32), "index": indexed(p.uint256), "target": p.address, "value": p.uint256, "data": p.bytes}),
+    CallSalt: event("0x20fda5fd27a1ea7bf5b9567f143ac5470bb059374a27e8f67cb44f946f6d0387", "CallSalt(bytes32,bytes32)", {"id": indexed(p.bytes32), "salt": p.bytes32}),
+    Cancelled: event("0xbaa1eb22f2a492ba1a5fea61b8df4d27c6c8b5f3971e63bb58fa14ff72eedb70", "Cancelled(bytes32)", {"id": indexed(p.bytes32)}),
+    MinDelayChange: event("0x11c24f4ead16507c69ac467fbd5e4eed5fb5c699626d2cc6d66421df253886d5", "MinDelayChange(uint256,uint256)", {"oldDuration": p.uint256, "newDuration": p.uint256}),
+    RoleAdminChanged: event("0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff", "RoleAdminChanged(bytes32,bytes32,bytes32)", {"role": indexed(p.bytes32), "previousAdminRole": indexed(p.bytes32), "newAdminRole": indexed(p.bytes32)}),
+    RoleGranted: event("0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d", "RoleGranted(bytes32,address,address)", {"role": indexed(p.bytes32), "account": indexed(p.address), "sender": indexed(p.address)}),
+    RoleRevoked: event("0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b", "RoleRevoked(bytes32,address,address)", {"role": indexed(p.bytes32), "account": indexed(p.address), "sender": indexed(p.address)}),
+}
+
+export const functions = {
+    getMinDelay: viewFun("0xf27a0c92", "getMinDelay()", {}, p.uint256),
+    GRACE_PERIOD: viewFun("0xc1a287e2", "GRACE_PERIOD()", {}, p.uint256),
+}
+
+export class Contract extends ContractBase {
+
+    getMinDelay() {
+        return this.eth_call(functions.getMinDelay, {})
+    }
+
+    GRACE_PERIOD() {
+        return this.eth_call(functions.GRACE_PERIOD, {})
+    }
+}
+
+/// Event types
+export type CallScheduledEventArgs = EParams<typeof events.CallScheduled>
+export type CallExecutedEventArgs = EParams<typeof events.CallExecuted>
+export type CallSaltEventArgs = EParams<typeof events.CallSalt>
+export type CancelledEventArgs = EParams<typeof events.Cancelled>
+export type MinDelayChangeEventArgs = EParams<typeof events.MinDelayChange>
+export type RoleAdminChangedEventArgs = EParams<typeof events.RoleAdminChanged>
+export type RoleGrantedEventArgs = EParams<typeof events.RoleGranted>
+export type RoleRevokedEventArgs = EParams<typeof events.RoleRevoked>
+
+/// Function types
+export type GetMinDelayParams = FunctionArguments<typeof functions.getMinDelay>
+export type GetMinDelayReturn = FunctionReturn<typeof functions.getMinDelay>
+
+export type GRACE_PERIODParams = FunctionArguments<typeof functions.GRACE_PERIOD>
+export type GRACE_PERIODReturn = FunctionReturn<typeof functions.GRACE_PERIOD>
+

--- a/packages/indexer/src/datasource.ts
+++ b/packages/indexer/src/datasource.ts
@@ -42,7 +42,7 @@ class DegovConfigDataSource {
     const contractNames = Object.keys(contracts);
     const indexContracts: IndexerContract[] = contractNames
       .filter((item) => {
-        return ["governor", "governorToken"].indexOf(item) != -1;
+        return ["governor", "governorToken", "timeLock"].indexOf(item) != -1;
       })
       .map((item) => {
         const c = contracts[item];

--- a/packages/indexer/src/handler/governor.ts
+++ b/packages/indexer/src/handler/governor.ts
@@ -18,7 +18,9 @@ import {
   ProposalStateEpoch,
   ProposalThresholdSet,
   QuorumNumeratorUpdated,
+  TimelockCall,
   TimelockChange,
+  TimelockOperation,
   VoteCast,
   VoteCastGroup,
   VoteCastWithParams,
@@ -34,6 +36,18 @@ import {
 import { ChainTool, ClockMode } from "../internal/chaintool";
 import { TextPlus } from "../internal/textplus";
 import { DegovIndexerHelpers } from "../internal/helpers";
+import {
+  governorTimelockSalt,
+  TIMELOCK_STATE_CANCELED,
+  TIMELOCK_STATE_DONE,
+  TIMELOCK_STATE_READY,
+  TIMELOCK_STATE_WAITING,
+  TIMELOCK_TYPE_CONTROL,
+  timelockCallEntityId,
+  timelockOperationEntityId,
+  timelockOperationIdForBatch,
+  ZERO_BYTES32,
+} from "../internal/timelock";
 
 const ABI_FUNCTION_COUNTING_MODE: Abi = [
   {
@@ -80,6 +94,16 @@ const ABI_FUNCTION_TIMELOCK: Abi = [
     inputs: [],
     name: "timelock",
     outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+const ABI_FUNCTION_GRACE_PERIOD: Abi = [
+  {
+    inputs: [],
+    name: "GRACE_PERIOD",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
     stateMutability: "view",
     type: "function",
   },
@@ -196,6 +220,162 @@ export class GovernorHandler {
         proposalId,
       }),
     });
+  }
+
+  private proposalTimelockOperationId(proposal: Proposal): string | undefined {
+    if (!proposal.timelockAddress || !proposal.descriptionHash) {
+      return undefined;
+    }
+
+    const salt = governorTimelockSalt({
+      governorAddress: this.governorAddress(),
+      descriptionHash: proposal.descriptionHash,
+    });
+
+    return timelockOperationIdForBatch({
+      targets: proposal.targets,
+      values: proposal.values,
+      calldatas: proposal.calldatas,
+      predecessor: ZERO_BYTES32,
+      salt,
+    });
+  }
+
+  private async findTimelockOperation(proposal: Proposal) {
+    const operationId = this.proposalTimelockOperationId(proposal);
+    if (!operationId || !proposal.timelockAddress) {
+      return undefined;
+    }
+
+    return this.ctx.store.findOne(TimelockOperation, {
+      where: {
+        chainId: this.options.chainId,
+        timelockAddress: proposal.timelockAddress,
+        operationId,
+      },
+    });
+  }
+
+  private async syncTimelockOperationForProposalQueue(
+    proposal: Proposal,
+    eventLog: EvmLog<EvmFieldSelection>,
+    etaSeconds: bigint
+  ) {
+    if (!proposal.timelockAddress || !proposal.descriptionHash) {
+      return;
+    }
+
+    const operationId =
+      this.proposalTimelockOperationId(proposal) ?? undefined;
+    if (!operationId) {
+      return;
+    }
+
+    const operation =
+      (await this.findTimelockOperation(proposal)) ??
+      new TimelockOperation({
+        id: timelockOperationEntityId({
+          chainId: this.options.chainId,
+          timelockAddress: proposal.timelockAddress,
+          operationId,
+        }),
+        operationId,
+        timelockAddress: proposal.timelockAddress,
+        timelockType: TIMELOCK_TYPE_CONTROL,
+        state: TIMELOCK_STATE_WAITING,
+      });
+
+    const delaySeconds =
+      etaSeconds > BigInt(Math.floor(eventLog.block.timestamp / 1000))
+        ? etaSeconds - BigInt(Math.floor(eventLog.block.timestamp / 1000))
+        : 0n;
+    const queuedState =
+      etaSeconds * 1000n <= BigInt(eventLog.block.timestamp)
+        ? TIMELOCK_STATE_READY
+        : TIMELOCK_STATE_WAITING;
+
+    operation.chainId = this.options.chainId;
+    operation.daoCode = this.options.work.daoCode;
+    operation.governorAddress = proposal.governorAddress;
+    operation.timelockAddress = proposal.timelockAddress;
+    operation.contractAddress = proposal.timelockAddress;
+    operation.proposal = proposal;
+    operation.proposalId = proposal.proposalId;
+    operation.logIndex = operation.logIndex ?? eventLog.logIndex;
+    operation.transactionIndex = operation.transactionIndex ?? eventLog.transactionIndex;
+    operation.predecessor = ZERO_BYTES32;
+    operation.salt = governorTimelockSalt({
+      governorAddress: this.governorAddress(),
+      descriptionHash: proposal.descriptionHash,
+    });
+    if (
+      operation.state !== TIMELOCK_STATE_DONE &&
+      operation.state !== TIMELOCK_STATE_CANCELED
+    ) {
+      operation.state = queuedState;
+    }
+    operation.callCount = proposal.targets.length;
+    operation.executedCallCount = operation.executedCallCount ?? 0;
+    operation.delaySeconds = operation.delaySeconds ?? delaySeconds;
+    operation.readyAt = operation.readyAt ?? etaSeconds * 1000n;
+    operation.queuedBlockNumber = operation.queuedBlockNumber ?? BigInt(eventLog.block.height);
+    operation.queuedBlockTimestamp =
+      operation.queuedBlockTimestamp ?? BigInt(eventLog.block.timestamp);
+    operation.queuedTransactionHash =
+      operation.queuedTransactionHash ?? eventLog.transactionHash;
+
+    await this.ctx.store.save(operation);
+
+    for (const [actionIndex, target] of proposal.targets.entries()) {
+      const callId = timelockCallEntityId(operation.id, actionIndex);
+      const existingCall = await this.ctx.store.findOne(TimelockCall, {
+        where: { id: callId },
+      });
+      const call =
+        existingCall ??
+        new TimelockCall({
+          id: callId,
+          operation,
+          operationId,
+          actionIndex,
+          target,
+          value: proposal.values[actionIndex] ?? "0",
+          data: proposal.calldatas[actionIndex] ?? "0x",
+          state: queuedState,
+        });
+
+      call.chainId = this.options.chainId;
+      call.daoCode = this.options.work.daoCode;
+      call.governorAddress = proposal.governorAddress;
+      call.timelockAddress = proposal.timelockAddress;
+      call.contractAddress = proposal.timelockAddress;
+      call.logIndex = call.logIndex ?? eventLog.logIndex;
+      call.transactionIndex = call.transactionIndex ?? eventLog.transactionIndex;
+      call.operation = operation;
+      call.operationId = operationId;
+      call.proposal = proposal;
+      call.proposalId = proposal.proposalId;
+      call.proposalActionIndex = actionIndex;
+      call.proposalActionId = this.proposalActionId(proposal, actionIndex);
+      call.actionIndex = actionIndex;
+      call.target = target;
+      call.value = proposal.values[actionIndex] ?? "0";
+      call.data = proposal.calldatas[actionIndex] ?? "0x";
+      call.predecessor = ZERO_BYTES32;
+      call.delaySeconds = call.delaySeconds ?? delaySeconds;
+      if (call.state !== TIMELOCK_STATE_DONE) {
+        call.state =
+          call.state === TIMELOCK_STATE_CANCELED ? call.state : queuedState;
+      }
+      call.scheduledBlockNumber =
+        call.scheduledBlockNumber ?? BigInt(eventLog.block.height);
+      call.scheduledBlockTimestamp =
+        call.scheduledBlockTimestamp ?? BigInt(eventLog.block.timestamp);
+      call.scheduledTransactionHash =
+        call.scheduledTransactionHash ?? eventLog.transactionHash;
+
+      await this.ctx.store.save(call);
+    }
   }
 
   async handle(eventLog: EvmLog<EvmFieldSelection>) {
@@ -450,6 +630,19 @@ export class GovernorHandler {
     state: string,
     eventLog: EvmLog<EvmFieldSelection>
   ) {
+    const existing = await this.ctx.store.findOne(ProposalStateEpoch, {
+      where: {
+        chainId: this.options.chainId,
+        governorAddress: this.governorAddress(),
+        proposalId: proposal.proposalId,
+        state,
+        transactionHash: eventLog.transactionHash,
+      },
+    });
+    if (existing) {
+      return;
+    }
+
     const clockMode = await this.options.chainTool.clockMode({
       chainId: this.options.chainId,
       contractAddress: this.options.indexContract.address,
@@ -590,7 +783,27 @@ export class GovernorHandler {
     const proposal = await this.findProposal(proposalId);
     if (proposal) {
       proposal.proposalEta = event.etaSeconds;
+      proposal.queueReadyAt = event.etaSeconds * 1000n;
+      if (proposal.timelockAddress) {
+        const gracePeriod = await this.options.chainTool.readOptionalContract<bigint>({
+          chainId: this.options.chainId,
+          contractAddress: proposal.timelockAddress as `0x${string}`,
+          rpcs: this.options.rpcs,
+          abi: ABI_FUNCTION_GRACE_PERIOD,
+          functionName: "GRACE_PERIOD",
+        });
+        proposal.timelockGracePeriod = gracePeriod;
+        proposal.queueExpiresAt =
+          gracePeriod !== undefined
+            ? (event.etaSeconds + gracePeriod) * 1000n
+            : undefined;
+      }
       await this.ctx.store.save(proposal);
+      await this.syncTimelockOperationForProposalQueue(
+        proposal,
+        eventLog,
+        event.etaSeconds
+      );
       await this.storeProposalStateEpoch(
         proposal,
         GOVERNANCE_STATE_QUEUED,
@@ -676,6 +889,15 @@ export class GovernorHandler {
 
     const proposal = await this.findProposal(proposalId);
     if (proposal) {
+      const operation = await this.findTimelockOperation(proposal);
+      if (operation) {
+        operation.state = TIMELOCK_STATE_DONE;
+        operation.executedBlockNumber = BigInt(eventLog.block.height);
+        operation.executedBlockTimestamp = BigInt(eventLog.block.timestamp);
+        operation.executedTransactionHash = eventLog.transactionHash;
+        operation.executedCallCount = operation.callCount ?? operation.executedCallCount;
+        await this.ctx.store.save(operation);
+      }
       await this.storeProposalStateEpoch(
         proposal,
         GOVERNANCE_STATE_EXECUTED,
@@ -699,6 +921,14 @@ export class GovernorHandler {
 
     const proposal = await this.findProposal(proposalId);
     if (proposal) {
+      const operation = await this.findTimelockOperation(proposal);
+      if (operation) {
+        operation.state = TIMELOCK_STATE_CANCELED;
+        operation.cancelledBlockNumber = BigInt(eventLog.block.height);
+        operation.cancelledBlockTimestamp = BigInt(eventLog.block.timestamp);
+        operation.cancelledTransactionHash = eventLog.transactionHash;
+        await this.ctx.store.save(operation);
+      }
       await this.storeProposalStateEpoch(
         proposal,
         GOVERNANCE_STATE_CANCELED,

--- a/packages/indexer/src/handler/timelock.ts
+++ b/packages/indexer/src/handler/timelock.ts
@@ -1,0 +1,555 @@
+import * as itimelockcontrollerAbi from "../abi/itimelockcontroller";
+import { Store } from "@subsquid/typeorm-store";
+import { DataHandlerContext, Log as EvmLog } from "@subsquid/evm-processor";
+import {
+  Proposal,
+  ProposalStateEpoch,
+  TimelockCall,
+  TimelockMinDelayChange,
+  TimelockOperation,
+  TimelockRoleEvent,
+} from "../model";
+import {
+  EvmFieldSelection,
+  IndexerContract,
+  IndexerWork,
+} from "../types";
+import { ChainTool, ClockMode } from "../internal/chaintool";
+import { DegovIndexerHelpers } from "../internal/helpers";
+import {
+  TIMELOCK_STATE_CANCELED,
+  TIMELOCK_STATE_DONE,
+  TIMELOCK_STATE_READY,
+  TIMELOCK_STATE_WAITING,
+  TIMELOCK_TYPE_CONTROL,
+  timelockCallEntityId,
+  timelockOperationEntityId,
+  timelockRoleLabel,
+} from "../internal/timelock";
+
+const GOVERNANCE_STATE_CANCELED = "Canceled";
+const GOVERNANCE_STATE_EXECUTED = "Executed";
+
+export interface TimelockHandlerOptions {
+  chainId: number;
+  rpcs: string[];
+  work: IndexerWork;
+  indexContract: IndexerContract;
+  chainTool: ChainTool;
+}
+
+interface TimelockScopeFields {
+  chainId?: number;
+  daoCode?: string;
+  governorAddress?: string;
+  timelockAddress?: string;
+  contractAddress?: string;
+  logIndex?: number;
+  transactionIndex?: number;
+}
+
+export class TimelockHandler {
+  constructor(
+    private readonly ctx: DataHandlerContext<Store, EvmFieldSelection>,
+    private readonly options: TimelockHandlerOptions
+  ) {}
+
+  private governorAddress(): string | undefined {
+    return DegovIndexerHelpers.findContractAddress(this.options.work, "governor");
+  }
+
+  private timelockAddress(): string {
+    return (
+      DegovIndexerHelpers.normalizeAddress(this.options.indexContract.address) ??
+      this.options.indexContract.address.toLowerCase()
+    );
+  }
+
+  private scopeFields(): TimelockScopeFields {
+    return {
+      chainId: this.options.chainId,
+      daoCode: this.options.work.daoCode,
+      governorAddress: this.governorAddress(),
+      timelockAddress: this.timelockAddress(),
+    };
+  }
+
+  private eventFields(
+    eventLog: EvmLog<EvmFieldSelection>
+  ): TimelockScopeFields {
+    return {
+      ...this.scopeFields(),
+      contractAddress: this.timelockAddress(),
+      logIndex: eventLog.logIndex,
+      transactionIndex: eventLog.transactionIndex,
+    };
+  }
+
+  private hasTopic(
+    eventLog: EvmLog<EvmFieldSelection>,
+    topic: string
+  ): boolean {
+    return eventLog.topics.includes(topic);
+  }
+
+  private proposalStateEpochId(
+    proposal: Proposal,
+    state: string,
+    eventLog: EvmLog<EvmFieldSelection>
+  ): string {
+    return `${proposal.id}:state:${state.toLowerCase()}:${eventLog.id}`;
+  }
+
+  private proposalActionId(proposal: Proposal, actionIndex: number): string {
+    return `${proposal.id}:action:${actionIndex}`;
+  }
+
+  private async findOperation(operationId: string) {
+    return this.ctx.store.findOne(TimelockOperation, {
+      where: {
+        chainId: this.options.chainId,
+        timelockAddress: this.timelockAddress(),
+        operationId: operationId.toLowerCase(),
+      },
+    });
+  }
+
+  private async findOrCreateOperation(
+    operationId: string
+  ): Promise<TimelockOperation> {
+    const existing = await this.findOperation(operationId);
+    if (existing) {
+      return existing;
+    }
+
+    return new TimelockOperation({
+      id: timelockOperationEntityId({
+        chainId: this.options.chainId,
+        timelockAddress: this.timelockAddress(),
+        operationId,
+      }),
+      ...this.scopeFields(),
+      operationId: operationId.toLowerCase(),
+      timelockType: TIMELOCK_TYPE_CONTROL,
+      state: TIMELOCK_STATE_WAITING,
+      callCount: 0,
+      executedCallCount: 0,
+    });
+  }
+
+  private async findProposalById(proposalId?: string | null) {
+    if (!proposalId) {
+      return undefined;
+    }
+
+    const governorAddress = this.governorAddress();
+    if (!governorAddress) {
+      return undefined;
+    }
+
+    return this.ctx.store.findOne(Proposal, {
+      where: DegovIndexerHelpers.proposalScopeWhere({
+        chainId: this.options.chainId,
+        governorAddress,
+        proposalId,
+      }),
+    });
+  }
+
+  private async bindOperationToProposal(
+    operation: TimelockOperation,
+    proposal: Proposal
+  ) {
+    operation.proposal = proposal;
+    operation.proposalId = proposal.proposalId;
+    operation.governorAddress = proposal.governorAddress;
+
+    const calls = await this.ctx.store.find(TimelockCall, {
+      where: {
+        chainId: this.options.chainId,
+        timelockAddress: this.timelockAddress(),
+        operationId: operation.operationId,
+      },
+    });
+
+    for (const call of calls) {
+      call.proposal = proposal;
+      call.proposalId = proposal.proposalId;
+      call.proposalActionIndex = call.actionIndex;
+      call.proposalActionId = this.proposalActionId(proposal, call.actionIndex);
+    }
+
+    await this.ctx.store.save(operation);
+    if (calls.length > 0) {
+      await this.ctx.store.save(calls);
+    }
+  }
+
+  private async ensureProposalStateEpoch(
+    proposal: Proposal,
+    state: string,
+    eventLog: EvmLog<EvmFieldSelection>
+  ) {
+    const existing = await this.ctx.store.findOne(ProposalStateEpoch, {
+      where: {
+        chainId: this.options.chainId,
+        governorAddress:
+          proposal.governorAddress ?? this.governorAddress() ?? undefined,
+        proposalId: proposal.proposalId,
+        state,
+        transactionHash: eventLog.transactionHash,
+      },
+    });
+    if (existing) {
+      return;
+    }
+
+    const clockMode =
+      proposal.clockMode === ClockMode.Timestamp
+        ? ClockMode.Timestamp
+        : ClockMode.BlockNumber;
+
+    const epoch = new ProposalStateEpoch({
+      id: this.proposalStateEpochId(proposal, state, eventLog),
+      chainId: this.options.chainId,
+      daoCode: this.options.work.daoCode,
+      governorAddress: proposal.governorAddress,
+      contractAddress: this.timelockAddress(),
+      logIndex: eventLog.logIndex,
+      transactionIndex: eventLog.transactionIndex,
+      proposal,
+      proposalId: proposal.proposalId,
+      state,
+      startTimepoint:
+        clockMode === ClockMode.Timestamp
+          ? BigInt(Math.floor(eventLog.block.timestamp / 1000))
+          : BigInt(eventLog.block.height),
+      startBlockNumber: BigInt(eventLog.block.height),
+      startBlockTimestamp: BigInt(eventLog.block.timestamp),
+      transactionHash: eventLog.transactionHash,
+    });
+
+    await this.ctx.store.insert(epoch);
+  }
+
+  private async finalizeOperationExecution(
+    operation: TimelockOperation,
+    eventLog: EvmLog<EvmFieldSelection>
+  ) {
+    operation.state = TIMELOCK_STATE_DONE;
+    operation.executedBlockNumber = BigInt(eventLog.block.height);
+    operation.executedBlockTimestamp = BigInt(eventLog.block.timestamp);
+    operation.executedTransactionHash = eventLog.transactionHash;
+    await this.ctx.store.save(operation);
+
+    if (operation.proposal) {
+      await this.ensureProposalStateEpoch(
+        operation.proposal,
+        GOVERNANCE_STATE_EXECUTED,
+        eventLog
+      );
+    }
+  }
+
+  async handle(eventLog: EvmLog<EvmFieldSelection>) {
+    if (
+      this.hasTopic(eventLog, itimelockcontrollerAbi.events.CallScheduled.topic)
+    ) {
+      await this.storeCallScheduled(eventLog);
+    }
+    if (
+      this.hasTopic(eventLog, itimelockcontrollerAbi.events.CallExecuted.topic)
+    ) {
+      await this.storeCallExecuted(eventLog);
+    }
+    if (this.hasTopic(eventLog, itimelockcontrollerAbi.events.CallSalt.topic)) {
+      await this.storeCallSalt(eventLog);
+    }
+    if (this.hasTopic(eventLog, itimelockcontrollerAbi.events.Cancelled.topic)) {
+      await this.storeCancelled(eventLog);
+    }
+    if (
+      this.hasTopic(eventLog, itimelockcontrollerAbi.events.MinDelayChange.topic)
+    ) {
+      await this.storeMinDelayChange(eventLog);
+    }
+    if (
+      this.hasTopic(eventLog, itimelockcontrollerAbi.events.RoleGranted.topic)
+    ) {
+      await this.storeRoleGranted(eventLog);
+    }
+    if (
+      this.hasTopic(eventLog, itimelockcontrollerAbi.events.RoleRevoked.topic)
+    ) {
+      await this.storeRoleRevoked(eventLog);
+    }
+    if (
+      this.hasTopic(
+        eventLog,
+        itimelockcontrollerAbi.events.RoleAdminChanged.topic
+      )
+    ) {
+      await this.storeRoleAdminChanged(eventLog);
+    }
+  }
+
+  private async storeCallScheduled(eventLog: EvmLog<EvmFieldSelection>) {
+    const event = itimelockcontrollerAbi.events.CallScheduled.decode(eventLog);
+    const operationId = event.id.toLowerCase();
+    const operation = await this.findOrCreateOperation(operationId);
+
+    operation.contractAddress = this.timelockAddress();
+    operation.logIndex ??= eventLog.logIndex;
+    operation.transactionIndex ??= eventLog.transactionIndex;
+    operation.predecessor = event.predecessor.toLowerCase();
+    operation.delaySeconds = BigInt(event.delay);
+    operation.readyAt = BigInt(eventLog.block.timestamp) + BigInt(event.delay) * 1000n;
+    operation.state =
+      operation.readyAt <= BigInt(eventLog.block.timestamp)
+        ? TIMELOCK_STATE_READY
+        : TIMELOCK_STATE_WAITING;
+    operation.callCount = Math.max(operation.callCount ?? 0, Number(event.index) + 1);
+    operation.queuedBlockNumber ??= BigInt(eventLog.block.height);
+    operation.queuedBlockTimestamp ??= BigInt(eventLog.block.timestamp);
+    operation.queuedTransactionHash ??= eventLog.transactionHash;
+
+    const call = (
+      await this.ctx.store.findOne(TimelockCall, {
+        where: { id: timelockCallEntityId(operation.id, Number(event.index)) },
+      })
+    ) ??
+      new TimelockCall({
+        id: timelockCallEntityId(operation.id, Number(event.index)),
+        ...this.scopeFields(),
+        operation,
+        operationId,
+        proposal: operation.proposal,
+        proposalId: operation.proposalId,
+        proposalActionIndex: Number(event.index),
+        proposalActionId: operation.proposal
+          ? this.proposalActionId(operation.proposal, Number(event.index))
+          : undefined,
+        actionIndex: Number(event.index),
+        target: event.target,
+        value: event.value.toString(),
+        data: event.data,
+        predecessor: event.predecessor.toLowerCase(),
+        state: TIMELOCK_STATE_WAITING,
+      });
+
+    call.chainId = this.options.chainId;
+    call.daoCode = this.options.work.daoCode;
+    call.governorAddress = operation.governorAddress ?? this.governorAddress();
+    call.timelockAddress = this.timelockAddress();
+    call.contractAddress = this.timelockAddress();
+    call.logIndex = eventLog.logIndex;
+    call.transactionIndex = eventLog.transactionIndex;
+    call.operation = operation;
+    call.operationId = operationId;
+    call.proposal = operation.proposal;
+    call.proposalId = operation.proposalId;
+    call.proposalActionIndex = Number(event.index);
+    call.proposalActionId = operation.proposal
+      ? this.proposalActionId(operation.proposal, Number(event.index))
+      : undefined;
+    call.target = event.target;
+    call.value = event.value.toString();
+    call.data = event.data;
+    call.predecessor = event.predecessor.toLowerCase();
+    call.delaySeconds = BigInt(event.delay);
+    call.state = operation.state;
+    call.scheduledBlockNumber = BigInt(eventLog.block.height);
+    call.scheduledBlockTimestamp = BigInt(eventLog.block.timestamp);
+    call.scheduledTransactionHash = eventLog.transactionHash;
+
+    await this.ctx.store.save(operation);
+    await this.ctx.store.save(call);
+  }
+
+  private async storeCallExecuted(eventLog: EvmLog<EvmFieldSelection>) {
+    const event = itimelockcontrollerAbi.events.CallExecuted.decode(eventLog);
+    const operationId = event.id.toLowerCase();
+    const operation = await this.findOrCreateOperation(operationId);
+    const actionIndex = Number(event.index);
+    const callId = timelockCallEntityId(operation.id, actionIndex);
+    const existingCall = await this.ctx.store.findOne(TimelockCall, {
+      where: { id: callId },
+    });
+
+    const call =
+      existingCall ??
+      new TimelockCall({
+        id: callId,
+        ...this.scopeFields(),
+        operation,
+        operationId,
+        proposal: operation.proposal,
+        proposalId: operation.proposalId,
+        proposalActionIndex: actionIndex,
+        proposalActionId: operation.proposal
+          ? this.proposalActionId(operation.proposal, actionIndex)
+          : undefined,
+        actionIndex,
+        target: event.target,
+        value: event.value.toString(),
+        data: event.data,
+        state: TIMELOCK_STATE_DONE,
+      });
+
+    const wasExecuted = existingCall?.state === TIMELOCK_STATE_DONE;
+    call.chainId = this.options.chainId;
+    call.daoCode = this.options.work.daoCode;
+    call.governorAddress = operation.governorAddress ?? this.governorAddress();
+    call.timelockAddress = this.timelockAddress();
+    call.contractAddress = this.timelockAddress();
+    call.logIndex = eventLog.logIndex;
+    call.transactionIndex = eventLog.transactionIndex;
+    call.operation = operation;
+    call.operationId = operationId;
+    call.proposal = operation.proposal;
+    call.proposalId = operation.proposalId;
+    call.proposalActionIndex = actionIndex;
+    call.proposalActionId = operation.proposal
+      ? this.proposalActionId(operation.proposal, actionIndex)
+      : undefined;
+    call.actionIndex = actionIndex;
+    call.target = event.target;
+    call.value = event.value.toString();
+    call.data = event.data;
+    call.state = TIMELOCK_STATE_DONE;
+    call.executedBlockNumber = BigInt(eventLog.block.height);
+    call.executedBlockTimestamp = BigInt(eventLog.block.timestamp);
+    call.executedTransactionHash = eventLog.transactionHash;
+
+    operation.contractAddress = this.timelockAddress();
+    operation.callCount = Math.max(operation.callCount ?? 0, actionIndex + 1);
+    if (!wasExecuted) {
+      operation.executedCallCount = (operation.executedCallCount ?? 0) + 1;
+    }
+
+    await this.ctx.store.save(operation);
+    await this.ctx.store.save(call);
+
+    if (
+      (operation.callCount ?? 0) > 0 &&
+      (operation.executedCallCount ?? 0) >= (operation.callCount ?? 0)
+    ) {
+      await this.finalizeOperationExecution(operation, eventLog);
+    }
+  }
+
+  private async storeCallSalt(eventLog: EvmLog<EvmFieldSelection>) {
+    const event = itimelockcontrollerAbi.events.CallSalt.decode(eventLog);
+    const operation = await this.findOrCreateOperation(event.id.toLowerCase());
+    operation.contractAddress = this.timelockAddress();
+    operation.salt = event.salt.toLowerCase();
+    await this.ctx.store.save(operation);
+  }
+
+  private async storeCancelled(eventLog: EvmLog<EvmFieldSelection>) {
+    const event = itimelockcontrollerAbi.events.Cancelled.decode(eventLog);
+    const operation = await this.findOrCreateOperation(event.id.toLowerCase());
+
+    operation.contractAddress = this.timelockAddress();
+    operation.state = TIMELOCK_STATE_CANCELED;
+    operation.cancelledBlockNumber = BigInt(eventLog.block.height);
+    operation.cancelledBlockTimestamp = BigInt(eventLog.block.timestamp);
+    operation.cancelledTransactionHash = eventLog.transactionHash;
+    await this.ctx.store.save(operation);
+
+    const calls = await this.ctx.store.find(TimelockCall, {
+      where: {
+        chainId: this.options.chainId,
+        timelockAddress: this.timelockAddress(),
+        operationId: operation.operationId,
+      },
+    });
+    for (const call of calls) {
+      if (call.state !== TIMELOCK_STATE_DONE) {
+        call.state = TIMELOCK_STATE_CANCELED;
+      }
+    }
+    if (calls.length > 0) {
+      await this.ctx.store.save(calls);
+    }
+
+    if (operation.proposal) {
+      await this.ensureProposalStateEpoch(
+        operation.proposal,
+        GOVERNANCE_STATE_CANCELED,
+        eventLog
+      );
+    }
+  }
+
+  private async storeMinDelayChange(eventLog: EvmLog<EvmFieldSelection>) {
+    const event = itimelockcontrollerAbi.events.MinDelayChange.decode(eventLog);
+    const entity = new TimelockMinDelayChange({
+      id: eventLog.id,
+      ...this.eventFields(eventLog),
+      oldDuration: event.oldDuration,
+      newDuration: event.newDuration,
+      blockNumber: BigInt(eventLog.block.height),
+      blockTimestamp: BigInt(eventLog.block.timestamp),
+      transactionHash: eventLog.transactionHash,
+    });
+
+    await this.ctx.store.insert(entity);
+  }
+
+  private async storeRoleGranted(eventLog: EvmLog<EvmFieldSelection>) {
+    const event = itimelockcontrollerAbi.events.RoleGranted.decode(eventLog);
+    const entity = new TimelockRoleEvent({
+      id: eventLog.id,
+      ...this.eventFields(eventLog),
+      eventName: "RoleGranted",
+      role: event.role.toLowerCase(),
+      roleLabel: timelockRoleLabel(event.role),
+      account: DegovIndexerHelpers.normalizeAddress(event.account),
+      sender: DegovIndexerHelpers.normalizeAddress(event.sender),
+      blockNumber: BigInt(eventLog.block.height),
+      blockTimestamp: BigInt(eventLog.block.timestamp),
+      transactionHash: eventLog.transactionHash,
+    });
+
+    await this.ctx.store.insert(entity);
+  }
+
+  private async storeRoleRevoked(eventLog: EvmLog<EvmFieldSelection>) {
+    const event = itimelockcontrollerAbi.events.RoleRevoked.decode(eventLog);
+    const entity = new TimelockRoleEvent({
+      id: eventLog.id,
+      ...this.eventFields(eventLog),
+      eventName: "RoleRevoked",
+      role: event.role.toLowerCase(),
+      roleLabel: timelockRoleLabel(event.role),
+      account: DegovIndexerHelpers.normalizeAddress(event.account),
+      sender: DegovIndexerHelpers.normalizeAddress(event.sender),
+      blockNumber: BigInt(eventLog.block.height),
+      blockTimestamp: BigInt(eventLog.block.timestamp),
+      transactionHash: eventLog.transactionHash,
+    });
+
+    await this.ctx.store.insert(entity);
+  }
+
+  private async storeRoleAdminChanged(eventLog: EvmLog<EvmFieldSelection>) {
+    const event = itimelockcontrollerAbi.events.RoleAdminChanged.decode(eventLog);
+    const entity = new TimelockRoleEvent({
+      id: eventLog.id,
+      ...this.eventFields(eventLog),
+      eventName: "RoleAdminChanged",
+      role: event.role.toLowerCase(),
+      roleLabel: timelockRoleLabel(event.role),
+      previousAdminRole: event.previousAdminRole.toLowerCase(),
+      previousAdminRoleLabel: timelockRoleLabel(event.previousAdminRole),
+      newAdminRole: event.newAdminRole.toLowerCase(),
+      newAdminRoleLabel: timelockRoleLabel(event.newAdminRole),
+      blockNumber: BigInt(eventLog.block.height),
+      blockTimestamp: BigInt(eventLog.block.timestamp),
+      transactionHash: eventLog.transactionHash,
+    });
+
+    await this.ctx.store.insert(entity);
+  }
+}

--- a/packages/indexer/src/internal/timelock.ts
+++ b/packages/indexer/src/internal/timelock.ts
@@ -1,0 +1,101 @@
+import {
+  encodeAbiParameters,
+  keccak256,
+  parseAbiParameters,
+  stringToHex,
+} from "viem";
+import { DegovIndexerHelpers } from "./helpers";
+
+export const TIMELOCK_TYPE_CONTROL = "GovernorTimelockControl";
+export const TIMELOCK_TYPE_COMPOUND = "GovernorTimelockCompound";
+
+export const TIMELOCK_STATE_WAITING = "Waiting";
+export const TIMELOCK_STATE_READY = "Ready";
+export const TIMELOCK_STATE_DONE = "Done";
+export const TIMELOCK_STATE_CANCELED = "Canceled";
+
+export const ZERO_BYTES32 = `0x${"0".repeat(64)}`;
+
+const DEFAULT_ADMIN_ROLE = ZERO_BYTES32;
+const PROPOSER_ROLE = keccak256(stringToHex("PROPOSER_ROLE"));
+const EXECUTOR_ROLE = keccak256(stringToHex("EXECUTOR_ROLE"));
+const CANCELLER_ROLE = keccak256(stringToHex("CANCELLER_ROLE"));
+
+function normalizeHex(value: string): string {
+  return value.toLowerCase();
+}
+
+export function timelockOperationEntityId(options: {
+  chainId: number;
+  timelockAddress: string;
+  operationId: string;
+}): string {
+  return [
+    "timelock",
+    options.chainId,
+    DegovIndexerHelpers.normalizeAddress(options.timelockAddress),
+    normalizeHex(options.operationId),
+  ].join(":");
+}
+
+export function timelockCallEntityId(
+  operationEntityId: string,
+  actionIndex: number
+): string {
+  return `${operationEntityId}:call:${actionIndex}`;
+}
+
+export function timelockRoleLabel(role?: string | null): string | undefined {
+  const normalizedRole = role ? normalizeHex(role) : undefined;
+  switch (normalizedRole) {
+    case DEFAULT_ADMIN_ROLE:
+      return "DEFAULT_ADMIN_ROLE";
+    case PROPOSER_ROLE:
+      return "PROPOSER_ROLE";
+    case EXECUTOR_ROLE:
+      return "EXECUTOR_ROLE";
+    case CANCELLER_ROLE:
+      return "CANCELLER_ROLE";
+    default:
+      return undefined;
+  }
+}
+
+export function governorTimelockSalt(options: {
+  governorAddress: string;
+  descriptionHash: string;
+}): string {
+  const normalizedGovernorAddress = (
+    DegovIndexerHelpers.normalizeAddress(options.governorAddress) ?? ""
+  ).replace(/^0x/, "");
+  const governorBytes32 = `0x${normalizedGovernorAddress}${"0".repeat(24)}`;
+  const saltBigInt =
+    BigInt(governorBytes32) ^ BigInt(normalizeHex(options.descriptionHash));
+  return `0x${saltBigInt.toString(16).padStart(64, "0")}`;
+}
+
+export function timelockOperationIdForBatch(options: {
+  targets: string[];
+  values: string[];
+  calldatas: string[];
+  predecessor?: string;
+  salt: string;
+}): string {
+  const payload = encodeAbiParameters(
+    parseAbiParameters(
+      "address[] targets, uint256[] values, bytes[] payloads, bytes32 predecessor, bytes32 salt"
+    ),
+    [
+      options.targets.map(
+        (target) =>
+          (DegovIndexerHelpers.normalizeAddress(target) ?? target) as `0x${string}`
+      ),
+      options.values.map((value) => BigInt(value)),
+      options.calldatas.map((data) => normalizeHex(data) as `0x${string}`),
+      normalizeHex(options.predecessor ?? ZERO_BYTES32) as `0x${string}`,
+      normalizeHex(options.salt) as `0x${string}`,
+    ]
+  );
+
+  return keccak256(payload);
+}

--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -1,5 +1,6 @@
 import { TypeormDatabase } from "@subsquid/typeorm-store";
 import { GovernorHandler } from "./handler/governor";
+import { TimelockHandler } from "./handler/timelock";
 import { TokenHandler } from "./handler/token";
 import { EvmBatchProcessor } from "@subsquid/evm-processor";
 import { evmFieldSelection, IndexerProcessorConfig } from "./types";
@@ -125,6 +126,15 @@ async function runProcessorEvm(config: IndexerProcessorConfig) {
                   break;
                 case "governorToken":
                   await new TokenHandler(ctx, {
+                    chainId: config.chainId,
+                    rpcs: [...new Set([...configRpcs, ...envRpcs])],
+                    work,
+                    indexContract,
+                    chainTool,
+                  }).handle(event);
+                  break;
+                case "timeLock":
+                  await new TimelockHandler(ctx, {
                     chainId: config.chainId,
                     rpcs: [...new Set([...configRpcs, ...envRpcs])],
                     work,

--- a/packages/indexer/src/types.ts
+++ b/packages/indexer/src/types.ts
@@ -15,7 +15,7 @@ export enum MetricsId {
   global = "global",
 }
 
-export type ContractName = "governor" | "governorToken";
+export type ContractName = "governor" | "governorToken" | "timeLock";
 
 export interface IndexerProcessorConfig {
   chainId: number;


### PR DESCRIPTION
## Summary
- watch `timeLock` contracts in the indexer processor and decode TimelockController plus AccessControl events
- materialize `TimelockOperation`, `TimelockCall`, `TimelockRoleEvent`, and `TimelockMinDelayChange` records
- link `ProposalQueued` to timelock operation ids and persist queue-ready / queue-expiry metadata for downstream state derivation
- cover the new datasource and proposal queue linkage with regression tests

## Validation
- `npx --yes yarn@1.22.22 build`
- `npx --yes yarn@1.22.22 test`

## Notes
- base branch: `ohh-32-indexer-baseline-upgrade`
- ordinary PR per OHH-36 execution rules
