### PR TITLE
fix(indexer): persist chain blockInterval

### DIFF
--- a/packages/indexer/__tests__/governor.test.ts
+++ b/packages/indexer/__tests__/governor.test.ts
@@ -39,6 +39,180 @@ describe("calculateProposalVoteTimestamp", () => {
   });
 });
 
+describe("GovernorHandler canonical proposal metadata", () => {
+  function createHandler(chainTool: Partial<any>) {
+    return new GovernorHandler(
+      {
+        store: {
+          findOne: jest.fn(async () => undefined),
+          insert: jest.fn(async (entity) => entity),
+          save: jest.fn(async (entity) => entity),
+        },
+        log: {
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
+      } as any,
+      {
+        chainId: 46,
+        rpcs: ["https://rpc.example.invalid"],
+        work: {
+          daoCode: "demo",
+          contracts: [
+            {
+              name: "governor",
+              address: "0x9999999999999999999999999999999999999999",
+            },
+            {
+              name: "governorToken",
+              address: "0x5555555555555555555555555555555555555555",
+              standard: "erc20",
+            },
+          ],
+        },
+        indexContract: {
+          name: "governor",
+          address: "0x9999999999999999999999999999999999999999",
+        },
+        chainTool: chainTool as any,
+        textPlus: new (class {} as any)(),
+      },
+    );
+  }
+
+  function createProposalCreatedEventLog() {
+    return {
+      address: "0x9999999999999999999999999999999999999999",
+      block: {
+        height: 100,
+        timestamp: 1_000,
+      },
+      id: "proposal-created-log",
+      logIndex: 1,
+      transactionHash: "0xdeadbeef",
+      transactionIndex: 0,
+    } as any;
+  }
+
+  function createProposalCreatedEvent() {
+    return {
+      description: "Test proposal",
+      proposalId: 1n,
+    } as any;
+  }
+
+  function createChainTool(options: {
+    clockMode: ClockMode;
+    exactStartTimestamp?: bigint;
+    exactEndTimestamp?: bigint;
+    blockInterval?: number;
+  }) {
+    const readContract = jest.fn(
+      async ({ functionName }: { functionName: string }) => {
+        switch (functionName) {
+          case "proposalSnapshot":
+            return 110n;
+          case "proposalDeadline":
+            return 130n;
+          case "COUNTING_MODE":
+            return "support=bravo";
+          default:
+            throw new Error(`Unexpected functionName: ${functionName}`);
+        }
+      },
+    );
+
+    return {
+      blockIntervalSeconds: jest.fn(async () => options.blockInterval ?? 12.5),
+      clockMode: jest.fn(async () => options.clockMode),
+      quorum: jest.fn(async () => ({
+        clockMode: options.clockMode,
+        quorum: 77n,
+        decimals: 18n,
+      })),
+      readContract,
+      readOptionalContract: jest.fn(async () => undefined),
+      timepointToTimestampMs: jest
+        .fn()
+        .mockResolvedValueOnce(options.exactStartTimestamp)
+        .mockResolvedValueOnce(options.exactEndTimestamp),
+    };
+  }
+
+  it("persists chain-average blockInterval for timestamp governors", async () => {
+    const chainTool = createChainTool({
+      clockMode: ClockMode.Timestamp,
+      exactStartTimestamp: 110_000n,
+      exactEndTimestamp: 130_000n,
+      blockInterval: 12.5,
+    });
+    const handler = createHandler(chainTool);
+
+    const metadata = await (handler as any).loadCanonicalProposalMetadata(
+      createProposalCreatedEventLog(),
+      createProposalCreatedEvent(),
+    );
+
+    expect(metadata).toMatchObject({
+      blockInterval: "12.5",
+      clockMode: ClockMode.Timestamp,
+      voteStartTimestamp: 110_000n,
+      voteEndTimestamp: 130_000n,
+    });
+    expect(chainTool.blockIntervalSeconds).toHaveBeenCalledWith({
+      chainId: 46,
+      rpcs: ["https://rpc.example.invalid"],
+      enableFloatValue: true,
+    });
+  });
+
+  it("persists chain-average blockInterval for blocknumber governors even with exact timestamps", async () => {
+    const chainTool = createChainTool({
+      clockMode: ClockMode.BlockNumber,
+      exactStartTimestamp: 126_000n,
+      exactEndTimestamp: 376_000n,
+      blockInterval: 12.5,
+    });
+    const handler = createHandler(chainTool);
+
+    const metadata = await (handler as any).loadCanonicalProposalMetadata(
+      createProposalCreatedEventLog(),
+      createProposalCreatedEvent(),
+    );
+
+    expect(metadata).toMatchObject({
+      blockInterval: "12.5",
+      clockMode: ClockMode.BlockNumber,
+      voteStartTimestamp: 126_000n,
+      voteEndTimestamp: 376_000n,
+    });
+    expect(chainTool.blockIntervalSeconds).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the chain-average blockInterval for blocknumber fallback timestamps", async () => {
+    const chainTool = createChainTool({
+      clockMode: ClockMode.BlockNumber,
+      exactStartTimestamp: undefined,
+      exactEndTimestamp: undefined,
+      blockInterval: 12.5,
+    });
+    const handler = createHandler(chainTool);
+
+    const metadata = await (handler as any).loadCanonicalProposalMetadata(
+      createProposalCreatedEventLog(),
+      createProposalCreatedEvent(),
+    );
+
+    expect(metadata).toMatchObject({
+      blockInterval: "12.5",
+      voteStartTimestamp: 126_000n,
+      voteEndTimestamp: 376_000n,
+    });
+    expect(chainTool.timepointToTimestampMs).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("GovernorHandler timelock queue materialization", () => {
   afterEach(() => {
     jest.restoreAllMocks();

--- a/packages/indexer/src/handler/governor.ts
+++ b/packages/indexer/src/handler/governor.ts
@@ -510,17 +510,11 @@ export class GovernorHandler {
       clockMode,
     });
 
-    let blockInterval: number | undefined;
-    if (
-      clockMode === ClockMode.BlockNumber &&
-      (exactStartTimestamp === undefined || exactEndTimestamp === undefined)
-    ) {
-      blockInterval = await chainTool.blockIntervalSeconds({
-        chainId: this.options.chainId,
-        rpcs: this.options.rpcs,
-        enableFloatValue: true,
-      });
-    }
+    const blockInterval = await chainTool.blockIntervalSeconds({
+      chainId: this.options.chainId,
+      rpcs: this.options.rpcs,
+      enableFloatValue: true,
+    });
 
     const fallbackTimestamps = calculateProposalVoteTimestamp({
       clockMode,
@@ -532,10 +526,7 @@ export class GovernorHandler {
     });
 
     return {
-      blockInterval:
-        clockMode === ClockMode.BlockNumber && blockInterval !== undefined
-          ? blockInterval.toString()
-          : undefined,
+      blockInterval: blockInterval.toString(),
       clockMode: qmr.clockMode,
       countingMode,
       decimals: qmr.decimals,


### PR DESCRIPTION
## Summary
- persist chain-average `blockInterval` for both `timestamp` and `blocknumber` proposal metadata
- keep exact vote timestamp resolution when block timestamps are available
- add regression tests for timestamp persistence and blocknumber persistence/fallback

Refs OHH-87