### PR TITLE
ci: run degov indexer unit tests in check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           yarn install
           yarn build
+          yarn test
 
   check-config:
     name: Check Config

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -7,7 +7,8 @@
     "codegen:schema": "npx sqd codegen",
     "codegen": "npm run codegen:abi && npm run codegen:schema",
     "migrate:db": "zx scripts/sqd-migration.mjs",
-    "build": "npm run codegen && rm -rf lib && tsc"
+    "build": "npm run codegen && rm -rf lib && tsc",
+    "test": "jest"
   },
   "dependencies": {
     "@openrouter/ai-sdk-provider": "^0.7.5",


### PR DESCRIPTION
## Summary
- add a standard `test` script for `packages/indexer`
- execute the indexer Jest suite from the existing `check-indexer` GitHub Actions job
- keep the change aligned with the repo's current Yarn-based indexer workflow

## Testing
- `cd packages/indexer && npx --yes yarn@1.22.22 install && npx --yes yarn@1.22.22 build && npx --yes yarn@1.22.22 test`

## Linear
- `OHH-75`
