### PR TITLE
Cap indexer audit report scope per target

### DIFF
--- a/.github/workflows/indexer-accuracy-audit.yml
+++ b/.github/workflows/indexer-accuracy-audit.yml
@@ -36,8 +36,20 @@ jobs:
         id: audit
         working-directory: packages/indexer
         run: |
+          cat <<'YAML' > indexer-accuracy-audit-config.yml
+          - name: ens-dao
+            indexer: https://indexer.degov.ai/ens-dao/graphql
+            limit: 100
+          - name: seamless-dao
+            indexer: https://indexer.degov.ai/seamless-dao/graphql
+            limit: 100
+          - name: ring-dao
+            indexer: https://indexer.degov.ai/ring-dao/graphql
+            limit: 100
+          YAML
+
           node scripts/indexer-accuracy-audit.js \
-            --limit 200 \
+            --audit-config-file indexer-accuracy-audit-config.yml \
             --json-file indexer-accuracy-report.json \
             --markdown-file indexer-accuracy-report.md
 

--- a/packages/indexer/__tests__/indexerAccuracyAudit.test.ts
+++ b/packages/indexer/__tests__/indexerAccuracyAudit.test.ts
@@ -1,9 +1,14 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
 const {
   auditTarget,
   buildMarkdownReport,
   compactAmount,
   fetchNegativeRows,
   fetchTopContributors,
+  loadTargets,
   parseArgs,
   summarizeAudit,
 } = require("../scripts/indexer-accuracy-audit");
@@ -158,6 +163,8 @@ describe("indexer accuracy audit", () => {
 
   it("parses CLI flags for report output and strict mode", () => {
     const options = parseArgs([
+      "--audit-config-file",
+      "workflow-targets.yml",
       "--limit",
       "50",
       "--negative-limit=25",
@@ -172,6 +179,7 @@ describe("indexer accuracy audit", () => {
       "--fail-on-anomalies",
     ]);
 
+    expect(options.auditConfigFile).toMatch(/workflow-targets\.yml$/);
     expect(options.limit).toBe(50);
     expect(options.negativeLimit).toBe(25);
     expect(options.concurrency).toBe(4);
@@ -185,7 +193,7 @@ describe("indexer accuracy audit", () => {
     expect(compactAmount("-1", 18)).toBe("-0");
   });
 
-  it("paginates contributors until the full set is fetched", async () => {
+  it("queries contributors with the requested cap", async () => {
     const originalFetch = global.fetch;
     const fetchMock = jest
       .fn()
@@ -196,15 +204,8 @@ describe("indexer accuracy audit", () => {
             contributors: [
               { id: "0x1", power: "100" },
               { id: "0x2", power: "90" },
+              { id: "0x3", power: "80" },
             ],
-          },
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: {
-            contributors: [{ id: "0x3", power: "80" }],
           },
         }),
       });
@@ -215,7 +216,7 @@ describe("indexer accuracy audit", () => {
         {
           indexerEndpoint: "https://indexer.example/graphql",
         },
-        2
+        3
       )
     ).resolves.toEqual([
       { id: "0x1", power: "100" },
@@ -223,20 +224,16 @@ describe("indexer accuracy audit", () => {
       { id: "0x3", power: "80" },
     ]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(JSON.parse(fetchMock.mock.calls[0][1].body).variables).toEqual({
-      limit: 2,
+      limit: 3,
       offset: 0,
-    });
-    expect(JSON.parse(fetchMock.mock.calls[1][1].body).variables).toEqual({
-      limit: 2,
-      offset: 2,
     });
 
     global.fetch = originalFetch;
   });
 
-  it("paginates negative rows until contributors and delegates are exhausted", async () => {
+  it("queries negative rows with the requested cap", async () => {
     const originalFetch = global.fetch;
     const fetchMock = jest
       .fn()
@@ -247,6 +244,7 @@ describe("indexer accuracy audit", () => {
             contributors: [
               { id: "0xdead", power: "-1" },
               { id: "0xbeef", power: "-2" },
+              { id: "0xcafe", power: "-6" },
             ],
             delegates: [
               {
@@ -261,16 +259,6 @@ describe("indexer accuracy audit", () => {
                 toDelegate: "0x4",
                 power: "-4",
               },
-            ],
-          },
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: {
-            contributors: [],
-            delegates: [
               {
                 id: "0x5_0x6",
                 fromDelegate: "0x5",
@@ -288,12 +276,13 @@ describe("indexer accuracy audit", () => {
         {
           indexerEndpoint: "https://indexer.example/graphql",
         },
-        2
+        3
       )
     ).resolves.toEqual({
       contributors: [
         { id: "0xdead", power: "-1" },
         { id: "0xbeef", power: "-2" },
+        { id: "0xcafe", power: "-6" },
       ],
       delegates: [
         {
@@ -317,7 +306,57 @@ describe("indexer accuracy audit", () => {
       ],
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).variables).toEqual({
+      limit: 3,
+      offset: 0,
+    });
+
     global.fetch = originalFetch;
+  });
+
+  it("loads workflow-configured targets with per-indexer caps", async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "indexer-accuracy-audit-")
+    );
+    const targetsFile = path.join(tempDir, "targets.json");
+    const auditConfigFile = path.join(tempDir, "audit-targets.yml");
+
+    fs.writeFileSync(
+      targetsFile,
+      JSON.stringify([
+        {
+          code: "ring-dao",
+          name: "RingDAO",
+          indexerEndpoint: "https://indexer.degov.ai/ring-dao/graphql",
+          rpcUrl: "https://rpc.darwinia.network",
+          governorToken: "0xdafa555e2785DC8834F4Ea9D1ED88B6049142999",
+          governor: "0x52cDD25f7C83c335236Ce209fA1ec8e197E96533",
+        },
+      ])
+    );
+    fs.writeFileSync(
+      auditConfigFile,
+      [
+        "- name: ring-dao",
+        "  indexer: https://indexer.degov.ai/ring-dao.graphql",
+        "  limit: 50",
+      ].join("\n")
+    );
+
+    await expect(loadTargets(targetsFile, auditConfigFile)).resolves.toEqual([
+      {
+        code: "ring-dao",
+        name: "RingDAO",
+        indexerEndpoint: "https://indexer.degov.ai/ring-dao.graphql",
+        rpcUrl: "https://rpc.darwinia.network",
+        governorToken: "0xdafa555e2785DC8834F4Ea9D1ED88B6049142999",
+        governor: "0x52cDD25f7C83c335236Ce209fA1ec8e197E96533",
+        tokenDecimals: 18,
+        limit: 50,
+        negativeLimit: 50,
+      },
+    ]);
   });
 
   it("builds a concise GitHub issue body with external report links", () => {

--- a/packages/indexer/scripts/indexer-accuracy-audit.js
+++ b/packages/indexer/scripts/indexer-accuracy-audit.js
@@ -1,5 +1,6 @@
 const fs = require("node:fs/promises");
 const path = require("node:path");
+const YAML = require("yaml");
 const {
   createPublicClient,
   formatUnits,
@@ -43,6 +44,7 @@ const GOVERNOR_ABI = parseAbi([
 ]);
 
 const DEFAULT_OPTIONS = {
+  auditConfigFile: "",
   concurrency: 10,
   failOnAnomalies: false,
   jsonFile: "",
@@ -72,6 +74,9 @@ function parseArgs(argv) {
     const expectsValue = inlineValue === undefined;
 
     switch (flag) {
+      case "--audit-config-file":
+        options.auditConfigFile = path.resolve(process.cwd(), value);
+        break;
       case "--limit":
         options.limit = Number.parseInt(value, 10);
         break;
@@ -118,18 +123,103 @@ function parseArgs(argv) {
   return options;
 }
 
-async function loadTargets(targetsFile) {
+function parseStructuredFile(raw, filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".yaml" || extension === ".yml") {
+    return YAML.parse(raw);
+  }
+
+  return JSON.parse(raw);
+}
+
+function parseOptionalPositiveInt(value, fieldName) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${fieldName} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
+function normalizeTarget(target) {
+  return {
+    tokenDecimals: 18,
+    ...target,
+  };
+}
+
+function resolveConfiguredTarget(baseTargets, configuredTarget) {
+  const targetCode = configuredTarget.code ?? configuredTarget.name;
+  const configuredIndexer =
+    configuredTarget.indexerEndpoint ?? configuredTarget.indexer;
+  const baseTarget = baseTargets.find((target) => {
+    if (targetCode && target.code === targetCode) {
+      return true;
+    }
+
+    if (!targetCode && configuredIndexer) {
+      return target.indexerEndpoint === configuredIndexer;
+    }
+
+    return false;
+  });
+
+  if (!baseTarget) {
+    throw new Error(
+      `Unknown audit target: ${targetCode ?? configuredIndexer ?? "unknown"}`
+    );
+  }
+
+  const limit = parseOptionalPositiveInt(configuredTarget.limit, "limit");
+  const negativeLimit = parseOptionalPositiveInt(
+    configuredTarget.negativeLimit,
+    "negativeLimit"
+  );
+
+  return {
+    ...baseTarget,
+    ...(configuredIndexer
+      ? {
+          indexerEndpoint: configuredIndexer,
+        }
+      : {}),
+    ...(limit !== undefined ? { limit } : {}),
+    ...(negativeLimit !== undefined
+      ? { negativeLimit }
+      : limit !== undefined
+        ? { negativeLimit: limit }
+        : {}),
+  };
+}
+
+async function loadTargets(targetsFile, auditConfigFile = "") {
   const raw = await fs.readFile(targetsFile, "utf8");
-  const targets = JSON.parse(raw);
+  const targets = parseStructuredFile(raw, targetsFile);
 
   if (!Array.isArray(targets) || targets.length === 0) {
     throw new Error("Targets file must contain a non-empty array");
   }
 
-  return targets.map((target) => ({
-    tokenDecimals: 18,
-    ...target,
-  }));
+  const baseTargets = targets.map(normalizeTarget);
+
+  if (!auditConfigFile) {
+    return baseTargets;
+  }
+
+  const auditConfigRaw = await fs.readFile(auditConfigFile, "utf8");
+  const auditConfig = parseStructuredFile(auditConfigRaw, auditConfigFile);
+
+  if (!Array.isArray(auditConfig) || auditConfig.length === 0) {
+    throw new Error("Audit config file must contain a non-empty array");
+  }
+
+  return auditConfig.map((configuredTarget) =>
+    resolveConfiguredTarget(baseTargets, configuredTarget)
+  );
 }
 
 async function graphqlRequest(endpoint, query, variables = {}) {
@@ -163,52 +253,26 @@ async function graphqlRequest(endpoint, query, variables = {}) {
 }
 
 async function fetchTopContributors(target, limit) {
-  const contributors = [];
-  let offset = 0;
+  const data = await graphqlRequest(
+    target.indexerEndpoint,
+    TOP_CONTRIBUTORS_QUERY,
+    { limit, offset: 0 }
+  );
 
-  while (true) {
-    const data = await graphqlRequest(
-      target.indexerEndpoint,
-      TOP_CONTRIBUTORS_QUERY,
-      { limit, offset }
-    );
-    const page = data.contributors ?? [];
-    contributors.push(...page);
-
-    if (page.length < limit) {
-      break;
-    }
-
-    offset += limit;
-  }
-
-  return contributors;
+  return data.contributors ?? [];
 }
 
 async function fetchNegativeRows(target, limit) {
-  const contributors = [];
-  const delegates = [];
-  let offset = 0;
+  const data = await graphqlRequest(
+    target.indexerEndpoint,
+    NEGATIVE_ROWS_QUERY,
+    { limit, offset: 0 }
+  );
 
-  while (true) {
-    const data = await graphqlRequest(
-      target.indexerEndpoint,
-      NEGATIVE_ROWS_QUERY,
-      { limit, offset }
-    );
-    const contributorPage = data.contributors ?? [];
-    const delegatePage = data.delegates ?? [];
-    contributors.push(...contributorPage);
-    delegates.push(...delegatePage);
-
-    if (contributorPage.length < limit && delegatePage.length < limit) {
-      break;
-    }
-
-    offset += limit;
-  }
-
-  return { contributors, delegates };
+  return {
+    contributors: data.contributors ?? [],
+    delegates: data.delegates ?? [],
+  };
 }
 
 function createClient(target) {
@@ -362,12 +426,15 @@ async function auditTarget(target, options, services = {}) {
     services.fetchTopContributors ?? fetchTopContributors;
   const fetchNegatives = services.fetchNegativeRows ?? fetchNegativeRows;
   const readVotes = services.readCurrentVotes ?? readCurrentVotes;
+  const contributorLimit = target.limit ?? options.limit;
+  const negativeLimit =
+    target.negativeLimit ?? target.limit ?? options.negativeLimit;
 
-  const result = createTargetSkeleton(target, options.limit);
+  const result = createTargetSkeleton(target, contributorLimit);
 
   const [contributorsResult, negativesResult] = await Promise.allSettled([
-    fetchContributors(target, options.limit),
-    fetchNegatives(target, options.negativeLimit),
+    fetchContributors(target, contributorLimit),
+    fetchNegatives(target, negativeLimit),
   ]);
 
   if (contributorsResult.status === "rejected") {
@@ -647,7 +714,10 @@ function printConsoleSummary(report) {
 
 async function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
-  const targets = await loadTargets(options.targetsFile);
+  const targets = await loadTargets(
+    options.targetsFile,
+    options.auditConfigFile
+  );
   const report = await runAudit(targets, options);
   const markdown = buildMarkdownReport(report, targets);
 


### PR DESCRIPTION
## Summary
- move the audit target selection and per-indexer row caps into the workflow job
- let the audit script merge workflow overrides onto the base target metadata and honor target-specific limits
- add regression coverage for capped queries and workflow-driven target selection

## Testing
- `cd packages/indexer && yarn test --runInBand --runTestsByPath __tests__/indexerAccuracyAudit.test.ts`

## Linear
- OHH-93
