### PR TITLE
Release v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "degov",
+  "version": "1.1.0",
   "private": true,
   "packageManager": "pnpm@10.32.1",
   "pnpm": {

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@degov/indexer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "codegen:abi": "squid-evm-typegen src/abi ./abi/*.json",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@degov/web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "postinstall": "prisma generate",


### PR DESCRIPTION
## Summary

Prepare Degov `v1.1.0` release.

## Changes

- Bump root `degov` package version to `1.1.0`.
- Bump `@degov/web` package version to `1.1.0`.
- Bump `@degov/indexer` package version to `1.1.0`.

## Release scope

The release notes were prepared from `v1.0.0..main` and will be posted as a PR comment.

## Validation

- `pnpm install --lockfile-only`
- `pnpm --filter @degov/web exec node -e 'console.log(require("./package.json").version)'`
- `pnpm --filter @degov/indexer exec node -e 'console.log(require("./package.json").version)'`
