### PR TITLE
feat(indexer): add replay and reconciliation workflow

### DIFF
--- a/docs/plans/20260325__degov_projection_replay_reconciliation_rollout.md
+++ b/docs/plans/20260325__degov_projection_replay_reconciliation_rollout.md
@@ -1,0 +1,64 @@
+# DeGov Projection Replay, Reconciliation, and Rollout
+
+This flow is designed for the additive migration introduced around `OHH-32` and the downstream field adoption in `OHH-37`.
+
+## Replay / backfill workflow
+
+Use a shadow PostgreSQL database or a fresh clone of the production indexer database. The replay flow intentionally targets a bounded end block so the run is repeatable and produces a stable reconciliation artifact.
+
+```bash
+cd packages/indexer
+npx -y yarn@1.22.22 replay:backfill
+```
+
+Environment controls:
+
+- `DEGOV_CONFIG_PATH`: DAO config path or URL. Defaults to `../../degov.yml`.
+- `DEGOV_INDEXER_START_BLOCK`: optional replay override for a narrower historical slice.
+- `DEGOV_INDEXER_END_BLOCK`: optional replay upper bound. If omitted, `scripts/replay-backfill.sh` resolves the current head block from the configured RPC set and freezes the run at that height.
+- `DEGOV_RECONCILIATION_OUTPUT`: optional absolute or relative JSON report path.
+- `DEGOV_RECONCILE_PROPOSAL_LIMIT`: number of proposals to reconcile after replay. Default `25`.
+- `DEGOV_RECONCILE_VOTE_SAMPLES`: number of historical vote samples per proposal. Default `5`.
+
+What the script does:
+
+1. Builds the indexer.
+2. Applies migrations to the selected database.
+3. Replays processor data up to the chosen `DEGOV_INDEXER_END_BLOCK`.
+4. Runs `node lib/reconcile.js` and writes a JSON artifact under `artifacts/reconciliation/`.
+
+## Reconciliation scope
+
+`lib/reconcile.js` verifies the additive projection against chain truth for each sampled proposal:
+
+- `state(proposalId)` using projection-side state derivation from proposal fields, vote aggregates, and timelock metadata
+- `proposalSnapshot(proposalId)`
+- `proposalDeadline(proposalId)`
+- `quorum(snapshot)`
+- sampled historical voting power via `getPastVotes`, with automatic fallback to `getPriorVotes`
+
+The JSON output includes:
+
+- coverage counts for `proposal_action`, `proposal_state_epoch`, `governance_parameter_checkpoint`, `vote_power_checkpoint`, and `timelock_operation`
+- per-proposal field checks
+- per-account vote-power samples
+- mismatch counts suitable for CI or release gating
+
+Any non-zero mismatch count causes `reconcile` to exit non-zero.
+
+## Release order
+
+1. Deploy additive schema and handlers that write new fields and new tables while preserving legacy tables.
+2. Run replay/backfill against a shadow database, freeze the run at a specific end block, and archive the reconciliation JSON.
+3. Fix mismatches until reconciliation passes for the required proposal and vote samples.
+4. Switch downstream consumers to `proposalDeadline`, `queueReadyAt`, `queueExpiresAt`, `clockMode`, `quorum`, `proposal_action`, `proposal_state_epoch`, `vote_power_checkpoint`, and timelock projections.
+5. Keep legacy reads available during the cutover window.
+6. Degrade and remove old logic only after downstream regression checks and reconciliation artifacts remain green.
+
+## Pre-release checklist
+
+- Replay/backfill completed against the target config and bounded end block.
+- Reconciliation JSON archived with zero field mismatches and zero sampled vote mismatches.
+- Coverage counts show the expected additive tables are populated for the target DAO scope.
+- Regression tests pass in `packages/indexer`.
+- Downstream smoke checks confirm proposal detail pages still render proposal timing, quorum, timelock timing, and vote power correctly after query cutover.

--- a/packages/indexer/__tests__/chaintool.test.ts
+++ b/packages/indexer/__tests__/chaintool.test.ts
@@ -114,4 +114,61 @@ describe("ChainTool", () => {
       { functionName: "decimals", args: undefined },
     ]);
   });
+
+  it("falls back to latest block when clock is unavailable", async () => {
+    const chainTool = new ChainTool();
+    jest.spyOn(chainTool, "clockMode").mockResolvedValue(ClockMode.BlockNumber);
+    jest
+      .spyOn(chainTool, "readContract")
+      .mockRejectedValue(new Error("execution reverted: selector not found"));
+    jest.spyOn(chainTool as any, "_executeWithFallbacks").mockImplementation(
+      async (_options: any, action: any) =>
+        action({
+          getBlock: jest.fn().mockResolvedValue({
+            number: 321n,
+            timestamp: 654n,
+          }),
+        })
+    );
+
+    await expect(
+      chainTool.currentClock({
+        chainId: 1,
+        contractAddress,
+      })
+    ).resolves.toEqual({
+      clockMode: ClockMode.BlockNumber,
+      timepoint: 321n,
+      timestampMs: 654_000n,
+    });
+  });
+
+  it("uses getPriorVotes when getPastVotes is unavailable", async () => {
+    const chainTool = new ChainTool();
+    const readContract = jest.spyOn(chainTool, "readContract");
+
+    readContract
+      .mockRejectedValueOnce(new Error("execution reverted: selector not found"))
+      .mockResolvedValueOnce(77n as never);
+
+    await expect(
+      chainTool.historicalVotes({
+        chainId: 1,
+        contractAddress,
+        account: "0x3333333333333333333333333333333333333333",
+        timepoint: 123n,
+      })
+    ).resolves.toEqual({
+      method: "getPriorVotes",
+      votes: 77n,
+    });
+
+    expect(readContract).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        functionName: "getPriorVotes",
+        args: ["0x3333333333333333333333333333333333333333", 123n],
+      })
+    );
+  });
 });

--- a/packages/indexer/__tests__/datasource.test.ts
+++ b/packages/indexer/__tests__/datasource.test.ts
@@ -4,6 +4,23 @@ import { join } from "path";
 import { DegovDataSource } from "../src/datasource";
 
 describe("DegovDataSource", () => {
+  const startBlockOverride = process.env.DEGOV_INDEXER_START_BLOCK;
+  const endBlockOverride = process.env.DEGOV_INDEXER_END_BLOCK;
+
+  afterEach(() => {
+    if (startBlockOverride === undefined) {
+      delete process.env.DEGOV_INDEXER_START_BLOCK;
+    } else {
+      process.env.DEGOV_INDEXER_START_BLOCK = startBlockOverride;
+    }
+
+    if (endBlockOverride === undefined) {
+      delete process.env.DEGOV_INDEXER_END_BLOCK;
+    } else {
+      process.env.DEGOV_INDEXER_END_BLOCK = endBlockOverride;
+    }
+  });
+
   it("includes timeLock in indexed contracts", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "degov-datasource-"));
     const configPath = join(tempDir, "degov.yml");
@@ -47,6 +64,42 @@ contracts:
           standard: undefined,
         },
       ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows start and end block overrides from the environment", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "degov-datasource-"));
+    const configPath = join(tempDir, "degov.yml");
+
+    process.env.DEGOV_INDEXER_START_BLOCK = "100";
+    process.env.DEGOV_INDEXER_END_BLOCK = "200";
+
+    try {
+      await writeFile(
+        configPath,
+        `
+code: demo
+chain:
+  id: 46
+  rpcs:
+    - https://rpc.darwinia.network
+indexer:
+  startBlock: 1
+  endBlock: 2
+contracts:
+  governor: "0x1111111111111111111111111111111111111111"
+  governorToken:
+    address: "0x2222222222222222222222222222222222222222"
+    standard: ERC20
+`
+      );
+
+      const config = await DegovDataSource.fromDegovConfigPath(configPath);
+
+      expect(config.startBlock).toBe(100);
+      expect(config.endBlock).toBe(200);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/indexer/__tests__/reconciliation.test.ts
+++ b/packages/indexer/__tests__/reconciliation.test.ts
@@ -1,0 +1,114 @@
+import { ClockMode } from "../src/internal/chaintool";
+import {
+  compareScalarField,
+  deriveProjectedProposalState,
+  governorStateName,
+} from "../src/internal/reconciliation";
+
+describe("reconciliation helpers", () => {
+  it("maps governor state enum values to readable names", () => {
+    expect(governorStateName(0)).toBe("Pending");
+    expect(governorStateName(7n)).toBe("Executed");
+    expect(governorStateName(99)).toBe("Unknown(99)");
+  });
+
+  it("marks pending and active states from proposal timepoints", () => {
+    expect(
+      deriveProjectedProposalState({
+        clockMode: ClockMode.BlockNumber,
+        proposalSnapshot: 100n,
+        proposalDeadline: 120n,
+        quorum: 10n,
+        votesFor: 0n,
+        votesAgainst: 0n,
+        votesAbstain: 0n,
+        currentTimepoint: 100n,
+        currentTimestampMs: 0n,
+        hasCanceledEvent: false,
+        hasExecutedEvent: false,
+        hasQueuedEvent: false,
+      })
+    ).toBe("Pending");
+
+    expect(
+      deriveProjectedProposalState({
+        clockMode: ClockMode.BlockNumber,
+        proposalSnapshot: 100n,
+        proposalDeadline: 120n,
+        quorum: 10n,
+        votesFor: 0n,
+        votesAgainst: 0n,
+        votesAbstain: 0n,
+        currentTimepoint: 115n,
+        currentTimestampMs: 0n,
+        hasCanceledEvent: false,
+        hasExecutedEvent: false,
+        hasQueuedEvent: false,
+      })
+    ).toBe("Active");
+  });
+
+  it("derives succeeded, defeated, queued, expired, canceled, and executed states", () => {
+    const baseInput = {
+      clockMode: ClockMode.Timestamp,
+      proposalSnapshot: 100n,
+      proposalDeadline: 120n,
+      quorum: 10n,
+      votesFor: 15n,
+      votesAgainst: 2n,
+      votesAbstain: 0n,
+      currentTimepoint: 121n,
+      currentTimestampMs: 200_000n,
+      hasCanceledEvent: false,
+      hasExecutedEvent: false,
+      hasQueuedEvent: false,
+    };
+
+    expect(deriveProjectedProposalState(baseInput)).toBe("Succeeded");
+    expect(
+      deriveProjectedProposalState({
+        ...baseInput,
+        votesFor: 2n,
+        votesAgainst: 15n,
+      })
+    ).toBe("Defeated");
+    expect(
+      deriveProjectedProposalState({
+        ...baseInput,
+        hasQueuedEvent: true,
+        timelockAddress: "0x4444444444444444444444444444444444444444",
+        queueReadyAt: 150_000n,
+      })
+    ).toBe("Queued");
+    expect(
+      deriveProjectedProposalState({
+        ...baseInput,
+        hasQueuedEvent: true,
+        timelockAddress: "0x4444444444444444444444444444444444444444",
+        queueExpiresAt: 150_000n,
+      })
+    ).toBe("Expired");
+    expect(
+      deriveProjectedProposalState({
+        ...baseInput,
+        hasCanceledEvent: true,
+      })
+    ).toBe("Canceled");
+    expect(
+      deriveProjectedProposalState({
+        ...baseInput,
+        hasExecutedEvent: true,
+      })
+    ).toBe("Executed");
+  });
+
+  it("compares scalar fields for report output", () => {
+    expect(compareScalarField("quorum", "10", "10")).toEqual({
+      field: "quorum",
+      projected: "10",
+      onChain: "10",
+      matches: true,
+      details: undefined,
+    });
+  });
+});

--- a/packages/indexer/jest.integration.config.js
+++ b/packages/indexer/jest.integration.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require("./jest.config");
+
+module.exports = {
+  ...baseConfig,
+  testPathIgnorePatterns: ["/node_modules/", "/build/", "/dist/"],
+};

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -9,8 +9,10 @@
     "codegen": "sqd codegen",
     "migrate:db": "zx scripts/sqd-migration.mjs",
     "build": "sqd build",
+    "reconcile": "node lib/reconcile.js",
+    "replay:backfill": "./scripts/replay-backfill.sh",
     "test": "jest --runInBand",
-    "test:integration": "jest --runInBand --runTestsByPath __tests__/chaintool.integration.test.ts __tests__/textplus.integration.test.ts"
+    "test:integration": "jest --runInBand --config jest.integration.config.js --runTestsByPath __tests__/chaintool.integration.test.ts __tests__/textplus.integration.test.ts"
   },
   "dependencies": {
     "@openrouter/ai-sdk-provider": "^2.3.3",

--- a/packages/indexer/scripts/replay-backfill.sh
+++ b/packages/indexer/scripts/replay-backfill.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -eu
+
+BIN_PATH=$(cd "$(dirname "$0")"; pwd -P)
+WORK_PATH="${BIN_PATH}/../"
+
+cd "${WORK_PATH}"
+
+CONFIG_PATH="${DEGOV_CONFIG_PATH:-../../degov.yml}"
+PROPOSAL_LIMIT="${DEGOV_RECONCILE_PROPOSAL_LIMIT:-25}"
+VOTE_SAMPLES="${DEGOV_RECONCILE_VOTE_SAMPLES:-5}"
+STAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
+OUTPUT_DIR="${DEGOV_RECONCILIATION_DIR:-${WORK_PATH}/artifacts/reconciliation}"
+OUTPUT_PATH="${DEGOV_RECONCILIATION_OUTPUT:-${OUTPUT_DIR}/reconciliation-${STAMP}.json}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+if [ -z "${DEGOV_INDEXER_END_BLOCK:-}" ]; then
+  export DEGOV_INDEXER_END_BLOCK="$(
+    DEGOV_CONFIG_PATH="${CONFIG_PATH}" node --input-type=module <<'EOF'
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+import { createPublicClient, http } from "viem";
+
+const configPath = process.env.DEGOV_CONFIG_PATH;
+const absoluteConfigPath = path.isAbsolute(configPath)
+  ? configPath
+  : path.resolve(process.cwd(), configPath);
+const config = yaml.parse(fs.readFileSync(absoluteConfigPath, "utf8"));
+const envVarName = `CHAIN_RPC_${config.chain.id}`;
+const envRpcs = `${process.env[envVarName] ?? ""}`
+  .replace(/\r\n|\n/g, ",")
+  .split(",")
+  .map((item) => item.trim())
+  .filter(Boolean);
+const configRpcs = [
+  ...(config.indexer?.rpc ? [config.indexer.rpc] : []),
+  ...(config.chain?.rpcs ?? []),
+];
+const [rpc] = [...new Set([...envRpcs, ...configRpcs])];
+
+if (!rpc) {
+  throw new Error(`No RPC endpoint found for ${configPath}`);
+}
+
+const client = createPublicClient({
+  transport: http(rpc.replace(/^ws:\/\//, "http://").replace(/^wss:\/\//, "https://")),
+});
+const latestBlock = await client.getBlock();
+process.stdout.write((latestBlock.number ?? 0n).toString());
+EOF
+  )"
+fi
+
+echo "Replay/backfill config: ${CONFIG_PATH}"
+echo "Replay/backfill end block: ${DEGOV_INDEXER_END_BLOCK}"
+echo "Reconciliation output: ${OUTPUT_PATH}"
+
+npx sqd build
+npx sqd migration:apply
+node -r dotenv/config lib/main.js
+node lib/reconcile.js \
+  --config "${CONFIG_PATH}" \
+  --output "${OUTPUT_PATH}" \
+  --proposal-sample-limit "${PROPOSAL_LIMIT}" \
+  --vote-samples "${VOTE_SAMPLES}"

--- a/packages/indexer/src/datasource.ts
+++ b/packages/indexer/src/datasource.ts
@@ -31,6 +31,12 @@ class DegovConfigDataSource {
   private packDataSource(rawDegovConfig: string): IndexerProcessorConfig {
     const degovConfig = yaml.parse(rawDegovConfig);
     const { chain, code, indexer, contracts } = degovConfig;
+    const startBlockOverride = this.readIntegerOverride(
+      "DEGOV_INDEXER_START_BLOCK"
+    );
+    const endBlockOverride = this.readIntegerOverride(
+      "DEGOV_INDEXER_END_BLOCK"
+    );
     let rpcs = chain.rpcs ?? [];
     if (indexer.rpc) {
       rpcs = [indexer.rpc, ...rpcs];
@@ -61,8 +67,8 @@ class DegovConfigDataSource {
       capacity: indexer.capacity ?? 30,
       maxBatchCallSize: indexer.maxBatchCallSize ?? 200,
       gateway: indexer.gateway,
-      startBlock: indexer.startBlock,
-      endBlock: indexer.endBlock,
+      startBlock: startBlockOverride ?? indexer.startBlock,
+      endBlock: endBlockOverride ?? indexer.endBlock,
       works: [
         {
           daoCode: code,
@@ -74,6 +80,22 @@ class DegovConfigDataSource {
       } as IndexerProcessorState,
     };
     return ipc;
+  }
+
+  private readIntegerOverride(name: string): number | undefined {
+    const rawValue = process.env[name];
+    if (!rawValue) {
+      return undefined;
+    }
+
+    const parsed = Number(rawValue);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new Error(
+        `Environment override ${name} must be a non-negative integer, received: ${rawValue}`
+      );
+    }
+
+    return parsed;
   }
 
   private async readDegovConfigRaw(): Promise<string> {

--- a/packages/indexer/src/internal/chaintool.ts
+++ b/packages/indexer/src/internal/chaintool.ts
@@ -38,6 +38,17 @@ export interface QuorumResult {
   decimals: bigint;
 }
 
+export interface CurrentClockResult {
+  clockMode: ClockMode;
+  timepoint: bigint;
+  timestampMs: bigint;
+}
+
+export interface HistoricalVotesResult {
+  method: "getPastVotes" | "getPriorVotes";
+  votes: bigint;
+}
+
 // Added interface for the quorum cache entry
 export interface QuorumCacheEntry {
   result: QuorumResult;
@@ -89,6 +100,32 @@ const ABI_FUNCTION_DECIMALS: Abi = [
     inputs: [],
     name: "decimals",
     outputs: [{ internalType: "uint8", name: "", type: "uint8" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+const ABI_FUNCTION_GET_PAST_VOTES: Abi = [
+  {
+    inputs: [
+      { internalType: "address", name: "account", type: "address" },
+      { internalType: "uint256", name: "timepoint", type: "uint256" },
+    ],
+    name: "getPastVotes",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+const ABI_FUNCTION_GET_PRIOR_VOTES: Abi = [
+  {
+    inputs: [
+      { internalType: "address", name: "account", type: "address" },
+      { internalType: "uint256", name: "blockNumber", type: "uint256" },
+    ],
+    name: "getPriorVotes",
+    outputs: [{ internalType: "uint96", name: "", type: "uint96" }],
     stateMutability: "view",
     type: "function",
   },
@@ -460,6 +497,99 @@ export class ChainTool {
     }
   }
 
+  async currentClock(options: BaseContractOptions): Promise<CurrentClockResult> {
+    const clockMode = await this.clockMode(options);
+
+    try {
+      const timepoint = BigInt(
+        await this.readContract<bigint>({
+          ...options,
+          abi: ABI_FUNCTION_CLOCK,
+          functionName: "clock",
+        })
+      );
+
+      if (clockMode === ClockMode.Timestamp) {
+        return {
+          clockMode,
+          timepoint,
+          timestampMs: timepoint * 1000n,
+        };
+      }
+
+      const timestampMs =
+        (await this.timepointToTimestampMs({
+          ...options,
+          timepoint,
+          clockMode,
+        })) ?? 0n;
+
+      return {
+        clockMode,
+        timepoint,
+        timestampMs,
+      };
+    } catch (error) {
+      if (!this.isMissingFunctionError(error)) {
+        throw error;
+      }
+    }
+
+    const latestBlock = await this._executeWithFallbacks(options, (client) =>
+      client.getBlock()
+    );
+
+    return {
+      clockMode,
+      timepoint:
+        clockMode === ClockMode.Timestamp
+          ? latestBlock.timestamp
+          : (latestBlock.number ?? 0n),
+      timestampMs: latestBlock.timestamp * 1000n,
+    };
+  }
+
+  async historicalVotes(
+    options: BaseContractOptions & {
+      account: `0x${string}`;
+      timepoint: bigint;
+    }
+  ): Promise<HistoricalVotesResult> {
+    try {
+      const votes = BigInt(
+        await this.readContract<bigint>({
+          ...options,
+          abi: ABI_FUNCTION_GET_PAST_VOTES,
+          functionName: "getPastVotes",
+          args: [options.account, options.timepoint],
+        })
+      );
+
+      return {
+        method: "getPastVotes",
+        votes,
+      };
+    } catch (error) {
+      if (!this.isMissingFunctionError(error)) {
+        throw error;
+      }
+    }
+
+    const votes = BigInt(
+      await this.readContract<bigint>({
+        ...options,
+        abi: ABI_FUNCTION_GET_PRIOR_VOTES,
+        functionName: "getPriorVotes",
+        args: [options.account, options.timepoint],
+      })
+    );
+
+    return {
+      method: "getPriorVotes",
+      votes,
+    };
+  }
+
   async timepointToTimestampMs(options: {
     chainId: number;
     contractAddress: `0x${string}`;
@@ -515,37 +645,15 @@ export class ChainTool {
       if (options.timepoint !== undefined) {
         timepoint = options.timepoint;
       } else {
-        try {
-          const clockResult = await this._executeWithFallbacks(
-            options,
-            (client) =>
-              client.readContract({
-                address: options.contractAddress,
-                abi: ABI_FUNCTION_CLOCK,
-                functionName: "clock",
-              })
-          );
-          timepoint = BigInt(clockResult as any);
-        } catch (e: any) {
-          console.warn(
-            `Failed to query clock for ${options.contractAddress}, falling back to latest block: ${e.message}`
-          );
-          const latestBlock = await this._executeWithFallbacks(
-            options,
-            (client) => client.getBlock()
-          );
-          timepoint =
-            clockMode === ClockMode.Timestamp
-              ? latestBlock.timestamp
-              : latestBlock.number!;
-        }
+        const currentClock = await this.currentClock(options);
+        timepoint = currentClock.timepoint;
 
         switch (clockMode) {
           case ClockMode.Timestamp:
-            timepoint -= 60n * 3n; // 3 minutes ago
+            timepoint = timepoint > 60n * 3n ? timepoint - 60n * 3n : 0n;
             break;
           case ClockMode.BlockNumber:
-            timepoint -= 15n; // 15 blocks ago
+            timepoint = timepoint > 15n ? timepoint - 15n : 0n;
             break;
         }
       }

--- a/packages/indexer/src/internal/reconciliation.ts
+++ b/packages/indexer/src/internal/reconciliation.ts
@@ -1,0 +1,125 @@
+import { ClockMode } from "./chaintool";
+
+export type ProjectedProposalState =
+  | "Pending"
+  | "Active"
+  | "Canceled"
+  | "Defeated"
+  | "Succeeded"
+  | "Queued"
+  | "Expired"
+  | "Executed";
+
+export interface ProjectionStateInput {
+  clockMode: ClockMode;
+  proposalSnapshot: bigint;
+  proposalDeadline: bigint;
+  quorum: bigint;
+  votesFor: bigint;
+  votesAgainst: bigint;
+  votesAbstain: bigint;
+  currentTimepoint: bigint;
+  currentTimestampMs: bigint;
+  hasCanceledEvent: boolean;
+  hasExecutedEvent: boolean;
+  hasQueuedEvent: boolean;
+  queueReadyAt?: bigint;
+  queueExpiresAt?: bigint;
+  timelockAddress?: string | null;
+}
+
+export interface ReconciliationCheck<T = bigint | string | undefined> {
+  field: string;
+  projected: T;
+  onChain: T;
+  matches: boolean;
+  details?: string;
+}
+
+export const GOVERNOR_STATE_NAMES: ProjectedProposalState[] = [
+  "Pending",
+  "Active",
+  "Canceled",
+  "Defeated",
+  "Succeeded",
+  "Queued",
+  "Expired",
+  "Executed",
+];
+
+export function governorStateName(
+  value: bigint | number
+): ProjectedProposalState | `Unknown(${string})` {
+  const index = Number(value);
+  return GOVERNOR_STATE_NAMES[index] ?? `Unknown(${value.toString()})`;
+}
+
+export function compareScalarField<T>(
+  field: string,
+  projected: T,
+  onChain: T,
+  details?: string
+): ReconciliationCheck<T> {
+  return {
+    field,
+    projected,
+    onChain,
+    matches: projected === onChain,
+    details,
+  };
+}
+
+export function deriveProjectedProposalState(
+  input: ProjectionStateInput
+): ProjectedProposalState {
+  if (input.hasExecutedEvent) {
+    return "Executed";
+  }
+
+  if (input.hasCanceledEvent) {
+    return "Canceled";
+  }
+
+  if (input.currentTimepoint <= input.proposalSnapshot) {
+    return "Pending";
+  }
+
+  if (input.currentTimepoint <= input.proposalDeadline) {
+    return "Active";
+  }
+
+  const hasQuorum =
+    input.votesFor + input.votesAgainst + input.votesAbstain >= input.quorum;
+  const votePassed = input.votesFor > input.votesAgainst;
+
+  if (!hasQuorum || !votePassed) {
+    return "Defeated";
+  }
+
+  const hasTimelock =
+    Boolean(input.timelockAddress) ||
+    input.hasQueuedEvent ||
+    input.queueReadyAt !== undefined ||
+    input.queueExpiresAt !== undefined;
+
+  if (!hasTimelock) {
+    return "Succeeded";
+  }
+
+  if (
+    input.queueExpiresAt !== undefined &&
+    input.currentTimestampMs > input.queueExpiresAt
+  ) {
+    return "Expired";
+  }
+
+  if (
+    input.hasQueuedEvent ||
+    input.queueReadyAt !== undefined ||
+    input.queueExpiresAt !== undefined
+  ) {
+    return "Queued";
+  }
+
+  return "Succeeded";
+}

--- a/packages/indexer/src/reconcile.ts
+++ b/packages/indexer/src/reconcile.ts
@@ -1,0 +1,625 @@
+import "reflect-metadata";
+
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { DataSource } from "typeorm";
+
+import { DegovDataSource } from "./datasource";
+import {
+  ChainTool,
+  ClockMode,
+  HistoricalVotesResult,
+} from "./internal/chaintool";
+import {
+  compareScalarField,
+  deriveProjectedProposalState,
+  governorStateName,
+  ProjectedProposalState,
+  ReconciliationCheck,
+} from "./internal/reconciliation";
+
+interface ReconcileCliOptions {
+  configPath: string;
+  outputPath: string;
+  proposalSampleLimit: number;
+  voteSamplesPerProposal: number;
+  proposalIds?: string[];
+}
+
+interface ProjectionProposalRow {
+  proposalId: string;
+  proposalSnapshot: string;
+  proposalDeadline: string;
+  queueReadyAt: string | null;
+  queueExpiresAt: string | null;
+  quorum: string;
+  clockMode: string;
+  timelockAddress: string | null;
+  votesFor: string | null;
+  votesAgainst: string | null;
+  votesAbstain: string | null;
+  hasCanceledEvent: boolean;
+  hasExecutedEvent: boolean;
+  hasQueuedEvent: boolean;
+}
+
+interface ProposalCoverageCounts {
+  proposalActions: number;
+  proposalStateEpochs: number;
+  governanceParameterCheckpoints: number;
+  votePowerCheckpoints: number;
+  timelockOperations: number;
+}
+
+interface VotePowerSampleResult {
+  account: string;
+  projectedVotes?: string;
+  onChainVotes: string;
+  method: HistoricalVotesResult["method"];
+  matches: boolean;
+}
+
+interface ProposalReconciliationResult {
+  proposalId: string;
+  projectedState: ProjectedProposalState;
+  onChainState: string;
+  checks: ReconciliationCheck<string>[];
+  voteSamples: VotePowerSampleResult[];
+}
+
+function parseArgs(argv: string[]): ReconcileCliOptions {
+  const options: ReconcileCliOptions = {
+    configPath: process.env.DEGOV_CONFIG_PATH ?? "../../degov.yml",
+    outputPath: path.resolve(
+      process.cwd(),
+      "artifacts/reconciliation/latest.json"
+    ),
+    proposalSampleLimit: 25,
+    voteSamplesPerProposal: 5,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    const next = argv[index + 1];
+
+    switch (current) {
+      case "--config":
+        options.configPath = next;
+        index += 1;
+        break;
+      case "--output":
+        options.outputPath = path.resolve(process.cwd(), next);
+        index += 1;
+        break;
+      case "--proposal-sample-limit":
+        options.proposalSampleLimit = Number(next);
+        index += 1;
+        break;
+      case "--vote-samples":
+        options.voteSamplesPerProposal = Number(next);
+        index += 1;
+        break;
+      case "--proposal-ids":
+        options.proposalIds = next
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean);
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (!options.configPath) {
+    throw new Error("Missing --config or DEGOV_CONFIG_PATH");
+  }
+
+  if (!Number.isInteger(options.proposalSampleLimit) || options.proposalSampleLimit <= 0) {
+    throw new Error("--proposal-sample-limit must be a positive integer");
+  }
+
+  if (!Number.isInteger(options.voteSamplesPerProposal) || options.voteSamplesPerProposal <= 0) {
+    throw new Error("--vote-samples must be a positive integer");
+  }
+
+  return options;
+}
+
+function toBigInt(value: string | number | bigint | null | undefined): bigint {
+  if (value === null || value === undefined) {
+    return 0n;
+  }
+
+  if (typeof value === "bigint") {
+    return value;
+  }
+
+  return BigInt(value);
+}
+
+function normalizeAddress(value: string | null | undefined): string | undefined {
+  return value ? value.toLowerCase() : undefined;
+}
+
+async function createDatabaseConnection(): Promise<DataSource> {
+  const databaseUrl = process.env.DATABASE_URL;
+  const ssl = process.env.DB_SSL === "true";
+  const dataSource = new DataSource(
+    databaseUrl
+      ? {
+          type: "postgres",
+          url: databaseUrl,
+          ssl,
+        }
+      : {
+          type: "postgres",
+          host: process.env.DB_HOST ?? "localhost",
+          port: Number(process.env.DB_PORT ?? 5432),
+          username: process.env.DB_USER ?? "postgres",
+          password: process.env.DB_PASS ?? "postgres",
+          database: process.env.DB_NAME ?? "squid",
+          ssl,
+        }
+  );
+
+  await dataSource.initialize();
+  return dataSource;
+}
+
+async function loadProjectionRows(
+  dataSource: DataSource,
+  chainId: number,
+  governorAddress: string,
+  proposalSampleLimit: number,
+  proposalIds?: string[]
+): Promise<ProjectionProposalRow[]> {
+  const filters: string[] = [
+    `p.chain_id = $1`,
+    `lower(p.governor_address) = lower($2)`,
+    `p.proposal_snapshot IS NOT NULL`,
+    `p.proposal_deadline IS NOT NULL`,
+  ];
+  const params: unknown[] = [chainId, governorAddress];
+
+  if (proposalIds && proposalIds.length > 0) {
+    filters.push(`p.proposal_id = ANY($3)`);
+    params.push(proposalIds);
+  }
+
+  params.push(proposalSampleLimit);
+  const limitPosition = params.length;
+
+  return dataSource.query(
+    `
+      SELECT
+        p.proposal_id AS "proposalId",
+        p.proposal_snapshot AS "proposalSnapshot",
+        p.proposal_deadline AS "proposalDeadline",
+        p.queue_ready_at AS "queueReadyAt",
+        p.queue_expires_at AS "queueExpiresAt",
+        p.quorum AS "quorum",
+        p.clock_mode AS "clockMode",
+        p.timelock_address AS "timelockAddress",
+        COALESCE(p.metrics_votes_weight_for_sum, 0) AS "votesFor",
+        COALESCE(p.metrics_votes_weight_against_sum, 0) AS "votesAgainst",
+        COALESCE(p.metrics_votes_weight_abstain_sum, 0) AS "votesAbstain",
+        EXISTS (
+          SELECT 1
+          FROM proposal_canceled pc
+          WHERE pc.chain_id = p.chain_id
+            AND lower(pc.governor_address) = lower(p.governor_address)
+            AND pc.proposal_id = p.proposal_id
+        ) AS "hasCanceledEvent",
+        EXISTS (
+          SELECT 1
+          FROM proposal_executed pe
+          WHERE pe.chain_id = p.chain_id
+            AND lower(pe.governor_address) = lower(p.governor_address)
+            AND pe.proposal_id = p.proposal_id
+        ) AS "hasExecutedEvent",
+        EXISTS (
+          SELECT 1
+          FROM proposal_queued pq
+          WHERE pq.chain_id = p.chain_id
+            AND lower(pq.governor_address) = lower(p.governor_address)
+            AND pq.proposal_id = p.proposal_id
+        ) AS "hasQueuedEvent"
+      FROM proposal p
+      WHERE ${filters.join(" AND ")}
+      ORDER BY p.block_number DESC NULLS LAST
+      LIMIT $${limitPosition}
+    `,
+    params
+  );
+}
+
+async function loadCoverageCounts(
+  dataSource: DataSource,
+  chainId: number,
+  governorAddress: string
+): Promise<ProposalCoverageCounts> {
+  const [row] = await dataSource.query(
+    `
+      SELECT
+        (SELECT COUNT(*) FROM proposal_action WHERE chain_id = $1 AND lower(governor_address) = lower($2)) AS "proposalActions",
+        (SELECT COUNT(*) FROM proposal_state_epoch WHERE chain_id = $1 AND lower(governor_address) = lower($2)) AS "proposalStateEpochs",
+        (SELECT COUNT(*) FROM governance_parameter_checkpoint WHERE chain_id = $1 AND lower(governor_address) = lower($2)) AS "governanceParameterCheckpoints",
+        (SELECT COUNT(*) FROM vote_power_checkpoint WHERE chain_id = $1 AND lower(governor_address) = lower($2)) AS "votePowerCheckpoints",
+        (SELECT COUNT(*) FROM timelock_operation WHERE chain_id = $1 AND lower(governor_address) = lower($2)) AS "timelockOperations"
+    `,
+    [chainId, governorAddress]
+  );
+
+  return {
+    proposalActions: Number(row.proposalActions ?? 0),
+    proposalStateEpochs: Number(row.proposalStateEpochs ?? 0),
+    governanceParameterCheckpoints: Number(
+      row.governanceParameterCheckpoints ?? 0
+    ),
+    votePowerCheckpoints: Number(row.votePowerCheckpoints ?? 0),
+    timelockOperations: Number(row.timelockOperations ?? 0),
+  };
+}
+
+async function loadVoteSampleAccounts(
+  dataSource: DataSource,
+  chainId: number,
+  governorAddress: string,
+  tokenAddress: string,
+  proposalId: string,
+  clockMode: string,
+  proposalSnapshot: bigint,
+  limit: number
+): Promise<string[]> {
+  const voterRows = await dataSource.query(
+    `
+      SELECT DISTINCT voter AS account
+      FROM vote_cast_group
+      WHERE chain_id = $1
+        AND lower(governor_address) = lower($2)
+        AND ref_proposal_id = $3
+      ORDER BY account ASC
+      LIMIT $4
+    `,
+    [chainId, governorAddress, proposalId, limit]
+  );
+
+  const accounts = new Set<string>(
+    voterRows.map((row: { account: string }) => row.account.toLowerCase())
+  );
+
+  if (accounts.size >= limit) {
+    return [...accounts].slice(0, limit);
+  }
+
+  const checkpointRows = await dataSource.query(
+    `
+      SELECT DISTINCT ON (account) account
+      FROM vote_power_checkpoint
+      WHERE chain_id = $1
+        AND lower(governor_address) = lower($2)
+        AND lower(token_address) = lower($3)
+        AND clock_mode = $4
+        AND timepoint <= $5
+      ORDER BY account ASC, timepoint DESC
+      LIMIT $6
+    `,
+    [chainId, governorAddress, tokenAddress, clockMode, proposalSnapshot.toString(), limit]
+  );
+
+  checkpointRows.forEach((row: { account: string }) => {
+    if (accounts.size < limit) {
+      accounts.add(row.account.toLowerCase());
+    }
+  });
+
+  return [...accounts];
+}
+
+async function loadProjectedVotePower(
+  dataSource: DataSource,
+  chainId: number,
+  governorAddress: string,
+  tokenAddress: string,
+  clockMode: string,
+  account: string,
+  proposalSnapshot: bigint
+): Promise<bigint | undefined> {
+  const [row] = await dataSource.query(
+    `
+      SELECT new_power AS "newPower"
+      FROM vote_power_checkpoint
+      WHERE chain_id = $1
+        AND lower(governor_address) = lower($2)
+        AND lower(token_address) = lower($3)
+        AND clock_mode = $4
+        AND lower(account) = lower($5)
+        AND timepoint <= $6
+      ORDER BY timepoint DESC
+      LIMIT 1
+    `,
+    [
+      chainId,
+      governorAddress,
+      tokenAddress,
+      clockMode,
+      account,
+      proposalSnapshot.toString(),
+    ]
+  );
+
+  if (!row) {
+    return undefined;
+  }
+
+  return BigInt(row.newPower);
+}
+
+async function reconcileProposal(
+  dataSource: DataSource,
+  chainTool: ChainTool,
+  row: ProjectionProposalRow,
+  context: {
+    chainId: number;
+    governorAddress: `0x${string}`;
+    tokenAddress: `0x${string}`;
+    tokenStandard: string;
+    rpcs: string[];
+    currentTimepoint: bigint;
+    currentTimestampMs: bigint;
+    voteSamplesPerProposal: number;
+  }
+): Promise<ProposalReconciliationResult> {
+  const proposalIdAsBigInt = BigInt(row.proposalId);
+  const [stateOnChain, snapshotOnChain, deadlineOnChain, quorumOnChain] =
+    await Promise.all([
+      chainTool.readContract<bigint>({
+        chainId: context.chainId,
+        contractAddress: context.governorAddress,
+        rpcs: context.rpcs,
+        abi: [
+          {
+            inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
+            name: "state",
+            outputs: [{ internalType: "uint8", name: "", type: "uint8" }],
+            stateMutability: "view",
+            type: "function",
+          },
+        ],
+        functionName: "state",
+        args: [proposalIdAsBigInt],
+      }),
+      chainTool.readContract<bigint>({
+        chainId: context.chainId,
+        contractAddress: context.governorAddress,
+        rpcs: context.rpcs,
+        abi: [
+          {
+            inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
+            name: "proposalSnapshot",
+            outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+            stateMutability: "view",
+            type: "function",
+          },
+        ],
+        functionName: "proposalSnapshot",
+        args: [proposalIdAsBigInt],
+      }),
+      chainTool.readContract<bigint>({
+        chainId: context.chainId,
+        contractAddress: context.governorAddress,
+        rpcs: context.rpcs,
+        abi: [
+          {
+            inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
+            name: "proposalDeadline",
+            outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+            stateMutability: "view",
+            type: "function",
+          },
+        ],
+        functionName: "proposalDeadline",
+        args: [proposalIdAsBigInt],
+      }),
+      chainTool.quorum({
+        chainId: context.chainId,
+        contractAddress: context.governorAddress,
+        rpcs: context.rpcs,
+        governorTokenAddress: context.tokenAddress,
+        governorTokenStandard: context.tokenStandard === "ERC721" ? "ERC721" : "ERC20",
+        timepoint: BigInt(row.proposalSnapshot),
+      }),
+    ]);
+
+  const projectedState = deriveProjectedProposalState({
+    clockMode:
+      row.clockMode === ClockMode.Timestamp
+        ? ClockMode.Timestamp
+        : ClockMode.BlockNumber,
+    proposalSnapshot: BigInt(row.proposalSnapshot),
+    proposalDeadline: BigInt(row.proposalDeadline),
+    quorum: BigInt(row.quorum),
+    votesFor: toBigInt(row.votesFor),
+    votesAgainst: toBigInt(row.votesAgainst),
+    votesAbstain: toBigInt(row.votesAbstain),
+    currentTimepoint: context.currentTimepoint,
+    currentTimestampMs: context.currentTimestampMs,
+    hasCanceledEvent: row.hasCanceledEvent,
+    hasExecutedEvent: row.hasExecutedEvent,
+    hasQueuedEvent: row.hasQueuedEvent,
+    queueReadyAt: row.queueReadyAt ? BigInt(row.queueReadyAt) : undefined,
+    queueExpiresAt: row.queueExpiresAt ? BigInt(row.queueExpiresAt) : undefined,
+    timelockAddress: row.timelockAddress,
+  });
+
+  const checks: ReconciliationCheck<string>[] = [
+    compareScalarField("state", projectedState, governorStateName(stateOnChain)),
+    compareScalarField(
+      "proposalSnapshot",
+      BigInt(row.proposalSnapshot).toString(),
+      snapshotOnChain.toString()
+    ),
+    compareScalarField(
+      "proposalDeadline",
+      BigInt(row.proposalDeadline).toString(),
+      deadlineOnChain.toString()
+    ),
+    compareScalarField("quorum", BigInt(row.quorum).toString(), quorumOnChain.quorum.toString()),
+  ];
+
+  const sampleAccounts = await loadVoteSampleAccounts(
+    dataSource,
+    context.chainId,
+    context.governorAddress,
+    context.tokenAddress,
+    row.proposalId,
+    row.clockMode,
+    BigInt(row.proposalSnapshot),
+    context.voteSamplesPerProposal
+  );
+
+  const voteSamples = await Promise.all(
+    sampleAccounts.map(async (account) => {
+      const [projectedVotes, onChainVotes] = await Promise.all([
+        loadProjectedVotePower(
+          dataSource,
+          context.chainId,
+          context.governorAddress,
+          context.tokenAddress,
+          row.clockMode,
+          account,
+          BigInt(row.proposalSnapshot)
+        ),
+        chainTool.historicalVotes({
+          chainId: context.chainId,
+          contractAddress: context.tokenAddress,
+          rpcs: context.rpcs,
+          account: account as `0x${string}`,
+          timepoint: BigInt(row.proposalSnapshot),
+        }),
+      ]);
+
+      return {
+        account,
+        projectedVotes: projectedVotes?.toString(),
+        onChainVotes: onChainVotes.votes.toString(),
+        method: onChainVotes.method,
+        matches:
+          projectedVotes !== undefined && projectedVotes === onChainVotes.votes,
+      };
+    })
+  );
+
+  return {
+    proposalId: row.proposalId,
+    projectedState,
+    onChainState: governorStateName(stateOnChain),
+    checks,
+    voteSamples,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const config = await DegovDataSource.fromDegovConfigPath(options.configPath);
+  const work = config.works[0];
+  const governor = work.contracts.find((item) => item.name === "governor");
+  const governorToken = work.contracts.find(
+    (item) => item.name === "governorToken"
+  );
+
+  if (!governor || !governorToken) {
+    throw new Error("Governor and governorToken must exist in the selected config");
+  }
+
+  const chainTool = new ChainTool();
+  const currentClock = await chainTool.currentClock({
+    chainId: config.chainId,
+    contractAddress: governor.address,
+    rpcs: config.rpcs,
+  });
+  const dataSource = await createDatabaseConnection();
+
+  try {
+    const [projectionRows, coverage] = await Promise.all([
+      loadProjectionRows(
+        dataSource,
+        config.chainId,
+        governor.address,
+        options.proposalSampleLimit,
+        options.proposalIds
+      ),
+      loadCoverageCounts(dataSource, config.chainId, governor.address),
+    ]);
+
+    if (projectionRows.length === 0) {
+      throw new Error("No proposals found for reconciliation in the selected scope");
+    }
+
+    const proposals = await Promise.all(
+      projectionRows.map((row) =>
+        reconcileProposal(dataSource, chainTool, row, {
+          chainId: config.chainId,
+          governorAddress: governor.address,
+          tokenAddress: governorToken.address,
+          tokenStandard: (governorToken.standard ?? "ERC20").toUpperCase(),
+          rpcs: config.rpcs,
+          currentTimepoint: currentClock.timepoint,
+          currentTimestampMs: currentClock.timestampMs,
+          voteSamplesPerProposal: options.voteSamplesPerProposal,
+        })
+      )
+    );
+
+    const fieldChecks = proposals.flatMap((proposal) => proposal.checks);
+    const voteSamples = proposals.flatMap((proposal) => proposal.voteSamples);
+    const summary = {
+      proposalsChecked: proposals.length,
+      fieldChecks: fieldChecks.length,
+      fieldMismatches: fieldChecks.filter((item) => !item.matches).length,
+      voteSamplesChecked: voteSamples.length,
+      voteSampleMismatches: voteSamples.filter((item) => !item.matches).length,
+    };
+
+    const output = {
+      generatedAt: new Date().toISOString(),
+      configPath: path.resolve(process.cwd(), options.configPath),
+      daoCode: work.daoCode,
+      chainId: config.chainId,
+      governorAddress: governor.address,
+      governorTokenAddress: governorToken.address,
+      governorTokenStandard: governorToken.standard ?? "ERC20",
+      currentClock,
+      coverage,
+      summary,
+      proposals,
+    };
+
+    await mkdir(path.dirname(options.outputPath), { recursive: true });
+    await writeFile(options.outputPath, JSON.stringify(output, null, 2) + "\n");
+
+    console.log(
+      JSON.stringify(
+        {
+          outputPath: options.outputPath,
+          ...summary,
+        },
+        null,
+        2
+      )
+    );
+
+    process.exitCode =
+      summary.fieldMismatches === 0 && summary.voteSampleMismatches === 0
+        ? 0
+        : 1;
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a shadow-db replay/backfill workflow via `packages/indexer/scripts/replay-backfill.sh`
- add `packages/indexer/src/reconcile.ts` to compare proposal projection fields and sampled historical vote power against on-chain truth
- add rollout documentation plus executable integration-test wiring for the new validation flow

## Validation
- `cd packages/indexer && npx -y yarn@1.22.22 build`
- `cd packages/indexer && npx -y yarn@1.22.22 test`
- `cd packages/indexer && npx -y yarn@1.22.22 test:integration`
- `cd packages/indexer && sh -n scripts/replay-backfill.sh`

## Notes
- Base branch: `ohh-32-indexer-baseline-upgrade`
- Reconciliation artifacts are written under `packages/indexer/artifacts/reconciliation/`
- `DEGOV_INDEXER_START_BLOCK` and `DEGOV_INDEXER_END_BLOCK` can freeze replay ranges for repeatable release validation
