### PR TITLE
fix(indexer): short-circuit deterministic governor clock reverts

### DIFF
--- a/packages/indexer/__tests__/chaintool.test.ts
+++ b/packages/indexer/__tests__/chaintool.test.ts
@@ -9,6 +9,83 @@ describe("ChainTool", () => {
     jest.restoreAllMocks();
   });
 
+  it("stops retrying deterministic contract call failures across RPC fallbacks", async () => {
+    const chainTool = new ChainTool();
+    let attempts = 0;
+    const executeWithFallbacks = (chainTool as any)._executeWithFallbacks.bind(
+      chainTool,
+    );
+
+    await expect(
+      executeWithFallbacks(
+        {
+          chainId: 999999,
+          rpcs: [
+            "https://rpc-1.example",
+            "https://rpc-2.example",
+            "https://rpc-3.example",
+          ],
+        },
+        async () => {
+          attempts += 1;
+          throw new Error(
+            'The contract function "CLOCK_MODE" reverted.\nDetails: execution reverted',
+          );
+        },
+      ),
+    ).rejects.toThrow('The contract function "CLOCK_MODE" reverted.');
+
+    expect(attempts).toBe(1);
+  });
+
+  it("keeps retrying transient RPC failures across fallback endpoints", async () => {
+    const chainTool = new ChainTool();
+    let attempts = 0;
+    const executeWithFallbacks = (chainTool as any)._executeWithFallbacks.bind(
+      chainTool,
+    );
+
+    await expect(
+      executeWithFallbacks(
+        {
+          chainId: 999999,
+          rpcs: [
+            "https://rpc-1.example",
+            "https://rpc-2.example",
+            "https://rpc-3.example",
+          ],
+        },
+        async () => {
+          attempts += 1;
+          throw new Error(
+            'HTTP request failed.\nStatus: 429\nDetails: "Too many connections. Please try again later."',
+          );
+        },
+      ),
+    ).rejects.toThrow("All RPC requests failed for chain 999999.");
+
+    expect(attempts).toBe(3);
+  });
+
+  it("falls back to blocknumber when CLOCK_MODE deterministically reverts", async () => {
+    const deterministicChainTool = new ChainTool();
+
+    jest
+      .spyOn(deterministicChainTool as any, "_executeWithFallbacks")
+      .mockRejectedValue(
+        new Error(
+          'The contract function "CLOCK_MODE" reverted.\nDetails: execution reverted',
+        ),
+      );
+
+    await expect(
+      deterministicChainTool.clockMode({
+        chainId: 1,
+        contractAddress: "0x323A76393544d5ecca80cd6ef2A560C6a395b7E3",
+      }),
+    ).resolves.toBe(ClockMode.BlockNumber);
+  });
+
   it("returns undefined for optional contract functions that are not available", async () => {
     const chainTool = new ChainTool();
     jest
@@ -205,6 +282,34 @@ describe("ChainTool", () => {
       clockMode: ClockMode.BlockNumber,
       timepoint: 321n,
       timestampMs: 654_000n,
+    });
+  });
+
+  it("falls back to latest block when clock deterministically reverts", async () => {
+    const chainTool = new ChainTool();
+    jest.spyOn(chainTool, "clockMode").mockResolvedValue(ClockMode.BlockNumber);
+    jest
+      .spyOn(chainTool, "readContract")
+      .mockRejectedValue(new Error('The contract function "clock" reverted.'));
+    jest.spyOn(chainTool as any, "_executeWithFallbacks").mockImplementation(
+      async (_options: any, action: any) =>
+        action({
+          getBlock: jest.fn().mockResolvedValue({
+            number: 987n,
+            timestamp: 111n,
+          }),
+        }),
+    );
+
+    await expect(
+      chainTool.currentClock({
+        chainId: 1,
+        contractAddress,
+      }),
+    ).resolves.toEqual({
+      clockMode: ClockMode.BlockNumber,
+      timepoint: 987n,
+      timestampMs: 111_000n,
     });
   });
 

--- a/packages/indexer/src/internal/chaintool.ts
+++ b/packages/indexer/src/internal/chaintool.ts
@@ -132,6 +132,55 @@ const ABI_FUNCTION_GET_PRIOR_VOTES: Abi = [
   },
 ];
 
+const DETERMINISTIC_CONTRACT_ERROR_PATTERNS = [
+  /contract function .* reverted/i,
+  /execution reverted/i,
+  /contract function not found/i,
+  /returned no data/i,
+  /function selector was not recognized/i,
+];
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error ?? "");
+}
+
+function isDeterministicContractCallError(error: unknown): boolean {
+  const message = errorMessage(error);
+  return DETERMINISTIC_CONTRACT_ERROR_PATTERNS.some((pattern) =>
+    pattern.test(message)
+  );
+}
+
+function isClockModeUnavailableError(error: unknown): boolean {
+  const message = errorMessage(error);
+  return (
+    message.includes("CLOCK_MODE") &&
+    isDeterministicContractCallError(error)
+  );
+}
+
+function clockModeFallbackReason(error: unknown): string {
+  const message = errorMessage(error);
+
+  if (
+    message.includes("contract function not found") ||
+    message.includes("returned no data") ||
+    message.includes("function selector was not recognized")
+  ) {
+    return "clock-mode-function-missing";
+  }
+
+  if (message.includes("reverted") || message.includes("execution reverted")) {
+    return "clock-mode-function-reverted";
+  }
+
+  return "clock-mode-function-unavailable";
+}
+
 // --- CHAINTOOL CLASS ---
 
 export class ChainTool {
@@ -261,10 +310,10 @@ export class ChainTool {
   }
 
   private isMissingFunctionError(error: any): boolean {
-    const message = `${error?.message ?? ""}`.toLowerCase();
+    const message = errorMessage(error).toLowerCase();
     return (
+      isDeterministicContractCallError(error) ||
       message.includes("contract function not found") ||
-      message.includes("execution reverted") ||
       message.includes("function does not exist") ||
       message.includes("reverted with the following reason") ||
       message.includes("vm exception while processing transaction: revert")
@@ -298,6 +347,9 @@ export class ChainTool {
         });
         return await action(client);
       } catch (error) {
+        if (isDeterministicContractCallError(error)) {
+          throw error;
+        }
         lastError = error;
         console.warn(
           DegovIndexerHelpers.formatLogLine("chaintool.rpc retry", {
@@ -476,19 +528,13 @@ export class ChainTool {
 
       this.clockModeCache.set(cacheKey, modeToCache);
       return modeToCache;
-    } catch (error: any) {
-      const message = error.message;
-      if (
-        message &&
-        (message.includes("contract function not found") ||
-          message.includes("CLOCK_MODE"))
-      ) {
-        // If the function doesn't exist, it's a blocknumber-based contract. Cache this result.
+    } catch (error) {
+      if (isClockModeUnavailableError(error)) {
         console.warn(
           DegovIndexerHelpers.formatLogLine("chaintool.clock-mode fallback", {
             chainId: options.chainId,
             contract: options.contractAddress,
-            reason: "clock-mode-function-missing",
+            reason: clockModeFallbackReason(error),
             fallback: ClockMode.BlockNumber,
           })
         );


### PR DESCRIPTION
## Summary
- stop retrying deterministic contract-call reverts across fallback RPCs
- keep ENS DAO clock mode fallback as blocknumber and let clock() fall back to the latest block
- add unit coverage for retry/fallback behavior and revalidate ENS quorum lookup

## Validation
- npx jest __tests__/chaintool.test.ts --runInBand --testNamePattern="stops retrying|keeps retrying|falls back to blocknumber|falls back to latest block when clock is unavailable|falls back to latest block when clock deterministically reverts|queries quorum with the proposal snapshot timepoint"
- npx jest --config jest.integration.config.js __tests__/chaintool.integration.test.ts --runInBand --testNamePattern="check quorum"
- just install
- just codegen
- npx tsc -p tsconfig.json --noEmit
- just build