### PR TITLE
fix(web): align delegates count display

### DIFF
--- a/packages/web/scripts/delegates-display-format.test.ts
+++ b/packages/web/scripts/delegates-display-format.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const workspaceRoot = path.resolve(import.meta.dirname, "..");
+
+test("delegates summary surfaces use full integer formatting", async () => {
+  const overviewSource = await readFile(
+    path.join(workspaceRoot, "src/app/_components/overview.tsx"),
+    "utf8"
+  );
+  const systemInfoSource = await readFile(
+    path.join(workspaceRoot, "src/components/system-info.tsx"),
+    "utf8"
+  );
+
+  assert.match(
+    overviewSource,
+    /formatInteger\(governanceCounts\?\.delegatesCount \?\? 0, "0"\)/
+  );
+  assert.match(
+    systemInfoSource,
+    /value=\{formatInteger\(systemData\.totalDelegates \?\? 0, "0"\)\}/
+  );
+});
+
+test("delegate formatting regression documents the intended 2700 display", () => {
+  assert.equal(new Intl.NumberFormat().format(2700), "2,700");
+});

--- a/packages/web/src/app/_components/overview.tsx
+++ b/packages/web/src/app/_components/overview.tsx
@@ -7,7 +7,7 @@ import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
 import { useGovernanceCounts } from "@/hooks/useGovernanceCounts";
 import { buildGovernanceScope, proposalService } from "@/services/graphql";
-import { formatNumberForDisplay } from "@/utils/number";
+import { formatInteger, formatNumberForDisplay } from "@/utils/number";
 
 import { OverviewItem } from "./overview-item";
 import { OverviewProposalsSummaryDropdown } from "./overview-proposals-summary";
@@ -73,7 +73,7 @@ export const Overview = () => {
           icon="/assets/image/members-colorful.svg"
           isLoading={isGovernanceCountsLoading}
         >
-          {formatNumberForDisplay(governanceCounts?.delegatesCount ?? 0, 0)[0]}
+          {formatInteger(governanceCounts?.delegatesCount ?? 0, "0")}
         </OverviewItem>
         <OverviewItem
           title="Total Voting Power"

--- a/packages/web/src/components/system-info.tsx
+++ b/packages/web/src/components/system-info.tsx
@@ -13,7 +13,7 @@ import { useGovernanceToken } from "@/hooks/useGovernanceToken";
 import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import { formatShortAddress } from "@/utils/address";
 import { dayjsHumanize } from "@/utils/date";
-import { formatNumberForDisplay } from "@/utils/number";
+import { formatInteger, formatNumberForDisplay } from "@/utils/number";
 
 import { Skeleton } from "./ui/skeleton";
 
@@ -294,7 +294,7 @@ export const SystemInfo = ({ type = "default" }: SystemInfoProps) => {
 
       <SystemInfoItem
         label="Total Delegates"
-        value={systemData.totalDelegates ?? 0}
+        value={formatInteger(systemData.totalDelegates ?? 0, "0")}
         isLoading={isGovernanceCountsLoading}
       />
     </div>


### PR DESCRIPTION
## Summary
- show full integer delegate totals in the homepage overview card
- show the same full integer total in the delegates page System Info card
- add a regression script that locks delegates summary surfaces to integer formatting

## Why
- Seamless DAO currently reports `contributorsConnection.totalCount = 2700`, but the homepage compact formatter rounds that to `3K` while the delegates page title shows `2700`
- keeping delegate totals un-abbreviated avoids conflicting summaries for the same dataset

## Validation
- `cd packages/web && node --experimental-strip-types --test scripts/governance-counts.test.ts scripts/delegates-display-format.test.ts`
- `cd packages/web && pnpm lint`

## Manual QA
- open the homepage delegates card and confirm it shows `2,700`
- click through to `/delegates` and confirm the title and Total Delegates summary also show `2,700`
