### PR TITLE
test(indexer): add missing voteClockMode mock in 4 token-vote-power t…

### DIFF
--- a/packages/indexer/__tests__/accuracy/token-vote-power.test.ts
+++ b/packages/indexer/__tests__/accuracy/token-vote-power.test.ts
@@ -3236,6 +3236,9 @@ describe("token vote power checkpoints", () => {
       }),
     ]);
     const handler = buildTokenHandler(store);
+    jest
+      .spyOn(handler as any, "voteClockMode")
+      .mockResolvedValue(ClockMode.BlockNumber);
 
     jest
       .spyOn(itokenerc20.events.DelegateChanged, "decode")
@@ -3559,6 +3562,9 @@ describe("token vote power checkpoints", () => {
       }),
     ]);
     const handler = buildTokenHandler(store);
+    jest
+      .spyOn(handler as any, "voteClockMode")
+      .mockResolvedValue(ClockMode.BlockNumber);
     const txHash =
       "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
@@ -3697,6 +3703,9 @@ describe("token vote power checkpoints", () => {
       }),
     ]);
     const handler = buildTokenHandler(store);
+    jest
+      .spyOn(handler as any, "voteClockMode")
+      .mockResolvedValue(ClockMode.BlockNumber);
     const txHash =
       "0x1111111111111111111111111111111111111111111111111111111111111111";
 
@@ -3863,6 +3872,9 @@ describe("token vote power checkpoints", () => {
       }),
     ]);
     const handler = buildTokenHandler(store);
+    jest
+      .spyOn(handler as any, "voteClockMode")
+      .mockResolvedValue(ClockMode.BlockNumber);
     const txHash =
       "0x2222222222222222222222222222222222222222222222222222222222222222";
 


### PR DESCRIPTION
…ests

Four test cases called storeDelegateVotesChanged without mocking voteClockMode, causing real RPC calls to https://rpc.example.invalid. This triggered retry loops with backoff and either a 5-second timeout or a TypeError when the response was undefined, making CI non-deterministic.

Fixed by adding jest.spyOn voteClockMode mock after buildTokenHandler in:
- does not leave transfer-only power behind after a redelegation plus same-tx incoming transfer
- matches same-tx zero-to-old and old-to-new vote deltas by delta sign
- keeps the second leg of a transfer-backed chained redelegation when logs are processed in order
- does not subtract same-tx incoming transfer from a redelegation when the old delegate has a vote delta first

All 95 tests pass locally after the fix.