### PR TITLE
fix(indexer): redact RPC URLs in logs

### DIFF
--- a/packages/indexer/__tests__/unit/helpers.test.ts
+++ b/packages/indexer/__tests__/unit/helpers.test.ts
@@ -99,6 +99,12 @@ describe("DegovIndexerHelpers", () => {
         selectedRpc: "not a url?apiKey=secret#fragment",
       })
     ).toBe('processor.rpc selected | selectedRpc="not a url"');
+
+    expect(
+      DegovIndexerHelpers.formatLogLine("processor.rpc selected", {
+        selectedRpc: "https://user:password@rpc.example.com/v3/path-api-key %%%",
+      })
+    ).toBe("processor.rpc selected | selectedRpc=https://rpc.example.com");
   });
 
   it("formats errors without leaking object noise", () => {
@@ -109,6 +115,16 @@ describe("DegovIndexerHelpers", () => {
     expect(
       DegovIndexerHelpers.formatError({ code: "E_TIMEOUT", retryable: true })
     ).toBe('{"code":"E_TIMEOUT","retryable":true}');
+  });
+
+  it("formats non-json errors without throwing", () => {
+    expect(DegovIndexerHelpers.formatError(undefined)).toBe("undefined");
+    expect(DegovIndexerHelpers.formatError(() => "failed")).toBe(
+      "() => \"failed\""
+    );
+    expect(DegovIndexerHelpers.formatError(Symbol("failed"))).toBe(
+      "Symbol(failed)"
+    );
   });
 
   it("redacts URLs embedded in error messages", () => {

--- a/packages/indexer/__tests__/unit/helpers.test.ts
+++ b/packages/indexer/__tests__/unit/helpers.test.ts
@@ -71,6 +71,36 @@ describe("DegovIndexerHelpers", () => {
     );
   });
 
+  it("redacts URL credentials and request data from url-like log fields", () => {
+    expect(
+      DegovIndexerHelpers.redactUrl(
+        "https://user:password@rpc.example.com/path?apiKey=secret#fragment"
+      )
+    ).toBe("https://rpc.example.com");
+
+    expect(
+      DegovIndexerHelpers.formatLogLine("processor.rpc selected", {
+        selectedRpc:
+          "https://user:password@rpc.example.com/path?apiKey=secret#fragment",
+        rpcs: [
+          "wss://rpc-one.example/ws?token=secret",
+          "https://rpc-two.example/v3/key",
+        ],
+        message: "keeps regular strings intact",
+      })
+    ).toBe(
+      'processor.rpc selected | selectedRpc=https://rpc.example.com rpcs=["wss://rpc-one.example","https://rpc-two.example"] message="keeps regular strings intact"'
+    );
+  });
+
+  it("redacts invalid URL log fields without throwing", () => {
+    expect(
+      DegovIndexerHelpers.formatLogLine("processor.rpc selected", {
+        selectedRpc: "not a url?apiKey=secret#fragment",
+      })
+    ).toBe('processor.rpc selected | selectedRpc="not a url"');
+  });
+
   it("formats errors without leaking object noise", () => {
     expect(
       DegovIndexerHelpers.formatError(new Error("rpc timeout"))
@@ -79,6 +109,16 @@ describe("DegovIndexerHelpers", () => {
     expect(
       DegovIndexerHelpers.formatError({ code: "E_TIMEOUT", retryable: true })
     ).toBe('{"code":"E_TIMEOUT","retryable":true}');
+  });
+
+  it("redacts URLs embedded in error messages", () => {
+    expect(
+      DegovIndexerHelpers.formatError(
+        new Error(
+          "request failed for https://user:password@rpc.example.com/path?apiKey=secret#fragment"
+        )
+      )
+    ).toBe("request failed for https://rpc.example.com");
   });
 
   it("keeps verbose logs disabled by default", () => {

--- a/packages/indexer/src/internal/helpers.ts
+++ b/packages/indexer/src/internal/helpers.ts
@@ -85,19 +85,28 @@ export class DegovIndexerHelpers {
   ): string {
     const details = Object.entries(fields)
       .filter(([, value]) => value !== undefined && value !== null && value !== "")
-      .map(([key, value]) => `${key}=${this.formatLogValue(value)}`);
+      .map(([key, value]) => `${key}=${this.formatLogValue(key, value)}`);
 
     return details.length > 0 ? `${step} | ${details.join(" ")}` : step;
   }
 
+  static redactUrl(value: string): string {
+    try {
+      const url = new URL(value);
+      return url.origin;
+    } catch {
+      return this.redactInvalidUrl(value);
+    }
+  }
+
   static formatError(error: unknown): string {
     if (error instanceof Error) {
-      return error.message;
+      return this.redactUrlsInText(error.message);
     }
     if (typeof error === "string") {
-      return error;
+      return this.redactUrlsInText(error);
     }
-    return this.safeJsonStringify(error);
+    return this.redactUrlsInText(this.safeJsonStringify(error));
   }
 
   static logVerbose(step: string, fields: Record<string, IndexerLogFieldValue> = {}) {
@@ -137,16 +146,64 @@ export class DegovIndexerHelpers {
     };
   }
 
-  private static formatLogValue(value: IndexerLogFieldValue): string {
-    if (typeof value === "bigint") {
-      return value.toString();
+  private static formatLogValue(key: string, value: IndexerLogFieldValue): string {
+    const logValue = this.redactLogValue(key, value);
+
+    if (typeof logValue === "bigint") {
+      return logValue.toString();
     }
+    if (typeof logValue === "string") {
+      return /\s/.test(logValue) ? JSON.stringify(logValue) : logValue;
+    }
+    if (typeof logValue === "number" || typeof logValue === "boolean") {
+      return String(logValue);
+    }
+    return this.safeJsonStringify(logValue);
+  }
+
+  private static redactLogValue(
+    key: string,
+    value: IndexerLogFieldValue
+  ): IndexerLogFieldValue {
     if (typeof value === "string") {
-      return /\s/.test(value) ? JSON.stringify(value) : value;
+      return this.isUrlLogField(key) ? this.redactUrl(value) : value;
     }
-    if (typeof value === "number" || typeof value === "boolean") {
-      return String(value);
+
+    if (typeof value === "bigint") {
+      return value;
     }
-    return this.safeJsonStringify(value);
+
+    if (Array.isArray(value)) {
+      return value.map((item) => this.redactLogValue(key, item as IndexerLogFieldValue));
+    }
+
+    if (value && typeof value === "object") {
+      return Object.fromEntries(
+        Object.entries(value).map(([nestedKey, nestedValue]) => [
+          nestedKey,
+          this.redactLogValue(nestedKey, nestedValue as IndexerLogFieldValue),
+        ])
+      );
+    }
+
+    return value;
+  }
+
+  private static isUrlLogField(key: string): boolean {
+    return /(rpc|url|endpoint|configpath)/i.test(key);
+  }
+
+  private static redactUrlsInText(value: string): string {
+    return value.replace(/https?:\/\/[^\s"'<>]+|wss?:\/\/[^\s"'<>]+/gi, (url) =>
+      this.redactUrl(url)
+    );
+  }
+
+  private static redactInvalidUrl(value: string): string {
+    const withoutQueryOrFragment = value.split(/[?#]/, 1)[0];
+    return withoutQueryOrFragment.replace(
+      /^([a-z][a-z\d+\-.]*:\/\/)[^/@\s]+@/i,
+      "$1"
+    );
   }
 }

--- a/packages/indexer/src/internal/helpers.ts
+++ b/packages/indexer/src/internal/helpers.ts
@@ -22,7 +22,7 @@ export class DegovIndexerHelpers {
   static safeJsonStringify(
     value: any,
     replacer: (key: string, value: any) => any = (_, v) => v
-  ): string {
+  ): string | undefined {
     return JSON.stringify(value, (_, v) => {
       if (typeof v === "bigint") {
         return v.toString();
@@ -106,7 +106,11 @@ export class DegovIndexerHelpers {
     if (typeof error === "string") {
       return this.redactUrlsInText(error);
     }
-    return this.redactUrlsInText(this.safeJsonStringify(error));
+    const serializedError = this.safeJsonStringify(error);
+    if (typeof serializedError === "string") {
+      return this.redactUrlsInText(serializedError);
+    }
+    return String(error);
   }
 
   static logVerbose(step: string, fields: Record<string, IndexerLogFieldValue> = {}) {
@@ -158,7 +162,7 @@ export class DegovIndexerHelpers {
     if (typeof logValue === "number" || typeof logValue === "boolean") {
       return String(logValue);
     }
-    return this.safeJsonStringify(logValue);
+    return this.formatJsonLogValue(logValue);
   }
 
   private static redactLogValue(
@@ -200,10 +204,23 @@ export class DegovIndexerHelpers {
   }
 
   private static redactInvalidUrl(value: string): string {
-    const withoutQueryOrFragment = value.split(/[?#]/, 1)[0];
+    const withoutQueryOrFragment = value.trim().split(/[?#]/, 1)[0];
+    const originMatch = withoutQueryOrFragment.match(
+      /^([a-z][a-z\d+\-.]*:\/\/)(?:[^/@\s]+@)?([^/\s]+)(?:\/|$)/i
+    );
+
+    if (originMatch) {
+      return `${originMatch[1]}${originMatch[2]}`;
+    }
+
     return withoutQueryOrFragment.replace(
       /^([a-z][a-z\d+\-.]*:\/\/)[^/@\s]+@/i,
       "$1"
     );
+  }
+
+  private static formatJsonLogValue(value: IndexerLogFieldValue): string {
+    const serializedValue = this.safeJsonStringify(value);
+    return typeof serializedValue === "string" ? serializedValue : String(value);
   }
 }


### PR DESCRIPTION
## What changed
- Added shared indexer URL redaction for RPC/url/endpoint/configPath log fields.
- Redacts query strings, fragments, embedded credentials, and path-based API keys by logging only URL origins.
- Redacts URLs embedded in formatted error messages and handles invalid URL strings without throwing.
- Added focused helper tests for query keys, credentials, embedded error URLs, and invalid URL handling.

## Tests
- `pnpm --dir packages/indexer exec jest --runInBand --runTestsByPath __tests__/unit/helpers.test.ts __tests__/unit/chaintool.test.ts`
- `pnpm --dir packages/indexer test:unit` fails before completing due existing generated model export errors in `__tests__/accuracy/token-vote-power.test.ts` and `__tests__/unit/governor.test.ts`.

Closes #694