### PR TITLE
fix: externalize indexer audit issue report

### DIFF
--- a/.github/workflows/indexer-accuracy-audit.yml
+++ b/.github/workflows/indexer-accuracy-audit.yml
@@ -80,21 +80,29 @@ jobs:
         working-directory: packages/indexer
         run: cat indexer-accuracy-report.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Build concise GitHub issue body
+        if: always() && steps.metadata.outputs.has_anomalies == 'true'
+        working-directory: packages/indexer
+        run: |
+          node scripts/indexer-accuracy-issue-body.js \
+            --report-json indexer-accuracy-report.json \
+            --report-markdown indexer-accuracy-report.md \
+            --issue-body-file indexer-accuracy-issue-body.md \
+            --report-url-file indexer-accuracy-report-url.txt \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       - name: Create or update GitHub issue
         if: always() && steps.metadata.outputs.has_anomalies == 'true'
         uses: actions/github-script@v8
         with:
           script: |
             const fs = require("node:fs");
-
-            const marker = "<!-- indexer-accuracy-audit -->";
             const title = "[Indexer Audit] Data accuracy anomalies";
             const body = fs.readFileSync(
-              "packages/indexer/indexer-accuracy-report.md",
+              "packages/indexer/indexer-accuracy-issue-body.md",
               "utf8"
             );
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const issueBody = `${marker}\n${body}\n_Run: ${runUrl}_\n`;
+            const issueBody = body;
 
             const { owner, repo } = context.repo;
             const { data: issues } = await github.rest.issues.listForRepo({

--- a/packages/indexer/__tests__/indexerAccuracyAudit.test.ts
+++ b/packages/indexer/__tests__/indexerAccuracyAudit.test.ts
@@ -4,6 +4,10 @@ const {
   parseArgs,
   summarizeAudit,
 } = require("../scripts/indexer-accuracy-audit");
+const {
+  buildIssueBody,
+  uploadMarkdownReport,
+} = require("../scripts/indexer-accuracy-issue-body");
 
 describe("indexer accuracy audit", () => {
   const target = {
@@ -172,5 +176,183 @@ describe("indexer accuracy audit", () => {
     expect(options.markdownFile).toBe("report.md");
     expect(options.targetsFile).toMatch(/custom-targets\.json$/);
     expect(options.failOnAnomalies).toBe(true);
+  });
+
+  it("builds a concise GitHub issue body with external report links", () => {
+    const report = {
+      generatedAt: "2026-03-30T06:00:00.000Z",
+      summary: {
+        checkedAccounts: 2,
+        matches: 1,
+        mismatches: 1,
+        voteReadErrors: 0,
+        negativeContributors: 0,
+        negativeDelegates: 1,
+        queryErrors: 0,
+        totalAnomalies: 2,
+      },
+      targets: [
+        {
+          code: "ens-dao",
+          name: "ENS",
+          checkedAccounts: 2,
+          limit: 2,
+          matches: 1,
+          mismatches: [
+            {
+              address: "0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5",
+              contributorPower: "963786580523623804032252",
+              detailPower: "149622029144045802445500",
+              detailSource: "token.getVotes",
+              delta: "814164551379578001586752",
+              hint: "index-higher-with-negative-delegates",
+            },
+          ],
+          voteReadErrors: [],
+          negativeContributors: [],
+          negativeDelegates: [
+            {
+              id: "0xaaa_0xbbb",
+              fromDelegate: "0xaaa",
+              toDelegate: "0xbbb",
+              power: "-2",
+              hint: "negative-delegate-power",
+            },
+          ],
+          queryErrors: [],
+          anomalyCount: 2,
+        },
+      ],
+    };
+
+    const issueBody = buildIssueBody({
+      report,
+      reportUrl: "https://paste.rs/abc123",
+      runUrl: "https://github.com/ringecosystem/degov/actions/runs/23730563489",
+    });
+
+    expect(issueBody).toContain("## Indexer accuracy audit detected anomalies");
+    expect(issueBody).toContain(
+      "ENS (`ens-dao`): 2 anomalies; mismatches 1; read errors 0; negative contributors 0; negative delegates 1; query errors 0"
+    );
+    expect(issueBody).toContain(
+      "- Full markdown report: [rendered report](https://paste.rs/abc123.md)"
+    );
+    expect(issueBody).toContain("- Raw markdown: https://paste.rs/abc123");
+    expect(issueBody).not.toContain(
+      "0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5"
+    );
+  });
+
+  it("keeps the GitHub issue body compact when many DAOs have anomalies", () => {
+    const targets = Array.from({ length: 12 }, (_value, index) => ({
+      code: `dao-${index + 1}`,
+      name: `DAO ${index + 1}`,
+      checkedAccounts: 1,
+      limit: 1,
+      matches: 0,
+      mismatches: [{}],
+      voteReadErrors: [],
+      negativeContributors: [],
+      negativeDelegates: [],
+      queryErrors: [],
+      anomalyCount: 1,
+    }));
+    const report = {
+      generatedAt: "2026-03-30T06:00:00.000Z",
+      summary: {
+        checkedAccounts: 12,
+        matches: 0,
+        mismatches: 12,
+        voteReadErrors: 0,
+        negativeContributors: 0,
+        negativeDelegates: 0,
+        queryErrors: 0,
+        totalAnomalies: 12,
+      },
+      targets,
+    };
+
+    const issueBody = buildIssueBody({
+      report,
+      reportUrl: "https://paste.rs/abc123",
+      runUrl: "https://github.com/ringecosystem/degov/actions/runs/23730563489",
+      maxSummaryTargets: 3,
+    });
+
+    expect(issueBody).toContain("DAO 1 (`dao-1`): 1 anomalies");
+    expect(issueBody).toContain("DAO 3 (`dao-3`): 1 anomalies");
+    expect(issueBody).not.toContain("DAO 4 (`dao-4`): 1 anomalies");
+    expect(issueBody).toContain(
+      "9 more DAOs omitted from this summary. See the full report for complete details."
+    );
+  });
+
+  it("uploads markdown reports to the configured paste host", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      status: 201,
+      statusText: "Created",
+      text: async () => "https://paste.rs/abc123\n",
+    });
+
+    await expect(
+      uploadMarkdownReport("# Hello", {
+        fetchImpl,
+        pasteBaseUrl: "https://paste.rs/",
+      })
+    ).resolves.toBe("https://paste.rs/abc123");
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://paste.rs/",
+      expect.objectContaining({
+        method: "POST",
+        body: "# Hello",
+      })
+    );
+  });
+
+  it("falls back to workflow artifacts when report upload fails", () => {
+    const report = {
+      generatedAt: "2026-03-30T06:00:00.000Z",
+      summary: {
+        checkedAccounts: 1,
+        matches: 0,
+        mismatches: 1,
+        voteReadErrors: 0,
+        negativeContributors: 0,
+        negativeDelegates: 0,
+        queryErrors: 0,
+        totalAnomalies: 1,
+      },
+      targets: [
+        {
+          code: "ens-dao",
+          name: "ENS",
+          checkedAccounts: 1,
+          limit: 1,
+          matches: 0,
+          mismatches: [{}],
+          voteReadErrors: [],
+          negativeContributors: [],
+          negativeDelegates: [],
+          queryErrors: [],
+          anomalyCount: 1,
+        },
+      ],
+    };
+
+    const issueBody = buildIssueBody({
+      report,
+      runUrl: "https://github.com/ringecosystem/degov/actions/runs/23730563489",
+      uploadError: "Paste upload failed with HTTP 503 Service Unavailable",
+    });
+
+    expect(issueBody).toContain(
+      "Full markdown report upload was unavailable. Use the workflow run artifacts for the complete report."
+    );
+    expect(issueBody).toContain(
+      "Upload error: Paste upload failed with HTTP 503 Service Unavailable"
+    );
+    expect(issueBody).not.toContain("rendered report");
   });
 });

--- a/packages/indexer/scripts/indexer-accuracy-issue-body.js
+++ b/packages/indexer/scripts/indexer-accuracy-issue-body.js
@@ -1,0 +1,281 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+const DEFAULT_MAX_SUMMARY_TARGETS = 10;
+const DEFAULT_PASTE_BASE_URL = "https://paste.rs/";
+const ISSUE_MARKER = "<!-- indexer-accuracy-audit -->";
+
+function parseArgs(argv) {
+  const options = {
+    issueBodyFile: "",
+    maxSummaryTargets: DEFAULT_MAX_SUMMARY_TARGETS,
+    pasteBaseUrl: DEFAULT_PASTE_BASE_URL,
+    reportJsonFile: "",
+    reportMarkdownFile: "",
+    reportUrlFile: "",
+    runUrl: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!token.startsWith("--")) {
+      continue;
+    }
+
+    const [flag, inlineValue] = token.split("=", 2);
+    const value = inlineValue ?? argv[index + 1];
+
+    switch (flag) {
+      case "--report-json":
+        options.reportJsonFile = value;
+        break;
+      case "--report-markdown":
+        options.reportMarkdownFile = value;
+        break;
+      case "--issue-body-file":
+        options.issueBodyFile = value;
+        break;
+      case "--report-url-file":
+        options.reportUrlFile = value;
+        break;
+      case "--run-url":
+        options.runUrl = value;
+        break;
+      case "--paste-base-url":
+        options.pasteBaseUrl = value.endsWith("/") ? value : `${value}/`;
+        break;
+      case "--max-summary-targets":
+        options.maxSummaryTargets = Number.parseInt(value, 10);
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+
+    if (inlineValue === undefined) {
+      index += 1;
+    }
+  }
+
+  if (!options.reportJsonFile) {
+    throw new Error("--report-json is required");
+  }
+  if (!options.reportMarkdownFile) {
+    throw new Error("--report-markdown is required");
+  }
+  if (!options.issueBodyFile) {
+    throw new Error("--issue-body-file is required");
+  }
+  if (!options.runUrl) {
+    throw new Error("--run-url is required");
+  }
+  if (
+    !Number.isInteger(options.maxSummaryTargets) ||
+    options.maxSummaryTargets <= 0
+  ) {
+    throw new Error("--max-summary-targets must be a positive integer");
+  }
+
+  return options;
+}
+
+function formatTargetSummary(target) {
+  return `- ${target.name} (\`${target.code}\`): ${target.anomalyCount} anomalies; mismatches ${target.mismatches.length}; read errors ${target.voteReadErrors.length}; negative contributors ${target.negativeContributors.length}; negative delegates ${target.negativeDelegates.length}; query errors ${target.queryErrors.length}`;
+}
+
+function sanitizeUploadError(uploadError) {
+  if (!uploadError) {
+    return "";
+  }
+
+  return uploadError.replace(/\s+/g, " ").trim();
+}
+
+function buildIssueBody({
+  report,
+  reportUrl = "",
+  runUrl,
+  uploadError = "",
+  maxSummaryTargets = DEFAULT_MAX_SUMMARY_TARGETS,
+}) {
+  const anomalousTargets = (report.targets ?? []).filter(
+    (target) => target.anomalyCount > 0
+  );
+  const displayedTargets = anomalousTargets.slice(0, maxSummaryTargets);
+  const omittedTargetCount = anomalousTargets.length - displayedTargets.length;
+  const safeUploadError = sanitizeUploadError(uploadError);
+  const lines = [];
+
+  lines.push(ISSUE_MARKER);
+  lines.push("");
+  lines.push("## Indexer accuracy audit detected anomalies");
+  lines.push("");
+  lines.push(`Generated at: ${report.generatedAt}`);
+  lines.push("");
+  lines.push("### Summary");
+  lines.push("");
+  lines.push(`- Checked accounts: ${report.summary.checkedAccounts}`);
+  lines.push(`- Matches: ${report.summary.matches}`);
+  lines.push(`- Vote mismatches: ${report.summary.mismatches}`);
+  lines.push(`- Vote read errors: ${report.summary.voteReadErrors}`);
+  lines.push(
+    `- Negative contributor rows: ${report.summary.negativeContributors}`
+  );
+  lines.push(`- Negative delegate rows: ${report.summary.negativeDelegates}`);
+  lines.push(`- Query errors: ${report.summary.queryErrors}`);
+  lines.push(`- Total anomalies: ${report.summary.totalAnomalies}`);
+
+  if (displayedTargets.length > 0) {
+    lines.push("");
+    lines.push("### Affected DAOs");
+    lines.push("");
+
+    for (const target of displayedTargets) {
+      lines.push(formatTargetSummary(target));
+    }
+
+    if (omittedTargetCount > 0) {
+      lines.push(
+        `- ${omittedTargetCount} more DAOs omitted from this summary. See the full report for complete details.`
+      );
+    }
+  }
+
+  lines.push("");
+  lines.push("### Details");
+  lines.push("");
+
+  if (reportUrl) {
+    lines.push(`- Full markdown report: [rendered report](${reportUrl}.md)`);
+    lines.push(`- Raw markdown: ${reportUrl}`);
+  } else {
+    lines.push(
+      "- Full markdown report upload was unavailable. Use the workflow run artifacts for the complete report."
+    );
+
+    if (safeUploadError) {
+      lines.push(`- Upload error: ${safeUploadError}`);
+    }
+  }
+
+  lines.push("- Artifact bundle: available on the workflow run page");
+  lines.push(`- Workflow run: ${runUrl}`);
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function uploadMarkdownReport(
+  markdown,
+  {
+    fetchImpl = global.fetch,
+    pasteBaseUrl = DEFAULT_PASTE_BASE_URL,
+  } = {}
+) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("A fetch implementation is required to upload the report");
+  }
+
+  const response = await fetchImpl(pasteBaseUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "text/markdown; charset=utf-8",
+      "user-agent": "ringecosystem-degov-indexer-accuracy-audit",
+    },
+    body: markdown,
+  });
+  const responseBody = (await response.text()).trim();
+
+  if (response.status === 201) {
+    if (!responseBody) {
+      throw new Error("Paste upload succeeded without returning a report URL");
+    }
+
+    return responseBody;
+  }
+
+  if (response.status === 206) {
+    throw new Error("Paste upload was truncated by the host (HTTP 206)");
+  }
+
+  const suffix = responseBody ? `: ${responseBody}` : "";
+  throw new Error(
+    `Paste upload failed with HTTP ${response.status} ${response.statusText}${suffix}`.trim()
+  );
+}
+
+async function writeFileIfNeeded(filePath, content) {
+  if (!filePath) {
+    return;
+  }
+
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, content, "utf8");
+}
+
+async function main(
+  argv = process.argv.slice(2),
+  { fetchImpl = global.fetch } = {}
+) {
+  const options = parseArgs(argv);
+  const reportJsonPath = path.resolve(process.cwd(), options.reportJsonFile);
+  const reportMarkdownPath = path.resolve(
+    process.cwd(),
+    options.reportMarkdownFile
+  );
+  const report = JSON.parse(await fs.readFile(reportJsonPath, "utf8"));
+  const markdown = await fs.readFile(reportMarkdownPath, "utf8");
+  let reportUrl = "";
+  let uploadError = "";
+
+  try {
+    reportUrl = await uploadMarkdownReport(markdown, {
+      fetchImpl,
+      pasteBaseUrl: options.pasteBaseUrl,
+    });
+  } catch (error) {
+    uploadError = error?.message ?? String(error);
+  }
+
+  const issueBody = buildIssueBody({
+    report,
+    reportUrl,
+    runUrl: options.runUrl,
+    uploadError,
+    maxSummaryTargets: options.maxSummaryTargets,
+  });
+
+  await writeFileIfNeeded(options.issueBodyFile, issueBody);
+  await writeFileIfNeeded(
+    options.reportUrlFile,
+    reportUrl ? `${reportUrl}\n` : ""
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        hasAnomalies: report.summary.totalAnomalies > 0,
+        issueBodyLength: issueBody.length,
+        reportUrl: reportUrl || null,
+        uploadError: uploadError || null,
+      },
+      null,
+      2
+    )
+  );
+}
+
+module.exports = {
+  buildIssueBody,
+  formatTargetSummary,
+  main,
+  parseArgs,
+  uploadMarkdownReport,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- upload the full indexer audit markdown report to paste.rs and keep the GitHub issue body concise
- fall back to workflow artifacts if the external upload is unavailable so issue publication still succeeds
- add regression coverage for concise body generation and report upload handling

## Testing
- npx -y yarn@1.22.22 test indexerAccuracyAudit.test.ts --runInBand
- synthetic long-report smoke via packages/indexer/scripts/indexer-accuracy-issue-body.js (issueBodyLength=722, paste upload HTTP 201)

Linear-Issue: OHH-90