### PR TITLE
fix(web): load governance counts from connection totals

### DIFF
--- a/packages/web/scripts/governance-counts.test.ts
+++ b/packages/web/scripts/governance-counts.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { GET_GOVERNANCE_COUNTS } from "../src/services/graphql/queries/counts.ts";
+import {
+  resolveGovernanceCounts,
+  type GovernanceCountsResponse,
+} from "../src/services/graphql/types/counts.ts";
+
+test("governance counts query requests proposal and contributor totals", () => {
+  assert.match(GET_GOVERNANCE_COUNTS, /proposalsConnection/);
+  assert.match(GET_GOVERNANCE_COUNTS, /contributorsConnection/);
+  assert.match(GET_GOVERNANCE_COUNTS, /totalCount/g);
+});
+
+test("governance counts fall back to zero when connection totals are missing", () => {
+  assert.deepEqual(resolveGovernanceCounts(), {
+    proposalsCount: 0,
+    delegatesCount: 0,
+  });
+});
+
+test("governance counts map proposal and delegate totals from connection responses", () => {
+  const response: GovernanceCountsResponse = {
+    proposalsConnection: {
+      totalCount: 47,
+    },
+    contributorsConnection: {
+      totalCount: 2516,
+    },
+  };
+
+  assert.deepEqual(resolveGovernanceCounts(response), {
+    proposalsCount: 47,
+    delegatesCount: 2516,
+  });
+});

--- a/packages/web/scripts/treasury-fallback.test.ts
+++ b/packages/web/scripts/treasury-fallback.test.ts
@@ -23,11 +23,13 @@ treasuryAssets:
   - name: ENS
     contract: "0x1234"
     standard: ERC20
+    logo: null
 `) as {
     treasuryAssets: {
       name: string;
       contract: string;
       standard: string;
+      logo: null;
     }[];
   };
 

--- a/packages/web/src/app/_components/overview.tsx
+++ b/packages/web/src/app/_components/overview.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { isNumber } from "lodash-es";
 import { useReadContract } from "wagmi";
 
 import { abi as tokenAbi } from "@/config/abi/token";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
+import { useGovernanceCounts } from "@/hooks/useGovernanceCounts";
 import { proposalService } from "@/services/graphql";
 import { formatNumberForDisplay } from "@/utils/number";
 
@@ -36,6 +36,8 @@ export const Overview = () => {
     enabled: !!daoConfig?.indexer?.endpoint,
     placeholderData: keepPreviousData,
   });
+  const { data: governanceCounts, isLoading: isGovernanceCountsLoading } =
+    useGovernanceCounts();
 
   return (
     <div className="flex flex-col gap-[15px] lg:gap-[20px]">
@@ -47,16 +49,14 @@ export const Overview = () => {
           title="Proposals"
           link={`/proposals`}
           icon="/assets/image/proposals-colorful.svg"
-          isLoading={isProposalMetricsLoading}
+          isLoading={isGovernanceCountsLoading}
           priority
         >
           <>
             <div className="flex items-center gap-[8px] lg:gap-[10px]">
               {
                 formatNumberForDisplay(
-                  isNumber(dataMetrics?.proposalsCount)
-                    ? dataMetrics?.proposalsCount
-                    : 0,
+                  governanceCounts?.proposalsCount ?? 0,
                   0
                 )[0]
               }
@@ -68,9 +68,9 @@ export const Overview = () => {
           title="Delegates"
           link={`/delegates`}
           icon="/assets/image/members-colorful.svg"
-          isLoading={isProposalMetricsLoading}
+          isLoading={isGovernanceCountsLoading}
         >
-          {formatNumberForDisplay(dataMetrics?.memberCount ?? 0, 0)[0]}
+          {formatNumberForDisplay(governanceCounts?.delegatesCount ?? 0, 0)[0]}
         </OverviewItem>
         <OverviewItem
           title="Total Voting Power"

--- a/packages/web/src/app/delegates/page.tsx
+++ b/packages/web/src/app/delegates/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useCallback, useEffect, useState } from "react";
@@ -19,8 +18,7 @@ import { ResponsiveRenderer } from "@/components/responsive-renderer";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WithConnect } from "@/components/with-connect";
-import { useDaoConfig } from "@/hooks/useDaoConfig";
-import { proposalService } from "@/services/graphql";
+import { useGovernanceCounts } from "@/hooks/useGovernanceCounts";
 import type { ContributorItem } from "@/services/graphql/types";
 
 import type { Address } from "viem";
@@ -63,7 +61,6 @@ const ORDER_BY_MAP: Record<
 
 export default function Members() {
   const { isConnected } = useAccount();
-  const daoConfig = useDaoConfig();
   const [address, setAddress] = useState<Address | undefined>(undefined);
   const [open, setOpen] = useState(false);
   const [isLoadAttempted, setIsLoadAttempted] = useState(false);
@@ -81,15 +78,7 @@ export default function Members() {
     300,
     [searchTerm]
   );
-
-  const { data: dataMetrics } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
-    queryFn: () =>
-      proposalService.getProposalMetrics(
-        daoConfig?.indexer?.endpoint as string
-      ),
-    enabled: !!daoConfig?.indexer?.endpoint,
-  });
+  const { data: governanceCounts } = useGovernanceCounts();
 
   const handleDelegate = useCallback(
     (value: ContributorItem) => {
@@ -143,7 +132,7 @@ export default function Members() {
     applySortState("delegators", direction);
 
   const getDisplayTitle = () => {
-    const totalCount = dataMetrics?.memberCount;
+    const totalCount = governanceCounts?.delegatesCount;
     if (totalCount !== undefined) {
       return `Delegates (${totalCount})`;
     }

--- a/packages/web/src/app/proposals/page.tsx
+++ b/packages/web/src/app/proposals/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useState } from "react";
@@ -21,9 +20,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useDaoConfig } from "@/hooks/useDaoConfig";
+import { useGovernanceCounts } from "@/hooks/useGovernanceCounts";
 import { useMyVotes } from "@/hooks/useMyVotes";
-import { proposalService } from "@/services/graphql";
 
 import type { CheckedState } from "@radix-ui/react-checkbox";
 
@@ -61,7 +59,6 @@ function ProposalsContent() {
   const typeParam = searchParams?.get("type");
   const supportParam = searchParams?.get("support");
   const addressParam = searchParams?.get("address");
-  const daoConfig = useDaoConfig();
 
   const [support, setSupport] = useState<SupportSelection>(
     normalizeSupportParam(supportParam)
@@ -76,16 +73,7 @@ function ProposalsContent() {
   // Get voting power information
   const { hasEnoughVotes, proposalThreshold, votes } = useMyVotes();
 
-  // Get proposal metrics (including total count)
-  const { data: dataMetrics } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
-    queryFn: () =>
-      proposalService.getProposalMetrics(
-        daoConfig?.indexer?.endpoint as string
-      ),
-    enabled: !!daoConfig?.indexer?.endpoint,
-    placeholderData: keepPreviousData,
-  });
+  const { data: governanceCounts } = useGovernanceCounts();
 
   // Update URL when filters change
   const updateUrlParams = (
@@ -126,10 +114,8 @@ function ProposalsContent() {
   };
 
   const getDisplayTitle = () => {
-    const totalCount = dataMetrics?.proposalsCount
-      ? parseInt(dataMetrics.proposalsCount)
-      : null;
-    if (totalCount !== null) {
+    const totalCount = governanceCounts?.proposalsCount;
+    if (totalCount !== undefined) {
       return `All Proposals (${totalCount})`;
     }
 

--- a/packages/web/src/components/system-info.tsx
+++ b/packages/web/src/components/system-info.tsx
@@ -7,6 +7,7 @@ import { useReadContract } from "wagmi";
 import { abi as tokenAbi } from "@/config/abi/token";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
+import { useGovernanceCounts } from "@/hooks/useGovernanceCounts";
 import { useGovernanceParams } from "@/hooks/useGovernanceParams";
 import { useGovernanceToken } from "@/hooks/useGovernanceToken";
 import { proposalService } from "@/services/graphql";
@@ -104,6 +105,10 @@ export const SystemInfo = ({ type = "default" }: SystemInfoProps) => {
       proposalService.getProposalMetrics(daoConfig?.indexer?.endpoint ?? ""),
     enabled: !!daoConfig?.indexer?.endpoint && type === "default",
   });
+  const { data: governanceCounts, isLoading: isGovernanceCountsLoading } =
+    useGovernanceCounts({
+      enabled: type === "default",
+    });
 
   const systemData = useMemo(() => {
     if (type === "proposal") {
@@ -148,7 +153,7 @@ export const SystemInfo = ({ type = "default" }: SystemInfoProps) => {
         ? formatTokenAmount(totalSupply)?.formatted ?? "0"
         : "0";
 
-      const totalDelegates: number = dataMetrics?.memberCount ?? 0;
+      const totalDelegates = governanceCounts?.delegatesCount ?? 0;
 
       const votingPowerPercentage =
         dataMetrics?.powerSum && totalSupply
@@ -165,7 +170,15 @@ export const SystemInfo = ({ type = "default" }: SystemInfoProps) => {
         votingPowerPercentage,
       };
     }
-  }, [type, dataMetrics, totalSupply, formatTokenAmount, governanceParams, isBlockTimeLoading]);
+  }, [
+    type,
+    dataMetrics,
+    governanceCounts,
+    totalSupply,
+    formatTokenAmount,
+    governanceParams,
+    isBlockTimeLoading,
+  ]);
 
   const explorerUrl = daoConfig?.chain?.explorers?.[0];
 
@@ -279,7 +292,7 @@ export const SystemInfo = ({ type = "default" }: SystemInfoProps) => {
       <SystemInfoItem
         label="Total Delegates"
         value={systemData.totalDelegates ?? 0}
-        isLoading={isProposalMetricsLoading}
+        isLoading={isGovernanceCountsLoading}
       />
     </div>
   );

--- a/packages/web/src/hooks/useGovernanceCounts.ts
+++ b/packages/web/src/hooks/useGovernanceCounts.ts
@@ -1,0 +1,25 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { useDaoConfig } from "@/hooks/useDaoConfig";
+import { proposalService } from "@/services/graphql";
+import { QUERY_CONFIGS } from "@/utils/query-config";
+
+interface GovernanceCountsOptions {
+  enabled?: boolean;
+}
+
+export function useGovernanceCounts(
+  options: GovernanceCountsOptions = {}
+) {
+  const { enabled = true } = options;
+  const daoConfig = useDaoConfig();
+  const endpoint = daoConfig?.indexer?.endpoint ?? "";
+
+  return useQuery({
+    queryKey: ["governanceCounts", endpoint],
+    queryFn: () => proposalService.getGovernanceCounts(endpoint),
+    enabled: enabled && !!endpoint,
+    placeholderData: keepPreviousData,
+    ...QUERY_CONFIGS.DEFAULT,
+  });
+}

--- a/packages/web/src/services/graphql/index.ts
+++ b/packages/web/src/services/graphql/index.ts
@@ -6,6 +6,7 @@ import { request } from "./client";
 import * as Mutations from "./mutations";
 import * as Queries from "./queries";
 import * as Types from "./types";
+import { resolveGovernanceCounts } from "./types/counts";
 
 import type { ProfileData } from "./types/profile";
 import type { EvmAbiResponse, EvmAbiInput } from "./types/proposals";
@@ -94,6 +95,13 @@ export const proposalService = {
       Queries.GET_PROPOSAL_METRICS
     );
     return response?.dataMetrics?.[0] ?? emptyProposalMetrics;
+  },
+  getGovernanceCounts: async (endpoint: string) => {
+    const response = await request<Types.GovernanceCountsResponse>(
+      endpoint,
+      Queries.GET_GOVERNANCE_COUNTS
+    );
+    return resolveGovernanceCounts(response);
   },
 
   getProposalVoteRate: async (endpoint: string, voter: string, limit = 10) => {

--- a/packages/web/src/services/graphql/queries/counts.ts
+++ b/packages/web/src/services/graphql/queries/counts.ts
@@ -1,0 +1,12 @@
+import { gql } from "graphql-request";
+
+export const GET_GOVERNANCE_COUNTS = gql`
+  query GetGovernanceCounts {
+    proposalsConnection(orderBy: id_ASC) {
+      totalCount
+    }
+    contributorsConnection(orderBy: id_ASC) {
+      totalCount
+    }
+  }
+`;

--- a/packages/web/src/services/graphql/queries/index.ts
+++ b/packages/web/src/services/graphql/queries/index.ts
@@ -2,4 +2,5 @@ export * from "./proposals";
 export * from "./delegates";
 export * from "./squidStatus";
 export * from "./contributors";
+export * from "./counts";
 export * from "./treasury";

--- a/packages/web/src/services/graphql/types/counts.ts
+++ b/packages/web/src/services/graphql/types/counts.ts
@@ -1,0 +1,22 @@
+export type CountConnectionItem = {
+  totalCount: number;
+};
+
+export type GovernanceCounts = {
+  proposalsCount: number;
+  delegatesCount: number;
+};
+
+export type GovernanceCountsResponse = {
+  proposalsConnection?: CountConnectionItem | null;
+  contributorsConnection?: CountConnectionItem | null;
+};
+
+export function resolveGovernanceCounts(
+  response?: GovernanceCountsResponse | null
+): GovernanceCounts {
+  return {
+    proposalsCount: response?.proposalsConnection?.totalCount ?? 0,
+    delegatesCount: response?.contributorsConnection?.totalCount ?? 0,
+  };
+}

--- a/packages/web/src/services/graphql/types/index.ts
+++ b/packages/web/src/services/graphql/types/index.ts
@@ -3,5 +3,6 @@ export * from "./delegates";
 export * from "./squidStatus";
 export * from "./profile";
 export * from "./contributors";
+export * from "./counts";
 export * from "./notifications";
 export * from "./treasury";

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- add a dedicated governance counts GraphQL query and shared hook based on `proposalsConnection.totalCount` and `contributorsConnection.totalCount`
- switch the homepage overview, `/proposals`, `/delegates`, and `System Info` delegate count to the stable connection totals instead of `dataMetrics`
- add a regression script for the new count query and align the existing script tests with TypeScript checking

## Root Cause
- the live `https://indexer.degov.ai/seamless-dao/graphql` `dataMetrics` query returns multiple historical rows with null or partial count fields
- the web app was reading `dataMetrics[0]`, which produced stale `0`/`null` counts in UI titles and overview cards

## Testing
- `pnpm exec node --test scripts/delegates-default-sort.test.ts scripts/treasury-fallback.test.ts scripts/governance-counts.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`

## Notes
- no visual layout change; screenshot omitted because this PR only corrects server-backed count values
