### PR TITLE
fix: add proposal share metadata

### DIFF
--- a/packages/web/scripts/proposal-metadata.test.ts
+++ b/packages/web/scripts/proposal-metadata.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildProposalMetadata,
+  cleanMetadataText,
+} from "../src/lib/metadata.ts";
+
+test("proposal metadata keeps a proposal-specific title and canonical url", () => {
+  const metadata = buildProposalMetadata({
+    config: {
+      name: "Lisk",
+      code: "lisk-dao",
+      logo: "https://example.com/logo.png",
+      siteUrl: "https://lisk.degov.ai",
+      description: "Lisk DAO",
+      links: {},
+      wallet: { walletConnectProjectId: "abc" },
+      chain: {
+        id: 1135,
+        name: "Lisk",
+        logo: "https://example.com/chain.png",
+        rpcs: ["https://rpc.api.lisk.com"],
+        explorers: ["https://blockscout.lisk.com"],
+        nativeToken: {
+          symbol: "ETH",
+          decimals: 18,
+          priceId: "ethereum",
+        },
+      },
+      contracts: {
+        governor: "0x123",
+        governorToken: {
+          address: "0x456",
+          standard: "ERC20",
+        },
+      },
+      treasuryAssets: [],
+      indexer: {
+        endpoint: "https://indexer.degov.ai/lisk-dao/graphql",
+        startBlock: 1,
+      },
+    },
+    proposalId: "0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878",
+    title: "Treasury allocation for grants season 2",
+    description: "Fund the next grants season with a staged treasury budget.",
+  });
+
+  assert.equal(metadata.title, "Treasury allocation for grants season 2");
+  assert.equal(
+    metadata.alternates?.canonical,
+    "https://lisk.degov.ai/proposal/0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878"
+  );
+  assert.equal(
+    metadata.openGraph?.title,
+    "Treasury allocation for grants season 2 | Lisk"
+  );
+  assert.equal(
+    metadata.twitter?.description,
+    "Fund the next grants season with a staged treasury budget."
+  );
+});
+
+test("proposal metadata text cleaning removes markdown, html, and collapses whitespace", () => {
+  const cleaned = cleanMetadataText(
+    "# Hello **world**\n\nSee [forum](https://example.com) <discussion>ignored</discussion>"
+  );
+
+  assert.equal(cleaned, "Hello world See forum ignored");
+});

--- a/packages/web/src/app/[locale]/proposal/[id]/layout.tsx
+++ b/packages/web/src/app/[locale]/proposal/[id]/layout.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata } from "../../../proposal/[id]/layout";

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Suspense } from "react";
 import "./globals.css";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { getDaoConfigServer } from "@/lib/config";
+import { buildSiteMetadata } from "@/lib/metadata";
 import { ConfigProvider } from "@/providers/config.provider";
 import { NextThemeProvider } from "@/providers/theme.provider";
 import type { Config } from "@/types/config";
@@ -39,63 +40,6 @@ const geistMono = Geist_Mono({
   adjustFontFallback: true, // Reduce layout shift
 });
 
-function buildMetadata(config: Config | null | undefined): Metadata {
-  const daoName = config?.name || "DeGov";
-  const description = `${daoName} - DAO governance platform powered by DeGov.AI`;
-  const siteUrl = config?.siteUrl ?? "https://localhost";
-  const metadataBase: URL = new URL(siteUrl);
-
-  let ogImageUrl: string | undefined;
-  if (siteUrl) {
-    const og = new URL("/assets/image/og.png", siteUrl);
-    ogImageUrl = og.toString();
-  }
-
-  const metadata = {
-    title: {
-      template: `%s | ${daoName}`,
-      default: `${daoName}`,
-    },
-    description,
-    icons: config?.logo
-      ? {
-          icon: [{ url: config.logo }],
-          shortcut: [config.logo],
-        }
-      : undefined,
-    metadataBase,
-    openGraph: {
-      type: "website",
-      siteName: daoName,
-      title: `${daoName} - Powered by DeGov.AI`,
-      description,
-      url: siteUrl,
-      images: ogImageUrl
-        ? [
-            {
-              url: ogImageUrl,
-              width: 512,
-              height: 512,
-              alt: `${daoName} - DAO governance platform`,
-            },
-          ]
-        : undefined,
-    },
-    twitter: {
-      card: "summary",
-      site: "@ai_degov",
-      creator: "@ai_degov",
-      title: `${daoName} - Powered by DeGov.AI`,
-      description,
-      images: ogImageUrl ? [ogImageUrl] : undefined,
-    },
-    other: {
-      configName: daoName,
-    },
-  };
-  return metadata;
-}
-
 async function getRemoteConfig(): Promise<Config> {
   const { getConfigCachedByHost } = await import("./_server/config-remote");
   return getConfigCachedByHost();
@@ -107,11 +51,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
   if (!apiMode) {
     const config = await getDaoConfigServer();
-    return buildMetadata(config);
+    return buildSiteMetadata(config);
   }
 
   const config = await getRemoteConfig();
-  return buildMetadata(config);
+  return buildSiteMetadata(config);
 }
 
 // Analytics Scripts component that accesses dynamic data

--- a/packages/web/src/app/proposal/[id]/layout.tsx
+++ b/packages/web/src/app/proposal/[id]/layout.tsx
@@ -1,0 +1,81 @@
+import { getConfigCachedByHost } from "@/app/_server/config-remote";
+import { getDaoConfigServer } from "@/lib/config";
+import { buildProposalMetadata } from "@/lib/metadata";
+import { buildGovernanceScope, proposalService } from "@/services/graphql";
+import { extractTitleAndDescription, parseDescription } from "@/utils/helpers";
+import { isDegovApiConfiguredServer } from "@/utils/remote-api";
+
+import type { Metadata } from "next";
+
+type LayoutProps = {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+};
+
+async function getDaoConfig() {
+  if (isDegovApiConfiguredServer()) {
+    return getConfigCachedByHost();
+  }
+
+  return getDaoConfigServer();
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const config = await getDaoConfig();
+
+  if (!config?.indexer?.endpoint) {
+    return buildProposalMetadata({
+      config,
+      proposalId: id,
+    });
+  }
+
+  try {
+    const proposals = await proposalService.getAllProposals(
+      config.indexer.endpoint,
+      {
+        where: {
+          ...buildGovernanceScope(config),
+          proposalId_eq: id,
+        },
+      }
+    );
+    const proposal = proposals[0];
+
+    if (!proposal) {
+      return buildProposalMetadata({
+        config,
+        proposalId: id,
+      });
+    }
+
+    const parsedDescription = parseDescription(proposal.description);
+    const titleAndDescription = extractTitleAndDescription(
+      parsedDescription.mainText
+    );
+
+    return buildProposalMetadata({
+      config,
+      proposalId: proposal.proposalId,
+      title: proposal.title || titleAndDescription.title,
+      description:
+        titleAndDescription.description || parsedDescription.mainText,
+    });
+  } catch (error) {
+    console.error("Failed to build proposal metadata:", error);
+
+    return buildProposalMetadata({
+      config,
+      proposalId: id,
+    });
+  }
+}
+
+export default function ProposalMetadataLayout({ children }: LayoutProps) {
+  return children;
+}

--- a/packages/web/src/lib/metadata.ts
+++ b/packages/web/src/lib/metadata.ts
@@ -1,0 +1,164 @@
+import type { Config } from "@/types/config";
+
+import type { Metadata } from "next";
+
+const DEFAULT_SITE_URL = "https://localhost";
+const DEFAULT_TWITTER_HANDLE = "@ai_degov";
+const TITLE_MAX_LENGTH = 120;
+const DESCRIPTION_MAX_LENGTH = 220;
+
+function getMetadataBase(siteUrl?: string): URL {
+  return new URL(siteUrl ?? DEFAULT_SITE_URL);
+}
+
+function buildDefaultOgImageUrl(siteUrl?: string): string {
+  return new URL("/assets/image/og.png", siteUrl ?? DEFAULT_SITE_URL).toString();
+}
+
+function shortenProposalId(proposalId: string): string {
+  if (proposalId.length <= 18) {
+    return proposalId;
+  }
+
+  return `${proposalId.slice(0, 8)}...${proposalId.slice(-6)}`;
+}
+
+export function cleanMetadataText(value?: string | null): string {
+  if (!value) {
+    return "";
+  }
+
+  return value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/[`*_~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function truncateMetadataText(
+  value: string,
+  maxLength: number
+): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+export function buildSiteMetadata(
+  config: Config | null | undefined
+): Metadata {
+  const daoName = config?.name || "DeGov";
+  const description = `${daoName} - DAO governance platform powered by DeGov.AI`;
+  const siteUrl = config?.siteUrl ?? DEFAULT_SITE_URL;
+  const metadataBase = getMetadataBase(siteUrl);
+  const ogImageUrl = buildDefaultOgImageUrl(siteUrl);
+
+  return {
+    title: {
+      template: `%s | ${daoName}`,
+      default: `${daoName}`,
+    },
+    description,
+    icons: config?.logo
+      ? {
+          icon: [{ url: config.logo }],
+          shortcut: [config.logo],
+        }
+      : undefined,
+    metadataBase,
+    openGraph: {
+      type: "website",
+      siteName: daoName,
+      title: `${daoName} - Powered by DeGov.AI`,
+      description,
+      url: siteUrl,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 512,
+          height: 512,
+          alt: `${daoName} - DAO governance platform`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary",
+      site: DEFAULT_TWITTER_HANDLE,
+      creator: DEFAULT_TWITTER_HANDLE,
+      title: `${daoName} - Powered by DeGov.AI`,
+      description,
+      images: [ogImageUrl],
+    },
+    other: {
+      configName: daoName,
+    },
+  };
+}
+
+type ProposalMetadataOptions = {
+  config: Config | null | undefined;
+  proposalId: string;
+  title?: string | null;
+  description?: string | null;
+};
+
+export function buildProposalMetadata({
+  config,
+  proposalId,
+  title,
+  description,
+}: ProposalMetadataOptions): Metadata {
+  const daoName = config?.name || "DeGov";
+  const siteUrl = config?.siteUrl ?? DEFAULT_SITE_URL;
+  const ogImageUrl = buildDefaultOgImageUrl(siteUrl);
+  const normalizedTitle = cleanMetadataText(title);
+  const normalizedDescription = cleanMetadataText(description);
+  const proposalTitle = truncateMetadataText(
+    normalizedTitle || `Proposal ${shortenProposalId(proposalId)}`,
+    TITLE_MAX_LENGTH
+  );
+  const proposalDescription = truncateMetadataText(
+    normalizedDescription ||
+      `${daoName} governance proposal ${shortenProposalId(proposalId)} on DeGov.AI.`,
+    DESCRIPTION_MAX_LENGTH
+  );
+  const proposalUrl = new URL(`/proposal/${proposalId}`, siteUrl).toString();
+  const socialTitle = `${proposalTitle} | ${daoName}`;
+
+  return {
+    title: proposalTitle,
+    description: proposalDescription,
+    alternates: {
+      canonical: proposalUrl,
+    },
+    openGraph: {
+      type: "article",
+      siteName: daoName,
+      title: socialTitle,
+      description: proposalDescription,
+      url: proposalUrl,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 512,
+          height: 512,
+          alt: `${daoName} proposal share card`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary",
+      site: DEFAULT_TWITTER_HANDLE,
+      creator: DEFAULT_TWITTER_HANDLE,
+      title: socialTitle,
+      description: proposalDescription,
+      images: [ogImageUrl],
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract shared site metadata helpers from the root app layout
- add proposal-specific `generateMetadata` on the canonical `/proposal/[id]` route and re-export it for the localized alias route
- add regression coverage for proposal metadata title, canonical URL, and text cleaning

## Validation
- `cd packages/web && pnpm lint`
- `cd packages/web && pnpm build`
- `cd packages/web && node --test scripts/proposal-metadata.test.ts`
- verified the built `/proposal/[id]` loader tree points at `src/app/proposal/[id]/layout.tsx` and a live proposal produces proposal-specific title/description/canonical metadata

Refs: OHH-104