### PR TITLE
feat(indexer): add justfile and indexer docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# DeGov Docs
+
+This directory collects project documentation that is specific to the code in
+this repository.
+
+## Indexer
+
+- [Developer guide](./guides/20260325__indexer_developer_guide.md)
+- [Architecture overview](./architecture/20260325__indexer_architecture.md)
+- [OpenZeppelin governance research](./research/20260325__ohh-28_openzeppelin_governor_indexing_research.md)
+
+## Plans
+
+- [Projection replay, reconciliation, and rollout](./plans/20260325__degov_projection_replay_reconciliation_rollout.md)

--- a/docs/architecture/20260325__indexer_architecture.md
+++ b/docs/architecture/20260325__indexer_architecture.md
@@ -1,0 +1,152 @@
+# DeGov Indexer Architecture
+
+This document describes the current `packages/indexer` implementation on top of
+the integrated OHH-32 to OHH-38 branch.
+
+## Runtime topology
+
+```mermaid
+flowchart LR
+    A[degov.yml or DEGOV_CONFIG_PATH] --> B[DegovDataSource]
+    B --> C[EvmBatchProcessor]
+    C --> D[GovernorHandler]
+    C --> E[TokenHandler]
+    C --> F[TimelockHandler]
+    D --> G[(PostgreSQL via TypeORM store)]
+    E --> G
+    F --> G
+    G --> H[GraphQL API]
+    G --> I[Reconciliation report]
+```
+
+## Main entrypoints
+
+### Processor startup
+
+`src/main.ts` is the processor entrypoint:
+
+1. Read `DEGOV_CONFIG_PATH`.
+2. Load and normalize the DAO config through `DegovDataSource`.
+3. Select RPC endpoints from `CHAIN_RPC_<chainId>` when present, otherwise
+   fall back to the config file RPC list.
+4. Build an `EvmBatchProcessor` with the configured finality, capacity,
+   gateway, and batch-call settings.
+5. Subscribe to logs for the configured `governor`, `governorToken`, and
+   `timeLock` contracts.
+6. Route each matched log into the corresponding handler.
+
+### GraphQL and local helper entrypoints
+
+- `npx sqd serve` starts the GraphQL API on top of the indexed PostgreSQL
+  state.
+- `scripts/start.sh` applies migrations and starts the processor.
+- `scripts/graphql-server.sh` starts the GraphQL server directly.
+- `scripts/smart-start.sh` is the local convenience wrapper for Docker,
+  code generation, builds, and runtime startup.
+- `src/reconcile.ts` is compiled to `lib/reconcile.js` and verifies indexed
+  proposal state against chain truth.
+
+## Configuration model
+
+`src/datasource.ts` turns `degov.yml` into the `IndexerProcessorConfig` used by
+the processor.
+
+Important behaviors:
+
+- The config source can be local or remote.
+- `DEGOV_INDEXER_START_BLOCK` and `DEGOV_INDEXER_END_BLOCK` override the
+  configured range for replay or debugging.
+- The package requires at least one RPC endpoint after env-var and config
+  merging.
+- Only the governance-relevant contracts are selected for indexing:
+  `governor`, `governorToken`, and `timeLock`.
+
+## Handler responsibilities
+
+### `GovernorHandler`
+
+The Governor handler owns the proposal lifecycle and governance parameter
+timeline:
+
+- `ProposalCreated`, `ProposalCanceled`, `ProposalExecuted`, and
+  `ProposalQueued`
+- proposal actions and scoped proposal identity
+- quorum, proposal threshold, voting delay, voting period, and proposal
+  deadline projections
+- late-quorum extensions and other state transitions derived from the
+  OpenZeppelin Governor model
+
+### `TokenHandler`
+
+The token handler materializes vote-power related data:
+
+- `DelegateChanged`
+- `DelegateVotesChanged`
+- ERC20 and ERC721 transfer events that affect voting-unit history
+- vote-power checkpoints keyed by chain, governor, token, account, clock mode,
+  and timepoint
+
+### `TimelockHandler`
+
+The timelock handler tracks execution-path data that Governor events alone do
+not fully describe:
+
+- `CallScheduled`, `CallExecuted`, and `Cancelled`
+- `RoleGranted`, `RoleRevoked`, and `RoleAdminChanged`
+- timelock operation metadata and queue timing
+- timelock ownership changes such as `TimelockChange`
+
+## Storage model
+
+`schema.graphql` shows the additive storage layout introduced by the current
+branch.
+
+The indexed data falls into four main groups:
+
+1. Proposal lifecycle data
+   - `ProposalCreated`, `ProposalQueued`, `ProposalExecuted`,
+     `ProposalCanceled`, `ProposalExtended`
+   - scoped proposal timelines and action payloads
+2. Governance parameter history
+   - `VotingDelaySet`, `VotingPeriodSet`, `ProposalThresholdSet`,
+     `QuorumNumeratorUpdated`, `LateQuorumVoteExtensionSet`
+3. Vote-power history
+   - `DelegateChanged`, `DelegateVotesChanged`, `TokenTransfer`,
+     `VotePowerCheckpoint`
+4. Timelock and AccessControl history
+   - timelock operations, queue state, and role changes
+
+The processor persists this data through `@subsquid/typeorm-store` with
+hot-block support enabled in `src/database.ts`.
+
+## Correctness strategy
+
+The current branch follows the OHH-28 and OHH-38 direction: event ingestion is
+only part of the story.
+
+Correctness depends on combining:
+
+- on-chain event ingestion through Subsquid
+- scoped entity keys so multichain and multi-governor data does not collide
+- replay and backfill tooling for additive migrations
+- reconciliation against contract views such as proposal state, snapshot vote
+  power, and quorum
+
+`scripts/replay-backfill.sh` and `src/reconcile.ts` exist specifically to
+validate that the indexed projection still matches OpenZeppelin Governor
+behavior after schema or handler changes.
+
+## Operational notes
+
+- Build output goes to `lib/`.
+- Generated ABI helpers live in `src/abi/`.
+- Generated entity models live in `src/model/`.
+- Database migrations live in `db/migrations/`.
+- The package expects `.env` support for runtime settings and database
+  credentials.
+
+## Related docs
+
+- [`docs/guides/20260325__indexer_developer_guide.md`](../guides/20260325__indexer_developer_guide.md)
+- [`docs/research/20260325__ohh-28_openzeppelin_governor_indexing_research.md`](../research/20260325__ohh-28_openzeppelin_governor_indexing_research.md)
+- [`docs/plans/20260325__degov_projection_replay_reconciliation_rollout.md`](../plans/20260325__degov_projection_replay_reconciliation_rollout.md)

--- a/docs/guides/20260325__indexer_developer_guide.md
+++ b/docs/guides/20260325__indexer_developer_guide.md
@@ -1,0 +1,147 @@
+# DeGov Indexer Developer Guide
+
+This guide explains how to work with `packages/indexer` after the OHH-32 to
+OHH-38 indexing upgrade and the OHH-55 developer ergonomics pass.
+
+## What lives in `packages/indexer`
+
+`packages/indexer` is the Subsquid-based indexer that reads the DAO config from
+`degov.yml`, ingests Governor, token, and timelock events, applies TypeORM
+migrations, and serves the indexed data over GraphQL.
+
+The package now exposes two command layers:
+
+- `package.json` scripts for the canonical Node and Subsquid tasks.
+- `justfile` recipes for a shorter day-to-day developer workflow.
+
+## Quickstart
+
+From the repository root:
+
+```bash
+cd packages/indexer
+just install
+just codegen
+just build
+just up
+just run
+```
+
+For the integrated replay and reconciliation flow:
+
+```bash
+cd packages/indexer
+just replay-backfill
+```
+
+## `justfile` recipes
+
+The package-local `justfile` is intentionally thin: each recipe wraps an
+existing `package.json` script, `commands.json` command, or package shell helper
+without changing runtime behavior.
+
+| Recipe | Underlying command | Use |
+| --- | --- | --- |
+| `just install` | `npx -y yarn@1.22.22 install --ignore-scripts` | Install the package with the pinned Yarn v1 toolchain. |
+| `just clean` | `npx sqd clean` | Remove generated build output. |
+| `just up` | `npx sqd up` | Start the local PostgreSQL container declared by the indexer package. |
+| `just down` | `npx sqd down` | Stop the local PostgreSQL container. |
+| `just codegen-abi` | `yarn run codegen:abi` | Rebuild ABI decoder bindings from `abi/*.json` into `src/abi/`. |
+| `just codegen-schema` | `yarn run codegen:schema` | Rebuild TypeORM entities from `schema.graphql`. |
+| `just codegen` | `yarn run codegen` | Run the full Subsquid code generation flow. |
+| `just build` | `yarn run build` | Compile the indexer into `lib/`. |
+| `just migrate-db` | `yarn run migrate:db` | Generate the additive migration for the current schema changes. |
+| `just migrate-db-force` | `yarn run migrate:db -- --force` | Regenerate migrations without preserving the previous `db/` folder contents. |
+| `just process` | `npx sqd process` | Start the processor only. |
+| `just serve` | `npx sqd serve` | Start the GraphQL server only. |
+| `just run` | `npx sqd run .` | Start the processor and GraphQL server together through Subsquid. |
+| `just start` | `sh ./scripts/start.sh` | Apply migrations and start `lib/main.js` with `.env` loading. |
+| `just smart-start` | `sh ./scripts/smart-start.sh` | Reset Docker services as needed, then build and start the indexer. |
+| `just smart-start-force` | `sh ./scripts/smart-start.sh force` | Force a local reset, rerun codegen, and regenerate migrations before starting. |
+| `just graphql-server` | `sh ./scripts/graphql-server.sh` | Launch the GraphQL server helper script directly. |
+| `just reconcile` | `yarn run build && node lib/reconcile.js` | Rebuild the package and compare indexed proposal data against on-chain truth. |
+| `just replay-backfill` | `yarn run replay:backfill` | Run the bounded replay plus reconciliation flow from OHH-38. |
+| `just test` | `yarn run test` | Run the deterministic Jest suite. |
+| `just test-integration` | `yarn run test:integration` | Run the network-backed integration tests. |
+
+## `package.json` scripts
+
+The package scripts remain the source of truth for the actual commands:
+
+| Script | Meaning |
+| --- | --- |
+| `codegen:abi` | Generate typed ABI helpers for the Governor and timelock JSON ABIs under `abi/`. |
+| `codegen:schema` | Generate TypeORM entities from `schema.graphql`. |
+| `codegen` | Run the full Subsquid code generation pipeline configured by `commands.json`. |
+| `migrate:db` | Run `scripts/sqd-migration.mjs` to generate a migration while preserving the current `db/` folder by default. |
+| `build` | Compile the indexer sources into `lib/` via `sqd build`. |
+| `reconcile` | Execute the built reconciliation entrypoint at `lib/reconcile.js` to compare indexed state with chain truth. |
+| `replay:backfill` | Run the replay and reconciliation helper script for bounded historical validation. |
+| `test` | Run the default Jest suite in band. |
+| `test:integration` | Run the dedicated integration tests for chain-backed helpers. |
+
+## Common developer flows
+
+### Build and run the local indexer
+
+```bash
+cd packages/indexer
+just install
+just codegen
+just build
+just up
+just run
+```
+
+### Generate a schema migration
+
+```bash
+cd packages/indexer
+just codegen
+just migrate-db
+```
+
+Use `just migrate-db-force` only when you intentionally want the migration
+generator to ignore the current `db/` contents and rebuild from the current
+schema state.
+
+### Serve the API against an already-built processor
+
+```bash
+cd packages/indexer
+just process
+just serve
+```
+
+### Validate a rollout with replay and reconciliation
+
+```bash
+cd packages/indexer
+just replay-backfill
+just test
+```
+
+This flow is described in more detail in
+[`docs/plans/20260325__degov_projection_replay_reconciliation_rollout.md`](../plans/20260325__degov_projection_replay_reconciliation_rollout.md).
+
+## Environment and config inputs
+
+The indexer reads runtime settings from both repository config and environment
+variables:
+
+- `degov.yml`: DAO identity, contract addresses, chain settings, indexer start
+  block, and default RPC list.
+- `DEGOV_CONFIG_PATH`: overrides the config source and can point to a local file
+  or a remote URL.
+- `CHAIN_<chainId>` style RPC env vars such as `CHAIN_RPC_46`: override the RPC
+  endpoints used by the processor.
+- `DEGOV_INDEXER_START_BLOCK` / `DEGOV_INDEXER_END_BLOCK`: narrow replay or
+  backfill ranges.
+- `DATABASE_URL` or `DB_*`: configure the PostgreSQL connection used by the
+  processor and reconciliation tooling.
+
+## Related docs
+
+- [`docs/architecture/20260325__indexer_architecture.md`](../architecture/20260325__indexer_architecture.md)
+- [`docs/research/20260325__ohh-28_openzeppelin_governor_indexing_research.md`](../research/20260325__ohh-28_openzeppelin_governor_indexing_research.md)
+- [`docs/plans/20260325__degov_projection_replay_reconciliation_rollout.md`](../plans/20260325__degov_projection_replay_reconciliation_rollout.md)

--- a/docs/research/20260325__ohh-28_openzeppelin_governor_indexing_research.md
+++ b/docs/research/20260325__ohh-28_openzeppelin_governor_indexing_research.md
@@ -1,0 +1,148 @@
+# OHH-28 OpenZeppelin Governor Indexing Research
+
+This document captures the parts of OHH-28 that directly shape the current
+`degov` indexer implementation and future upgrades.
+
+## Why this research matters
+
+OHH-28 established the correctness rules for indexing OpenZeppelin Governor
+contracts:
+
+- proposal state is only partially event-driven
+- vote power must be read at the Governor snapshot timepoint
+- timelock state and AccessControl history are required for a complete
+  execution view
+- reconciliation against contract views is required when correctness matters
+  more than ingestion speed alone
+
+The current OHH-32 to OHH-38 branch applies those conclusions in code. This
+document keeps the high-signal parts of that research inside the repository.
+
+## Contract families that matter
+
+| Contract family | Why it matters to the indexer |
+| --- | --- |
+| `Governor` / `IGovernor` | Defines proposal creation, voting, queuing, execution, cancellation, and derived proposal state. |
+| `GovernorVotes` / `GovernorVotesComp` | Defines how proposal snapshot vote power is resolved from `IVotes`. |
+| `GovernorCountingSimple` | Defines `Against`, `For`, and `Abstain` semantics. |
+| `GovernorVotesQuorumFraction` | Defines quorum as a snapshot-time calculation, not a live vote total. |
+| `GovernorSettings` | Adds mutable governance parameters such as voting delay, voting period, and proposal threshold. |
+| `GovernorPreventLateQuorum` | Allows `proposalDeadline` to move when quorum arrives late. |
+| `GovernorTimelockControl` / `GovernorTimelockCompound` | Adds queue, execute, cancel, and expiry paths that are not visible from Governor events alone. |
+| `TimelockController` | Emits the low-level scheduling and execution events needed to explain queued proposals. |
+| `AccessControl` | Emits the role history needed to explain who can queue, execute, or cancel. |
+| `Votes`, `ERC20Votes`, `ERC20VotesComp`, `ERC721Votes`, `IVotes` | Define delegation edges, checkpoint history, and historical vote-power lookups. |
+
+## Proposal state model
+
+OpenZeppelin Governor uses these canonical states:
+
+| State | Important indexing note |
+| --- | --- |
+| `Pending` | Derived from `ProposalCreated` plus the snapshot start timepoint. |
+| `Active` | Derived from time progression, not a dedicated event. |
+| `Canceled` | Can come from Governor or timelock cancellation paths. |
+| `Defeated` | Derived after deadline when quorum or vote outcome fails. |
+| `Succeeded` | Derived after deadline when quorum and vote outcome pass. |
+| `Queued` | Only appears when a timelock extension is present. |
+| `Expired` | Only appears for timelock variants that have a grace-period expiry model. |
+| `Executed` | Final execution state. |
+
+The key conclusion is that the indexer cannot treat emitted events as the whole
+state machine. Some transitions only become visible when time moves forward or
+when a contract view is queried.
+
+## Event groups to index
+
+### Governor proposal events
+
+- `ProposalCreated`
+- `ProposalCanceled`
+- `ProposalExecuted`
+- `ProposalQueued`
+- `ProposalExtended`
+- `VoteCast`
+- `VoteCastWithParams`
+
+### Governance parameter events
+
+- `VotingDelaySet`
+- `VotingPeriodSet`
+- `ProposalThresholdSet`
+- `QuorumNumeratorUpdated`
+- `LateQuorumVoteExtensionSet`
+- `TimelockChange`
+
+### Vote-power and delegation events
+
+- `DelegateChanged`
+- `DelegateVotesChanged`
+- token `Transfer` events for the voting token
+
+### Timelock and role events
+
+- `CallScheduled`
+- `CallExecuted`
+- `Cancelled`
+- `CallSalt`
+- `MinDelayChange`
+- `RoleGranted`
+- `RoleRevoked`
+- `RoleAdminChanged`
+
+## Vote-power correctness rules
+
+OHH-28 established a few rules that the indexer must not violate:
+
+1. Use proposal snapshot vote power, not current balance.
+2. Use `getPastVotes(snapshot)` or `getPriorVotes(snapshot)` semantics, not
+   live vote totals.
+3. Track `DelegateChanged` and `DelegateVotesChanged` together.
+4. Track token transfers because voting units can move even when delegation
+   edges do not.
+5. Do not derive quorum from delegated vote totals; quorum is based on the
+   snapshot supply calculation.
+6. Treat same-timepoint checkpoint merges carefully when materializing
+   historical vote-power tables.
+
+These rules directly explain why the current schema includes vote-power
+checkpoints and transfer history alongside raw voting events.
+
+## Timelock and execution-path conclusions
+
+For complete proposal visualization, the indexer must combine Governor data with
+timelock data:
+
+- `ProposalQueued` alone is not enough to explain queued execution state.
+- `CallScheduled` and `CallExecuted` expose the actual execution payload and
+  timing.
+- role events explain which accounts can administer, queue, execute, or cancel.
+- timelock cancellations can affect proposal state even when no new Governor
+  event is emitted.
+
+## How the current implementation reflects OHH-28
+
+The integrated PR #567 branch applies the research in four concrete ways:
+
+1. Proposal indexing is additive and scoped by chain and governor identity.
+2. Vote-power history is materialized through checkpoint-style entities.
+3. Timelock and AccessControl events are indexed together with Governor events.
+4. Replay and reconciliation tooling exists so proposal state and vote-power
+   projections can be checked against on-chain views.
+
+## Practical guidance for future changes
+
+When modifying the indexer, treat these as non-negotiable:
+
+- preserve scoped entity keys
+- keep raw event ingestion and derived projections conceptually separate
+- validate proposal state against contract views when changing handler logic
+- validate vote-power projections against historical vote APIs when changing
+  token indexing logic
+- include timelock data whenever changing queue or execution-related behavior
+
+## Source trail
+
+- OHH-28 Linear research comment
+- PR #567 integration summary and validation notes
+- current `packages/indexer` handler, schema, replay, and reconciliation code

--- a/packages/indexer/justfile
+++ b/packages/indexer/justfile
@@ -1,0 +1,70 @@
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+default:
+    @just --list
+
+yarn := "npx -y yarn@1.22.22"
+
+install:
+    {{yarn}} install --ignore-scripts
+
+clean:
+    npx sqd clean
+
+up:
+    npx sqd up
+
+down:
+    npx sqd down
+
+codegen-abi:
+    {{yarn}} run codegen:abi
+
+codegen-schema:
+    {{yarn}} run codegen:schema
+
+codegen:
+    {{yarn}} run codegen
+
+build:
+    {{yarn}} run build
+
+migrate-db:
+    {{yarn}} run migrate:db
+
+migrate-db-force:
+    {{yarn}} run migrate:db -- --force
+
+process:
+    npx sqd process
+
+serve:
+    npx sqd serve
+
+run:
+    npx sqd run .
+
+start:
+    sh ./scripts/start.sh
+
+smart-start:
+    sh ./scripts/smart-start.sh
+
+smart-start-force:
+    sh ./scripts/smart-start.sh force
+
+graphql-server:
+    sh ./scripts/graphql-server.sh
+
+reconcile:
+    {{yarn}} run build
+    node lib/reconcile.js
+
+replay-backfill:
+    {{yarn}} run replay:backfill
+
+test:
+    {{yarn}} run test
+
+test-integration:
+    {{yarn}} run test:integration


### PR DESCRIPTION
## Summary
- add a package-local `packages/indexer/justfile` for common build, run, migration, codegen, and validation flows
- add repo docs for the indexer guide, architecture overview, and OHH-28 OpenZeppelin research under `docs/`
- keep the change scoped to developer ergonomics and repository documentation

## Validation
- `cd packages/indexer && just --list`
- `cd packages/indexer && sh -n scripts/start.sh scripts/smart-start.sh scripts/graphql-server.sh scripts/replay-backfill.sh`
- `cd packages/indexer && npx -y yarn@1.22.22 build`
- `cd packages/indexer && npx -y yarn@1.22.22 test`

## Notes
- base branch is `ohh-32-indexer-baseline-upgrade` because OHH-55 needs to stack on PR #567 rather than `main`
