### PR TITLE
fix(indexer): persist blockInterval for timestamp governors

### DIFF
--- a/packages/indexer/__tests__/governor.test.ts
+++ b/packages/indexer/__tests__/governor.test.ts
@@ -157,3 +157,223 @@ describe("GovernorHandler timelock queue materialization", () => {
     });
   });
 });
+
+describe("GovernorHandler canonical proposal metadata", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function createHandler(chainTool: Record<string, jest.Mock>) {
+    return new GovernorHandler(
+      {
+        store: {
+          findOne: jest.fn(),
+          save: jest.fn(),
+          insert: jest.fn(),
+        },
+        log: {
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
+      } as any,
+      {
+        chainId: 46,
+        rpcs: ["https://rpc.example.invalid"],
+        work: {
+          daoCode: "demo",
+          contracts: [
+            {
+              name: "governor",
+              address: "0x9999999999999999999999999999999999999999",
+            },
+            {
+              name: "governorToken",
+              address: "0x8888888888888888888888888888888888888888",
+              standard: "ERC20",
+            },
+          ],
+        },
+        indexContract: {
+          name: "governor",
+          address: "0x9999999999999999999999999999999999999999",
+        },
+        chainTool: chainTool as any,
+        textPlus: new (class {} as any)(),
+      },
+    );
+  }
+
+  function createProposalCreatedLog() {
+    return {
+      id: "proposal-created-log",
+      block: {
+        height: 100,
+        timestamp: 1_000,
+      },
+      transactionHash: "0xdeadbeef",
+    } as any;
+  }
+
+  function createProposalCreatedEvent() {
+    return {
+      proposalId: 0x1n,
+      description: "Proposal body",
+    } as any;
+  }
+
+  it("persists a chain-average blockInterval for timestamp governors", async () => {
+    const chainTool = {
+      blockIntervalSeconds: jest.fn(async () => 12.5),
+      clockMode: jest.fn(async () => ClockMode.Timestamp),
+      quorum: jest.fn(async () => ({
+        clockMode: ClockMode.Timestamp,
+        quorum: 77n,
+        decimals: 18n,
+      })),
+      readContract: jest.fn(
+        async ({
+          functionName,
+        }: {
+          functionName: string;
+        }) => {
+          switch (functionName) {
+            case "proposalSnapshot":
+              return 1_700_000_000n;
+            case "proposalDeadline":
+              return 1_700_086_400n;
+            case "COUNTING_MODE":
+              return "support=bravo";
+            default:
+              throw new Error(`Unexpected functionName: ${functionName}`);
+          }
+        },
+      ),
+      readOptionalContract: jest.fn(async () => undefined),
+      timepointToTimestampMs: jest.fn(async ({ timepoint }: { timepoint: bigint }) =>
+        timepoint * 1000n,
+      ),
+    };
+    const handler = createHandler(chainTool);
+
+    const metadata = await (handler as any).loadCanonicalProposalMetadata(
+      createProposalCreatedLog(),
+      createProposalCreatedEvent(),
+    );
+
+    expect(metadata).toMatchObject({
+      blockInterval: "12.5",
+      clockMode: ClockMode.Timestamp,
+      countingMode: "support=bravo",
+      decimals: 18n,
+      proposalDeadline: 1_700_086_400n,
+      proposalSnapshot: 1_700_000_000n,
+      quorum: 77n,
+      voteEndTimestamp: 1_700_086_400_000n,
+      voteStartTimestamp: 1_700_000_000_000n,
+    });
+    expect(chainTool.blockIntervalSeconds).toHaveBeenCalledTimes(1);
+  });
+
+  it("derives blockInterval from exact block timestamps when available", async () => {
+    const chainTool = {
+      blockIntervalSeconds: jest.fn(),
+      clockMode: jest.fn(async () => ClockMode.BlockNumber),
+      quorum: jest.fn(async () => ({
+        clockMode: ClockMode.BlockNumber,
+        quorum: 55n,
+        decimals: 18n,
+      })),
+      readContract: jest.fn(
+        async ({
+          functionName,
+        }: {
+          functionName: string;
+        }) => {
+          switch (functionName) {
+            case "proposalSnapshot":
+              return 110n;
+            case "proposalDeadline":
+              return 130n;
+            case "COUNTING_MODE":
+              return "support=bravo";
+            default:
+              throw new Error(`Unexpected functionName: ${functionName}`);
+          }
+        },
+      ),
+      readOptionalContract: jest.fn(async () => undefined),
+      timepointToTimestampMs: jest.fn(
+        async ({ timepoint }: { timepoint: bigint }) => {
+          if (timepoint === 110n) {
+            return 126_000n;
+          }
+          if (timepoint === 130n) {
+            return 376_000n;
+          }
+          throw new Error(`Unexpected timepoint: ${timepoint.toString()}`);
+        },
+      ),
+    };
+    const handler = createHandler(chainTool);
+
+    const metadata = await (handler as any).loadCanonicalProposalMetadata(
+      createProposalCreatedLog(),
+      createProposalCreatedEvent(),
+    );
+
+    expect(metadata).toMatchObject({
+      blockInterval: "12.5",
+      clockMode: ClockMode.BlockNumber,
+      voteStartTimestamp: 126_000n,
+      voteEndTimestamp: 376_000n,
+    });
+    expect(chainTool.blockIntervalSeconds).not.toHaveBeenCalled();
+  });
+
+  it("falls back to chain-average blockInterval when block timestamps are unresolved", async () => {
+    const chainTool = {
+      blockIntervalSeconds: jest.fn(async () => 12.5),
+      clockMode: jest.fn(async () => ClockMode.BlockNumber),
+      quorum: jest.fn(async () => ({
+        clockMode: ClockMode.BlockNumber,
+        quorum: 55n,
+        decimals: 18n,
+      })),
+      readContract: jest.fn(
+        async ({
+          functionName,
+        }: {
+          functionName: string;
+        }) => {
+          switch (functionName) {
+            case "proposalSnapshot":
+              return 110n;
+            case "proposalDeadline":
+              return 130n;
+            case "COUNTING_MODE":
+              return "support=bravo";
+            default:
+              throw new Error(`Unexpected functionName: ${functionName}`);
+          }
+        },
+      ),
+      readOptionalContract: jest.fn(async () => undefined),
+      timepointToTimestampMs: jest.fn(async () => undefined),
+    };
+    const handler = createHandler(chainTool);
+
+    const metadata = await (handler as any).loadCanonicalProposalMetadata(
+      createProposalCreatedLog(),
+      createProposalCreatedEvent(),
+    );
+
+    expect(metadata).toMatchObject({
+      blockInterval: "12.5",
+      clockMode: ClockMode.BlockNumber,
+      voteStartTimestamp: 126_000n,
+      voteEndTimestamp: 376_000n,
+    });
+    expect(chainTool.blockIntervalSeconds).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/indexer/src/handler/governor.ts
+++ b/packages/indexer/src/handler/governor.ts
@@ -510,16 +510,36 @@ export class GovernorHandler {
       clockMode,
     });
 
-    let blockInterval: number | undefined;
+    let blockInterval = resolveProposalBlockInterval({
+      clockMode,
+      proposalVoteStart: proposalSnapshot,
+      proposalVoteEnd: proposalDeadline,
+      exactStartTimestamp,
+      exactEndTimestamp,
+    });
     if (
-      clockMode === ClockMode.BlockNumber &&
-      (exactStartTimestamp === undefined || exactEndTimestamp === undefined)
+      blockInterval === undefined &&
+      (clockMode === ClockMode.Timestamp ||
+        exactStartTimestamp === undefined ||
+        exactEndTimestamp === undefined)
     ) {
-      blockInterval = await chainTool.blockIntervalSeconds({
-        chainId: this.options.chainId,
-        rpcs: this.options.rpcs,
-        enableFloatValue: true,
-      });
+      try {
+        blockInterval = await chainTool.blockIntervalSeconds({
+          chainId: this.options.chainId,
+          rpcs: this.options.rpcs,
+          enableFloatValue: true,
+        });
+      } catch (error) {
+        if (clockMode === ClockMode.Timestamp) {
+          this.ctx.log.warn(
+            `Unable to persist blockInterval for timestamp proposal ${this.stdProposalId(
+              event.proposalId,
+            )}: ${DegovIndexerHelpers.formatError(error)}`,
+          );
+        } else {
+          throw error;
+        }
+      }
     }
 
     const fallbackTimestamps = calculateProposalVoteTimestamp({
@@ -533,9 +553,7 @@ export class GovernorHandler {
 
     return {
       blockInterval:
-        clockMode === ClockMode.BlockNumber && blockInterval !== undefined
-          ? blockInterval.toString()
-          : undefined,
+        blockInterval !== undefined ? blockInterval.toString() : undefined,
       clockMode: qmr.clockMode,
       countingMode,
       decimals: qmr.decimals,
@@ -1339,4 +1357,29 @@ export function calculateProposalVoteTimestamp(options: {
     voteStart: +proposalStartTimestamp,
     voteEnd: +proposalEndTimestamp,
   };
+}
+
+function resolveProposalBlockInterval(options: {
+  clockMode: ClockMode;
+  proposalVoteStart: bigint;
+  proposalVoteEnd: bigint;
+  exactStartTimestamp?: bigint;
+  exactEndTimestamp?: bigint;
+}): number | undefined {
+  if (
+    options.clockMode !== ClockMode.BlockNumber ||
+    options.exactStartTimestamp === undefined ||
+    options.exactEndTimestamp === undefined
+  ) {
+    return undefined;
+  }
+
+  const blockSpan = options.proposalVoteEnd - options.proposalVoteStart;
+  const timestampSpanMs =
+    options.exactEndTimestamp - options.exactStartTimestamp;
+  if (blockSpan <= 0n || timestampSpanMs <= 0n) {
+    return undefined;
+  }
+
+  return Number(timestampSpanMs) / Number(blockSpan) / 1000;
 }


### PR DESCRIPTION
## Summary
- persist `blockInterval` for timestamp-governed proposals instead of leaving it `null`
- derive blocknumber proposal intervals from exact resolved boundary timestamps before falling back to a chain-average interval
- add regression coverage for timestamp, exact blocknumber, and fallback metadata paths

## Why
`seamless-dao` proposals use `clockMode = timestamp`, but downstream consumers still expect `blockInterval` to be populated. The active `ohh-32-indexer-baseline-upgrade` branch only persisted `blockInterval` for `blocknumber` governors, which matches the null production signal from OHH-87.

## Validation
- `cd packages/indexer && npx -y yarn@1.22.22 run test --runTestsByPath __tests__/governor.test.ts __tests__/chaintool.test.ts`
- `cd packages/indexer && just build`
