### PR TITLE
OHH-91: stop failing indexer accuracy audit workflow on anomalies

### DIFF
--- a/.github/workflows/indexer-accuracy-audit.yml
+++ b/.github/workflows/indexer-accuracy-audit.yml
@@ -34,14 +34,12 @@ jobs:
 
       - name: Run accuracy audit
         id: audit
-        continue-on-error: true
         working-directory: packages/indexer
         run: |
           node scripts/indexer-accuracy-audit.js \
             --limit 200 \
             --json-file indexer-accuracy-report.json \
-            --markdown-file indexer-accuracy-report.md \
-            --fail-on-anomalies
+            --markdown-file indexer-accuracy-report.md
 
       - name: Read report metadata
         id: metadata
@@ -131,9 +129,3 @@ jobs:
                 body: issueBody,
               });
             }
-
-      - name: Fail workflow when anomalies are present
-        if: steps.audit.outcome == 'failure'
-        run: |
-          echo "Indexer accuracy audit detected anomalies."
-          exit 1


### PR DESCRIPTION
## Summary
- stop the indexer accuracy audit workflow from failing the job when anomalies are detected
- keep anomaly reporting intact by continuing to upload artifacts and create or update the GitHub issue
- leave real script/runtime failures as red workflow runs

## Root Cause
- the linked job failed by design because the workflow ran the audit in `--fail-on-anomalies` mode and then explicitly exited 1 when anomalies were present
- that made expected anomaly reports look like broken CI execution instead of monitoring output

## Validation
- `cd packages/indexer && npm test -- --runInBand __tests__/indexerAccuracyAudit.test.ts`
- `cd packages/indexer && node scripts/indexer-accuracy-audit.js --limit 200 --json-file /tmp/ohh-91-indexer-accuracy-report.json --markdown-file /tmp/ohh-91-indexer-accuracy-report.md --fail-on-anomalies`
- `cd packages/indexer && node scripts/indexer-accuracy-audit.js --limit 200 --json-file /tmp/ohh-91-indexer-accuracy-report-postfix.json --markdown-file /tmp/ohh-91-indexer-accuracy-report-postfix.md`
- `cd packages/indexer && node -e "const fs=require('fs'); const YAML=require('./node_modules/yaml'); YAML.parse(fs.readFileSync('../../.github/workflows/indexer-accuracy-audit.yml','utf8')); console.log('ok');"`
