### PR TITLE
fix(indexer): wire ERC721 quorum test token standard

### DIFF
--- a/packages/indexer/__tests__/chaintool.integration.test.ts
+++ b/packages/indexer/__tests__/chaintool.integration.test.ts
@@ -177,7 +177,7 @@ describe("Chain Tool Test", () => {
               contractAddress: dao.contracts.governor as `0x${string}`,
               governorTokenAddress: dao.contracts.governorToken
                 .address as `0x${string}`,
-              standard: dao.contracts.governorToken.standard as
+              governorTokenStandard: dao.contracts.governorToken.standard as
                 | "ERC20"
                 | "ERC721",
             });


### PR DESCRIPTION
## Summary
- pass `governorTokenStandard` instead of `standard` in the quorum integration test
- keep the fixture data unchanged while aligning the test call with production wiring
- avoid an unnecessary `decimals()` read for the `ring-dao-guild` ERC721 governor token

## Testing
- `cd packages/indexer && npx -y yarn@1.22.22 run test:integration --testNamePattern 'check quorum'`

Refs OHH-73.
