### PR TITLE
Strengthen SIWE server-side context validation

### DIFF
--- a/packages/web/scripts/siwe-context.test.ts
+++ b/packages/web/scripts/siwe-context.test.ts
@@ -3,33 +3,69 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
-  expectedSiweContextFromConfig,
+  expectedSiweContextFromRequest,
   validateSiweContext,
   type SiweContext,
 } from "../src/app/api/common/siwe-context.ts";
 
 const validConfig = {
-  siteUrl: "https://degov-dev.vercel.app",
   chain: { id: 46 },
 };
 
 const issuedNonce = "nonce-123";
 const now = new Date("2026-04-16T12:00:00.000Z");
 const validSiweContext: SiweContext = {
-  domain: "degov-dev.vercel.app",
-  uri: "https://degov-dev.vercel.app",
+  domain: "preview.degov.example",
+  uri: "https://preview.degov.example",
   chainId: 46,
   nonce: issuedNonce,
   expirationTime: "2026-04-16T12:05:00.000Z",
   notBefore: "2026-04-16T11:55:00.000Z",
 };
 
+function requestHeaders() {
+  return new Headers({
+    host: "internal.example",
+    "x-forwarded-host": "preview.degov.example",
+    "x-forwarded-proto": "https",
+  });
+}
+
 function expectedContext() {
   return {
-    ...expectedSiweContextFromConfig(validConfig, issuedNonce),
+    ...expectedSiweContextFromRequest(
+      validConfig,
+      requestHeaders(),
+      issuedNonce
+    ),
     now,
   };
 }
+
+test("SIWE context expectation derives domain and URI from request Origin when it matches Host", () => {
+  const context = expectedSiweContextFromRequest(
+    validConfig,
+    new Headers({
+      host: "localhost:3000",
+      origin: "http://localhost:3000",
+    }),
+    issuedNonce
+  );
+
+  assert.equal(context.domain, "localhost:3000");
+  assert.equal(context.uri, "http://localhost:3000");
+});
+
+test("SIWE context expectation derives domain and URI from forwarded request headers", () => {
+  const context = expectedSiweContextFromRequest(
+    validConfig,
+    requestHeaders(),
+    issuedNonce
+  );
+
+  assert.equal(context.domain, "preview.degov.example");
+  assert.equal(context.uri, "https://preview.degov.example");
+});
 
 test("SIWE context validation accepts the configured domain, URI, chain and nonce", () => {
   assert.doesNotThrow(() => {
@@ -37,7 +73,7 @@ test("SIWE context validation accepts the configured domain, URI, chain and nonc
   });
 });
 
-test("SIWE context validation rejects a mismatched domain", () => {
+test("SIWE context validation rejects a domain that mismatches the request origin", () => {
   assert.throws(
     () =>
       validateSiweContext(
@@ -48,7 +84,7 @@ test("SIWE context validation rejects a mismatched domain", () => {
   );
 });
 
-test("SIWE context validation rejects a mismatched URI", () => {
+test("SIWE context validation rejects a URI that mismatches the request origin", () => {
   assert.throws(
     () =>
       validateSiweContext(
@@ -147,5 +183,7 @@ test("login route binds SIWE verify to the issued nonce, domain and current time
   assert.match(loginRouteSource, /domain: expectedSiweContext\.domain/);
   assert.match(loginRouteSource, /nonce: expectedSiweContext\.nonce/);
   assert.match(loginRouteSource, /time: verificationTime\.toISOString\(\)/);
+  assert.match(loginRouteSource, /expectedSiweContextFromRequest/);
+  assert.match(loginRouteSource, /request\.headers/);
   assert.match(loginRouteSource, /validateSiweContext\(fields\.data/);
 });

--- a/packages/web/scripts/siwe-context.test.ts
+++ b/packages/web/scripts/siwe-context.test.ts
@@ -95,6 +95,20 @@ test("SIWE context validation rejects expired messages", () => {
   );
 });
 
+test("SIWE context validation rejects invalid expirationTime strings", () => {
+  assert.throws(
+    () =>
+      validateSiweContext(
+        {
+          ...validSiweContext,
+          expirationTime: "not-a-date",
+        },
+        expectedContext()
+      ),
+    /expirationTime is not a valid date/
+  );
+});
+
 test("SIWE context validation rejects messages that are not yet valid", () => {
   assert.throws(
     () =>
@@ -106,6 +120,20 @@ test("SIWE context validation rejects messages that are not yet valid", () => {
         expectedContext()
       ),
     /not yet valid/
+  );
+});
+
+test("SIWE context validation rejects invalid notBefore strings", () => {
+  assert.throws(
+    () =>
+      validateSiweContext(
+        {
+          ...validSiweContext,
+          notBefore: "not-a-date",
+        },
+        expectedContext()
+      ),
+    /notBefore is not a valid date/
   );
 });
 

--- a/packages/web/scripts/siwe-context.test.ts
+++ b/packages/web/scripts/siwe-context.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  expectedSiweContextFromConfig,
+  validateSiweContext,
+  type SiweContext,
+} from "../src/app/api/common/siwe-context.ts";
+
+const validConfig = {
+  siteUrl: "https://degov-dev.vercel.app",
+  chain: { id: 46 },
+};
+
+const issuedNonce = "nonce-123";
+const now = new Date("2026-04-16T12:00:00.000Z");
+const validSiweContext: SiweContext = {
+  domain: "degov-dev.vercel.app",
+  uri: "https://degov-dev.vercel.app",
+  chainId: 46,
+  nonce: issuedNonce,
+  expirationTime: "2026-04-16T12:05:00.000Z",
+  notBefore: "2026-04-16T11:55:00.000Z",
+};
+
+function expectedContext() {
+  return {
+    ...expectedSiweContextFromConfig(validConfig, issuedNonce),
+    now,
+  };
+}
+
+test("SIWE context validation accepts the configured domain, URI, chain and nonce", () => {
+  assert.doesNotThrow(() => {
+    validateSiweContext(validSiweContext, expectedContext());
+  });
+});
+
+test("SIWE context validation rejects a mismatched domain", () => {
+  assert.throws(
+    () =>
+      validateSiweContext(
+        { ...validSiweContext, domain: "evil.example" },
+        expectedContext()
+      ),
+    /domain/
+  );
+});
+
+test("SIWE context validation rejects a mismatched URI", () => {
+  assert.throws(
+    () =>
+      validateSiweContext(
+        { ...validSiweContext, uri: "https://evil.example" },
+        expectedContext()
+      ),
+    /URI/
+  );
+});
+
+test("SIWE context validation rejects an unsupported chainId", () => {
+  assert.throws(
+    () =>
+      validateSiweContext(
+        { ...validSiweContext, chainId: 1 },
+        expectedContext()
+      ),
+    /chainId/
+  );
+});
+
+test("SIWE context validation rejects a mismatched nonce", () => {
+  assert.throws(
+    () =>
+      validateSiweContext(
+        { ...validSiweContext, nonce: "different-nonce" },
+        expectedContext()
+      ),
+    /nonce/
+  );
+});
+
+test("SIWE context validation rejects expired messages", () => {
+  assert.throws(
+    () =>
+      validateSiweContext(
+        {
+          ...validSiweContext,
+          expirationTime: "2026-04-16T11:59:59.000Z",
+        },
+        expectedContext()
+      ),
+    /expired/
+  );
+});
+
+test("SIWE context validation rejects messages that are not yet valid", () => {
+  assert.throws(
+    () =>
+      validateSiweContext(
+        {
+          ...validSiweContext,
+          notBefore: "2026-04-16T12:00:01.000Z",
+        },
+        expectedContext()
+      ),
+    /not yet valid/
+  );
+});
+
+test("login route binds SIWE verify to the issued nonce, domain and current time", () => {
+  const loginRouteSource = readFileSync(
+    new URL("../src/app/api/auth/login/route.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(loginRouteSource, /siweMessage\.verify\(\{/);
+  assert.match(loginRouteSource, /domain: expectedSiweContext\.domain/);
+  assert.match(loginRouteSource, /nonce: expectedSiweContext\.nonce/);
+  assert.match(loginRouteSource, /time: verificationTime\.toISOString\(\)/);
+  assert.match(loginRouteSource, /validateSiweContext\(fields\.data/);
+});

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -8,6 +8,10 @@ import { Resp } from "@/types/api";
 import * as config from "../../common/config";
 import { databaseConnection } from "../../common/database";
 import {
+  expectedSiweContextFromConfig,
+  validateSiweContext,
+} from "../../common/siwe-context";
+import {
   SIWE_NONCE_COOKIE_NAME,
   verifySiweNonceCookieValue,
 } from "../../common/siwe-nonce";
@@ -30,11 +34,46 @@ export async function POST(request: NextRequest) {
     }
 
     const { message, signature } = await request.json();
+    const signedNonceCookie = request.cookies.get(SIWE_NONCE_COOKIE_NAME)?.value;
+    const cookieNonce = signedNonceCookie
+      ? await verifySiweNonceCookieValue(signedNonceCookie, jwtSecretKey)
+      : null;
+
+    if (!cookieNonce) {
+      const invalidNonceResponse = NextResponse.json(
+        Resp.err("nonce expired or invalid, please get a new nonce"),
+        { status: 400 }
+      );
+
+      invalidNonceResponse.cookies.set({
+        name: SIWE_NONCE_COOKIE_NAME,
+        value: "",
+        maxAge: 0,
+        path: "/",
+      });
+
+      return invalidNonceResponse;
+    }
+
+    const expectedSiweContext = expectedSiweContextFromConfig(
+      degovConfig,
+      cookieNonce
+    );
 
     let fields;
     try {
       const siweMessage = new SiweMessage(message);
-      fields = await siweMessage.verify({ signature });
+      const verificationTime = new Date();
+      fields = await siweMessage.verify({
+        signature,
+        domain: expectedSiweContext.domain,
+        nonce: expectedSiweContext.nonce,
+        time: verificationTime.toISOString(),
+      });
+      validateSiweContext(fields.data, {
+        ...expectedSiweContext,
+        now: verificationTime,
+      });
 
       // fields = { data: { nonce: "3456789235", address: "0x2376628375284594" } };
     } catch (err) {
@@ -44,12 +83,7 @@ export async function POST(request: NextRequest) {
 
     // Validate if nonce is still valid
     const nonce = fields.data.nonce;
-    const signedNonceCookie = request.cookies.get(SIWE_NONCE_COOKIE_NAME)?.value;
-    const cookieNonce = signedNonceCookie
-      ? await verifySiweNonceCookieValue(signedNonceCookie, jwtSecretKey)
-      : null;
-    const nonceIsValid =
-      cookieNonce === nonce && (await consumeSiweNonce(nonce));
+    const nonceIsValid = await consumeSiweNonce(nonce);
 
     if (!nonceIsValid) {
       const invalidNonceResponse = NextResponse.json(

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -8,7 +8,7 @@ import { Resp } from "@/types/api";
 import * as config from "../../common/config";
 import { databaseConnection } from "../../common/database";
 import {
-  expectedSiweContextFromConfig,
+  expectedSiweContextFromRequest,
   validateSiweContext,
 } from "../../common/siwe-context";
 import {
@@ -55,8 +55,9 @@ export async function POST(request: NextRequest) {
       return invalidNonceResponse;
     }
 
-    const expectedSiweContext = expectedSiweContextFromConfig(
+    const expectedSiweContext = expectedSiweContextFromRequest(
       degovConfig,
+      request.headers,
       cookieNonce
     );
 

--- a/packages/web/src/app/api/common/siwe-context.ts
+++ b/packages/web/src/app/api/common/siwe-context.ts
@@ -15,15 +15,62 @@ export interface ExpectedSiweContext {
   now?: Date;
 }
 
-export function expectedSiweContextFromConfig(
-  degovConfig: { siteUrl: string; chain: { id: number } },
+type HeaderReader = Pick<Headers, "get">;
+
+function firstHeaderValue(value: string | null): string | null {
+  return value?.split(",")[0]?.trim() || null;
+}
+
+function isLocalHost(host: string): boolean {
+  const hostname = host.split(":")[0]?.toLowerCase();
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1"
+  );
+}
+
+function resolveSiweRequestOrigin(headers: HeaderReader): URL {
+  const forwardedHost = firstHeaderValue(headers.get("x-forwarded-host"));
+  const host = forwardedHost ?? firstHeaderValue(headers.get("host"));
+
+  if (!host) {
+    throw new Error("Unable to resolve SIWE request host");
+  }
+
+  const origin = headers.get("origin");
+  if (origin) {
+    try {
+      const originUrl = new URL(origin);
+      if (originUrl.host === host) {
+        return originUrl;
+      }
+    } catch {
+      // Fall back to forwarded headers below.
+    }
+  }
+
+  const forwardedProto = firstHeaderValue(headers.get("x-forwarded-proto"));
+  const protocol =
+    forwardedProto === "http" || forwardedProto === "https"
+      ? forwardedProto
+      : isLocalHost(host)
+        ? "http"
+        : "https";
+
+  return new URL(`${protocol}://${host}`);
+}
+
+export function expectedSiweContextFromRequest(
+  degovConfig: { chain: { id: number } },
+  headers: HeaderReader,
   nonce: string
 ): ExpectedSiweContext {
-  const siteUrl = new URL(degovConfig.siteUrl);
+  const requestOrigin = resolveSiweRequestOrigin(headers);
 
   return {
-    domain: siteUrl.host,
-    uri: siteUrl.origin,
+    domain: requestOrigin.host,
+    uri: requestOrigin.origin,
     chainId: degovConfig.chain.id,
     nonce,
   };
@@ -34,11 +81,11 @@ export function validateSiweContext(
   expectedContext: ExpectedSiweContext
 ): void {
   if (siweContext.domain !== expectedContext.domain) {
-    throw new Error("SIWE domain does not match the configured site");
+    throw new Error("SIWE domain does not match the request origin");
   }
 
   if (siweContext.uri !== expectedContext.uri) {
-    throw new Error("SIWE URI does not match the configured site");
+    throw new Error("SIWE URI does not match the request origin");
   }
 
   if (siweContext.chainId !== expectedContext.chainId) {

--- a/packages/web/src/app/api/common/siwe-context.ts
+++ b/packages/web/src/app/api/common/siwe-context.ts
@@ -51,17 +51,27 @@ export function validateSiweContext(
 
   const now = expectedContext.now ?? new Date();
 
-  if (
-    siweContext.expirationTime &&
-    new Date(siweContext.expirationTime).getTime() <= now.getTime()
-  ) {
-    throw new Error("SIWE message has expired");
+  if (siweContext.expirationTime) {
+    const expirationTimeMs = new Date(siweContext.expirationTime).getTime();
+
+    if (!Number.isFinite(expirationTimeMs)) {
+      throw new Error("SIWE expirationTime is not a valid date");
+    }
+
+    if (expirationTimeMs <= now.getTime()) {
+      throw new Error("SIWE message has expired");
+    }
   }
 
-  if (
-    siweContext.notBefore &&
-    new Date(siweContext.notBefore).getTime() > now.getTime()
-  ) {
-    throw new Error("SIWE message is not yet valid");
+  if (siweContext.notBefore) {
+    const notBeforeMs = new Date(siweContext.notBefore).getTime();
+
+    if (!Number.isFinite(notBeforeMs)) {
+      throw new Error("SIWE notBefore is not a valid date");
+    }
+
+    if (notBeforeMs > now.getTime()) {
+      throw new Error("SIWE message is not yet valid");
+    }
   }
 }

--- a/packages/web/src/app/api/common/siwe-context.ts
+++ b/packages/web/src/app/api/common/siwe-context.ts
@@ -1,0 +1,67 @@
+export interface SiweContext {
+  domain?: string;
+  uri?: string;
+  chainId?: number;
+  nonce?: string;
+  expirationTime?: string;
+  notBefore?: string;
+}
+
+export interface ExpectedSiweContext {
+  domain: string;
+  uri: string;
+  chainId: number;
+  nonce: string;
+  now?: Date;
+}
+
+export function expectedSiweContextFromConfig(
+  degovConfig: { siteUrl: string; chain: { id: number } },
+  nonce: string
+): ExpectedSiweContext {
+  const siteUrl = new URL(degovConfig.siteUrl);
+
+  return {
+    domain: siteUrl.host,
+    uri: siteUrl.origin,
+    chainId: degovConfig.chain.id,
+    nonce,
+  };
+}
+
+export function validateSiweContext(
+  siweContext: SiweContext,
+  expectedContext: ExpectedSiweContext
+): void {
+  if (siweContext.domain !== expectedContext.domain) {
+    throw new Error("SIWE domain does not match the configured site");
+  }
+
+  if (siweContext.uri !== expectedContext.uri) {
+    throw new Error("SIWE URI does not match the configured site");
+  }
+
+  if (siweContext.chainId !== expectedContext.chainId) {
+    throw new Error("SIWE chainId is not supported");
+  }
+
+  if (siweContext.nonce !== expectedContext.nonce) {
+    throw new Error("SIWE nonce does not match the issued nonce");
+  }
+
+  const now = expectedContext.now ?? new Date();
+
+  if (
+    siweContext.expirationTime &&
+    new Date(siweContext.expirationTime).getTime() <= now.getTime()
+  ) {
+    throw new Error("SIWE message has expired");
+  }
+
+  if (
+    siweContext.notBefore &&
+    new Date(siweContext.notBefore).getTime() > now.getTime()
+  ) {
+    throw new Error("SIWE message is not yet valid");
+  }
+}


### PR DESCRIPTION
## Problem

The SIWE login route verified the wallet signature and consumed a nonce, but it did not explicitly bind the signed message to the expected application context. A valid signature could be accepted without server-side checks for the request domain, URI, supported chain ID, nonce, or SIWE validity window.

## Fix

- Resolve the expected SIWE context from the incoming request origin/host, DAO chain config, and the signed nonce cookie.
- Support local and preview/proxy hosts by deriving domain/URI from request headers while still rejecting mismatched signed-message context.
- Pass the expected `domain`, `nonce`, and current `time` into `SiweMessage.verify`.
- Add server-side validation for `domain`, `uri`, `chainId`, `nonce`, `expirationTime`, and `notBefore`, including invalid date strings, before consuming the nonce.
- Reject missing or invalid nonce cookies before signature verification and preserve successful nonce consumption/JWT behavior for valid logins.

## Tests

- `node --test --experimental-strip-types packages/web/scripts/siwe-context.test.ts`
- `node --test --experimental-strip-types packages/web/scripts/profile-auth.test.ts`
- `pnpm --dir packages/web exec tsc --noEmit`
- `pnpm --dir packages/web lint` (passes with one pre-existing import-order warning in `packages/web/src/app/_server/config-remote.ts`)

Closes #691.