### PR TITLE
OHH-74 fix(web): restore ENS sync lookup index

### DIFF
--- a/packages/web/prisma/migrations/20260327080000_d_user_sync_lookup_index/migration.sql
+++ b/packages/web/prisma/migrations/20260327080000_d_user_sync_lookup_index/migration.sql
@@ -1,0 +1,2 @@
+-- Restore an indexed lookup for sync/auth queries after the multi-dao migration
+CREATE INDEX "d_user_dao_code_address_idx" ON "d_user"("dao_code", "address");

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -23,6 +23,8 @@ model d_user {
   last_login_time    DateTime
   ctime              DateTime  @default(now())
   utime              DateTime? @updatedAt
+
+  @@index([dao_code, address], map: "d_user_dao_code_address_idx")
 }
 
 model d_avatar {

--- a/packages/web/scripts/degov-sync-index.test.ts
+++ b/packages/web/scripts/degov-sync-index.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const schemaSource = readFileSync(
+  new URL("../prisma/schema.prisma", import.meta.url),
+  "utf8"
+);
+const syncRouteSource = readFileSync(
+  new URL("../src/app/api/degov/sync/route.ts", import.meta.url),
+  "utf8"
+);
+const migrationSource = readFileSync(
+  new URL(
+    "../prisma/migrations/20260327080000_d_user_sync_lookup_index/migration.sql",
+    import.meta.url
+  ),
+  "utf8"
+);
+
+test("sync route keeps the dao-scoped lookup backed by an index", () => {
+  assert.match(
+    syncRouteSource,
+    /update d_user set power = \$\{hexPower\} where address = \$\{address\} and dao_code = \$\{inputDaocode\}/
+  );
+  assert.match(
+    schemaSource,
+    /@@index\(\[dao_code, address\], map: "d_user_dao_code_address_idx"\)/
+  );
+  assert.match(
+    migrationSource,
+    /CREATE INDEX "d_user_dao_code_address_idx" ON "d_user"\("dao_code", "address"\);/
+  );
+});


### PR DESCRIPTION
## Summary
- restore a deployable Prisma index for  so  stops table-scanning during ENS replay
- keep the schema definition aligned with the migration
- add a focused regression test that ties the sync route lookup to the supporting index

## Validation
- cd packages/web && node --experimental-strip-types --test scripts/degov-sync-index.test.ts
- cd packages/web && pnpm install --frozen-lockfile && pnpm build