### PR TITLE
Reduce web and indexer Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,14 @@
 
 .git
 node_modules
+packages/*/node_modules
+packages/web/.next
+packages/indexer/.data
+packages/indexer/lib
+coverage
+.turbo
+.pnpm-store
+*.log
 
 # OS Files
 .DS_Store
-

--- a/docker/copy-prisma-runtime.cjs
+++ b/docker/copy-prisma-runtime.cjs
@@ -1,16 +1,13 @@
 const fs = require("fs");
+const Module = require("module");
 const path = require("path");
 
 const sourceRoot = "/app/node_modules";
 const targetRoot = "/app/prisma-runtime/node_modules";
 const seen = new Set();
 
-function copyPackage(name, optional = false) {
-  if (seen.has(name)) {
-    return;
-  }
-
-  const packageJsonPath = path.join(sourceRoot, name, "package.json");
+function copyPackage(name, optional = false, fromDir = "/app") {
+  const packageJsonPath = findPackageJson(name, fromDir);
   if (!fs.existsSync(packageJsonPath)) {
     if (optional) {
       return;
@@ -18,9 +15,14 @@ function copyPackage(name, optional = false) {
     throw new Error(`Cannot find package ${name}`);
   }
 
-  seen.add(name);
   const packageDir = path.dirname(packageJsonPath);
-  const targetDir = path.join(targetRoot, name);
+  const seenKey = packageDir;
+  if (seen.has(seenKey)) {
+    return;
+  }
+  seen.add(seenKey);
+
+  const targetDir = path.join(targetRoot, path.relative(sourceRoot, packageDir));
 
   fs.mkdirSync(path.dirname(targetDir), { recursive: true });
   fs.cpSync(packageDir, targetDir, {
@@ -31,11 +33,22 @@ function copyPackage(name, optional = false) {
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 
   for (const dependency of Object.keys(packageJson.dependencies || {})) {
-    copyPackage(dependency);
+    copyPackage(dependency, false, packageDir);
   }
   for (const dependency of Object.keys(packageJson.optionalDependencies || {})) {
-    copyPackage(dependency, true);
+    copyPackage(dependency, true, packageDir);
   }
+}
+
+function findPackageJson(name, fromDir) {
+  for (const nodeModulesPath of Module._nodeModulePaths(fromDir)) {
+    const packageJsonPath = path.join(nodeModulesPath, name, "package.json");
+    if (fs.existsSync(packageJsonPath)) {
+      return fs.realpathSync(packageJsonPath);
+    }
+  }
+
+  return path.join(sourceRoot, name, "package.json");
 }
 
 for (const dependency of ["@prisma/client", "prisma"]) {
@@ -46,7 +59,5 @@ fs.cpSync(path.join(sourceRoot, ".prisma"), path.join(targetRoot, ".prisma"), {
   recursive: true,
   dereference: true,
 });
-fs.cpSync(path.join(sourceRoot, ".bin"), path.join(targetRoot, ".bin"), {
-  recursive: true,
-  dereference: true,
-});
+fs.mkdirSync(path.join(targetRoot, ".bin"), { recursive: true });
+fs.symlinkSync("../prisma/build/index.js", path.join(targetRoot, ".bin/prisma"));

--- a/docker/copy-prisma-runtime.cjs
+++ b/docker/copy-prisma-runtime.cjs
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const path = require("path");
+
+const sourceRoot = "/app/node_modules";
+const targetRoot = "/app/prisma-runtime/node_modules";
+const seen = new Set();
+
+function copyPackage(name, optional = false) {
+  if (seen.has(name)) {
+    return;
+  }
+
+  const packageJsonPath = path.join(sourceRoot, name, "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
+    if (optional) {
+      return;
+    }
+    throw new Error(`Cannot find package ${name}`);
+  }
+
+  seen.add(name);
+  const packageDir = path.dirname(packageJsonPath);
+  const targetDir = path.join(targetRoot, name);
+
+  fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+  fs.cpSync(packageDir, targetDir, {
+    recursive: true,
+    dereference: true,
+  });
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+  for (const dependency of Object.keys(packageJson.dependencies || {})) {
+    copyPackage(dependency);
+  }
+  for (const dependency of Object.keys(packageJson.optionalDependencies || {})) {
+    copyPackage(dependency, true);
+  }
+}
+
+for (const dependency of ["@prisma/client", "prisma"]) {
+  copyPackage(dependency);
+}
+
+fs.cpSync(path.join(sourceRoot, ".prisma"), path.join(targetRoot, ".prisma"), {
+  recursive: true,
+  dereference: true,
+});
+fs.cpSync(path.join(sourceRoot, ".bin"), path.join(targetRoot, ".bin"), {
+  recursive: true,
+  dereference: true,
+});

--- a/docker/indexer.Dockerfile
+++ b/docker/indexer.Dockerfile
@@ -1,6 +1,14 @@
-FROM node:22-alpine
+FROM node:22-alpine AS base
 
 WORKDIR /app
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN corepack enable \
+  && corepack prepare pnpm@10.32.1 --activate
+
+FROM base AS s6
 
 ARG S6_OVERLAY_VERSION=3.2.1.0
 ARG TARGETARCH
@@ -18,24 +26,44 @@ RUN set -eux; \
   tar -C / -Jxpf /tmp/s6-overlay-${s6_arch}.tar.xz; \
   rm -f /tmp/s6-overlay-noarch.tar.xz /tmp/s6-overlay-${s6_arch}.tar.xz
 
+FROM base AS manifests
+
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/indexer/package.json packages/indexer/package.json
 COPY packages/web/package.json packages/web/package.json
-COPY docker/services.d /etc/services.d
 
-RUN apk add --no-cache --virtual .build-deps python3 make g++ \
-  && npm i -g @subsquid/cli \
-  && corepack enable \
-  && corepack prepare pnpm@10.32.1 --activate \
-  && pnpm install --filter @degov/indexer --frozen-lockfile
+FROM manifests AS builder
+
+RUN apk add --no-cache python3 make g++ \
+  && pnpm install --filter @degov/indexer... --frozen-lockfile
 
 COPY packages/indexer packages/indexer
 
 WORKDIR /app/packages/indexer
 
-RUN pnpm run build \
-  && apk del .build-deps \
-  && pnpm store prune \
-  && npm cache clean --force
+RUN pnpm run build
+
+FROM manifests AS prod-deps
+
+RUN pnpm install --filter @degov/indexer --prod --frozen-lockfile --ignore-scripts \
+  && pnpm store prune
+
+FROM s6 AS runner
+
+COPY docker/services.d /etc/services.d
+
+COPY --from=prod-deps /app/node_modules node_modules
+COPY --from=prod-deps /app/packages/indexer/package.json packages/indexer/package.json
+COPY --from=prod-deps /app/packages/indexer/node_modules packages/indexer/node_modules
+
+COPY --from=builder /app/packages/indexer/lib packages/indexer/lib
+COPY --from=builder /app/packages/indexer/db packages/indexer/db
+COPY --from=builder /app/packages/indexer/scripts/start.sh packages/indexer/scripts/start.sh
+COPY --from=builder /app/packages/indexer/scripts/graphql-server.sh packages/indexer/scripts/graphql-server.sh
+COPY --from=builder /app/packages/indexer/schema.graphql packages/indexer/schema.graphql
+COPY --from=builder /app/packages/indexer/commands.json packages/indexer/commands.json
+COPY --from=builder /app/packages/indexer/squid.yaml packages/indexer/squid.yaml
+
+WORKDIR /app/packages/indexer
 
 ENTRYPOINT ["/init"]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -2,23 +2,36 @@
 
 FROM node:22-alpine AS base
 
-FROM base AS builder
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
 
-COPY . /code
+RUN corepack enable \
+    && corepack prepare pnpm@10.32.1 --activate
+
+FROM base AS builder
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/web/package.json packages/web/package.json
+COPY packages/indexer/package.json packages/indexer/package.json
 
 ENV DEGOV_CONFIG_PATH=/app/degov.yml
 ENV CI=true
 
 RUN apk add --no-cache python3 make g++ \
-    && corepack enable pnpm \
-    && mv /code/packages/web /app \
-    && mv /code/degov.yml /app \
-    && rm -rf /code \
-    && cd /app \
     && echo "node-linker=hoisted" > .npmrc \
-    && pnpm install --frozen-lockfile \
-    && npx prisma generate \
-    && pnpm build
+    && pnpm install --filter @degov/web... --frozen-lockfile --ignore-scripts
+
+COPY degov.yml degov.yml
+COPY docker/copy-prisma-runtime.cjs docker/copy-prisma-runtime.cjs
+COPY packages/web packages/web
+
+WORKDIR /app/packages/web
+
+RUN pnpm exec prisma generate \
+    && pnpm run build
+
+RUN node /app/docker/copy-prisma-runtime.cjs
 
 FROM base AS runner
 WORKDIR /app
@@ -29,15 +42,16 @@ ENV DEGOV_CONFIG_PATH=/app/degov.yml
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone .
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static .next/static
-COPY --from=builder --chown=nextjs:nodejs /app/public public
-COPY --from=builder --chown=nextjs:nodejs /app/scripts scripts
-COPY --from=builder --chown=nextjs:nodejs /app/prisma prisma
-COPY --from=builder --chown=nextjs:nodejs /app/prisma.config.ts prisma.config.ts
+COPY --from=builder --chown=nextjs:nodejs /app/degov.yml degov.yml
+COPY --from=builder --chown=nextjs:nodejs /app/packages/web/.next/standalone .
+COPY --from=builder --chown=nextjs:nodejs /app/packages/web/.next/static packages/web/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/packages/web/public packages/web/public
+COPY --from=builder --chown=nextjs:nodejs /app/packages/web/scripts packages/web/scripts
+COPY --from=builder --chown=nextjs:nodejs /app/packages/web/prisma packages/web/prisma
+COPY --from=builder --chown=nextjs:nodejs /app/packages/web/prisma.config.ts packages/web/prisma.config.ts
 
-# Copy the entire node_modules from builder (includes Prisma client and engines)
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules node_modules
+# Runtime Prisma support for entrypoint.sh without copying the full install tree.
+COPY --from=builder --chown=nextjs:nodejs /app/prisma-runtime/node_modules node_modules
 
 USER nextjs
 
@@ -46,4 +60,4 @@ ENV HOSTNAME="0.0.0.0"
 
 EXPOSE 3000
 
-ENTRYPOINT [ "/app/scripts/entrypoint.sh" ]
+ENTRYPOINT [ "/app/packages/web/scripts/entrypoint.sh" ]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -43,6 +43,7 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 COPY --from=builder --chown=nextjs:nodejs /app/degov.yml degov.yml
+# Standalone output keeps the workspace layout, including packages/web/server.js.
 COPY --from=builder --chown=nextjs:nodejs /app/packages/web/.next/standalone .
 COPY --from=builder --chown=nextjs:nodejs /app/packages/web/.next/static packages/web/.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/packages/web/public packages/web/public

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@openrouter/ai-sdk-provider": "^2.3.3",
+    "@subsquid/cli": "^3.3.3",
     "@subsquid/evm-abi": "^0.3.1",
     "@subsquid/evm-codec": "^0.3.0",
     "@subsquid/evm-processor": "^1.29.0",
@@ -43,7 +44,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@subsquid/cli": "^3.3.3",
     "@subsquid/evm-typegen": "^4.6.0",
     "@subsquid/typeorm-codegen": "^2.1.0",
     "@types/jest": "30.0.0",

--- a/packages/indexer/scripts/graphql-server.sh
+++ b/packages/indexer/scripts/graphql-server.sh
@@ -8,6 +8,5 @@ WORK_PATH=${BIN_PATH}/../
 
 cd ${WORK_PATH}
 
-npx squid-graphql-server
-
+pnpm exec squid-graphql-server
 

--- a/packages/indexer/scripts/start.sh
+++ b/packages/indexer/scripts/start.sh
@@ -8,6 +8,6 @@ WORK_PATH=${BIN_PATH}/../
 
 cd ${WORK_PATH}
 
-npx sqd migration:apply
+pnpm exec sqd migration:apply
 
 node -r dotenv/config lib/main.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@openrouter/ai-sdk-provider':
         specifier: ^2.3.3
         version: 2.5.1(ai@6.0.159(zod@4.3.6))(zod@4.3.6)
+      '@subsquid/cli':
+        specifier: ^3.3.3
+        version: 3.3.5(@types/node@25.6.0)
       '@subsquid/evm-abi':
         specifier: ^0.3.1
         version: 0.3.1
@@ -55,9 +58,6 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@subsquid/cli':
-        specifier: ^3.3.3
-        version: 3.3.5(@types/node@25.6.0)
       '@subsquid/evm-typegen':
         specifier: ^4.6.0
         version: 4.6.0


### PR DESCRIPTION
## Summary

This PR reduces the runtime Docker image size for both degov web and indexer. It follows the direction from PR #668 for the web image, but adapts it to the current root pnpm workspace layout.

## Changes

- Update `docker/web.Dockerfile` to build from the root pnpm workspace instead of moving `packages/web` out of the workspace.
- Keep the Next.js standalone runtime output and avoid copying the full install tree into the web runner image.
- Add `docker/copy-prisma-runtime.cjs` to copy only the Prisma CLI/client runtime dependency closure required by `entrypoint.sh`.
- Convert `docker/indexer.Dockerfile` to a multi-stage build with separate builder, production dependencies, and runtime stages.
- Remove the global `npm i -g @subsquid/cli` from the indexer image and make `@subsquid/cli` a runtime dependency because production startup runs `sqd migration:apply`.
- Update indexer runtime scripts to use `pnpm exec` instead of `npx`.
- Expand `.dockerignore` to keep local build outputs, node_modules, logs, and indexer data out of the Docker build context.

## Validation

- `pnpm --filter @degov/indexer run build`
- `pnpm --filter @degov/indexer run test:unit`
- `pnpm --filter @degov/web run build`
- `docker build --network host -f docker/web.Dockerfile -t degov-web-size-test .`
- `docker build --network host -f docker/indexer.Dockerfile -t degov-indexer-size-test .`
- Web runtime Prisma check: `prisma --version` and `prisma validate --schema /app/packages/web/prisma/schema.prisma`
- Web server smoke test: started `node server.js` in the image and received HTTP 200 from `/`
- Indexer runtime check: verified `sqd`, `squid-graphql-server`, required runtime files, and core Subsquid modules inside the image

## Local image sizes

- `degov-web-size-test:latest`: 518MB
- `degov-indexer-size-test:latest`: 408MB

Note: local Docker builds used `--network host` because this machine's default Docker bridge network timed out while Corepack was fetching pnpm from the npm registry. The Dockerfiles themselves do not require host networking.