### PR TITLE
test(indexer): cover initial self-delegation ordering after #655

### DIFF
--- a/packages/indexer/__tests__/accuracy/token-vote-power.test.ts
+++ b/packages/indexer/__tests__/accuracy/token-vote-power.test.ts
@@ -1848,6 +1848,13 @@ describe("token vote power checkpoints", () => {
       }),
     ]);
 
+    const originalInsert = store.insert.bind(store);
+    const insertSpy = jest
+      .spyOn(store, "insert")
+      .mockImplementation(async (entity: any) => {
+        await originalInsert(entity);
+      });
+
     const handler = buildTokenHandler(store);
     const account = "0xd144d064a7e573e8c77c0d0d2049a243c740882f";
     const txHash =
@@ -1883,6 +1890,14 @@ describe("token vote power checkpoints", () => {
       power: 0n,
       isCurrent: true,
     });
+    expect(
+      insertSpy.mock.calls.filter(
+        ([entity]) =>
+          entity instanceof Delegate &&
+          entity.fromDelegate === account &&
+          entity.toDelegate === account
+      )
+    ).toHaveLength(1);
 
     jest.spyOn(itokenerc20.events.Transfer, "decode").mockReturnValueOnce({
       from: "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
@@ -1911,6 +1926,20 @@ describe("token vote power checkpoints", () => {
       power: 0n,
       isCurrent: true,
     });
+    expect(
+      insertSpy.mock.calls.filter(
+        ([entity]) =>
+          entity instanceof Delegate &&
+          entity.fromDelegate === account &&
+          entity.toDelegate === account
+      )
+    ).toHaveLength(1);
+    expect(store.findEntity(Contributor, account)).toMatchObject({
+      power: 0n,
+      delegatesCountAll: 1,
+      delegatesCountEffective: 0,
+    });
+    expect(store.findEntity(DataMetric, "global")?.powerSum).toBe(0n);
 
     jest
       .spyOn(itokenerc20.events.DelegateVotesChanged, "decode")

--- a/packages/indexer/__tests__/accuracy/token-vote-power.test.ts
+++ b/packages/indexer/__tests__/accuracy/token-vote-power.test.ts
@@ -603,7 +603,7 @@ describe("token vote power checkpoints", () => {
     ).toMatchObject({
       power: 0n,
       delegatesCountAll: 1,
-      delegatesCountEffective: 1,
+      delegatesCountEffective: 0,
     });
     expect(store.findEntity(DataMetric, "global")?.powerSum).toBe(0n);
     expect(
@@ -1838,6 +1838,115 @@ describe("token vote power checkpoints", () => {
       power: 0n,
       isCurrent: true,
     });
+  });
+
+  it("does not materialize a duplicate self-edge when initial self-delegation is seen before same-tx transfer-in", async () => {
+    const store = new MemoryStore([
+      new DataMetric({
+        id: "global",
+        powerSum: 0n,
+      }),
+    ]);
+
+    const handler = buildTokenHandler(store);
+    const account = "0xd144d064a7e573e8c77c0d0d2049a243c740882f";
+    const txHash =
+      "0xb2e42c615286384babed2c89ee5e14c38c98b0221b7baeab958babf735435414";
+    const amount = 1143544204434688311296n;
+
+    jest
+      .spyOn(itokenerc20.events.DelegateChanged, "decode")
+      .mockReturnValueOnce({
+        delegator: account,
+        fromDelegate: zeroAddress,
+        toDelegate: account,
+      } as any);
+
+    await (handler as any).storeDelegateChanged({
+      id: "log-self-delegate-before-transfer",
+      address: "0x8888888888888888888888888888888888888888",
+      logIndex: 99,
+      transactionIndex: 1,
+      block: {
+        height: 13579039,
+        timestamp: 1_700_000_000_000,
+      },
+      transactionHash: txHash,
+    } as any);
+
+    expect(store.findEntity(DelegateMapping, account)).toMatchObject({
+      from: account,
+      to: account,
+      power: 0n,
+    });
+    expect(store.findEntity(Delegate, `${account}_${account}`)).toMatchObject({
+      power: 0n,
+      isCurrent: true,
+    });
+
+    jest.spyOn(itokenerc20.events.Transfer, "decode").mockReturnValueOnce({
+      from: "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+      to: account,
+      value: amount,
+    } as any);
+
+    await (handler as any).storeTokenTransfer({
+      id: "log-transfer-after-self-delegate",
+      address: "0x8888888888888888888888888888888888888888",
+      logIndex: 100,
+      transactionIndex: 1,
+      block: {
+        height: 13579039,
+        timestamp: 1_700_000_000_000,
+      },
+      transactionHash: txHash,
+    } as any);
+
+    expect(store.findEntity(DelegateMapping, account)).toMatchObject({
+      from: account,
+      to: account,
+      power: 0n,
+    });
+    expect(store.findEntity(Delegate, `${account}_${account}`)).toMatchObject({
+      power: 0n,
+      isCurrent: true,
+    });
+
+    jest
+      .spyOn(itokenerc20.events.DelegateVotesChanged, "decode")
+      .mockReturnValueOnce({
+        delegate: account,
+        previousVotes: 0n,
+        newVotes: amount,
+      } as any);
+
+    await (handler as any).storeDelegateVotesChanged({
+      id: "log-self-delegate-votes-changed",
+      address: "0x8888888888888888888888888888888888888888",
+      logIndex: 101,
+      transactionIndex: 1,
+      block: {
+        height: 13579039,
+        timestamp: 1_700_000_000_000,
+      },
+      transactionHash: txHash,
+    } as any);
+
+    expect(store.findEntity(DelegateMapping, account)).toMatchObject({
+      from: account,
+      to: account,
+      power: amount,
+    });
+    expect(store.findEntity(Delegate, `${account}_${account}`)).toMatchObject({
+      power: amount,
+      isCurrent: true,
+    });
+    expect(store.findEntity(Contributor, account)).toMatchObject({
+      power: amount,
+      delegatesCountAll: 1,
+      delegatesCountEffective: 1,
+    });
+    expect(store.findEntity(DataMetric, "global")?.powerSum).toBe(amount);
   });
 
   it("reactivates a historical relation without carrying forward stale power", async () => {

--- a/packages/indexer/__tests__/accuracy/token-vote-power.test.ts
+++ b/packages/indexer/__tests__/accuracy/token-vote-power.test.ts
@@ -1978,6 +1978,158 @@ describe("token vote power checkpoints", () => {
     expect(store.findEntity(DataMetric, "global")?.powerSum).toBe(amount);
   });
 
+  it("counts a zero-power current relation as effective only after vote power materializes", async () => {
+    const account = "0x5656565656565656565656565656565656565656";
+    const amount = 42n;
+    const store = new MemoryStore([
+      new DataMetric({
+        id: "global",
+        powerSum: 0n,
+      }),
+      new Contributor({
+        id: account,
+        power: 0n,
+        delegatesCountAll: 1,
+        delegatesCountEffective: 0,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new Delegate({
+        id: `${account}_${account}`,
+        fromDelegate: account,
+        toDelegate: account,
+        isCurrent: true,
+        power: 0n,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new DelegateMapping({
+        id: account,
+        from: account,
+        to: account,
+        power: 0n,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+    ]);
+
+    const handler = buildTokenHandler(store);
+
+    await (handler as any).storeDelegate(
+      new Delegate({
+        chainId: 1,
+        daoCode: "demo",
+        governorAddress: "0x9999999999999999999999999999999999999999",
+        tokenAddress: "0x8888888888888888888888888888888888888888",
+        contractAddress: "0x8888888888888888888888888888888888888888",
+        logIndex: 2,
+        transactionIndex: 1,
+        fromDelegate: account,
+        toDelegate: account,
+        blockNumber: 2n,
+        blockTimestamp: 2n,
+        transactionHash: "0xmaterialize",
+        power: amount,
+        isCurrent: true,
+      }),
+    );
+
+    expect(store.findEntity(DelegateMapping, account)).toMatchObject({
+      from: account,
+      to: account,
+      power: amount,
+    });
+    expect(store.findEntity(Delegate, `${account}_${account}`)).toMatchObject({
+      power: amount,
+      isCurrent: true,
+    });
+    expect(store.findEntity(Contributor, account)).toMatchObject({
+      power: amount,
+      delegatesCountAll: 1,
+      delegatesCountEffective: 1,
+    });
+    expect(store.findEntity(DataMetric, "global")?.powerSum).toBe(amount);
+  });
+
+  it("drops delegatesCountEffective when a current relation loses all materialized power", async () => {
+    const account = "0x7878787878787878787878787878787878787878";
+    const amount = 42n;
+    const store = new MemoryStore([
+      new DataMetric({
+        id: "global",
+        powerSum: amount,
+      }),
+      new Contributor({
+        id: account,
+        power: amount,
+        delegatesCountAll: 1,
+        delegatesCountEffective: 1,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new Delegate({
+        id: `${account}_${account}`,
+        fromDelegate: account,
+        toDelegate: account,
+        isCurrent: true,
+        power: amount,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+      new DelegateMapping({
+        id: account,
+        from: account,
+        to: account,
+        power: amount,
+        blockNumber: 1n,
+        blockTimestamp: 1n,
+        transactionHash: "0xseed",
+      }),
+    ]);
+
+    const handler = buildTokenHandler(store);
+
+    await (handler as any).storeDelegate(
+      new Delegate({
+        chainId: 1,
+        daoCode: "demo",
+        governorAddress: "0x9999999999999999999999999999999999999999",
+        tokenAddress: "0x8888888888888888888888888888888888888888",
+        contractAddress: "0x8888888888888888888888888888888888888888",
+        logIndex: 2,
+        transactionIndex: 1,
+        fromDelegate: account,
+        toDelegate: account,
+        blockNumber: 2n,
+        blockTimestamp: 2n,
+        transactionHash: "0xdematerialize",
+        power: -amount,
+        isCurrent: true,
+      }),
+    );
+
+    expect(store.findEntity(DelegateMapping, account)).toMatchObject({
+      from: account,
+      to: account,
+      power: 0n,
+    });
+    expect(store.findEntity(Delegate, `${account}_${account}`)).toMatchObject({
+      power: 0n,
+      isCurrent: true,
+    });
+    expect(store.findEntity(Contributor, account)).toMatchObject({
+      power: 0n,
+      delegatesCountAll: 1,
+      delegatesCountEffective: 0,
+    });
+    expect(store.findEntity(DataMetric, "global")?.powerSum).toBe(0n);
+  });
+
   it("reactivates a historical relation without carrying forward stale power", async () => {
     const store = new MemoryStore([
       new DataMetric({

--- a/packages/indexer/src/handler/token.ts
+++ b/packages/indexer/src/handler/token.ts
@@ -1418,10 +1418,7 @@ export class TokenHandler {
       currentDelegate.power = persistedPower;
       await this.ctx.store.insert(currentDelegate);
       this.rememberDelegate(currentDelegate);
-      if (
-        options?.replaceStoredPowerWith === undefined ||
-        persistedPower !== 0n
-      ) {
+      if (persistedPower !== 0n) {
         delegatesCountEffective += 1;
       }
     } else {


### PR DESCRIPTION
## Summary

This PR adds a focused regression test around the event-ordering scenario behind #655 and tightens the token handler behavior that the new test exposed.

The main goal is to verify the previous #655 fix against a realistic same-transaction ordering:

- `DelegateChanged(0x0 -> self)` is observed first
- the delegator receives tokens later in the same transaction
- `DelegateVotesChanged` materializes the voting power afterward

## What this PR does

- adds a regression test for the "initial self-delegation before same-tx transfer-in" path
- verifies that the indexer keeps a single current self-edge instead of materializing a duplicate relation
- verifies that the self-edge stays at `power = 0` until `DelegateVotesChanged` arrives
- verifies that contributor power and the global power sum are updated only when the vote power is actually materialized

## Additional issue found while testing

While adding the regression coverage, the new test exposed a separate counting bug in `delegatesCountEffective`.

Before this patch, a newly inserted current delegate relation with `power = 0` could still be counted as an effective delegate in the initial self-delegation flow. That inflated the effective delegate count before any voting power actually existed.

This PR fixes that behavior so zero-power placeholder relations are not counted as effective until the relation has non-zero power.

## Validation

I ran the following tests locally:

- the new targeted regression test for the initial self-delegation ordering case
- neighboring ordering scenarios in the same accuracy suite
- the full `packages/indexer/__tests__/accuracy/token-vote-power.test.ts` file

All passed.
