### PR TITLE
fix: scope degov web proposal consumers for new index fields

### DIFF
--- a/packages/web/src/app/_components/overview.tsx
+++ b/packages/web/src/app/_components/overview.tsx
@@ -6,7 +6,7 @@ import { useReadContract } from "wagmi";
 import { abi as tokenAbi } from "@/config/abi/token";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import { formatNumberForDisplay } from "@/utils/number";
 
 import { OverviewItem } from "./overview-item";
@@ -30,9 +30,12 @@ export const Overview = () => {
     });
 
   const { data: dataMetrics, isLoading: isProposalMetricsLoading } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
+    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint, daoConfig],
     queryFn: () =>
-      proposalService.getProposalMetrics(daoConfig?.indexer?.endpoint ?? ""),
+      proposalService.getProposalMetrics(
+        daoConfig?.indexer?.endpoint ?? "",
+        buildGovernanceScope(daoConfig)
+      ),
     enabled: !!daoConfig?.indexer?.endpoint,
     placeholderData: keepPreviousData,
   });

--- a/packages/web/src/app/ai-analysis/[proposalId]/page.tsx
+++ b/packages/web/src/app/ai-analysis/[proposalId]/page.tsx
@@ -7,7 +7,7 @@ import { useReadContract } from "wagmi";
 import { abi as GovernorAbi } from "@/config/abi/governor";
 import { useAiAnalysis } from "@/hooks/useAiAnalysis";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import { ProposalState } from "@/types/proposal";
 import { parseDescription } from "@/utils/helpers";
 
@@ -54,7 +54,13 @@ export default function AiAnalysisPage({
     error: proposalError,
     refetch: refetchProposal,
   } = useQuery({
-    queryKey: ["proposal", proposalId, daoConfig?.indexer?.endpoint],
+    queryKey: [
+      "proposal",
+      proposalId,
+      daoConfig?.code,
+      daoConfig?.indexer?.endpoint,
+      daoConfig,
+    ],
     queryFn: async () => {
       if (!proposalId || !daoConfig?.indexer?.endpoint) return null;
 
@@ -62,6 +68,7 @@ export default function AiAnalysisPage({
         daoConfig.indexer.endpoint,
         {
           where: {
+            ...buildGovernanceScope(daoConfig),
             proposalId_eq: proposalId,
           },
         }

--- a/packages/web/src/app/delegates/page.tsx
+++ b/packages/web/src/app/delegates/page.tsx
@@ -20,7 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WithConnect } from "@/components/with-connect";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import type { ContributorItem } from "@/services/graphql/types";
 
 import type { Address } from "viem";
@@ -83,10 +83,11 @@ export default function Members() {
   );
 
   const { data: dataMetrics } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
+    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint, daoConfig],
     queryFn: () =>
       proposalService.getProposalMetrics(
-        daoConfig?.indexer?.endpoint as string
+        daoConfig?.indexer?.endpoint as string,
+        buildGovernanceScope(daoConfig)
       ),
     enabled: !!daoConfig?.indexer?.endpoint,
   });

--- a/packages/web/src/app/profile/_components/overview.tsx
+++ b/packages/web/src/app/profile/_components/overview.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useAddressVotes } from "@/hooks/useAddressVotes";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 
 import { OverviewItem } from "./overview-item";
 
@@ -42,9 +42,12 @@ export const Overview = ({
 
   const daoConfig = useDaoConfig();
   const { data: dataMetrics, isLoading: isMetricsLoading } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
+    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint, daoConfig],
     queryFn: () =>
-      proposalService.getProposalMetrics(daoConfig?.indexer?.endpoint ?? ""),
+      proposalService.getProposalMetrics(
+        daoConfig?.indexer?.endpoint ?? "",
+        buildGovernanceScope(daoConfig)
+      ),
     enabled: !!daoConfig?.indexer?.endpoint,
   });
 
@@ -54,12 +57,14 @@ export const Overview = ({
       address,
       daoConfig?.indexer?.endpoint,
       PARTICIPATION_WINDOW,
+      daoConfig,
     ],
     queryFn: () =>
       proposalService.getProposalVoteRate(
         daoConfig?.indexer?.endpoint ?? "",
         address,
-        PARTICIPATION_WINDOW
+        PARTICIPATION_WINDOW,
+        buildGovernanceScope(daoConfig)
       ),
     enabled: !!daoConfig?.indexer?.endpoint && !!address,
   });

--- a/packages/web/src/app/proposal/[id]/action-group.tsx
+++ b/packages/web/src/app/proposal/[id]/action-group.tsx
@@ -279,10 +279,18 @@ export default function ActionGroup({
 
   const hasTimelock = useMemo(() => {
     return (
+      Boolean(data?.timelockAddress) ||
+      Boolean(data?.queueReadyAt) ||
+      Boolean(data?.queueExpiresAt) ||
       govParams?.timeLockDelayInSeconds !== undefined &&
       govParams?.timeLockDelayInSeconds !== null
     );
-  }, [govParams?.timeLockDelayInSeconds]);
+  }, [
+    data?.queueExpiresAt,
+    data?.queueReadyAt,
+    data?.timelockAddress,
+    govParams?.timeLockDelayInSeconds,
+  ]);
 
   useEffect(() => {
     if (status !== ProposalState.Queued || !hasTimelock) {
@@ -304,6 +312,9 @@ export default function ActionGroup({
     }
 
     if (status === ProposalState.Queued) {
+      const queueReadyAt = data?.queueReadyAt
+        ? BigInt(data.queueReadyAt)
+        : undefined;
       const queuedBlockTimestamp = proposalQueuedById?.blockTimestamp
         ? BigInt(proposalQueuedById?.blockTimestamp)
         : undefined;
@@ -314,6 +325,9 @@ export default function ActionGroup({
           ? BigInt(BigInt(timeLockDelayInSeconds) * 1000n)
           : undefined;
 
+      if (queueReadyAt !== undefined) {
+        return currentTime >= queueReadyAt;
+      }
       if (!queuedBlockTimestamp) return false;
       if (timeLockDelay === undefined) return true;
 
@@ -322,6 +336,7 @@ export default function ActionGroup({
     }
     return false;
   }, [
+    data?.queueReadyAt,
     status,
     proposalQueuedById,
     govParams?.timeLockDelayInSeconds,

--- a/packages/web/src/app/proposal/[id]/page.tsx
+++ b/packages/web/src/app/proposal/[id]/page.tsx
@@ -13,7 +13,7 @@ import { LoadingState } from "@/components/ui/loading-spinner";
 import { abi as GovernorAbi } from "@/config/abi/governor";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useNotificationVisibility } from "@/hooks/useNotificationVisibility";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import { ProposalState } from "@/types/proposal";
 import { parseDescription } from "@/utils";
 import { CACHE_TIMES } from "@/utils/query-config";
@@ -85,15 +85,27 @@ export default function ProposalDetailPage() {
     return ACTIVE_STATES.includes(proposalStatus?.data as ProposalState);
   }, [proposalStatus?.data]);
 
+  const proposalScope = useMemo(
+    () => buildGovernanceScope(daoConfig),
+    [daoConfig]
+  );
+
   const {
     data: allData,
     isPending,
     refetch: refetchProposal,
   } = useQuery({
-    queryKey: ["proposal", id, daoConfig?.indexer?.endpoint],
+    queryKey: [
+      "proposal",
+      id,
+      daoConfig?.code,
+      daoConfig?.indexer?.endpoint,
+      proposalScope,
+    ],
     queryFn: () =>
       proposalService.getAllProposals(daoConfig?.indexer.endpoint as string, {
         where: {
+          ...proposalScope,
           proposalId_eq: id as string,
         },
       }),
@@ -142,12 +154,15 @@ export default function ProposalDetailPage() {
         queryKey: [
           "proposalCanceledById",
           data?.proposalId,
+          daoConfig?.code,
           daoConfig?.indexer?.endpoint,
+          proposalScope,
         ],
         queryFn: async () => {
           const result = await proposalService.getProposalCanceledById(
             daoConfig?.indexer?.endpoint as string,
-            data?.proposalId as string
+            data?.proposalId as string,
+            proposalScope
           );
           return result ?? null;
         },
@@ -159,12 +174,15 @@ export default function ProposalDetailPage() {
         queryKey: [
           "proposalExecutedById",
           data?.proposalId,
+          daoConfig?.code,
           daoConfig?.indexer?.endpoint,
+          proposalScope,
         ],
         queryFn: async () => {
           const result = await proposalService.getProposalExecutedById(
             daoConfig?.indexer?.endpoint as string,
-            data?.proposalId as string
+            data?.proposalId as string,
+            proposalScope
           );
           return result ?? null;
         },
@@ -176,12 +194,15 @@ export default function ProposalDetailPage() {
         queryKey: [
           "proposalQueuedById",
           data?.proposalId,
+          daoConfig?.code,
           daoConfig?.indexer?.endpoint,
+          proposalScope,
         ],
         queryFn: async () => {
           const result = await proposalService.getProposalQueuedById(
             daoConfig?.indexer?.endpoint as string,
-            data?.proposalId as string
+            data?.proposalId as string,
+            proposalScope
           );
           return result ?? null;
         },

--- a/packages/web/src/app/proposal/[id]/status.tsx
+++ b/packages/web/src/app/proposal/[id]/status.tsx
@@ -126,12 +126,24 @@ const Status: React.FC<StatusProps> = ({
 
   const hasTimelock = useMemo(() => {
     return (
+      Boolean(data?.timelockAddress) ||
+      Boolean(data?.queueReadyAt) ||
+      Boolean(data?.queueExpiresAt) ||
       govParams?.timeLockDelayInSeconds !== undefined &&
       govParams?.timeLockDelayInSeconds !== null
     );
-  }, [govParams?.timeLockDelayInSeconds]);
+  }, [
+    data?.queueExpiresAt,
+    data?.queueReadyAt,
+    data?.timelockAddress,
+    govParams?.timeLockDelayInSeconds,
+  ]);
 
   const executeEnabledTime = useMemo(() => {
+    if (data?.queueReadyAt) {
+      return BigInt(data.queueReadyAt);
+    }
+
     if (
       !proposalQueuedById?.blockTimestamp ||
       !govParams?.timeLockDelayInSeconds ||
@@ -144,7 +156,11 @@ const Status: React.FC<StatusProps> = ({
       BigInt(proposalQueuedById.blockTimestamp) +
       BigInt(govParams.timeLockDelayInSeconds * 1000)
     );
-  }, [proposalQueuedById?.blockTimestamp, govParams?.timeLockDelayInSeconds]);
+  }, [
+    data?.queueReadyAt,
+    proposalQueuedById?.blockTimestamp,
+    govParams?.timeLockDelayInSeconds,
+  ]);
 
   const stages: ProposalStage[] = useMemo(() => {
     const baseStages: ProposalStage[] = [
@@ -364,8 +380,10 @@ const Status: React.FC<StatusProps> = ({
           {
             key: "expired" as ProposalStageKey,
             title: "Proposal expired",
-            timestamp: proposalQueuedById?.blockTimestamp
-              ? formatTimestampToDayTime(proposalQueuedById?.blockTimestamp)
+            timestamp: data?.queueExpiresAt
+              ? formatTimestampToDayTime(data.queueExpiresAt)
+              : proposalQueuedById?.blockTimestamp
+                ? formatTimestampToDayTime(proposalQueuedById?.blockTimestamp)
               : "",
             icon: (
               <StatusQueuedIcon

--- a/packages/web/src/app/proposals/page.tsx
+++ b/packages/web/src/app/proposals/page.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/select";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useMyVotes } from "@/hooks/useMyVotes";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 
 import type { CheckedState } from "@radix-ui/react-checkbox";
 
@@ -78,10 +78,11 @@ function ProposalsContent() {
 
   // Get proposal metrics (including total count)
   const { data: dataMetrics } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
+    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint, daoConfig],
     queryFn: () =>
       proposalService.getProposalMetrics(
-        daoConfig?.indexer?.endpoint as string
+        daoConfig?.indexer?.endpoint as string,
+        buildGovernanceScope(daoConfig)
       ),
     enabled: !!daoConfig?.indexer?.endpoint,
     placeholderData: keepPreviousData,

--- a/packages/web/src/components/members-list/index.tsx
+++ b/packages/web/src/components/members-list/index.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { DEFAULT_PAGE_SIZE, INITIAL_LIST_PAGE_SIZE } from "@/config/base";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import type { ContributorItem } from "@/services/graphql/types";
 
 import { AddressAvatar } from "../address-avatar";
@@ -54,9 +54,12 @@ export function MembersList({
   const formatTokenAmount = useFormatGovernanceTokenAmount();
 
   const { data: dataMetrics, isLoading: isProposalMetricsLoading } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
+    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint, daoConfig],
     queryFn: () =>
-      proposalService.getProposalMetrics(daoConfig?.indexer?.endpoint ?? ""),
+      proposalService.getProposalMetrics(
+        daoConfig?.indexer?.endpoint ?? "",
+        buildGovernanceScope(daoConfig)
+      ),
     enabled: !!daoConfig?.indexer?.endpoint,
   });
 

--- a/packages/web/src/components/members-table/index.tsx
+++ b/packages/web/src/components/members-table/index.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { DEFAULT_PAGE_SIZE, INITIAL_LIST_PAGE_SIZE } from "@/config/base";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import type { ContributorItem } from "@/services/graphql/types";
 import { formatTimeAgo } from "@/utils/date";
 import { formatInteger } from "@/utils/number";
@@ -48,9 +48,12 @@ export function MembersTable({
   const formatTokenAmount = useFormatGovernanceTokenAmount();
 
   const { data: dataMetrics, isLoading: isProposalMetricsLoading } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
+    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint, daoConfig],
     queryFn: () =>
-      proposalService.getProposalMetrics(daoConfig?.indexer?.endpoint ?? ""),
+      proposalService.getProposalMetrics(
+        daoConfig?.indexer?.endpoint ?? "",
+        buildGovernanceScope(daoConfig)
+      ),
     enabled: !!daoConfig?.indexer?.endpoint,
   });
   const initialPageSize =

--- a/packages/web/src/components/proposals-table/hooks/useProposalData.ts
+++ b/packages/web/src/components/proposals-table/hooks/useProposalData.ts
@@ -5,7 +5,11 @@ import { useAccount, useReadContracts } from "wagmi";
 import { abi as GovernorAbi } from "@/config/abi/governor";
 import { DEFAULT_MULTICALL_BATCH_SIZE, DEFAULT_PAGE_SIZE } from "@/config/base";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
-import { proposalService } from "@/services/graphql";
+import {
+  buildGovernanceScope,
+  proposalService,
+  type ProposalWhere,
+} from "@/services/graphql";
 import type { ProposalListItem } from "@/services/graphql/types";
 import type { ProposalState as ProposalStatus } from "@/types/proposal";
 
@@ -44,7 +48,9 @@ export function useProposalData(
   } = useInfiniteQuery<ProposalListItem[]>({
     queryKey: [
       "proposals",
+      daoConfig?.code,
       daoConfig?.indexer?.endpoint,
+      daoConfig,
       address,
       support,
       pageSize,
@@ -56,10 +62,13 @@ export function useProposalData(
         offset: 0,
         limit: normalizedInitialPageSize,
       };
-      let whereCondition = {};
+      let whereCondition: ProposalWhere = {
+        ...buildGovernanceScope(daoConfig),
+      };
 
       if (address && !support) {
         whereCondition = {
+          ...buildGovernanceScope(daoConfig),
           proposer_eq: address?.toLowerCase(),
           OR: {
             voters_some: {
@@ -69,6 +78,7 @@ export function useProposalData(
         };
       } else if (address && support) {
         whereCondition = {
+          ...buildGovernanceScope(daoConfig),
           voters_some: {
             voter_eq: address?.toLowerCase(),
             support_eq: support ? parseInt(support) : undefined,

--- a/packages/web/src/components/search-modal.tsx
+++ b/packages/web/src/components/search-modal.tsx
@@ -15,7 +15,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { DEFAULT_PAGE_SIZE } from "@/config/base";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import type { Types } from "@/services/graphql";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import { extractTitleAndDescription, parseDescription } from "@/utils";
 
 // Helper function to strip HTML tags from text
@@ -58,7 +58,9 @@ export function SearchModal({
   const queryKey = [
     "proposals-search",
     debouncedSearch,
+    daoConfig?.code,
     daoConfig?.indexer?.endpoint,
+    daoConfig,
   ] as const;
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -75,6 +77,7 @@ export function SearchModal({
           daoConfig?.indexer?.endpoint ?? "",
           {
             where: {
+              ...buildGovernanceScope(daoConfig),
               description_containsInsensitive: debouncedSearch,
             },
             limit: DEFAULT_PAGE_SIZE,

--- a/packages/web/src/components/system-info.tsx
+++ b/packages/web/src/components/system-info.tsx
@@ -9,7 +9,7 @@ import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
 import { useGovernanceParams } from "@/hooks/useGovernanceParams";
 import { useGovernanceToken } from "@/hooks/useGovernanceToken";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import { formatShortAddress } from "@/utils/address";
 import { dayjsHumanize } from "@/utils/date";
 import { formatNumberForDisplay } from "@/utils/number";
@@ -99,9 +99,12 @@ export const SystemInfo = ({ type = "default" }: SystemInfoProps) => {
     });
 
   const { data: dataMetrics, isLoading: isProposalMetricsLoading } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
+    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint, daoConfig],
     queryFn: () =>
-      proposalService.getProposalMetrics(daoConfig?.indexer?.endpoint ?? ""),
+      proposalService.getProposalMetrics(
+        daoConfig?.indexer?.endpoint ?? "",
+        buildGovernanceScope(daoConfig)
+      ),
     enabled: !!daoConfig?.indexer?.endpoint && type === "default",
   });
 

--- a/packages/web/src/services/graphql/index.ts
+++ b/packages/web/src/services/graphql/index.ts
@@ -1,5 +1,6 @@
 import { clearToken } from "@/lib/auth/token-manager";
 import { getToken } from "@/lib/auth/token-manager";
+import type { Config } from "@/types/config";
 import { degovGraphqlApi } from "@/utils/remote-api";
 
 import { request } from "./client";
@@ -22,6 +23,52 @@ const emptyProposalMetrics: Types.ProposalMetricsItem = {
   votesWithoutParamsCount: "0",
 };
 
+export type GovernanceScope = {
+  chainId_eq?: number;
+  governorAddress_eq?: string;
+  daoCode_eq?: string;
+};
+
+type ProposalVoterFilter = {
+  voter_eq?: string;
+  support_eq?: number;
+};
+
+export type ProposalWhere = GovernanceScope & {
+  proposalId_eq?: string;
+  proposer_eq?: string;
+  description_containsInsensitive?: string;
+  voters_every?: ProposalVoterFilter;
+  voters_some?: ProposalVoterFilter;
+  OR?: {
+    voters_some?: ProposalVoterFilter;
+  };
+};
+
+type ProposalMetricsWhere = GovernanceScope & {
+  id_eq?: string;
+};
+
+const normalizeScopeAddress = (address?: string | null) => {
+  return address ? address.toLowerCase() : undefined;
+};
+
+export const buildGovernanceScope = (
+  daoConfig?: Config | null
+): GovernanceScope => {
+  if (!daoConfig) {
+    return {};
+  }
+
+  return {
+    chainId_eq: daoConfig.chain?.id,
+    governorAddress_eq: normalizeScopeAddress(
+      daoConfig.contracts?.governor
+    ),
+    daoCode_eq: daoConfig.code,
+  };
+};
+
 export const proposalService = {
   getAllProposals: async (
     endpoint: string,
@@ -29,14 +76,7 @@ export const proposalService = {
       limit?: number;
       offset?: number;
       orderBy?: string;
-      where?: {
-        proposalId_eq?: string;
-        proposer_eq?: string;
-        voters_every?: {
-          voter_eq?: string;
-          support_eq?: number;
-        };
-      };
+      where?: ProposalWhere;
     } = {}
   ) => {
     const response = await request<Types.ProposalResponse>(
@@ -52,14 +92,7 @@ export const proposalService = {
       limit?: number;
       offset?: number;
       orderBy?: string;
-      where?: {
-        proposalId_eq?: string;
-        proposer_eq?: string;
-        voters_every?: {
-          voter_eq?: string;
-          support_eq?: number;
-        };
-      };
+      where?: ProposalWhere;
       voter?: string;
     } = {}
   ) => {
@@ -76,9 +109,7 @@ export const proposalService = {
       limit?: number;
       offset?: number;
       orderBy?: string;
-      where?: {
-        description_containsInsensitive?: string;
-      };
+      where?: ProposalWhere;
     } = {}
   ) => {
     const response = await request<Types.ProposalDescriptionResponse>(
@@ -88,15 +119,26 @@ export const proposalService = {
     );
     return response?.proposals ?? [];
   },
-  getProposalMetrics: async (endpoint: string) => {
+  getProposalMetrics: async (endpoint: string, scope?: GovernanceScope) => {
     const response = await request<Types.ProposalMetricsResponse>(
       endpoint,
-      Queries.GET_PROPOSAL_METRICS
+      Queries.GET_PROPOSAL_METRICS,
+      {
+        where: {
+          id_eq: "global",
+          ...scope,
+        } satisfies ProposalMetricsWhere,
+      }
     );
     return response?.dataMetrics?.[0] ?? emptyProposalMetrics;
   },
 
-  getProposalVoteRate: async (endpoint: string, voter: string, limit = 10) => {
+  getProposalVoteRate: async (
+    endpoint: string,
+    voter: string,
+    limit = 10,
+    scope?: GovernanceScope
+  ) => {
     if (!voter) {
       return [] as Types.ProposalVoteRateResponse["proposals"];
     }
@@ -106,6 +148,7 @@ export const proposalService = {
       {
         limit,
         voter: voter.toLowerCase(),
+        where: scope,
       }
     );
     return response?.proposals ?? [];
@@ -175,37 +218,52 @@ export const proposalService = {
     }
   },
 
-  getProposalCanceledById: async (endpoint: string, id: string) => {
+  getProposalCanceledById: async (
+    endpoint: string,
+    id: string,
+    scope?: GovernanceScope
+  ) => {
     const response = await request<Types.ProposalCanceledByIdResponse>(
       endpoint,
       Queries.GET_PROPOSAL_CANCELED_BY_ID,
       {
         where: {
           proposalId_eq: id,
+          ...scope,
         },
       }
     );
     return response?.proposalCanceleds?.[0];
   },
-  getProposalExecutedById: async (endpoint: string, id: string) => {
+  getProposalExecutedById: async (
+    endpoint: string,
+    id: string,
+    scope?: GovernanceScope
+  ) => {
     const response = await request<Types.ProposalExecutedByIdResponse>(
       endpoint,
       Queries.GET_PROPOSAL_EXECUTED_BY_ID,
       {
         where: {
           proposalId_eq: id,
+          ...scope,
         },
       }
     );
     return response?.proposalExecuteds?.[0];
   },
-  getProposalQueuedById: async (endpoint: string, id: string) => {
+  getProposalQueuedById: async (
+    endpoint: string,
+    id: string,
+    scope?: GovernanceScope
+  ) => {
     const response = await request<Types.ProposalQueuedByIdResponse>(
       endpoint,
       Queries.GET_PROPOSAL_QUEUED_BY_ID,
       {
         where: {
           proposalId_eq: id,
+          ...scope,
         },
       }
     );

--- a/packages/web/src/services/graphql/queries/proposals.ts
+++ b/packages/web/src/services/graphql/queries/proposals.ts
@@ -28,11 +28,20 @@ export const GET_ALL_PROPOSALS = gql`
       voteStart
       voteStartTimestamp
       voteEndTimestamp
+      proposalDeadline
+      proposalEta
+      queueReadyAt
+      queueExpiresAt
       blockInterval
       clockMode
       quorum
       decimals
       title
+      chainId
+      daoCode
+      governorAddress
+      timelockAddress
+      timelockGracePeriod
       metricsVotesWeightAbstainSum
       metricsVotesWeightAgainstSum
       metricsVotesWeightForSum
@@ -70,6 +79,8 @@ export const GET_PROPOSALS_LIST = gql`
       blockTimestamp
       id
       proposalId
+      chainId
+      governorAddress
       proposer
       title
       metricsVotesWeightAbstainSum
@@ -97,6 +108,8 @@ export const GET_PROPOSALS_BY_DESCRIPTION = gql`
       where: $where
     ) {
       proposalId
+      chainId
+      governorAddress
       description
     }
   }
@@ -151,8 +164,8 @@ export const GET_PROPOSAL_QUEUED_BY_ID = gql`
 `;
 
 export const GET_PROPOSAL_METRICS = gql`
-  query GetProposalMetrics {
-    dataMetrics {
+  query GetProposalMetrics($where: DataMetricWhereInput) {
+    dataMetrics(where: $where) {
       memberCount
       powerSum
       proposalsCount
@@ -167,11 +180,16 @@ export const GET_PROPOSAL_METRICS = gql`
 `;
 
 export const GET_PROPOSAL_VOTE_RATE = gql`
-  query QueryProposalVoteRate($voter: String!, $limit: Int!) {
+  query QueryProposalVoteRate(
+    $voter: String!
+    $limit: Int!
+    $where: ProposalWhereInput
+  ) {
     proposals(
       offset: 0
       limit: $limit
       orderBy: blockTimestamp_DESC_NULLS_LAST
+      where: $where
     ) {
       id
       title

--- a/packages/web/src/services/graphql/types/proposals.ts
+++ b/packages/web/src/services/graphql/types/proposals.ts
@@ -23,9 +23,12 @@ export type ProposalItem = {
   blockNumber: string;
   blockTimestamp: string;
   calldatas: string[];
+  chainId?: number | null;
+  daoCode?: string | null;
   description: string;
   id: string;
   proposalId: string;
+  governorAddress?: string | null;
   proposer: string;
   signatures: string[];
   targets: string[];
@@ -37,8 +40,14 @@ export type ProposalItem = {
   voteEndTimestamp: string;
   blockInterval?: string | null;
   clockMode: string;
+  proposalDeadline?: string | null;
+  proposalEta?: string | null;
+  queueReadyAt?: string | null;
+  queueExpiresAt?: string | null;
   quorum: string;
   decimals: string;
+  timelockAddress?: string | null;
+  timelockGracePeriod?: string | null;
   title: string;
   metricsVotesWeightAbstainSum: string;
   metricsVotesWeightAgainstSum: string;
@@ -55,6 +64,8 @@ export type ProposalResponse = {
 
 export type ProposalListItem = {
   blockTimestamp: string;
+  chainId?: number | null;
+  governorAddress?: string | null;
   id: string;
   proposalId: string;
   proposer: string;
@@ -70,6 +81,8 @@ export type ProposalListResponse = {
 };
 
 export type ProposalDescriptionItem = {
+  chainId?: number | null;
+  governorAddress?: string | null;
   proposalId: string;
   description: string;
 };


### PR DESCRIPTION
## Summary
- scope proposal, proposal-event, search, vote-rate, and metrics reads by chain/governor/dao context
- consume indexed queue timing fields in proposal detail status/action flows with fallbacks
- keep AI analysis and overview flows aligned with the scoped proposal identity

## Testing
- pnpm lint
- pnpm build

## Notes
- Base branch is `ohh-32-indexer-baseline-upgrade` per `OHH-37` integration requirement.
