### PR TITLE
fix(web): preserve existing routes without locale prefix

### DIFF
--- a/packages/web/src/i18n/routing.ts
+++ b/packages/web/src/i18n/routing.ts
@@ -3,7 +3,7 @@ import { defineRouting } from "next-intl/routing";
 export const routing = defineRouting({
   locales: ["en"],
   defaultLocale: "en",
-  localePrefix: "always",
+  localePrefix: "never",
 });
 
 export type AppLocale = (typeof routing.locales)[number];


### PR DESCRIPTION
## Summary
- switch the web app's `next-intl` routing mode from always-prefixed paths to never-prefixed paths
- preserve the existing DAO pathname structure so loading `/` no longer surfaces `/en` in the browser URL
- keep the existing shared navigation and message-loading flow intact for the current `en` locale setup

## Problem
- the language-pack split introduced locale-prefixed routing in the web app
- that changed deployed DAO URLs and risked breaking relative asset/resource paths that assume the original route structure

## Validation
- `pnpm lint`
- `pnpm build`
- start the built app locally and request `/`; verified `200 OK` with no redirect response to `/en`
- fetched the rendered `/` HTML and confirmed it did not emit `/en` route hrefs
