### PR TITLE
fix(indexer): short-circuit deterministic governor clock reverts

### DIFF
--- a/packages/indexer/__tests__/chaintool.test.ts
+++ b/packages/indexer/__tests__/chaintool.test.ts
@@ -1,9 +1,84 @@
-import { ChainTool } from "../src/internal/chaintool";
+import { ChainTool, ClockMode } from "../src/internal/chaintool";
 
 describe("Chain Tool Test", () => {
   const chainTool = new ChainTool();
   // Increased timeout to allow for multiple network requests, especially with RPC fallbacks.
   const TEST_TIMEOUT = 1000 * 60 * 5;
+
+  it("stops retrying deterministic contract call failures across RPC fallbacks", async () => {
+    let attempts = 0;
+    const executeWithFallbacks = (chainTool as any)._executeWithFallbacks.bind(
+      chainTool
+    );
+
+    await expect(
+      executeWithFallbacks(
+        {
+          chainId: 999999,
+          rpcs: [
+            "https://rpc-1.example",
+            "https://rpc-2.example",
+            "https://rpc-3.example",
+          ],
+        },
+        async () => {
+          attempts += 1;
+          throw new Error(
+            'The contract function "CLOCK_MODE" reverted.\nDetails: execution reverted'
+          );
+        }
+      )
+    ).rejects.toThrow('The contract function "CLOCK_MODE" reverted.');
+
+    expect(attempts).toBe(1);
+  });
+
+  it("keeps retrying transient RPC failures across fallback endpoints", async () => {
+    let attempts = 0;
+    const executeWithFallbacks = (chainTool as any)._executeWithFallbacks.bind(
+      chainTool
+    );
+
+    await expect(
+      executeWithFallbacks(
+        {
+          chainId: 999999,
+          rpcs: [
+            "https://rpc-1.example",
+            "https://rpc-2.example",
+            "https://rpc-3.example",
+          ],
+        },
+        async () => {
+          attempts += 1;
+          throw new Error(
+            'HTTP request failed.\nStatus: 429\nDetails: "Too many connections. Please try again later."'
+          );
+        }
+      )
+    ).rejects.toThrow("All RPC requests failed for chain 999999.");
+
+    expect(attempts).toBe(3);
+  });
+
+  it("falls back to blocknumber when CLOCK_MODE deterministically reverts", async () => {
+    const deterministicChainTool = new ChainTool();
+
+    (deterministicChainTool as any)._executeWithFallbacks = jest
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          'The contract function "CLOCK_MODE" reverted.\nDetails: execution reverted'
+        )
+      );
+
+    await expect(
+      deterministicChainTool.clockMode({
+        chainId: 1,
+        contractAddress: "0x323A76393544d5ecca80cd6ef2A560C6a395b7E3",
+      })
+    ).resolves.toBe(ClockMode.BlockNumber);
+  });
 
   it(
     "should fetch block intervals and print all results at once",

--- a/packages/indexer/src/internal/chaintool.ts
+++ b/packages/indexer/src/internal/chaintool.ts
@@ -87,6 +87,56 @@ const ABI_FUNCTION_DECIMALS: Abi = [
   },
 ];
 
+const DETERMINISTIC_CONTRACT_ERROR_PATTERNS = [
+  /contract function .* reverted/i,
+  /execution reverted/i,
+  /contract function not found/i,
+  /returned no data/i,
+  /function selector was not recognized/i,
+];
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error ?? "");
+}
+
+function isDeterministicContractCallError(error: unknown): boolean {
+  const message = errorMessage(error);
+  return DETERMINISTIC_CONTRACT_ERROR_PATTERNS.some((pattern) =>
+    pattern.test(message)
+  );
+}
+
+function isClockModeUnavailableError(error: unknown): boolean {
+  const message = errorMessage(error);
+
+  return (
+    message.includes("CLOCK_MODE") &&
+    isDeterministicContractCallError(error)
+  );
+}
+
+function clockModeFallbackReason(error: unknown): string {
+  const message = errorMessage(error);
+
+  if (
+    message.includes("contract function not found") ||
+    message.includes("returned no data") ||
+    message.includes("Function selector was not recognized")
+  ) {
+    return "missing";
+  }
+
+  if (message.includes("reverted") || message.includes("execution reverted")) {
+    return "reverted";
+  }
+
+  return "unavailable";
+}
+
 // --- CHAINTOOL CLASS ---
 
 export class ChainTool {
@@ -242,6 +292,9 @@ export class ChainTool {
         });
         return await action(client);
       } catch (error) {
+        if (isDeterministicContractCallError(error)) {
+          throw error;
+        }
         lastError = error;
         console.warn(
           `[ChainTool] RPC request to ${rpcUrl} failed. Trying next...`
@@ -400,16 +453,11 @@ export class ChainTool {
 
       this.clockModeCache.set(cacheKey, modeToCache);
       return modeToCache;
-    } catch (error: any) {
-      const message = error.message;
-      if (
-        message &&
-        (message.includes("contract function not found") ||
-          message.includes("CLOCK_MODE"))
-      ) {
-        // If the function doesn't exist, it's a blocknumber-based contract. Cache this result.
+    } catch (error) {
+      if (isClockModeUnavailableError(error)) {
+        const reason = clockModeFallbackReason(error);
         console.warn(
-          `CLOCK_MODE function not found for ${options.contractAddress}. Caching as ${ClockMode.BlockNumber}.`
+          `CLOCK_MODE unavailable for ${options.contractAddress} (${reason}). Caching as ${ClockMode.BlockNumber}.`
         );
         this.clockModeCache.set(cacheKey, ClockMode.BlockNumber);
         return ClockMode.BlockNumber;


### PR DESCRIPTION
## Summary
- stop retrying deterministic contract call reverts across fallback RPCs in ChainTool
- keep CLOCK_MODE fallback behavior for legacy governors but log whether the call was missing or reverted
- add regression coverage for deterministic fallback handling and the ENS DAO quorum path

## Validation
- curl -sS -X POST https://ethereum-rpc.publicnode.com -H 'content-type: application/json' --data '{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0x323a76393544d5ecca80cd6ef2a560c6a395b7e3","data":"0x4bf5d7e9"},"latest"]}'
- npx jest __tests__/chaintool.test.ts --runInBand --testNamePattern='stops retrying|keeps retrying|falls back to blocknumber|check quorum'
- npm run codegen && npx tsc -p tsconfig.json --noEmit