### PR TITLE
fix(config): preserve hex addresses in remote dao config

### DIFF
--- a/packages/indexer/__tests__/unit/datasource.test.ts
+++ b/packages/indexer/__tests__/unit/datasource.test.ts
@@ -104,4 +104,52 @@ contracts:
       await rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("preserves unquoted hex contract addresses as strings", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "degov-datasource-"));
+    const configPath = join(tempDir, "degov.yml");
+
+    try {
+      await writeFile(
+        configPath,
+        `
+code: demo
+chain:
+  id: 1
+  rpcs:
+    - https://ethereum-rpc.publicnode.com
+indexer:
+  startBlock: 21390346
+contracts:
+  governor: 0x7ae22bebF28366c328d5558E6Fad935487299DfE
+  governorToken:
+    address: 0x970C30646E5c95DC77A3D768C4362E113Ed92b5b
+    standard: ERC20
+  timeLock: 0xEd4f981249Dde7Cd3c295fc28CB934D4682d7ef9
+`
+      );
+
+      const config = await DegovDataSource.fromDegovConfigPath(configPath);
+
+      expect(config.works[0].contracts).toEqual([
+        {
+          name: "governor",
+          address: "0x7ae22bebF28366c328d5558E6Fad935487299DfE",
+          standard: undefined,
+        },
+        {
+          name: "governorToken",
+          address: "0x970C30646E5c95DC77A3D768C4362E113Ed92b5b",
+          standard: "ERC20",
+        },
+        {
+          name: "timeLock",
+          address: "0xEd4f981249Dde7Cd3c295fc28CB934D4682d7ef9",
+          standard: undefined,
+        },
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/indexer/src/database.ts
+++ b/packages/indexer/src/database.ts
@@ -6,6 +6,7 @@ import {
 export function getDatabaseOptions(): TypeormDatabaseOptions {
   return {
     supportHotBlocks: true,
+    isolationLevel: "READ COMMITTED",
   };
 }
 

--- a/packages/indexer/src/database.ts
+++ b/packages/indexer/src/database.ts
@@ -6,7 +6,6 @@ import {
 export function getDatabaseOptions(): TypeormDatabaseOptions {
   return {
     supportHotBlocks: true,
-    isolationLevel: "READ COMMITTED",
   };
 }
 

--- a/packages/indexer/src/datasource.ts
+++ b/packages/indexer/src/datasource.ts
@@ -9,11 +9,12 @@ import {
 } from "./types";
 import { DegovIndexerHelpers } from "./internal/helpers";
 
-const HEX_SCALAR_VALUE = /^(\s*[^:#\n][^:\n]*:\s*)(0x[0-9a-fA-F]+)(\s*(?:#.*)?)$/gm;
+const ETH_ADDRESS_SCALAR_VALUE =
+  /^(\s*[^:#\n][^:\n]*:\s*)(0x[0-9a-fA-F]{40})(\s*(?:#.*)?)$/gm;
 
-function quoteHexScalars(yamlText: string): string {
+function quoteAddressScalars(yamlText: string): string {
   return yamlText.replace(
-    HEX_SCALAR_VALUE,
+    ETH_ADDRESS_SCALAR_VALUE,
     (_match, prefix: string, value: string, suffix: string) =>
       `${prefix}"${value}"${suffix ?? ""}`
   );
@@ -40,7 +41,7 @@ class DegovConfigDataSource {
   }
 
   private packDataSource(rawDegovConfig: string): IndexerProcessorConfig {
-    const degovConfig = yaml.parse(quoteHexScalars(rawDegovConfig));
+    const degovConfig = yaml.parse(quoteAddressScalars(rawDegovConfig));
     const { chain, code, indexer, contracts } = degovConfig;
     const startBlockOverride = this.readIntegerOverride(
       "DEGOV_INDEXER_START_BLOCK"

--- a/packages/indexer/src/datasource.ts
+++ b/packages/indexer/src/datasource.ts
@@ -9,6 +9,16 @@ import {
 } from "./types";
 import { DegovIndexerHelpers } from "./internal/helpers";
 
+const HEX_SCALAR_VALUE = /^(\s*[^:#\n][^:\n]*:\s*)(0x[0-9a-fA-F]+)(\s*(?:#.*)?)$/gm;
+
+function quoteHexScalars(yamlText: string): string {
+  return yamlText.replace(
+    HEX_SCALAR_VALUE,
+    (_match, prefix: string, value: string, suffix: string) =>
+      `${prefix}"${value}"${suffix ?? ""}`
+  );
+}
+
 export class DegovDataSource {
   constructor() {}
 
@@ -30,7 +40,7 @@ class DegovConfigDataSource {
   }
 
   private packDataSource(rawDegovConfig: string): IndexerProcessorConfig {
-    const degovConfig = yaml.parse(rawDegovConfig);
+    const degovConfig = yaml.parse(quoteHexScalars(rawDegovConfig));
     const { chain, code, indexer, contracts } = degovConfig;
     const startBlockOverride = this.readIntegerOverride(
       "DEGOV_INDEXER_START_BLOCK"

--- a/packages/web/scripts/config-yaml.test.ts
+++ b/packages/web/scripts/config-yaml.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadConfigYaml } from "../src/lib/config-yaml.ts";
+
+test("loadConfigYaml preserves unquoted contract addresses as strings", () => {
+  const config = loadConfigYaml(`
+contracts:
+  governor: 0x7ae22bebF28366c328d5558E6Fad935487299DfE
+  governorToken:
+    address: 0x970C30646E5c95DC77A3D768C4362E113Ed92b5b
+    standard: ERC20
+chain:
+  id: 1
+`) as {
+    contracts: {
+      governor: unknown;
+      governorToken: {
+        address: unknown;
+        standard: string;
+      };
+    };
+    chain: {
+      id: unknown;
+    };
+  };
+
+  assert.equal(config.contracts.governor, "0x7ae22bebF28366c328d5558E6Fad935487299DfE");
+  assert.equal(typeof config.contracts.governor, "string");
+  assert.equal(
+    config.contracts.governorToken.address,
+    "0x970C30646E5c95DC77A3D768C4362E113Ed92b5b"
+  );
+  assert.equal(typeof config.contracts.governorToken.address, "string");
+});
+
+test("loadConfigYaml keeps hex numeric fields as numbers", () => {
+  const config = loadConfigYaml(`
+chain:
+  id: 0x1
+indexer:
+  startBlock: 0x10
+contracts:
+  governor: 0x7ae22bebF28366c328d5558E6Fad935487299DfE
+`) as {
+    chain: {
+      id: unknown;
+    };
+    indexer: {
+      startBlock: unknown;
+    };
+  };
+
+  assert.equal(config.chain.id, 1);
+  assert.equal(typeof config.chain.id, "number");
+  assert.equal(config.indexer.startBlock, 16);
+  assert.equal(typeof config.indexer.startBlock, "number");
+});

--- a/packages/web/src/app/_server/config-remote.ts
+++ b/packages/web/src/app/_server/config-remote.ts
@@ -1,6 +1,7 @@
 import { unstable_cache } from "next/cache";
 import { headers } from "next/headers";
 
+import { loadConfigYaml } from "@/lib/config-yaml";
 import { getDaoConfigServer } from "@/lib/config";
 import type { Config } from "@/types/config";
 import { degovApiDaoConfigServer } from "@/utils/remote-api";
@@ -26,8 +27,7 @@ export async function getConfigCachedByHost(): Promise<Config> {
         if (!res.ok) throw new Error(`API ${res.status}`);
 
         const yamlText = await res.text();
-        const yaml = await import("js-yaml");
-        const result = yaml.load(yamlText) as Config;
+        const result = loadConfigYaml(yamlText);
 
         return result;
       } catch (err) {

--- a/packages/web/src/app/api/common/config.ts
+++ b/packages/web/src/app/api/common/config.ts
@@ -1,8 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-import yaml from "js-yaml";
-
+import { loadConfigYaml } from "@/lib/config-yaml";
 import type { Config } from "@/types/config";
 import {
   isDegovApiConfiguredServer,
@@ -46,7 +45,7 @@ export async function degovConfig(request: NextRequest): Promise<Config> {
     }
 
     const yamlText = await response.text();
-    const yamlData = yaml.load(yamlText) as Config;
+    const yamlData = loadConfigYaml(yamlText);
 
     cachedConfig.set(cacheKey, yamlData);
     return yamlData;
@@ -54,7 +53,7 @@ export async function degovConfig(request: NextRequest): Promise<Config> {
 
   const configPath = path.join(process.cwd(), "public/degov.yml");
   const yamlText = fs.readFileSync(configPath, "utf-8");
-  const config = yaml.load(yamlText) as Config;
+  const config = loadConfigYaml(yamlText);
   cachedConfig.set(cacheKey, config);
   return config;
 }

--- a/packages/web/src/hooks/useConfigSWR.ts
+++ b/packages/web/src/hooks/useConfigSWR.ts
@@ -1,6 +1,6 @@
-import yaml from "js-yaml";
 import { useEffect, useState } from "react";
 
+import { loadConfigYaml } from "@/lib/config-yaml";
 import type { Config } from "@/types/config";
 import { processStandardProperties } from "@/utils";
 import { degovApiDaoConfigClient } from "@/utils/remote-api";
@@ -30,7 +30,7 @@ async function fetchConfig(signal?: AbortSignal): Promise<Config> {
   }
 
   const yamlText = await response.text();
-  return yaml.load(yamlText) as Config;
+  return loadConfigYaml(yamlText);
 }
 
 function configsAreEqual(a: Config | null, b: Config | null): boolean {

--- a/packages/web/src/lib/config-yaml.ts
+++ b/packages/web/src/lib/config-yaml.ts
@@ -2,16 +2,17 @@ import yaml from "js-yaml";
 
 import type { Config } from "@/types/config";
 
-const HEX_SCALAR_VALUE = /^(\s*[^:#\n][^:\n]*:\s*)(0x[0-9a-fA-F]+)(\s*(?:#.*)?)$/gm;
+const ETH_ADDRESS_SCALAR_VALUE =
+  /^(\s*[^:#\n][^:\n]*:\s*)(0x[0-9a-fA-F]{40})(\s*(?:#.*)?)$/gm;
 
-function quoteHexScalars(yamlText: string): string {
+function quoteAddressScalars(yamlText: string): string {
   return yamlText.replace(
-    HEX_SCALAR_VALUE,
+    ETH_ADDRESS_SCALAR_VALUE,
     (_match, prefix: string, value: string, suffix: string) =>
       `${prefix}"${value}"${suffix ?? ""}`
   );
 }
 
 export function loadConfigYaml(yamlText: string): Config {
-  return yaml.load(quoteHexScalars(yamlText)) as Config;
+  return yaml.load(quoteAddressScalars(yamlText)) as Config;
 }

--- a/packages/web/src/lib/config-yaml.ts
+++ b/packages/web/src/lib/config-yaml.ts
@@ -1,0 +1,17 @@
+import yaml from "js-yaml";
+
+import type { Config } from "@/types/config";
+
+const HEX_SCALAR_VALUE = /^(\s*[^:#\n][^:\n]*:\s*)(0x[0-9a-fA-F]+)(\s*(?:#.*)?)$/gm;
+
+function quoteHexScalars(yamlText: string): string {
+  return yamlText.replace(
+    HEX_SCALAR_VALUE,
+    (_match, prefix: string, value: string, suffix: string) =>
+      `${prefix}"${value}"${suffix ?? ""}`
+  );
+}
+
+export function loadConfigYaml(yamlText: string): Config {
+  return yaml.load(quoteHexScalars(yamlText)) as Config;
+}

--- a/packages/web/src/lib/config.ts
+++ b/packages/web/src/lib/config.ts
@@ -1,9 +1,9 @@
 import fs from "fs/promises";
 import path from "path";
 
-import yaml from "js-yaml";
 import { unstable_cache } from "next/cache";
 
+import { loadConfigYaml } from "@/lib/config-yaml";
 import type { Config } from "@/types/config";
 
 const defaultConfig = {
@@ -20,7 +20,7 @@ export const getDaoConfigServer = unstable_cache(
         return defaultConfig as Config;
       }
 
-      const config = yaml.load(yamlText) as Config;
+      const config = loadConfigYaml(yamlText);
 
       if (
         config &&


### PR DESCRIPTION
## Summary
This PR fixes the same root cause in both the web app and the indexer: unquoted `0x...` values from remote DAO YAML config were being parsed as numbers instead of strings.

## What changed
- Fix web-side remote DAO config loading so hex contract addresses stay as strings.
- Fix indexer-side DAO config loading so `contracts.governor`, `contracts.governorToken.address`, and `contracts.timeLock` are not coerced into scientific-notation numbers.
- Add regression coverage for the indexer datasource parser.

## Why this matters
In staging, `api.next.degov.ai/dao/config/<dao>` returns YAML where contract addresses are emitted as unquoted `0x...` scalars. That caused two different failures:

1. Web failure
- The web app parsed some contract addresses as numbers.
- Client code later called string methods such as `toLowerCase()` on those values and crashed.

2. Indexer failure
- Archive-backed indexers built archive queries with numeric contract addresses instead of strings.
- Subsquid archive rejected those queries with `400 Bad Request` and `Not a valid string`.
- As a result, many staging indexers were `Running` at the pod level but were not actually syncing.

## Validation
- `yarn test:unit __tests__/unit/datasource.test.ts`

## Staging observations that motivated the indexer fix
During the stg cluster sweep, indexer logs showed entries like:
- `contracts=[7.015406685723831e+47,...]`
- archive response: `Not a valid string`

That is the direct symptom fixed by the indexer part of this PR.
