### PR TITLE
fix: prevent unlock indexer quorum future-checkpoint crash

### DIFF
--- a/packages/indexer/__tests__/unit/chaintool.test.ts
+++ b/packages/indexer/__tests__/unit/chaintool.test.ts
@@ -452,7 +452,7 @@ describe("ChainTool", () => {
 
     expect(readContractCalls).toEqual([
       { functionName: "quorum", args: [1_200n] },
-      { functionName: "quorum", args: [999n] },
+      { functionName: "quorum", args: [820n] },
       { functionName: "decimals", args: undefined },
     ]);
     expect(currentClockSpy).toHaveBeenCalledTimes(1);
@@ -492,11 +492,87 @@ describe("ChainTool", () => {
           >;
         }
       ).quorumCache.get(`8453:${contractAddress}:999`)?.result,
+    ).toBeUndefined();
+    expect(
+      (
+        chainTool as unknown as {
+          quorumCache: Map<
+            string,
+            {
+              result: {
+                clockMode: ClockMode;
+                quorum: bigint;
+                decimals: bigint;
+              };
+              timestamp: number;
+            }
+          >;
+        }
+      ).quorumCache.get(`8453:${contractAddress}:820`)?.result,
     ).toEqual({
       clockMode: ClockMode.Timestamp,
       quorum: 42n,
       decimals: 18n,
     });
+  });
+
+  it("uses stale clamped quorum cache when the retry fetch fails", async () => {
+    const chainTool = new ChainTool();
+    const staleClampedResult = {
+      clockMode: ClockMode.Timestamp,
+      quorum: 42n,
+      decimals: 18n,
+    };
+
+    (
+      chainTool as unknown as {
+        quorumCache: Map<
+          string,
+          { result: typeof staleClampedResult; timestamp: number }
+        >;
+      }
+    ).quorumCache.set(`8453:${contractAddress}:820`, {
+      result: staleClampedResult,
+      timestamp: Date.now() - 31 * 60 * 1000,
+    });
+
+    jest.spyOn(chainTool, "clockMode").mockResolvedValue(ClockMode.Timestamp);
+    jest.spyOn(chainTool, "currentClock").mockResolvedValue({
+      clockMode: ClockMode.Timestamp,
+      timepoint: 1_000n,
+      timestampMs: 1_000_000n,
+    });
+    jest
+      .spyOn(chainTool as any, "_executeWithFallbacks")
+      .mockImplementation(async (_options: any, action: any) =>
+        action({
+          readContract: jest.fn().mockImplementation(async (request) => {
+            if (request.functionName === "quorum") {
+              if (request.args?.[0] === 1_200n) {
+                throw new Error(
+                  'The contract function "quorum" reverted.\nDetails: execution reverted',
+                );
+              }
+              throw new Error("RPC unavailable");
+            }
+            throw new Error(`Unexpected function: ${request.functionName}`);
+          }),
+        }),
+      );
+
+    await expect(
+      chainTool.quorum({
+        chainId: 8453,
+        contractAddress,
+        governorTokenAddress,
+        governorTokenStandard: "ERC20",
+        timepoint: 1_200n,
+      }),
+    ).resolves.toEqual(staleClampedResult);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("chaintool.quorum cache used"),
+    );
   });
 
   it("treats ERC721 governor tokens as zero-decimal without calling decimals()", async () => {

--- a/packages/indexer/src/internal/chaintool.ts
+++ b/packages/indexer/src/internal/chaintool.ts
@@ -199,9 +199,9 @@ function stablePastQuorumTimepoint(
 ): bigint {
   switch (clockMode) {
     case ClockMode.Timestamp:
-      return currentTimepoint > 0n ? currentTimepoint - 1n : 0n;
+      return currentTimepoint > 60n * 3n ? currentTimepoint - 60n * 3n : 0n;
     case ClockMode.BlockNumber:
-      return currentTimepoint > 10n ? currentTimepoint - 10n : 0n;
+      return currentTimepoint > 15n ? currentTimepoint - 15n : 0n;
   }
 }
 
@@ -734,6 +734,7 @@ export class ChainTool {
   async quorum(options: QueryQuorumOptions): Promise<QuorumResult> {
     const cacheKey = quorumCacheKey(options, options.timepoint);
     const cachedEntry = this.quorumCache.get(cacheKey);
+    let fallbackCacheEntry = cachedEntry;
 
     // 1. Check if a valid, non-expired cache entry exists.
     if (
@@ -828,6 +829,7 @@ export class ChainTool {
           effectiveCacheKey = quorumCacheKey(options, timepoint);
 
           const effectiveCachedEntry = this.quorumCache.get(effectiveCacheKey);
+          fallbackCacheEntry = effectiveCachedEntry ?? fallbackCacheEntry;
           if (
             effectiveCachedEntry &&
             Date.now() - effectiveCachedEntry.timestamp < QUORUM_CACHE_DURATION_MS
@@ -902,7 +904,7 @@ export class ChainTool {
         })
       );
 
-      if (cachedEntry) {
+      if (fallbackCacheEntry) {
         console.warn(
           DegovIndexerHelpers.formatLogLine("chaintool.quorum cache used", {
             chainId: options.chainId,
@@ -910,7 +912,7 @@ export class ChainTool {
             reason: "fetch-failed",
           })
         );
-        return cachedEntry.result;
+        return fallbackCacheEntry.result;
       }
 
       // If there's no cached entry at all, we must throw the error.


### PR DESCRIPTION
## Summary
- clamp `ChainTool.quorum()` to a safe past checkpoint when the requested quorum timepoint is still in the future
- reuse the existing near-head safety margin for future-checkpoint retries so RPC clock skew cannot reintroduce the fatal revert path
- keep stale data under the effective clamped cache key available as fetch-failure fallback
- add regression coverage for the future-checkpoint path

## Problem
- `unlock-dao` was stuck at block `44021688` in production
- the next `ProposalCreated` at block `44022375` triggered `quorum(proposalSnapshot)` with a future timestamp checkpoint (`1775179697`)
- the governor deterministically reverted on that future checkpoint, and the indexer treated the revert as fatal, so the processor died and restarted in a loop

## Validation
- `./node_modules/.bin/jest --runInBand __tests__/unit/chaintool.test.ts`
- `npx -y tsx -e 'import { ChainTool } from "./src/internal/chaintool.ts"; void (async () => { const tool = new ChainTool(); const result = await tool.quorum({ chainId: 8453, contractAddress: "0x65bA0624403Fc5Ca2b20479e9F626eD4D78E0aD9", governorTokenAddress: "0xaC27fa800955849d6D17cC8952Ba9dD6EAA66187", governorTokenStandard: "ERC20", timepoint: 1775179697n }); console.log(JSON.stringify({ clockMode: result.clockMode, quorum: result.quorum.toString(), decimals: result.decimals.toString() })); })();'`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit` currently fails on pre-existing generated model/type baseline issues unrelated to this PR
