### PR TITLE
fix: cap indexer audit issue body length

### DIFF
--- a/.github/workflows/indexer-accuracy-audit.yml
+++ b/.github/workflows/indexer-accuracy-audit.yml
@@ -86,15 +86,15 @@ jobs:
         with:
           script: |
             const fs = require("node:fs");
+            const { buildIssueBody } = require("./packages/indexer/scripts/indexer-accuracy-issue-body");
 
-            const marker = "<!-- indexer-accuracy-audit -->";
             const title = "[Indexer Audit] Data accuracy anomalies";
             const body = fs.readFileSync(
               "packages/indexer/indexer-accuracy-report.md",
               "utf8"
             );
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const issueBody = `${marker}\n${body}\n_Run: ${runUrl}_\n`;
+            const issueBody = buildIssueBody(body, runUrl);
 
             const { owner, repo } = context.repo;
             const { data: issues } = await github.rest.issues.listForRepo({

--- a/packages/indexer/__tests__/indexerAccuracyAudit.test.ts
+++ b/packages/indexer/__tests__/indexerAccuracyAudit.test.ts
@@ -4,6 +4,12 @@ const {
   parseArgs,
   summarizeAudit,
 } = require("../scripts/indexer-accuracy-audit");
+const {
+  buildIssueBody,
+  GITHUB_ISSUE_BODY_MAX_LENGTH,
+  ISSUE_BODY_MARKER,
+  ISSUE_BODY_TRUNCATION_NOTICE,
+} = require("../scripts/indexer-accuracy-issue-body");
 
 describe("indexer accuracy audit", () => {
   const target = {
@@ -172,5 +178,37 @@ describe("indexer accuracy audit", () => {
     expect(options.markdownFile).toBe("report.md");
     expect(options.targetsFile).toMatch(/custom-targets\.json$/);
     expect(options.failOnAnomalies).toBe(true);
+  });
+
+  it("keeps short GitHub issue bodies unchanged", () => {
+    const reportMarkdown = "## Indexer Accuracy Audit\n\n- Total anomalies: 1\n";
+    const runUrl = "https://github.com/ringecosystem/degov/actions/runs/123";
+
+    const body = buildIssueBody(reportMarkdown, runUrl);
+
+    expect(body).toBe(
+      `${ISSUE_BODY_MARKER}\n${reportMarkdown.trimEnd()}\n_Run: ${runUrl}_\n`
+    );
+  });
+
+  it("truncates oversized GitHub issue bodies to the API limit", () => {
+    const reportMarkdown = [
+      "## Indexer Accuracy Audit",
+      "",
+      "### Summary",
+      "",
+      `- Total anomalies: ${2000}`,
+      "",
+      `${"mismatch detail\n".repeat(8000)}`,
+    ].join("\n");
+    const runUrl = "https://github.com/ringecosystem/degov/actions/runs/123";
+
+    const body = buildIssueBody(reportMarkdown, runUrl);
+
+    expect(body.length).toBeLessThanOrEqual(GITHUB_ISSUE_BODY_MAX_LENGTH);
+    expect(body).toContain("## Indexer Accuracy Audit");
+    expect(body).toContain(ISSUE_BODY_TRUNCATION_NOTICE);
+    expect(body).toContain(`_Run: ${runUrl}_`);
+    expect(body.startsWith(`${ISSUE_BODY_MARKER}\n`)).toBe(true);
   });
 });

--- a/packages/indexer/scripts/indexer-accuracy-issue-body.js
+++ b/packages/indexer/scripts/indexer-accuracy-issue-body.js
@@ -1,0 +1,34 @@
+const GITHUB_ISSUE_BODY_MAX_LENGTH = 65536;
+const ISSUE_BODY_MARKER = "<!-- indexer-accuracy-audit -->";
+const ISSUE_BODY_TRUNCATION_NOTICE = [
+  "> Report truncated to fit GitHub issue body limit.",
+  "> See the workflow artifact and job summary for the full report.",
+].join("\n");
+
+function buildIssueBody(reportMarkdown, runUrl, options = {}) {
+  const marker = options.marker ?? ISSUE_BODY_MARKER;
+  const maxLength = options.maxLength ?? GITHUB_ISSUE_BODY_MAX_LENGTH;
+  const normalizedReport = reportMarkdown.trimEnd();
+  const runLine = `_Run: ${runUrl}_`;
+  const fullBody = `${marker}\n${normalizedReport}\n${runLine}\n`;
+
+  if (fullBody.length <= maxLength) {
+    return fullBody;
+  }
+
+  const truncationSuffix = `\n...\n\n${ISSUE_BODY_TRUNCATION_NOTICE}\n\n${runLine}\n`;
+  const availableLength =
+    maxLength - `${marker}\n`.length - truncationSuffix.length;
+  const truncatedReport = normalizedReport
+    .slice(0, Math.max(0, availableLength))
+    .trimEnd();
+
+  return `${marker}\n${truncatedReport}${truncationSuffix}`;
+}
+
+module.exports = {
+  buildIssueBody,
+  GITHUB_ISSUE_BODY_MAX_LENGTH,
+  ISSUE_BODY_MARKER,
+  ISSUE_BODY_TRUNCATION_NOTICE,
+};


### PR DESCRIPTION
## Summary
- cap the indexer accuracy audit GitHub issue body at the GitHub API limit before create/update calls
- keep the full markdown report in artifacts/job summary while truncating the issue body with an explicit notice and run link
- add regression tests for both unchanged short bodies and oversized-body truncation

## Testing
- `cd packages/indexer && npx -y yarn@1.22.22 test indexerAccuracyAudit.test.ts --runInBand`
- local reproduction script: synthetic 1200-mismatch report now produces `issueBodyLength=65536` with truncation notice instead of exceeding the limit

## Issue
- OHH-90
