### PR TITLE
test(indexer): lock erc721 governance compatibility

### DIFF
--- a/packages/indexer/__tests__/chaintool.test.ts
+++ b/packages/indexer/__tests__/chaintool.test.ts
@@ -115,6 +115,53 @@ describe("ChainTool", () => {
     ]);
   });
 
+  it("treats ERC721 governor tokens as zero-decimal without calling decimals()", async () => {
+    const chainTool = new ChainTool();
+    const readContractCalls: Array<{
+      functionName: string;
+      args?: readonly unknown[];
+    }> = [];
+
+    jest.spyOn(chainTool, "clockMode").mockResolvedValue(ClockMode.BlockNumber);
+    const executeWithFallbacks = jest
+      .spyOn(chainTool as any, "_executeWithFallbacks")
+      .mockImplementation(async (_options: any, action: any) => {
+        return action({
+          readContract: jest.fn().mockImplementation(async (request) => {
+            readContractCalls.push({
+              functionName: request.functionName,
+              args: request.args,
+            });
+
+            if (request.functionName === "quorum") {
+              return 7n;
+            }
+
+            throw new Error(`Unexpected function: ${request.functionName}`);
+          }),
+        });
+      }) as jest.Mock;
+
+    await expect(
+      chainTool.quorum({
+        chainId: 1,
+        contractAddress,
+        governorTokenAddress,
+        governorTokenStandard: "ERC721",
+        timepoint: 123n,
+      }),
+    ).resolves.toEqual({
+      clockMode: ClockMode.BlockNumber,
+      quorum: 7n,
+      decimals: 0n,
+    });
+
+    expect(executeWithFallbacks).toHaveBeenCalledTimes(1);
+    expect(readContractCalls).toEqual([
+      { functionName: "quorum", args: [123n] },
+    ]);
+  });
+
   it("falls back to latest block when clock is unavailable", async () => {
     const chainTool = new ChainTool();
     jest.spyOn(chainTool, "clockMode").mockResolvedValue(ClockMode.BlockNumber);

--- a/packages/indexer/__tests__/token-vote-power.test.ts
+++ b/packages/indexer/__tests__/token-vote-power.test.ts
@@ -4,6 +4,7 @@ import {
   votePowerTimepointForLog,
 } from "../src/handler/token";
 import * as itokenerc20 from "../src/abi/itokenerc20";
+import * as itokenerc721 from "../src/abi/itokenerc721";
 import { ChainTool, ClockMode } from "../src/internal/chaintool";
 import {
   Contributor,
@@ -519,6 +520,124 @@ describe("token vote power checkpoints", () => {
       store.findEntity(Contributor, "0x0000000000000000000000000000000000000000")
     ).toBeUndefined();
   });
+
+  it("tracks ERC721 transfers as token ids while applying single-vote power deltas", async () => {
+    const store = new MemoryStore([
+      new DataMetric({
+        id: "global",
+        powerSum: 2n,
+      }),
+      new Contributor({
+        id: "0x1111111111111111111111111111111111111111",
+        power: 1n,
+        delegatesCountAll: 1,
+        delegatesCountEffective: 1,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new Contributor({
+        id: "0x2222222222222222222222222222222222222222",
+        power: 1n,
+        delegatesCountAll: 1,
+        delegatesCountEffective: 1,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new Delegate({
+        id: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_0x1111111111111111111111111111111111111111",
+        fromDelegate: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        toDelegate: "0x1111111111111111111111111111111111111111",
+        power: 1n,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new Delegate({
+        id: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb_0x2222222222222222222222222222222222222222",
+        fromDelegate: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        toDelegate: "0x2222222222222222222222222222222222222222",
+        power: 1n,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new DelegateMapping({
+        id: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        from: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        to: "0x1111111111111111111111111111111111111111",
+        power: 1n,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new DelegateMapping({
+        id: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        from: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        to: "0x2222222222222222222222222222222222222222",
+        power: 1n,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+    ]);
+
+    const handler = buildTokenHandler(store, "ERC721");
+
+    jest.spyOn(itokenerc721.events.Transfer, "decode").mockReturnValue({
+      from: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+      to: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+      tokenId: 1234n,
+    } as any);
+
+    await (handler as any).storeTokenTransfer({
+      id: "log-erc721-transfer",
+      address: "0x8888888888888888888888888888888888888888",
+      logIndex: 1,
+      transactionIndex: 1,
+      block: {
+        height: 15,
+        timestamp: 1_700_000_000_000,
+      },
+      transactionHash: "0xerc721-transfer",
+    } as any);
+
+    expect(store.findEntity(TokenTransfer, "log-erc721-transfer")).toMatchObject({
+      from: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+      to: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+      value: 1234n,
+      standard: "erc721",
+      transactionHash: "0xerc721-transfer",
+    });
+    expect(
+      store.findEntity(
+        Delegate,
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_0x1111111111111111111111111111111111111111",
+      ),
+    ).toBeUndefined();
+    expect(
+      store.findEntity(
+        Delegate,
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb_0x2222222222222222222222222222222222222222",
+      ),
+    ).toMatchObject({
+      power: 2n,
+    });
+    expect(
+      store.findEntity(Contributor, "0x1111111111111111111111111111111111111111"),
+    ).toMatchObject({
+      power: 0n,
+      delegatesCountEffective: 0,
+    });
+    expect(
+      store.findEntity(Contributor, "0x2222222222222222222222222222222222222222"),
+    ).toMatchObject({
+      power: 2n,
+      delegatesCountEffective: 1,
+    });
+    expect(store.findEntity(DataMetric, "global")?.powerSum).toBe(2n);
+  });
 });
 
 class MemoryStore {
@@ -561,7 +680,7 @@ class MemoryStore {
   }
 }
 
-function buildTokenHandler(store: MemoryStore) {
+function buildTokenHandler(store: MemoryStore, standard: "ERC20" | "ERC721" = "ERC20") {
   return new TokenHandler(
     {
       store,
@@ -584,14 +703,14 @@ function buildTokenHandler(store: MemoryStore) {
           {
             name: "governorToken",
             address: "0x8888888888888888888888888888888888888888",
-            standard: "ERC20",
+            standard,
           },
         ],
       },
       indexContract: {
         name: "governorToken",
         address: "0x8888888888888888888888888888888888888888",
-        standard: "ERC20",
+        standard,
       },
       chainTool: new ChainTool(),
     }


### PR DESCRIPTION
## Summary
- verify the  refactor branch still preserves historical ERC-721 governance-token behavior
- add a  regression test for ERC-721 governor tokens returning 
- add a  regression test that keeps , stores  as , and applies single-unit vote deltas

## Validation
- yarn install v1.22.22
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.25s.
- yarn run v1.22.22
$ sqd build
Done in 7.40s.
- yarn run v1.22.22
$ jest --runInBand --runTestsByPath __tests__/chaintool.test.ts __tests__/token-vote-power.test.ts
Done in 3.61s.

Refs: OHH-71