### PR TITLE
Move auth token to HttpOnly cookie

### DIFF
--- a/packages/web/scripts/profile-auth.test.ts
+++ b/packages/web/scripts/profile-auth.test.ts
@@ -4,7 +4,10 @@ import test, { type TestContext } from "node:test";
 
 import { SignJWT } from "jose";
 
-import { resolveAuthPayload } from "../src/app/api/common/auth.ts";
+import {
+  AUTH_COOKIE_NAME,
+  resolveAuthPayload,
+} from "../src/app/api/common/auth.ts";
 import {
   signSiweNonceCookieValue,
   verifySiweNonceCookieValue,
@@ -61,6 +64,19 @@ test("resolveAuthPayload falls back to bearer tokens for profile updates", async
       Authorization: `Bearer ${token}`,
     })
   );
+
+  assert.deepEqual(resolvedPayload, { address: "0xabcdef" });
+});
+
+test("resolveAuthPayload verifies auth cookies for profile updates", async (t) => {
+  setJwtSecretForTest(t, "test-secret");
+  const token = await signToken("0xAbCdEf", "test-secret");
+
+  const resolvedPayload = await resolveAuthPayload(new Headers(), {
+    get(name: string) {
+      return name === AUTH_COOKIE_NAME ? { value: token } : undefined;
+    },
+  });
 
   assert.deepEqual(resolvedPayload, { address: "0xabcdef" });
 });
@@ -146,6 +162,42 @@ test("SIWE auth routes use a DB-backed nonce store with a signed nonce cookie", 
   assert.match(loginRouteSource, /verifySiweNonceCookieValue/);
   assert.match(loginRouteSource, /SIWE_NONCE_COOKIE_NAME/);
   assert.doesNotMatch(loginRouteSource, /nonceCache/);
+});
+
+test("login issues the auth token as an HttpOnly secure SameSite cookie", () => {
+  const loginRouteSource = readFileSync(
+    new URL("../src/app/api/auth/login/route.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(loginRouteSource, /AUTH_COOKIE_NAME/);
+  assert.match(loginRouteSource, /value: token/);
+  assert.match(loginRouteSource, /httpOnly: true/);
+  assert.match(loginRouteSource, /secure: true/);
+  assert.match(loginRouteSource, /sameSite: "lax"/);
+  assert.match(loginRouteSource, /Resp\.ok\(\{ authenticated: true \}\)/);
+  assert.doesNotMatch(loginRouteSource, /Resp\.ok\(\{ token \}\)/);
+});
+
+test("client no longer persists auth tokens in localStorage or sends bearer auth to local APIs", () => {
+  const tokenManagerSource = readFileSync(
+    new URL("../src/lib/auth/token-manager.ts", import.meta.url),
+    "utf8"
+  );
+  const graphqlServiceSource = readFileSync(
+    new URL("../src/services/graphql/index.ts", import.meta.url),
+    "utf8"
+  );
+  const siweServiceSource = readFileSync(
+    new URL("../src/lib/auth/siwe-service.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.doesNotMatch(tokenManagerSource, /localStorage/);
+  assert.doesNotMatch(graphqlServiceSource, /Authorization: `Bearer/);
+  assert.match(graphqlServiceSource, /credentials: "same-origin"/);
+  assert.doesNotMatch(siweServiceSource, /setToken\(localResult\.token/);
+  assert.match(siweServiceSource, /\/api\/auth\/logout/);
 });
 
 test("profile edit retries a 401 only after a fresh authentication attempt", () => {

--- a/packages/web/scripts/profile-auth.test.ts
+++ b/packages/web/scripts/profile-auth.test.ts
@@ -6,6 +6,7 @@ import { SignJWT } from "jose";
 
 import {
   AUTH_COOKIE_NAME,
+  authCookieOptions,
   resolveAuthPayload,
 } from "../src/app/api/common/auth.ts";
 import {
@@ -42,7 +43,7 @@ function setJwtSecretForTest(t: TestContext, value: string | undefined) {
   process.env.JWT_SECRET_KEY = value;
 }
 
-test("resolveAuthPayload keeps backwards compatibility with x-degov-auth-payload", async () => {
+test("resolveAuthPayload rejects unsigned x-degov-auth-payload headers", async () => {
   const payload = { address: "0xabcDEF" };
   const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64");
 
@@ -52,7 +53,7 @@ test("resolveAuthPayload keeps backwards compatibility with x-degov-auth-payload
     })
   );
 
-  assert.deepEqual(resolvedPayload, payload);
+  assert.equal(resolvedPayload, null);
 });
 
 test("resolveAuthPayload falls back to bearer tokens for profile updates", async (t) => {
@@ -97,6 +98,34 @@ test("resolveAuthPayload returns null for malformed legacy auth payloads", async
   );
 
   assert.equal(resolvedPayload, null);
+});
+
+test("auth cookie secure flag is conditional and shared by auth routes", () => {
+  const httpRequest = {
+    headers: new Headers(),
+    nextUrl: { protocol: "http:" },
+  };
+  const httpsRequest = {
+    headers: new Headers({ "x-forwarded-proto": "https" }),
+    nextUrl: { protocol: "http:" },
+  };
+
+  assert.equal(authCookieOptions(httpRequest).secure, false);
+  assert.equal(authCookieOptions(httpsRequest).secure, true);
+
+  const loginRouteSource = readFileSync(
+    new URL("../src/app/api/auth/login/route.ts", import.meta.url),
+    "utf8"
+  );
+  const logoutRouteSource = readFileSync(
+    new URL("../src/app/api/auth/logout/route.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(loginRouteSource, /authCookieOptions\(request\)/);
+  assert.match(logoutRouteSource, /authCookieOptions\(request\)/);
+  assert.doesNotMatch(loginRouteSource, /secure: true/);
+  assert.doesNotMatch(logoutRouteSource, /secure: true/);
 });
 
 test("resolveAuthPayload returns null when bearer auth is configured without a JWT secret", async (t) => {
@@ -172,14 +201,22 @@ test("login issues the auth token as an HttpOnly secure SameSite cookie", () => 
 
   assert.match(loginRouteSource, /AUTH_COOKIE_NAME/);
   assert.match(loginRouteSource, /value: token/);
-  assert.match(loginRouteSource, /httpOnly: true/);
-  assert.match(loginRouteSource, /secure: true/);
-  assert.match(loginRouteSource, /sameSite: "lax"/);
+  assert.match(loginRouteSource, /authCookieOptions\(request\)/);
   assert.match(loginRouteSource, /Resp\.ok\(\{ authenticated: true \}\)/);
   assert.doesNotMatch(loginRouteSource, /Resp\.ok\(\{ token \}\)/);
 });
 
-test("client no longer persists auth tokens in localStorage or sends bearer auth to local APIs", () => {
+test("auth status route verifies the cookie-backed session", () => {
+  const statusRouteSource = readFileSync(
+    new URL("../src/app/api/auth/status/route.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(statusRouteSource, /resolveAuthPayload\(request\.headers, request\.cookies\)/);
+  assert.match(statusRouteSource, /authenticated: Boolean\(authPayload\?\.address\)/);
+});
+
+test("client hydrates auth state from cookie status and clears it on 401", () => {
   const tokenManagerSource = readFileSync(
     new URL("../src/lib/auth/token-manager.ts", import.meta.url),
     "utf8"
@@ -192,12 +229,25 @@ test("client no longer persists auth tokens in localStorage or sends bearer auth
     new URL("../src/lib/auth/siwe-service.ts", import.meta.url),
     "utf8"
   );
+  const authStatusSource = readFileSync(
+    new URL("../src/hooks/useAuthStatus.ts", import.meta.url),
+    "utf8"
+  );
+  const ensureAuthSource = readFileSync(
+    new URL("../src/hooks/useEnsureAuth.ts", import.meta.url),
+    "utf8"
+  );
 
   assert.doesNotMatch(tokenManagerSource, /localStorage/);
+  assert.doesNotMatch(tokenManagerSource, /getToken/);
   assert.doesNotMatch(graphqlServiceSource, /Authorization: `Bearer/);
   assert.match(graphqlServiceSource, /credentials: "same-origin"/);
+  assert.match(graphqlServiceSource, /clearToken\(address\)/);
   assert.doesNotMatch(siweServiceSource, /setToken\(localResult\.token/);
   assert.match(siweServiceSource, /\/api\/auth\/logout/);
+  assert.match(siweServiceSource, /\/api\/auth\/status/);
+  assert.match(authStatusSource, /getAuthStatus\(address\)/);
+  assert.match(ensureAuthSource, /getAuthStatus\(address\)/);
 });
 
 test("profile edit retries a 401 only after a fresh authentication attempt", () => {

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -8,6 +8,7 @@ import { Resp } from "@/types/api";
 import {
   AUTH_COOKIE_MAX_AGE_SECONDS,
   AUTH_COOKIE_NAME,
+  authCookieOptions,
 } from "../../common/auth";
 import * as config from "../../common/config";
 import { databaseConnection } from "../../common/database";
@@ -124,11 +125,8 @@ export async function POST(request: NextRequest) {
     response.cookies.set({
       name: AUTH_COOKIE_NAME,
       value: token,
-      httpOnly: true,
-      sameSite: "lax",
-      secure: true,
       maxAge: AUTH_COOKIE_MAX_AGE_SECONDS,
-      path: "/",
+      ...authCookieOptions(request),
     });
 
     return response;

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -5,6 +5,10 @@ import { SiweMessage } from "siwe";
 import type { DUser } from "@/types/api";
 import { Resp } from "@/types/api";
 
+import {
+  AUTH_COOKIE_MAX_AGE_SECONDS,
+  AUTH_COOKIE_NAME,
+} from "../../common/auth";
 import * as config from "../../common/config";
 import { databaseConnection } from "../../common/database";
 import {
@@ -108,12 +112,22 @@ export async function POST(request: NextRequest) {
         where id=${storedUser.id};
       `;
     }
-    const response = NextResponse.json(Resp.ok({ token }));
+    const response = NextResponse.json(Resp.ok({ authenticated: true }));
 
     response.cookies.set({
       name: SIWE_NONCE_COOKIE_NAME,
       value: "",
       maxAge: 0,
+      path: "/",
+    });
+
+    response.cookies.set({
+      name: AUTH_COOKIE_NAME,
+      value: token,
+      httpOnly: true,
+      sameSite: "lax",
+      secure: true,
+      maxAge: AUTH_COOKIE_MAX_AGE_SECONDS,
       path: "/",
     });
 

--- a/packages/web/src/app/api/auth/logout/route.ts
+++ b/packages/web/src/app/api/auth/logout/route.ts
@@ -2,19 +2,18 @@ import { NextResponse } from "next/server";
 
 import { Resp } from "@/types/api";
 
-import { AUTH_COOKIE_NAME } from "../../common/auth";
+import { AUTH_COOKIE_NAME, authCookieOptions } from "../../common/auth";
 
-export async function POST() {
+import type { NextRequest } from "next/server";
+
+export async function POST(request: NextRequest) {
   const response = NextResponse.json(Resp.ok({ authenticated: false }));
 
   response.cookies.set({
     name: AUTH_COOKIE_NAME,
     value: "",
-    httpOnly: true,
-    sameSite: "lax",
-    secure: true,
     maxAge: 0,
-    path: "/",
+    ...authCookieOptions(request),
   });
 
   return response;

--- a/packages/web/src/app/api/auth/logout/route.ts
+++ b/packages/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+import { Resp } from "@/types/api";
+
+import { AUTH_COOKIE_NAME } from "../../common/auth";
+
+export async function POST() {
+  const response = NextResponse.json(Resp.ok({ authenticated: false }));
+
+  response.cookies.set({
+    name: AUTH_COOKIE_NAME,
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: true,
+    maxAge: 0,
+    path: "/",
+  });
+
+  return response;
+}

--- a/packages/web/src/app/api/auth/status/route.ts
+++ b/packages/web/src/app/api/auth/status/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { Resp } from "@/types/api";
+
+import { resolveAuthPayload } from "../../common/auth";
+
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const authPayload = await resolveAuthPayload(request.headers, request.cookies);
+
+  return NextResponse.json(
+    Resp.ok({
+      authenticated: Boolean(authPayload?.address),
+      address: authPayload?.address ?? null,
+    })
+  );
+}

--- a/packages/web/src/app/api/common/auth.ts
+++ b/packages/web/src/app/api/common/auth.ts
@@ -15,8 +15,30 @@ export const AUTH_COOKIE_MAX_AGE_SECONDS = 5 * 60 * 60;
 
 const textEncoder = new TextEncoder();
 
-function decodeEncodedAuthPayload(encodedPayload: string): AuthPayload {
-  return JSON.parse(Buffer.from(encodedPayload, "base64").toString());
+function isSecureAuthCookieRequest(request?: {
+  headers: HeaderAccessor;
+  nextUrl?: { protocol: string };
+}) {
+  if (process.env.NODE_ENV === "production") {
+    return true;
+  }
+
+  const forwardedProto = request?.headers.get("x-forwarded-proto");
+  const protocol =
+    forwardedProto?.split(",")[0]?.trim() ?? request?.nextUrl?.protocol;
+  return protocol === "https" || protocol === "https:";
+}
+
+export function authCookieOptions(request?: {
+  headers: HeaderAccessor;
+  nextUrl?: { protocol: string };
+}) {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: isSecureAuthCookieRequest(request),
+    path: "/",
+  };
 }
 
 async function verifyAuthToken(token: string): Promise<AuthPayload | null> {
@@ -47,15 +69,6 @@ export async function resolveAuthPayload(
   headers: HeaderAccessor,
   cookies?: CookieAccessor
 ): Promise<AuthPayload | null> {
-  const encodedPayload = headers.get("x-degov-auth-payload");
-  if (encodedPayload) {
-    try {
-      return decodeEncodedAuthPayload(encodedPayload);
-    } catch {
-      return null;
-    }
-  }
-
   const cookieToken = cookies?.get(AUTH_COOKIE_NAME)?.value;
   if (cookieToken) {
     const cookiePayload = await verifyAuthToken(cookieToken);

--- a/packages/web/src/app/api/common/auth.ts
+++ b/packages/web/src/app/api/common/auth.ts
@@ -6,30 +6,20 @@ interface HeaderAccessor {
   get(name: string): string | null;
 }
 
+interface CookieAccessor {
+  get(name: string): { value?: string } | undefined;
+}
+
+export const AUTH_COOKIE_NAME = "degov_auth";
+export const AUTH_COOKIE_MAX_AGE_SECONDS = 5 * 60 * 60;
+
 const textEncoder = new TextEncoder();
 
 function decodeEncodedAuthPayload(encodedPayload: string): AuthPayload {
   return JSON.parse(Buffer.from(encodedPayload, "base64").toString());
 }
 
-export async function resolveAuthPayload(
-  headers: HeaderAccessor
-): Promise<AuthPayload | null> {
-  const encodedPayload = headers.get("x-degov-auth-payload");
-  if (encodedPayload) {
-    try {
-      return decodeEncodedAuthPayload(encodedPayload);
-    } catch {
-      return null;
-    }
-  }
-
-  const authorizationHeader = headers.get("authorization");
-  const bearerToken = authorizationHeader?.match(/^Bearer\s+(.+)$/i)?.[1];
-  if (!bearerToken) {
-    return null;
-  }
-
+async function verifyAuthToken(token: string): Promise<AuthPayload | null> {
   const jwtSecretKey = process.env.JWT_SECRET_KEY;
   if (!jwtSecretKey) {
     return null;
@@ -37,7 +27,7 @@ export async function resolveAuthPayload(
 
   try {
     const { payload } = await jwtVerify<AuthPayload>(
-      bearerToken,
+      token,
       textEncoder.encode(jwtSecretKey)
     );
 
@@ -51,4 +41,34 @@ export async function resolveAuthPayload(
   } catch {
     return null;
   }
+}
+
+export async function resolveAuthPayload(
+  headers: HeaderAccessor,
+  cookies?: CookieAccessor
+): Promise<AuthPayload | null> {
+  const encodedPayload = headers.get("x-degov-auth-payload");
+  if (encodedPayload) {
+    try {
+      return decodeEncodedAuthPayload(encodedPayload);
+    } catch {
+      return null;
+    }
+  }
+
+  const cookieToken = cookies?.get(AUTH_COOKIE_NAME)?.value;
+  if (cookieToken) {
+    const cookiePayload = await verifyAuthToken(cookieToken);
+    if (cookiePayload) {
+      return cookiePayload;
+    }
+  }
+
+  const authorizationHeader = headers.get("authorization");
+  const bearerToken = authorizationHeader?.match(/^Bearer\s+(.+)$/i)?.[1];
+  if (!bearerToken) {
+    return null;
+  }
+
+  return verifyAuthToken(bearerToken);
 }

--- a/packages/web/src/app/api/profile/[address]/route.ts
+++ b/packages/web/src/app/api/profile/[address]/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const headersList = await headers();
-    const authPayload = await resolveAuthPayload(headersList);
+    const authPayload = await resolveAuthPayload(headersList, request.cookies);
     if (!authPayload?.address) {
       return NextResponse.json(Resp.err("permission denied"), { status: 401 });
     }

--- a/packages/web/src/hooks/useAuthStatus.ts
+++ b/packages/web/src/hooks/useAuthStatus.ts
@@ -9,14 +9,16 @@ import { tokenManager } from "@/lib/auth/token-manager";
  */
 export const useAuthStatus = () => {
   const { address } = useAccount();
-  const token = tokenManager.getToken(address);
+  const isAuthenticated = tokenManager.isAuthenticated(address);
   const [mounted, setMounted] = useState(false);
   const prevAddressRef = useRef<string | undefined>(undefined);
 
   const status = useMemo(() => {
     if (!mounted) return "loading" as const;
-    return token ? ("authenticated" as const) : ("unauthenticated" as const);
-  }, [mounted, token]);
+    return isAuthenticated
+      ? ("authenticated" as const)
+      : ("unauthenticated" as const);
+  }, [mounted, isAuthenticated]);
 
   // Mark mounted after first client render
   useEffect(() => {

--- a/packages/web/src/hooks/useAuthStatus.ts
+++ b/packages/web/src/hooks/useAuthStatus.ts
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAccount } from "wagmi";
 
+import { siweService } from "@/lib/auth/siwe-service";
 import { tokenManager } from "@/lib/auth/token-manager";
 
 /**
@@ -9,16 +10,17 @@ import { tokenManager } from "@/lib/auth/token-manager";
  */
 export const useAuthStatus = () => {
   const { address } = useAccount();
-  const isAuthenticated = tokenManager.isAuthenticated(address);
   const [mounted, setMounted] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isCheckingSession, setIsCheckingSession] = useState(false);
   const prevAddressRef = useRef<string | undefined>(undefined);
 
   const status = useMemo(() => {
-    if (!mounted) return "loading" as const;
+    if (!mounted || isCheckingSession) return "loading" as const;
     return isAuthenticated
       ? ("authenticated" as const)
       : ("unauthenticated" as const);
-  }, [mounted, isAuthenticated]);
+  }, [mounted, isAuthenticated, isCheckingSession]);
 
   // Mark mounted after first client render
   useEffect(() => {
@@ -30,9 +32,43 @@ export const useAuthStatus = () => {
     const prev = prevAddressRef.current;
     if (prev && prev !== address) {
       tokenManager.clearAllTokens(prev);
+      setIsAuthenticated(false);
     }
     prevAddressRef.current = address;
   }, [address]);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    if (!address) {
+      setIsAuthenticated(false);
+      setIsCheckingSession(false);
+      return;
+    }
+
+    let canceled = false;
+    setIsCheckingSession(true);
+
+    siweService
+      .getAuthStatus(address)
+      .then((result) => {
+        if (canceled) return;
+        setIsAuthenticated(result.authenticated);
+      })
+      .catch(() => {
+        if (canceled) return;
+        tokenManager.clearToken(address);
+        setIsAuthenticated(false);
+      })
+      .finally(() => {
+        if (canceled) return;
+        setIsCheckingSession(false);
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, [address, mounted]);
 
   return status;
 };

--- a/packages/web/src/hooks/useEnsureAuth.ts
+++ b/packages/web/src/hooks/useEnsureAuth.ts
@@ -1,9 +1,9 @@
 "use client";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
-import { tokenManager } from "@/lib/auth/token-manager";
+import { siweService } from "@/lib/auth/siwe-service";
 
 import { useSiweAuth } from "./useSiweAuth";
 
@@ -17,6 +17,13 @@ export const useEnsureAuth = () => {
 
   const { openConnectModal } = useConnectModal();
   const { authenticate, isAuthenticating } = useSiweAuth();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    if (!isConnected || !address) {
+      setIsAuthenticated(false);
+    }
+  }, [address, isConnected]);
 
   const ensureAuth = useCallback(async (): Promise<EnsureAuthResult> => {
     try {
@@ -35,11 +42,14 @@ export const useEnsureAuth = () => {
         };
       }
 
-      if (tokenManager.isAuthenticated(address)) {
+      const currentSession = await siweService.getAuthStatus(address);
+      if (currentSession.authenticated) {
+        setIsAuthenticated(true);
         return { success: true };
       }
 
       const authResult = await authenticate();
+      setIsAuthenticated(authResult.success);
 
       return {
         success: authResult.success,
@@ -59,6 +69,6 @@ export const useEnsureAuth = () => {
     ensureAuth,
     isAuthenticating,
     isConnected,
-    isAuthenticated: tokenManager.isAuthenticated(address),
+    isAuthenticated,
   };
 };

--- a/packages/web/src/hooks/useEnsureAuth.ts
+++ b/packages/web/src/hooks/useEnsureAuth.ts
@@ -35,7 +35,7 @@ export const useEnsureAuth = () => {
         };
       }
 
-      if (tokenManager.getToken(address)) {
+      if (tokenManager.isAuthenticated(address)) {
         return { success: true };
       }
 
@@ -59,6 +59,6 @@ export const useEnsureAuth = () => {
     ensureAuth,
     isAuthenticating,
     isConnected,
-    isAuthenticated: !!tokenManager.getToken(address),
+    isAuthenticated: tokenManager.isAuthenticated(address),
   };
 };

--- a/packages/web/src/hooks/useSiweAuth.ts
+++ b/packages/web/src/hooks/useSiweAuth.ts
@@ -55,9 +55,7 @@ export const useSiweAuth = () => {
         signMessageAsync,
       });
 
-      if (result.success && result.token) {
-        // set token
-      } else {
+      if (!result.success) {
         setError(new Error(result.error || "Authentication failed"));
       }
 

--- a/packages/web/src/lib/auth/siwe-service.ts
+++ b/packages/web/src/lib/auth/siwe-service.ts
@@ -85,14 +85,14 @@ export class SiweService {
     try {
       const { message, signature, address, nonceSource } = params;
 
-      let localToken: string | undefined;
+      let localAuthenticated = false;
       let remoteToken: string | undefined;
       const errors: string[] = [];
 
       const localResult = await this.loginLocal(message, signature);
       if (localResult.success) {
-        localToken = localResult.token;
-        tokenManager.setToken(localToken!, address);
+        localAuthenticated = true;
+        tokenManager.setToken("authenticated", address);
       } else {
         errors.push(`Local login failed: ${localResult.error}`);
       }
@@ -107,10 +107,9 @@ export class SiweService {
         }
       }
 
-      if (localToken || remoteToken) {
+      if (localAuthenticated || remoteToken) {
         return {
           success: true,
-          token: localToken,
           remoteToken,
           error: errors.length > 0 ? errors.join("; ") : undefined,
         };
@@ -138,12 +137,17 @@ export class SiweService {
       },
       body: JSON.stringify({ message, signature }),
       cache: "no-store",
+      credentials: "same-origin",
     });
 
     const result = await response.json();
 
     if (result?.code === 0 && result?.data?.token) {
       return { success: true, token: result.data.token };
+    }
+
+    if (result?.code === 0 && result?.data?.authenticated) {
+      return { success: true };
     }
 
     return {
@@ -209,6 +213,12 @@ export class SiweService {
   }
 
   async signOut(): Promise<void> {
+    await fetch("/api/auth/logout", {
+      method: "POST",
+      cache: "no-store",
+      credentials: "same-origin",
+    }).catch(() => undefined);
+
     tokenManager.clearAllTokens();
     // Clear persisted react-query cache if present
     try {

--- a/packages/web/src/lib/auth/siwe-service.ts
+++ b/packages/web/src/lib/auth/siwe-service.ts
@@ -12,6 +12,11 @@ export interface SiweAuthConfig {
   version?: string;
 }
 
+export interface AuthStatusResult {
+  authenticated: boolean;
+  address?: string;
+}
+
 export class SiweService {
   private static instance: SiweService;
   private config: SiweAuthConfig;
@@ -69,6 +74,42 @@ export class SiweService {
       chainId,
       nonce,
     });
+  }
+
+  async getAuthStatus(address?: string): Promise<AuthStatusResult> {
+    const response = await fetch("/api/auth/status", {
+      method: "GET",
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+
+    if (!response.ok) {
+      if (address) {
+        tokenManager.clearToken(address);
+      }
+      return { authenticated: false };
+    }
+
+    const result = await response.json();
+    const sessionAddress =
+      typeof result?.data?.address === "string"
+        ? result.data.address.toLowerCase()
+        : undefined;
+    const requestedAddress = address?.toLowerCase();
+    const authenticated =
+      Boolean(result?.data?.authenticated && sessionAddress) &&
+      (!requestedAddress || sessionAddress === requestedAddress);
+
+    if (authenticated) {
+      tokenManager.setToken("authenticated", sessionAddress);
+      return { authenticated: true, address: sessionAddress };
+    }
+
+    if (address) {
+      tokenManager.clearToken(address);
+    }
+
+    return { authenticated: false };
   }
 
   async verifySignature(params: {

--- a/packages/web/src/lib/auth/token-manager.ts
+++ b/packages/web/src/lib/auth/token-manager.ts
@@ -8,10 +8,6 @@ class TokenManager {
     return address?.toLowerCase() ?? "";
   }
 
-  getToken(address?: string): string | null {
-    return this.isAuthenticated(address) ? "cookie" : null;
-  }
-
   isAuthenticated(address?: string): boolean {
     return this.authenticatedAddresses.has(this.normalizeAddress(address));
   }
@@ -57,7 +53,6 @@ class TokenManager {
 
 export const tokenManager = new TokenManager();
 
-export const getToken = (address?: string) => tokenManager.getToken(address);
 export const clearToken = (address?: string) =>
   tokenManager.clearToken(address);
 

--- a/packages/web/src/lib/auth/token-manager.ts
+++ b/packages/web/src/lib/auth/token-manager.ts
@@ -1,32 +1,26 @@
 "use client";
 
-const TOKEN_KEY_PREFIX = "degov_auth_token";
-const REMOTE_TOKEN_KEY_PREFIX = "degov_remote_auth_token";
-
 class TokenManager {
-  private getTokenKey(address?: string): string {
-    if (!address) return TOKEN_KEY_PREFIX;
-    return `${TOKEN_KEY_PREFIX}_${address.toLowerCase()}`;
-  }
+  private authenticatedAddresses = new Set<string>();
+  private remoteTokens = new Map<string, string>();
 
-  private getRemoteTokenKey(address?: string): string {
-    if (!address) return REMOTE_TOKEN_KEY_PREFIX;
-    return `${REMOTE_TOKEN_KEY_PREFIX}_${address.toLowerCase()}`;
+  private normalizeAddress(address?: string): string {
+    return address?.toLowerCase() ?? "";
   }
 
   getToken(address?: string): string | null {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem(this.getTokenKey(address));
+    return this.isAuthenticated(address) ? "cookie" : null;
+  }
+
+  isAuthenticated(address?: string): boolean {
+    return this.authenticatedAddresses.has(this.normalizeAddress(address));
   }
 
   setToken(token: string | null, address?: string): void {
-    if (typeof window === "undefined") return;
-
-    const key = this.getTokenKey(address);
     if (token) {
-      localStorage.setItem(key, token);
+      this.authenticatedAddresses.add(this.normalizeAddress(address));
     } else {
-      localStorage.removeItem(key);
+      this.authenticatedAddresses.delete(this.normalizeAddress(address));
     }
   }
 
@@ -35,18 +29,14 @@ class TokenManager {
   }
 
   getRemoteToken(address?: string): string | null {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem(this.getRemoteTokenKey(address));
+    return this.remoteTokens.get(this.normalizeAddress(address)) ?? null;
   }
 
   setRemoteToken(token: string | null, address?: string): void {
-    if (typeof window === "undefined") return;
-
-    const key = this.getRemoteTokenKey(address);
     if (token) {
-      localStorage.setItem(key, token);
+      this.remoteTokens.set(this.normalizeAddress(address), token);
     } else {
-      localStorage.removeItem(key);
+      this.remoteTokens.delete(this.normalizeAddress(address));
     }
   }
 
@@ -60,16 +50,8 @@ class TokenManager {
   }
 
   clearAllAddressTokens(): void {
-    if (typeof window === "undefined") return;
-
-    const keys = Object.keys(localStorage);
-    const tokenKeys = keys.filter(
-      (key) =>
-        key.startsWith(TOKEN_KEY_PREFIX) ||
-        key.startsWith(REMOTE_TOKEN_KEY_PREFIX)
-    );
-
-    tokenKeys.forEach((key) => localStorage.removeItem(key));
+    this.authenticatedAddresses.clear();
+    this.remoteTokens.clear();
   }
 }
 

--- a/packages/web/src/services/graphql/index.ts
+++ b/packages/web/src/services/graphql/index.ts
@@ -1,3 +1,4 @@
+import { clearToken } from "@/lib/auth/token-manager";
 import type { Config } from "@/types/config";
 import { degovGraphqlApi } from "@/utils/remote-api";
 
@@ -483,6 +484,7 @@ export const profileService = {
       },
     });
     if (response.status === 401) {
+      clearToken(address);
       return { code: 401, msg: "Unauthorized" } as const;
     }
     const data = await response.json();

--- a/packages/web/src/services/graphql/index.ts
+++ b/packages/web/src/services/graphql/index.ts
@@ -1,5 +1,3 @@
-import { clearToken } from "@/lib/auth/token-manager";
-import { getToken } from "@/lib/auth/token-manager";
 import type { Config } from "@/types/config";
 import { degovGraphqlApi } from "@/utils/remote-api";
 
@@ -475,18 +473,16 @@ export const profileService = {
   },
 
   updateProfile: async (address: string, profile: Partial<ProfileData>) => {
-    const token = getToken(address);
     const response = await fetch(`/api/profile/${address}`, {
       method: "POST",
       body: JSON.stringify(profile),
       cache: "no-store",
+      credentials: "same-origin",
       headers: {
         "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
     });
     if (response.status === 401) {
-      clearToken(address);
       return { code: 401, msg: "Unauthorized" } as const;
     }
     const data = await response.json();


### PR DESCRIPTION
## Problem

Auth credentials for the local SIWE session were returned to browser JavaScript and persisted through `localStorage`, which makes session theft possible after an XSS.

## Fix

- Issue the local auth JWT as the `degov_auth` cookie on successful login with `HttpOnly`, `SameSite=Lax`, `Path=/`, and the existing 5 hour lifetime.
- Use a secure cookie on HTTPS/production while keeping local HTTP development usable, and clear logout cookies with matching attributes.
- Stop returning the local JWT in the login JSON response; the client now treats local auth as cookie-backed state.
- Verify authenticated API requests from the HttpOnly cookie and remove the forgeable unsigned legacy auth-payload header path.
- Add a cookie-backed auth status endpoint and hydrate client auth state from the server so refresh/new tabs keep the valid session.
- Remove localStorage-backed auth-token persistence and clear local auth state on cookie/session 401 responses.

## Tests

- `node --test packages/web/scripts/profile-auth.test.ts`
- `pnpm --filter @degov/web exec tsc --noEmit`
- `pnpm --filter @degov/web lint` (passes with one pre-existing import/order warning in `packages/web/src/app/_server/config-remote.ts`)

Closes #692.