### PR TITLE
fix(indexer): restore serializable isolation default

### DIFF
--- a/packages/indexer/__tests__/database-options.test.ts
+++ b/packages/indexer/__tests__/database-options.test.ts
@@ -1,0 +1,12 @@
+import { getDatabaseOptions } from "../src/database";
+
+describe("database options", () => {
+  it("keeps hot blocks enabled without overriding the default isolation level", () => {
+    const options = getDatabaseOptions();
+
+    expect(options).toEqual({
+      supportHotBlocks: true,
+    });
+    expect(options).not.toHaveProperty("isolationLevel");
+  });
+});

--- a/packages/indexer/src/database.ts
+++ b/packages/indexer/src/database.ts
@@ -1,0 +1,14 @@
+import {
+  TypeormDatabase,
+  type TypeormDatabaseOptions,
+} from "@subsquid/typeorm-store";
+
+export function getDatabaseOptions(): TypeormDatabaseOptions {
+  return {
+    supportHotBlocks: true,
+  };
+}
+
+export function createDatabase() {
+  return new TypeormDatabase(getDatabaseOptions());
+}

--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -1,4 +1,3 @@
-import { TypeormDatabase } from "@subsquid/typeorm-store";
 import { GovernorHandler } from "./handler/governor";
 import { TokenHandler } from "./handler/token";
 import { EvmBatchProcessor } from "@subsquid/evm-processor";
@@ -6,6 +5,7 @@ import { evmFieldSelection, IndexerProcessorConfig } from "./types";
 import { DegovDataSource } from "./datasource";
 import { ChainTool } from "./internal/chaintool";
 import { TextPlus } from "./internal/textplus";
+import { createDatabase } from "./database";
 
 async function main() {
   const degovConfigPath = process.env.DEGOV_CONFIG_PATH;
@@ -94,10 +94,7 @@ async function runProcessorEvm(config: IndexerProcessorConfig) {
   const textPlus = new TextPlus();
 
   processor.run(
-    new TypeormDatabase({
-      supportHotBlocks: true,
-      isolationLevel: "READ COMMITTED",
-    }),
+    createDatabase(),
     async (ctx) => {
       for (const c of ctx.blocks) {
         for (const event of c.logs) {


### PR DESCRIPTION
## Summary
- remove the explicit `READ COMMITTED` override from the indexer database setup
- keep `supportHotBlocks` enabled while letting `@subsquid/typeorm-store` use its default `SERIALIZABLE` isolation level
- add a regression test covering the database options helper

## Rationale
- `@subsquid/typeorm-store@1.5.1` already defaults `TypeormDatabase` to `SERIALIZABLE`
- the library retries PostgreSQL serialization failures (`40001`) up to 3 times in `submit()`
- its `updateStatus()` logic explicitly documents the race that can happen under `READ COMMITTED`, so keeping the lower override is counterproductive for the requested behavior

## Validation
- `cd packages/indexer && npx jest __tests__/database-options.test.ts --runInBand`
- `cd packages/indexer && npx tsc -p tsconfig.test.json --noEmit`
