### PR TITLE
Move web ENS lookup behind the DeGov API

### DIFF
--- a/packages/web/src/components/address-resolver.tsx
+++ b/packages/web/src/components/address-resolver.tsx
@@ -1,7 +1,9 @@
-import { useEnsName } from "wagmi";
+import { useQuery } from "@tanstack/react-query";
 
 import { useProfileQuery } from "@/hooks/useProfileQuery";
+import { ensService } from "@/services/graphql";
 import { formatShortAddress } from "@/utils/address";
+import { QUERY_CONFIGS } from "@/utils/query-config";
 
 import type { Address } from "viem";
 
@@ -21,18 +23,16 @@ export function AddressResolver({
   const { data: profileData } = useProfileQuery(address, { skip: skipFetch });
 
   const profileName = profileData?.data?.name;
+  const normalizedAddress = address.toLowerCase();
 
-  const { data: ensName } = useEnsName({
-    address,
-    chainId: 1,
-    query: {
-      staleTime: 1000 * 60 * 60,
-      gcTime: 1000 * 60 * 60 * 24,
-      // Even when profile fetching is skipped, still try ENS as a lightweight fallback
-      enabled: !profileName,
-    },
+  const { data: ensRecord } = useQuery({
+    queryKey: ["ens-record", normalizedAddress],
+    queryFn: () => ensService.getEnsRecord({ address: normalizedAddress }),
+    enabled: !profileName,
+    ...QUERY_CONFIGS.STATIC,
   });
 
+  const ensName = ensRecord?.name ?? undefined;
   const displayValue =
     profileName ||
     ensName ||

--- a/packages/web/src/components/members-table/hooks/useMembersData.ts
+++ b/packages/web/src/components/members-table/hooks/useMembersData.ts
@@ -1,8 +1,6 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { isAddress, type Address } from "viem";
-import { usePublicClient } from "wagmi";
-import { mainnet } from "wagmi/chains";
 
 import { DEFAULT_PAGE_SIZE } from "@/config/base";
 import { useAiBotAddress } from "@/hooks/useAiBotAddress";
@@ -12,6 +10,7 @@ import { normalizeAddress } from "@/hooks/useProfileQuery";
 import {
   buildGovernanceScope,
   contributorService,
+  ensService,
 } from "@/services/graphql";
 import type { ContributorItem } from "@/services/graphql/types";
 
@@ -33,7 +32,6 @@ export function useMembersData(
   const { botAddress } = useAiBotAddress();
   const isSearching = searchTerm.trim().length > 0;
   const normalizedInitialPageSize = Math.max(pageSize, initialPageSize);
-  const publicClient = usePublicClient({ chainId: mainnet.id });
   const governanceScope = useMemo(
     () => buildGovernanceScope(daoConfig),
     [daoConfig]
@@ -49,19 +47,20 @@ export function useMembersData(
         return normalizedTerm as Address;
       }
 
-      if (!publicClient || !trimmedTerm.includes(".")) return undefined;
+      if (!trimmedTerm.includes(".")) return undefined;
 
       try {
-        const ensAddress = await publicClient.getEnsAddress({
+        const ensRecord = await ensService.getEnsRecord({
           name: trimmedTerm,
         });
+        const ensAddress = ensRecord?.address;
 
         return ensAddress ? (ensAddress.toLowerCase() as Address) : undefined;
       } catch {
         return undefined;
       }
     },
-    [publicClient]
+    []
   );
 
   const membersQuery = useInfiniteQuery({

--- a/packages/web/src/services/graphql/index.ts
+++ b/packages/web/src/services/graphql/index.ts
@@ -9,6 +9,7 @@ import * as Queries from "./queries";
 import * as Types from "./types";
 import { resolveGovernanceCounts } from "./types/counts";
 
+import type { EnsRecordInput, EnsRecordResponse } from "./types/ens";
 import type { ProfileData } from "./types/profile";
 import type { EvmAbiResponse, EvmAbiInput } from "./types/proposals";
 
@@ -304,6 +305,27 @@ export const proposalService = {
       }
     );
     return response?.evmAbi;
+  },
+};
+
+export const ensService = {
+  getEnsRecord: async (input: EnsRecordInput) => {
+    const endpoint = degovGraphqlApi();
+    if (!endpoint) {
+      return undefined;
+    }
+
+    try {
+      const response = await request<EnsRecordResponse>(
+        endpoint,
+        Queries.GET_ENS_RECORD,
+        input
+      );
+      return response?.ens ?? undefined;
+    } catch (error) {
+      console.error("Failed to resolve ENS record:", error);
+      return undefined;
+    }
   },
 };
 

--- a/packages/web/src/services/graphql/queries/ens.ts
+++ b/packages/web/src/services/graphql/queries/ens.ts
@@ -1,0 +1,10 @@
+import { gql } from "graphql-request";
+
+export const GET_ENS_RECORD = gql`
+  query GetEnsRecord($address: String, $name: String) {
+    ens(input: { address: $address, name: $name }) {
+      address
+      name
+    }
+  }
+`;

--- a/packages/web/src/services/graphql/queries/index.ts
+++ b/packages/web/src/services/graphql/queries/index.ts
@@ -4,3 +4,4 @@ export * from "./squidStatus";
 export * from "./contributors";
 export * from "./counts";
 export * from "./treasury";
+export * from "./ens";

--- a/packages/web/src/services/graphql/types/ens.ts
+++ b/packages/web/src/services/graphql/types/ens.ts
@@ -1,0 +1,13 @@
+export type EnsRecord = {
+  address?: string | null;
+  name?: string | null;
+};
+
+export type EnsRecordResponse = {
+  ens?: EnsRecord | null;
+};
+
+export type EnsRecordInput = {
+  address?: string;
+  name?: string;
+};

--- a/packages/web/src/services/graphql/types/index.ts
+++ b/packages/web/src/services/graphql/types/index.ts
@@ -6,3 +6,4 @@ export * from "./contributors";
 export * from "./counts";
 export * from "./notifications";
 export * from "./treasury";
+export * from "./ens";


### PR DESCRIPTION
## Summary
- switch ENS display resolution to the DeGov GraphQL API instead of browser-side wagmi hooks
- switch member ENS search resolution to the backend `ens` query
- add shared ENS GraphQL query/types for the web app

## Testing
- pnpm lint
- pnpm exec tsc --noEmit
- pnpm build

## Issue
- OHH-110
