### PR TITLE
fix(indexer): tolerate missing timelock grace period

### DIFF
--- a/packages/indexer/__tests__/chaintool.test.ts
+++ b/packages/indexer/__tests__/chaintool.test.ts
@@ -25,6 +25,24 @@ describe("ChainTool", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("returns undefined when optional contract reads fail through RPC fallback wrapping", async () => {
+    const chainTool = new ChainTool();
+    jest.spyOn(chainTool, "readContract").mockRejectedValue(
+      new Error(
+        'All RPC requests failed for chain 46. Last error: The contract function "GRACE_PERIOD" reverted with the following reason:\nVM Exception while processing transaction: revert',
+      ),
+    );
+
+    await expect(
+      chainTool.readOptionalContract({
+        chainId: 46,
+        contractAddress,
+        abi: [],
+        functionName: "GRACE_PERIOD",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("resolves block-number timepoints to block timestamps in milliseconds", async () => {
     const chainTool = new ChainTool();
     const executeWithFallbacks = jest

--- a/packages/indexer/src/internal/chaintool.ts
+++ b/packages/indexer/src/internal/chaintool.ts
@@ -261,11 +261,13 @@ export class ChainTool {
   }
 
   private isMissingFunctionError(error: any): boolean {
-    const message = `${error?.message ?? ""}`;
+    const message = `${error?.message ?? ""}`.toLowerCase();
     return (
       message.includes("contract function not found") ||
       message.includes("execution reverted") ||
-      message.includes("Function does not exist")
+      message.includes("function does not exist") ||
+      message.includes("reverted with the following reason") ||
+      message.includes("vm exception while processing transaction: revert")
     );
   }
 


### PR DESCRIPTION
## Summary
- broaden `ChainTool.isMissingFunctionError()` to treat wrapped revert messages as missing optional contract functions
- keep `readOptionalContract()` on the recoverable path when `GRACE_PERIOD()` is absent on ringdao's timelock
- add a regression test for the RPC fallback error shape seen in `OHH-70`

## Testing
- `cd packages/indexer && npx -y yarn@1.22.22 test --runTestsByPath __tests__/chaintool.test.ts`
- `cd packages/indexer && just build`

## Context
- Targets `ohh-32-indexer-baseline-upgrade`
- Fixes the ringdao indexer crash-loop caused by treating missing `GRACE_PERIOD()` as a fatal error
