### PR TITLE
fix(web): keep compact delegate totals precise

### DIFF
--- a/packages/web/scripts/delegates-display-format.test.ts
+++ b/packages/web/scripts/delegates-display-format.test.ts
@@ -15,20 +15,17 @@ const systemInfoSource = readFileSync(
   "utf8"
 );
 
-test("delegate display helper keeps one decimal of compact precision", () => {
-  assert.match(
-    numberUtilsSource,
-    /export function formatDelegateCountForDisplay\(num: number\): string \{\s+return formatNumberForDisplay\(num, 1\)\[0\];\s+\}/
-  );
+test("delegate display uses shared number formatting without a delegate-specific helper", () => {
+  assert.doesNotMatch(numberUtilsSource, /formatDelegateCountForDisplay/);
 });
 
-test("overview and system info both use the delegate display helper", () => {
+test("overview and system info both use compact number formatting with one decimal for delegates", () => {
   assert.match(
     overviewSource,
-    /formatDelegateCountForDisplay\(governanceCounts\?\.delegatesCount \?\? 0\)/
+    /formatNumberForDisplay\(governanceCounts\?\.delegatesCount \?\? 0, 1\)\[0\]/
   );
   assert.match(
     systemInfoSource,
-    /const totalDelegates = formatDelegateCountForDisplay\(\s*governanceCounts\?\.delegatesCount \?\? 0\s*\)/
+    /const totalDelegates = formatNumberForDisplay\(\s*governanceCounts\?\.delegatesCount \?\? 0,\s*1\s*\)\[0\]/
   );
 });

--- a/packages/web/src/app/_components/overview.tsx
+++ b/packages/web/src/app/_components/overview.tsx
@@ -7,10 +7,7 @@ import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
 import { useGovernanceCounts } from "@/hooks/useGovernanceCounts";
 import { buildGovernanceScope, proposalService } from "@/services/graphql";
-import {
-  formatDelegateCountForDisplay,
-  formatNumberForDisplay,
-} from "@/utils/number";
+import { formatNumberForDisplay } from "@/utils/number";
 
 import { OverviewItem } from "./overview-item";
 import { OverviewProposalsSummaryDropdown } from "./overview-proposals-summary";
@@ -76,7 +73,7 @@ export const Overview = () => {
           icon="/assets/image/members-colorful.svg"
           isLoading={isGovernanceCountsLoading}
         >
-          {formatDelegateCountForDisplay(governanceCounts?.delegatesCount ?? 0)}
+          {formatNumberForDisplay(governanceCounts?.delegatesCount ?? 0, 1)[0]}
         </OverviewItem>
         <OverviewItem
           title="Total Voting Power"

--- a/packages/web/src/components/system-info.tsx
+++ b/packages/web/src/components/system-info.tsx
@@ -13,10 +13,7 @@ import { useGovernanceToken } from "@/hooks/useGovernanceToken";
 import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import { formatShortAddress } from "@/utils/address";
 import { dayjsHumanize } from "@/utils/date";
-import {
-  formatDelegateCountForDisplay,
-  formatNumberForDisplay,
-} from "@/utils/number";
+import { formatNumberForDisplay } from "@/utils/number";
 
 import { Skeleton } from "./ui/skeleton";
 
@@ -159,9 +156,10 @@ export const SystemInfo = ({ type = "default" }: SystemInfoProps) => {
         ? formatTokenAmount(totalSupply)?.formatted ?? "0"
         : "0";
 
-      const totalDelegates = formatDelegateCountForDisplay(
-        governanceCounts?.delegatesCount ?? 0
-      );
+      const totalDelegates = formatNumberForDisplay(
+        governanceCounts?.delegatesCount ?? 0,
+        1
+      )[0];
 
       const votingPowerPercentage =
         dataMetrics?.powerSum && totalSupply

--- a/packages/web/src/utils/number.ts
+++ b/packages/web/src/utils/number.ts
@@ -16,8 +16,8 @@ export function toFixedTrimZeros(num: number, decimals: number): string {
 
 /**
  * Formats a number according to its magnitude, returning both abbreviated and full formats.
- * @param {number} num - The number to format.
- * @param {number} decimals - Number of decimal places
+ * @param {number} num - Raw numeric value before any compact suffixing or locale separator formatting.
+ * @param {number} decimals - Non-negative integer count of fraction digits to keep in both the compact and full display strings.
  * @returns {[string, string]} - An array containing shortFormat and longFormat.
  */
 export function formatNumberForDisplay(
@@ -63,10 +63,6 @@ export function formatBigIntForDisplay(
 ): string {
   const numberValue = Number(formatUnits(value ?? 0n, decimals));
   return formatNumberForDisplay(numberValue)[0];
-}
-
-export function formatDelegateCountForDisplay(num: number): string {
-  return formatNumberForDisplay(num, 1)[0];
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep delegate totals in compact display format with one decimal of precision
- reuse `formatNumberForDisplay(..., 1)` directly in the homepage overview and delegates system info card
- update regression coverage so the approved shared formatter path stays in place

## Testing
- cd packages/web && node --experimental-strip-types --test scripts/governance-counts.test.ts scripts/delegates-display-format.test.ts
- cd packages/web && pnpm lint

## Manual QA Plan
- Open the homepage on a DAO whose delegate total is 2700.
- Confirm the Delegates overview card shows `2.7K` instead of `3K`.
- Click through to `/delegates` and confirm the System Info `Total Delegates` value also shows `2.7K`.
- Confirm the page title still reflects the raw total (`Delegates (2700)`).
