### PR TITLE
Install build dependencies for node-gyp

### DIFF
--- a/docker/indexer.Dockerfile
+++ b/docker/indexer.Dockerfile
@@ -2,6 +2,13 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+# Install build dependencies for node-gyp
+RUN apk add --no-cache \
+    python3 \
+    make \
+    g++ \
+    libc6-compat
+
 ARG S6_OVERLAY_VERSION=3.2.1.0
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp


### PR DESCRIPTION
Added build dependencies for node-gyp to Dockerfile to fix error on build

```bash
 => ERROR [indexer 9/9] RUN npm i -g @subsquid/cli   && yarn install   && yarn build   && yarn cache clean   && npm cache clean --force                        58.5s
------
 > [indexer 9/9] RUN npm i -g @subsquid/cli   && yarn install   && yarn build   && yarn cache clean   && npm cache clean --force:
23.70 npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
26.79 
26.79 added 342 packages in 27s
26.79 
26.79 72 packages are looking for funding
26.79   run `npm fund` for details
26.79 npm notice
26.79 npm notice New major version of npm available! 10.9.7 -> 11.12.1
26.79 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.12.1
26.79 npm notice To update run: npm install -g npm@11.12.1
26.79 npm notice
27.05 yarn install v1.22.22
27.15 [1/4] Resolving packages...
27.50 [2/4] Fetching packages...
48.92 [3/4] Linking dependencies...
48.93 warning " > @subsquid/typeorm-store@1.5.1" has unmet peer dependency "@subsquid/big-decimal@^1.0.0".
48.93 warning "ai > @ai-sdk/react@1.2.12" has unmet peer dependency "react@^18 || ^19 || ^19.0.0-rc".
48.93 warning "ai > @ai-sdk/react > swr@2.3.6" has unmet peer dependency "react@^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0".
48.93 warning "ai > @ai-sdk/react > swr > use-sync-external-store@1.5.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0".
57.23 [4/4] Building fresh packages...
57.74 error /app/node_modules/bufferutil: Command failed.
57.74 Exit code: 1
57.74 Command: node-gyp-build
57.74 Arguments: 
57.74 Directory: /app/node_modules/bufferutil
57.74 Output:
57.74 gyp info it worked if it ends with ok
57.74 gyp info using node-gyp@11.5.0
57.74 gyp info using node@22.22.2 | linux | arm64
57.74 gyp ERR! find Python 
57.74 gyp ERR! find Python Python is not set from command line or npm configuration
57.74 gyp ERR! find Python Python is not set from environment variable PYTHON
57.74 gyp ERR! find Python checking if "python3" can be used
57.74 gyp ERR! find Python - executable path is ""
57.74 gyp ERR! find Python - "" could not be run
57.74 gyp ERR! find Python checking if "python" can be used
57.74 gyp ERR! find Python - executable path is ""
57.74 gyp ERR! find Python - "" could not be run
57.74 gyp ERR! find Python 
57.74 gyp ERR! find Python **********************************************************
57.74 gyp ERR! find Python You need to install the latest version of Python.
57.74 gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
57.74 gyp ERR! find Python you can try one of the following options:
57.74 gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
57.74 gyp ERR! find Python (accepted by both node-gyp and npm)
57.74 gyp ERR! find Python - Set the environment variable PYTHON
57.74 gyp ERR! find Python - Set the npm configuration variable python:
57.74 gyp ERR! find Python npm config set python "/path/to/pythonexecutable"
57.74 gyp ERR! find Python For more information consult the documentation at:
57.74 gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
57.74 gyp ERR! find Python **********************************************************
57.74 gyp ERR! find Python 
57.74 gyp ERR! configure error 
57.74 gyp ERR! stack Error: Could not find any Python installation to use
57.74 gyp ERR! stack at PythonFinder.fail (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:306:11)
57.74 gyp ERR! stack at PythonFinder.findPython (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:164:17)
57.74 gyp ERR! stack at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
57.74 gyp ERR! stack at async configure (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:27:18)
57.74 gyp ERR! stack at async run (/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js:81:18)
57.74 gyp ERR! System Linux 6.12.76-linuxkit
57.74 gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
57.74 gyp ERR! cwd /app/node_modules/bufferutil
57.74 gyp ERR! node -v v22.22.2
57.74 gyp ERR! node-gyp -v v11.5.0
[+] up 0/2ERR! not ok
 ⠸ Image degov-web     Building                                                                                                                                 66.6s
 ⠸ Image degov-indexer Building                                                                                                                                 66.6s
indexer.Dockerfile:15
--------------------
  14 |     
  15 | >>> RUN npm i -g @subsquid/cli \
  16 | >>>   && yarn install \
  17 | >>>   && yarn build \
  18 | >>>   && yarn cache clean \
  19 | >>>   && npm cache clean --force
  20 |     
--------------------
target indexer: failed to solve: process "/bin/sh -c npm i -g @subsquid/cli   && yarn install   && yarn build   && yarn cache clean   && npm cache clean --force" did not complete successfully: exit code: 1
```