### PR TITLE
Add SIWE nonce and login abuse controls

### DIFF
--- a/packages/web/scripts/profile-auth.test.ts
+++ b/packages/web/scripts/profile-auth.test.ts
@@ -13,6 +13,7 @@ import {
   createSiweRequestIdentity,
   recordSiweLoginFailure,
   resetSiweLoginFailures,
+  SIWE_ABUSE_BUCKET_LIMITS,
   SIWE_LOGIN_FAILURE_BACKOFF,
   SIWE_LOGIN_RATE_LIMIT,
   SIWE_NONCE_RATE_LIMIT,
@@ -168,6 +169,36 @@ test("SIWE auth routes use a DB-backed nonce store with a signed nonce cookie", 
   assert.doesNotMatch(loginRouteSource, /nonceCache/);
 });
 
+test("SIWE login route only uses address controls after signature verification", () => {
+  const loginRouteSource = readFileSync(
+    new URL("../src/app/api/auth/login/route.ts", import.meta.url),
+    "utf8"
+  );
+  const verifyIndex = loginRouteSource.indexOf(
+    "fields = await siweMessage.verify"
+  );
+  const addressIndex = loginRouteSource.indexOf(
+    "const address = fields.data.address.toLowerCase()"
+  );
+  const addressThrottleIndex = loginRouteSource.indexOf(
+    "checkSiweLoginAddressRequest(address)"
+  );
+  const addressFailureIndex = loginRouteSource.indexOf(
+    "checkSiweLoginFailureBackoff(\n      identity,\n      address"
+  );
+  const invalidSignatureFailureIndex = loginRouteSource.indexOf(
+    'recordSiweLoginFailure(\n        "invalid_message_or_signature",\n        identity\n      )'
+  );
+
+  assert.ok(verifyIndex > 0);
+  assert.ok(addressIndex > verifyIndex);
+  assert.ok(addressThrottleIndex > addressIndex);
+  assert.ok(addressFailureIndex > addressIndex);
+  assert.ok(invalidSignatureFailureIndex > 0);
+  assert.doesNotMatch(loginRouteSource, /siweMessage\.address/);
+  assert.doesNotMatch(loginRouteSource, /attemptedAddress/);
+});
+
 test("SIWE nonce store makes nonces short-lived and single-use", () => {
   const nonceStoreSource = readFileSync(
     new URL("../src/app/api/common/siwe-nonce-store.ts", import.meta.url),
@@ -187,7 +218,7 @@ test("SIWE nonce requests are throttled by client identity", () => {
   const store = new SiweAbuseControlStore();
   const identity = createSiweRequestIdentity(
     new Headers({
-      "x-forwarded-for": "203.0.113.10, 10.0.0.1",
+      "x-real-ip": "203.0.113.10",
       "user-agent": "nonce-test-agent",
     })
   );
@@ -211,6 +242,43 @@ test("SIWE nonce requests are throttled by client identity", () => {
       now + SIWE_NONCE_RATE_LIMIT.windowMilliseconds
     ).allowed,
     true
+  );
+});
+
+test("SIWE request identity prefers trusted normalized IP sources", () => {
+  assert.equal(
+    createSiweRequestIdentity(
+      new Headers({
+        "cf-connecting-ip": "192.0.2.44",
+        "x-forwarded-for": "198.51.100.1, 198.51.100.2",
+      })
+    ).ip,
+    "192.0.2.44"
+  );
+  assert.equal(
+    createSiweRequestIdentity(
+      new Headers({
+        "x-real-ip": "[2001:db8::1]:443",
+        "x-forwarded-for": "198.51.100.1",
+      })
+    ).ip,
+    "2001:db8::1"
+  );
+  assert.equal(
+    createSiweRequestIdentity(
+      new Headers({
+        "x-forwarded-for": "spoofed, 198.51.100.10:1234",
+      })
+    ).ip,
+    "198.51.100.10"
+  );
+  assert.equal(
+    createSiweRequestIdentity(
+      new Headers({
+        "x-forwarded-for": "spoofed, also-spoofed",
+      })
+    ).ip,
+    "unknown"
   );
 });
 
@@ -318,6 +386,88 @@ test("SIWE failed login backoff is temporary, resettable, and observable", (t) =
     checkSiweLoginFailureBackoff(identity, address, store, now).allowed,
     true
   );
+});
+
+test("SIWE abuse buckets evict stale entries and enforce caps", (t) => {
+  const rateLimitStore = new SiweAbuseControlStore();
+  const now = Date.parse("2026-04-16T00:00:00.000Z");
+  const previousWarn = console.warn;
+  console.warn = () => {};
+  t.after(() => {
+    console.warn = previousWarn;
+  });
+
+  for (
+    let index = 0;
+    index < SIWE_ABUSE_BUCKET_LIMITS.maxRateLimitBuckets + 10;
+    index += 1
+  ) {
+    checkSiweNonceRequest(
+      {
+        ip: `198.51.100.${index}`,
+        userAgent: `agent-${index}`,
+        userAgentHash: `agent-${index}`,
+      },
+      rateLimitStore,
+      now
+    );
+  }
+
+  assert.equal(
+    rateLimitStore.bucketCounts().rateLimit,
+    SIWE_ABUSE_BUCKET_LIMITS.maxRateLimitBuckets
+  );
+  assert.equal(
+    checkSiweNonceRequest(
+      {
+        ip: "203.0.113.200",
+        userAgent: "fresh-agent",
+        userAgentHash: "fresh-agent",
+      },
+      rateLimitStore,
+      now + SIWE_NONCE_RATE_LIMIT.windowMilliseconds
+    ).allowed,
+    true
+  );
+  assert.equal(rateLimitStore.bucketCounts().rateLimit, 2);
+
+  const failedLoginStore = new SiweAbuseControlStore();
+  for (
+    let index = 0;
+    index < SIWE_ABUSE_BUCKET_LIMITS.maxFailedLoginBuckets + 10;
+    index += 1
+  ) {
+    recordSiweLoginFailure(
+      "invalid_message_or_signature",
+      {
+        ip: `203.0.113.${index}`,
+        userAgent: `failure-agent-${index}`,
+        userAgentHash: `failure-agent-${index}`,
+      },
+      undefined,
+      failedLoginStore,
+      now
+    );
+  }
+
+  assert.equal(
+    failedLoginStore.bucketCounts().failedLogin,
+    SIWE_ABUSE_BUCKET_LIMITS.maxFailedLoginBuckets
+  );
+  assert.equal(
+    checkSiweLoginFailureBackoff(
+      {
+        ip: "192.0.2.200",
+        userAgent: "fresh-failure-agent",
+        userAgentHash: "fresh-failure-agent",
+      },
+      undefined,
+      failedLoginStore,
+      now + SIWE_ABUSE_BUCKET_LIMITS.failureStaleMilliseconds
+    ).allowed,
+    true
+  );
+  assert.equal(failedLoginStore.bucketCounts().failedLogin, 0);
 });
 
 test("profile edit retries a 401 only after a fresh authentication attempt", () => {

--- a/packages/web/scripts/profile-auth.test.ts
+++ b/packages/web/scripts/profile-auth.test.ts
@@ -6,6 +6,21 @@ import { SignJWT } from "jose";
 
 import { resolveAuthPayload } from "../src/app/api/common/auth.ts";
 import {
+  checkSiweLoginAddressRequest,
+  checkSiweLoginFailureBackoff,
+  checkSiweLoginRequest,
+  checkSiweNonceRequest,
+  createSiweRequestIdentity,
+  recordSiweLoginFailure,
+  resetSiweLoginFailures,
+  SIWE_LOGIN_FAILURE_BACKOFF,
+  SIWE_LOGIN_RATE_LIMIT,
+  SIWE_NONCE_RATE_LIMIT,
+  SiweAbuseControlStore,
+} from "../src/app/api/common/siwe-abuse-controls.ts";
+import {
+  siweNonceExpiresAt,
+  siweNonceIsUsable,
   signSiweNonceCookieValue,
   verifySiweNonceCookieValue,
 } from "../src/app/api/common/siwe-nonce.ts";
@@ -142,10 +157,167 @@ test("SIWE auth routes use a DB-backed nonce store with a signed nonce cookie", 
   assert.match(nonceRouteSource, /storeSiweNonce/);
   assert.match(nonceRouteSource, /signSiweNonceCookieValue/);
   assert.match(nonceRouteSource, /SIWE_NONCE_COOKIE_NAME/);
+  assert.match(nonceRouteSource, /checkSiweNonceRequest/);
   assert.match(loginRouteSource, /consumeSiweNonce/);
   assert.match(loginRouteSource, /verifySiweNonceCookieValue/);
   assert.match(loginRouteSource, /SIWE_NONCE_COOKIE_NAME/);
+  assert.match(loginRouteSource, /checkSiweLoginRequest/);
+  assert.match(loginRouteSource, /checkSiweLoginAddressRequest/);
+  assert.match(loginRouteSource, /checkSiweLoginFailureBackoff/);
+  assert.match(loginRouteSource, /recordSiweLoginFailure/);
   assert.doesNotMatch(loginRouteSource, /nonceCache/);
+});
+
+test("SIWE nonce store makes nonces short-lived and single-use", () => {
+  const nonceStoreSource = readFileSync(
+    new URL("../src/app/api/common/siwe-nonce-store.ts", import.meta.url),
+    "utf8"
+  );
+  const now = new Date("2026-04-16T00:00:00.000Z");
+  const expiresAt = siweNonceExpiresAt(now);
+
+  assert.equal(siweNonceIsUsable(expiresAt, now), true);
+  assert.equal(siweNonceIsUsable(expiresAt, expiresAt), false);
+  assert.match(nonceStoreSource, /delete from d_siwe_nonce/);
+  assert.match(nonceStoreSource, /expires_at > \$\{now\.toISOString\(\)\}/);
+  assert.match(nonceStoreSource, /returning nonce/);
+});
+
+test("SIWE nonce requests are throttled by client identity", () => {
+  const store = new SiweAbuseControlStore();
+  const identity = createSiweRequestIdentity(
+    new Headers({
+      "x-forwarded-for": "203.0.113.10, 10.0.0.1",
+      "user-agent": "nonce-test-agent",
+    })
+  );
+  const now = Date.parse("2026-04-16T00:00:00.000Z");
+
+  assert.equal(identity.ip, "203.0.113.10");
+
+  for (let index = 0; index < SIWE_NONCE_RATE_LIMIT.ipLimit; index += 1) {
+    assert.equal(checkSiweNonceRequest(identity, store, now).allowed, true);
+  }
+
+  const throttled = checkSiweNonceRequest(identity, store, now);
+  assert.equal(throttled.allowed, false);
+  assert.equal(throttled.reason, "nonce_ip_rate_limited");
+  assert.equal(throttled.retryAfterSeconds, 60);
+
+  assert.equal(
+    checkSiweNonceRequest(
+      identity,
+      store,
+      now + SIWE_NONCE_RATE_LIMIT.windowMilliseconds
+    ).allowed,
+    true
+  );
+});
+
+test("SIWE login attempts are throttled by IP and address", () => {
+  const store = new SiweAbuseControlStore();
+  const identity = createSiweRequestIdentity(
+    new Headers({
+      "x-real-ip": "198.51.100.25",
+      "user-agent": "login-test-agent",
+    })
+  );
+  const address = "0x0000000000000000000000000000000000000001";
+  const now = Date.parse("2026-04-16T00:00:00.000Z");
+
+  for (let index = 0; index < SIWE_LOGIN_RATE_LIMIT.ipLimit; index += 1) {
+    assert.equal(checkSiweLoginRequest(identity, store, now).allowed, true);
+  }
+
+  const ipThrottled = checkSiweLoginRequest(identity, store, now);
+  assert.equal(ipThrottled.allowed, false);
+  assert.equal(ipThrottled.reason, "login_ip_rate_limited");
+
+  for (let index = 0; index < SIWE_LOGIN_RATE_LIMIT.addressLimit; index += 1) {
+    assert.equal(
+      checkSiweLoginAddressRequest(address, store, now).allowed,
+      true
+    );
+  }
+
+  const addressThrottled = checkSiweLoginAddressRequest(address, store, now);
+  assert.equal(addressThrottled.allowed, false);
+  assert.equal(addressThrottled.reason, "login_address_rate_limited");
+});
+
+test("SIWE failed login backoff is temporary, resettable, and observable", (t) => {
+  const store = new SiweAbuseControlStore();
+  const identity = createSiweRequestIdentity(
+    new Headers({
+      "cf-connecting-ip": "192.0.2.44",
+      "user-agent": "failure-test-agent",
+    })
+  );
+  const address = "0x0000000000000000000000000000000000000002";
+  const now = Date.parse("2026-04-16T00:00:00.000Z");
+  const warnings: unknown[] = [];
+  const previousWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+  t.after(() => {
+    console.warn = previousWarn;
+  });
+
+  for (
+    let index = 0;
+    index < SIWE_LOGIN_FAILURE_BACKOFF.threshold - 1;
+    index += 1
+  ) {
+    assert.equal(
+      recordSiweLoginFailure(
+        "invalid_nonce",
+        identity,
+        address,
+        store,
+        now
+      ).allowed,
+      true
+    );
+  }
+
+  const locked = recordSiweLoginFailure(
+    "invalid_nonce",
+    identity,
+    address,
+    store,
+    now
+  );
+  assert.equal(locked.allowed, false);
+  assert.equal(locked.reason, "login_failure_backoff");
+  assert.equal(locked.retryAfterSeconds, 60);
+  assert.equal(
+    checkSiweLoginFailureBackoff(identity, address, store, now).allowed,
+    false
+  );
+  assert.equal(warnings.length, SIWE_LOGIN_FAILURE_BACKOFF.threshold);
+  assert.deepEqual((warnings.at(-1) as unknown[])[0], "siwe_login_failure");
+  assert.equal(
+    ((warnings.at(-1) as unknown[])[1] as { reason: string }).reason,
+    "invalid_nonce"
+  );
+
+  assert.equal(
+    checkSiweLoginFailureBackoff(
+      identity,
+      address,
+      store,
+      now + SIWE_LOGIN_FAILURE_BACKOFF.baseLockMilliseconds
+    ).allowed,
+    true
+  );
+
+  recordSiweLoginFailure("invalid_nonce", identity, address, store, now);
+  resetSiweLoginFailures(identity, address, store);
+  assert.equal(
+    checkSiweLoginFailureBackoff(identity, address, store, now).allowed,
+    true
+  );
 });
 
 test("profile edit retries a 401 only after a fresh authentication attempt", () => {

--- a/packages/web/scripts/profile-auth.test.ts
+++ b/packages/web/scripts/profile-auth.test.ts
@@ -197,6 +197,8 @@ test("SIWE login route only uses address controls after signature verification",
   assert.ok(invalidSignatureFailureIndex > 0);
   assert.doesNotMatch(loginRouteSource, /siweMessage\.address/);
   assert.doesNotMatch(loginRouteSource, /attemptedAddress/);
+  assert.doesNotMatch(loginRouteSource, /console\.warn\("err", err\)/);
+  assert.match(loginRouteSource, /siwe_login_invalid_message/);
 });
 
 test("SIWE nonce store makes nonces short-lived and single-use", () => {
@@ -210,7 +212,8 @@ test("SIWE nonce store makes nonces short-lived and single-use", () => {
   assert.equal(siweNonceIsUsable(expiresAt, now), true);
   assert.equal(siweNonceIsUsable(expiresAt, expiresAt), false);
   assert.match(nonceStoreSource, /delete from d_siwe_nonce/);
-  assert.match(nonceStoreSource, /expires_at > \$\{now\.toISOString\(\)\}/);
+  assert.match(nonceStoreSource, /values \(\$\{nonce\}, \$\{expiresAt\}\)/);
+  assert.match(nonceStoreSource, /expires_at > now\(\)/);
   assert.match(nonceStoreSource, /returning nonce/);
 });
 
@@ -379,6 +382,7 @@ test("SIWE failed login backoff is temporary, resettable, and observable", (t) =
     ).allowed,
     true
   );
+  assert.equal(store.bucketCounts().failedLogin, 0);
 
   recordSiweLoginFailure("invalid_nonce", identity, address, store, now);
   resetSiweLoginFailures(identity, address, store);

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -55,38 +55,14 @@ export async function POST(request: NextRequest) {
     }
 
     let fields;
-    let attemptedAddress: string | undefined;
     try {
       const siweMessage = new SiweMessage(message);
-      attemptedAddress = siweMessage.address?.toLowerCase();
-
-      const addressRateLimit = checkSiweLoginAddressRequest(attemptedAddress);
-      if (!addressRateLimit.allowed) {
-        logSiweThrottle(
-          "siwe_login_throttled",
-          identity,
-          addressRateLimit,
-          attemptedAddress
-        );
-
-        return NextResponse.json(Resp.err("too many login attempts"), {
-          status: 429,
-          headers: {
-            "Retry-After": String(addressRateLimit.retryAfterSeconds ?? 1),
-          },
-        });
-      }
-
-      const failureBackoff = checkSiweLoginFailureBackoff(
-        identity,
-        attemptedAddress
-      );
+      const failureBackoff = checkSiweLoginFailureBackoff(identity);
       if (!failureBackoff.allowed) {
         logSiweThrottle(
           "siwe_login_throttled",
           identity,
-          failureBackoff,
-          attemptedAddress
+          failureBackoff
         );
 
         return NextResponse.json(Resp.err("too many failed login attempts"), {
@@ -104,8 +80,7 @@ export async function POST(request: NextRequest) {
       console.warn("err", err);
       const failureDecision = recordSiweLoginFailure(
         "invalid_message_or_signature",
-        identity,
-        attemptedAddress
+        identity
       );
       if (!failureDecision.allowed) {
         return NextResponse.json(Resp.err("too many failed login attempts"), {
@@ -117,6 +92,44 @@ export async function POST(request: NextRequest) {
       }
 
       return NextResponse.json(Resp.err("invalid message"), { status: 400 });
+    }
+
+    const address = fields.data.address.toLowerCase();
+    const addressRateLimit = checkSiweLoginAddressRequest(address);
+    if (!addressRateLimit.allowed) {
+      logSiweThrottle(
+        "siwe_login_throttled",
+        identity,
+        addressRateLimit,
+        address
+      );
+
+      return NextResponse.json(Resp.err("too many login attempts"), {
+        status: 429,
+        headers: {
+          "Retry-After": String(addressRateLimit.retryAfterSeconds ?? 1),
+        },
+      });
+    }
+
+    const addressFailureBackoff = checkSiweLoginFailureBackoff(
+      identity,
+      address
+    );
+    if (!addressFailureBackoff.allowed) {
+      logSiweThrottle(
+        "siwe_login_throttled",
+        identity,
+        addressFailureBackoff,
+        address
+      );
+
+      return NextResponse.json(Resp.err("too many failed login attempts"), {
+        status: 429,
+        headers: {
+          "Retry-After": String(addressFailureBackoff.retryAfterSeconds ?? 1),
+        },
+      });
     }
 
     // Validate if nonce is still valid
@@ -144,7 +157,7 @@ export async function POST(request: NextRequest) {
       const failureDecision = recordSiweLoginFailure(
         "invalid_nonce",
         identity,
-        attemptedAddress
+        address
       );
       if (!failureDecision.allowed) {
         const backoffResponse = NextResponse.json(
@@ -169,7 +182,6 @@ export async function POST(request: NextRequest) {
       return invalidNonceResponse;
     }
 
-    const address = fields.data.address.toLowerCase();
     resetSiweLoginFailures(identity, address);
 
     const token = await new SignJWT({ address })

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -77,7 +77,13 @@ export async function POST(request: NextRequest) {
 
       // fields = { data: { nonce: "3456789235", address: "0x2376628375284594" } };
     } catch (err) {
-      console.warn("err", err);
+      console.warn("siwe_login_invalid_message", {
+        event: "siwe_login_invalid_message",
+        reason: "invalid_message_or_signature",
+        ip: identity.ip,
+        userAgentHash: identity.userAgentHash,
+        errorName: err instanceof Error ? err.name : "UnknownError",
+      });
       const failureDecision = recordSiweLoginFailure(
         "invalid_message_or_signature",
         identity
@@ -235,7 +241,12 @@ export async function POST(request: NextRequest) {
 
     return response;
   } catch (err) {
-    console.warn("err", err);
+    console.warn("siwe_login_route_error", {
+      event: "siwe_login_route_error",
+      ip: identity.ip,
+      userAgentHash: identity.userAgentHash,
+      errorName: err instanceof Error ? err.name : "UnknownError",
+    });
     const message = err instanceof Error ? err.message : "unknown error";
     return NextResponse.json(Resp.errWithData("logion failed", message), {
       status: 400,

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -8,6 +8,15 @@ import { Resp } from "@/types/api";
 import * as config from "../../common/config";
 import { databaseConnection } from "../../common/database";
 import {
+  checkSiweLoginAddressRequest,
+  checkSiweLoginFailureBackoff,
+  checkSiweLoginRequest,
+  createSiweRequestIdentity,
+  logSiweThrottle,
+  recordSiweLoginFailure,
+  resetSiweLoginFailures,
+} from "../../common/siwe-abuse-controls";
+import {
   SIWE_NONCE_COOKIE_NAME,
   verifySiweNonceCookieValue,
 } from "../../common/siwe-nonce";
@@ -17,6 +26,8 @@ import { snowflake } from "../../common/toolkit";
 import type { NextRequest } from "next/server";
 
 export async function POST(request: NextRequest) {
+  const identity = createSiweRequestIdentity(request.headers);
+
   try {
     const degovConfig = await config.degovConfig(request);
     const daocode = degovConfig.code;
@@ -31,14 +42,80 @@ export async function POST(request: NextRequest) {
 
     const { message, signature } = await request.json();
 
+    const loginRateLimit = checkSiweLoginRequest(identity);
+    if (!loginRateLimit.allowed) {
+      logSiweThrottle("siwe_login_throttled", identity, loginRateLimit);
+
+      return NextResponse.json(Resp.err("too many login attempts"), {
+        status: 429,
+        headers: {
+          "Retry-After": String(loginRateLimit.retryAfterSeconds ?? 1),
+        },
+      });
+    }
+
     let fields;
+    let attemptedAddress: string | undefined;
     try {
       const siweMessage = new SiweMessage(message);
+      attemptedAddress = siweMessage.address?.toLowerCase();
+
+      const addressRateLimit = checkSiweLoginAddressRequest(attemptedAddress);
+      if (!addressRateLimit.allowed) {
+        logSiweThrottle(
+          "siwe_login_throttled",
+          identity,
+          addressRateLimit,
+          attemptedAddress
+        );
+
+        return NextResponse.json(Resp.err("too many login attempts"), {
+          status: 429,
+          headers: {
+            "Retry-After": String(addressRateLimit.retryAfterSeconds ?? 1),
+          },
+        });
+      }
+
+      const failureBackoff = checkSiweLoginFailureBackoff(
+        identity,
+        attemptedAddress
+      );
+      if (!failureBackoff.allowed) {
+        logSiweThrottle(
+          "siwe_login_throttled",
+          identity,
+          failureBackoff,
+          attemptedAddress
+        );
+
+        return NextResponse.json(Resp.err("too many failed login attempts"), {
+          status: 429,
+          headers: {
+            "Retry-After": String(failureBackoff.retryAfterSeconds ?? 1),
+          },
+        });
+      }
+
       fields = await siweMessage.verify({ signature });
 
       // fields = { data: { nonce: "3456789235", address: "0x2376628375284594" } };
     } catch (err) {
       console.warn("err", err);
+      const failureDecision = recordSiweLoginFailure(
+        "invalid_message_or_signature",
+        identity,
+        attemptedAddress
+      );
+      if (!failureDecision.allowed) {
+        return NextResponse.json(Resp.err("too many failed login attempts"), {
+          status: 429,
+          headers: {
+            "Retry-After": String(failureDecision.retryAfterSeconds ?? 1),
+          },
+        });
+      }
+
       return NextResponse.json(Resp.err("invalid message"), { status: 400 });
     }
 
@@ -64,10 +141,37 @@ export async function POST(request: NextRequest) {
         path: "/",
       });
 
+      const failureDecision = recordSiweLoginFailure(
+        "invalid_nonce",
+        identity,
+        attemptedAddress
+      );
+      if (!failureDecision.allowed) {
+        const backoffResponse = NextResponse.json(
+          Resp.err("too many failed login attempts"),
+          {
+            status: 429,
+            headers: {
+              "Retry-After": String(failureDecision.retryAfterSeconds ?? 1),
+            },
+          }
+        );
+        backoffResponse.cookies.set({
+          name: SIWE_NONCE_COOKIE_NAME,
+          value: "",
+          maxAge: 0,
+          path: "/",
+        });
+
+        return backoffResponse;
+      }
+
       return invalidNonceResponse;
     }
 
     const address = fields.data.address.toLowerCase();
+    resetSiweLoginFailures(identity, address);
+
     const token = await new SignJWT({ address })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt()

--- a/packages/web/src/app/api/auth/nonce/route.ts
+++ b/packages/web/src/app/api/auth/nonce/route.ts
@@ -5,22 +5,42 @@ import { Resp } from "@/types/api";
 import { degovGraphqlApi } from "@/utils/remote-api";
 
 import {
+  checkSiweNonceRequest,
+  createSiweRequestIdentity,
+  logSiweThrottle,
+} from "../../common/siwe-abuse-controls";
+import {
   SIWE_NONCE_COOKIE_MAX_AGE_SECONDS,
   SIWE_NONCE_COOKIE_NAME,
   signSiweNonceCookieValue,
 } from "../../common/siwe-nonce";
 import { storeSiweNonce } from "../../common/siwe-nonce-store";
 
+import type { NextRequest } from "next/server";
+
 // Define a type for the source of the nonce for better type-safety
 type NonceSource = "generated" | "remote";
 
-export async function POST() {
+export async function POST(request: NextRequest) {
   const jwtSecretKey = process.env.JWT_SECRET_KEY;
   if (!jwtSecretKey) {
     return NextResponse.json(
       Resp.err("please contact admin about login issue, missing key"),
       { status: 400 }
     );
+  }
+
+  const identity = createSiweRequestIdentity(request.headers);
+  const nonceRateLimit = checkSiweNonceRequest(identity);
+  if (!nonceRateLimit.allowed) {
+    logSiweThrottle("siwe_nonce_throttled", identity, nonceRateLimit);
+
+    return NextResponse.json(Resp.err("too many nonce requests"), {
+      status: 429,
+      headers: {
+        "Retry-After": String(nonceRateLimit.retryAfterSeconds ?? 1),
+      },
+    });
   }
 
   let nonce = CryptoJS.lib.WordArray.random(32).toString(CryptoJS.enc.Hex);

--- a/packages/web/src/app/api/common/siwe-abuse-controls.ts
+++ b/packages/web/src/app/api/common/siwe-abuse-controls.ts
@@ -202,11 +202,12 @@ export class SiweAbuseControlStore {
 
     for (const [key, bucket] of this.failedLoginBuckets) {
       const lockIsActive = !!bucket.lockedUntil && bucket.lockedUntil > now;
+      const lockExpired = !!bucket.lockedUntil && bucket.lockedUntil <= now;
       const stale =
         bucket.updatedAt + SIWE_ABUSE_BUCKET_LIMITS.failureStaleMilliseconds <=
         now;
 
-      if (!lockIsActive && stale) {
+      if (!lockIsActive && (lockExpired || stale)) {
         this.failedLoginBuckets.delete(key);
       }
     }

--- a/packages/web/src/app/api/common/siwe-abuse-controls.ts
+++ b/packages/web/src/app/api/common/siwe-abuse-controls.ts
@@ -1,0 +1,339 @@
+type HeaderReader = {
+  get(name: string): string | null;
+};
+
+export type SiweRequestIdentity = {
+  ip: string;
+  userAgent: string;
+  userAgentHash: string;
+};
+
+export type AbuseControlDecision = {
+  allowed: boolean;
+  reason?: string;
+  retryAfterSeconds?: number;
+};
+
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+type FailedLoginBucket = {
+  failures: number;
+  lockedUntil?: number;
+};
+
+type RateLimitRule = {
+  key: string;
+  limit: number;
+  windowMilliseconds: number;
+  reason: string;
+};
+
+export const SIWE_NONCE_RATE_LIMIT = {
+  ipLimit: 30,
+  userAgentLimit: 60,
+  windowMilliseconds: 60_000,
+} as const;
+
+export const SIWE_LOGIN_RATE_LIMIT = {
+  ipLimit: 30,
+  userAgentLimit: 60,
+  addressLimit: 20,
+  windowMilliseconds: 60_000,
+} as const;
+
+export const SIWE_LOGIN_FAILURE_BACKOFF = {
+  threshold: 5,
+  baseLockMilliseconds: 60_000,
+  maxLockMilliseconds: 15 * 60_000,
+} as const;
+
+export class SiweAbuseControlStore {
+  private readonly rateLimitBuckets = new Map<string, RateLimitBucket>();
+  private readonly failedLoginBuckets = new Map<string, FailedLoginBucket>();
+
+  checkRateLimit(
+    rules: RateLimitRule[],
+    now = Date.now()
+  ): AbuseControlDecision {
+    for (const rule of rules) {
+      const bucket = this.rateLimitBuckets.get(rule.key);
+
+      if (bucket && bucket.resetAt > now && bucket.count >= rule.limit) {
+        return {
+          allowed: false,
+          reason: rule.reason,
+          retryAfterSeconds: retryAfterSeconds(bucket.resetAt, now),
+        };
+      }
+    }
+
+    for (const rule of rules) {
+      const bucket = this.rateLimitBuckets.get(rule.key);
+
+      if (!bucket || bucket.resetAt <= now) {
+        this.rateLimitBuckets.set(rule.key, {
+          count: 1,
+          resetAt: now + rule.windowMilliseconds,
+        });
+        continue;
+      }
+
+      bucket.count += 1;
+    }
+
+    return { allowed: true };
+  }
+
+  checkFailureBackoff(
+    keys: string[],
+    now = Date.now()
+  ): AbuseControlDecision {
+    for (const key of keys) {
+      const bucket = this.failedLoginBuckets.get(key);
+
+      if (bucket?.lockedUntil && bucket.lockedUntil > now) {
+        return {
+          allowed: false,
+          reason: "login_failure_backoff",
+          retryAfterSeconds: retryAfterSeconds(bucket.lockedUntil, now),
+        };
+      }
+    }
+
+    return { allowed: true };
+  }
+
+  recordLoginFailure(
+    keys: string[],
+    now = Date.now()
+  ): FailedLoginBucket | undefined {
+    let strictestBucket: FailedLoginBucket | undefined;
+
+    for (const key of keys) {
+      const bucket = this.failedLoginBuckets.get(key) ?? { failures: 0 };
+      bucket.failures += 1;
+
+      if (bucket.failures >= SIWE_LOGIN_FAILURE_BACKOFF.threshold) {
+        const lockMilliseconds = Math.min(
+          SIWE_LOGIN_FAILURE_BACKOFF.baseLockMilliseconds *
+            2 **
+              (bucket.failures - SIWE_LOGIN_FAILURE_BACKOFF.threshold),
+          SIWE_LOGIN_FAILURE_BACKOFF.maxLockMilliseconds
+        );
+        bucket.lockedUntil = now + lockMilliseconds;
+      }
+
+      this.failedLoginBuckets.set(key, bucket);
+
+      if (
+        !strictestBucket ||
+        (bucket.lockedUntil ?? 0) > (strictestBucket.lockedUntil ?? 0) ||
+        bucket.failures > strictestBucket.failures
+      ) {
+        strictestBucket = { ...bucket };
+      }
+    }
+
+    return strictestBucket;
+  }
+
+  resetLoginFailures(keys: string[]): void {
+    for (const key of keys) {
+      this.failedLoginBuckets.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.rateLimitBuckets.clear();
+    this.failedLoginBuckets.clear();
+  }
+}
+
+const defaultSiweAbuseControlStore = new SiweAbuseControlStore();
+
+export function createSiweRequestIdentity(
+  headers: HeaderReader
+): SiweRequestIdentity {
+  const forwardedFor = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const ip =
+    forwardedFor ||
+    headers.get("x-real-ip")?.trim() ||
+    headers.get("cf-connecting-ip")?.trim() ||
+    "unknown";
+  const userAgent = headers.get("user-agent")?.trim() || "unknown";
+
+  return {
+    ip,
+    userAgent,
+    userAgentHash: hashIdentityPart(userAgent),
+  };
+}
+
+export function checkSiweNonceRequest(
+  identity: SiweRequestIdentity,
+  store = defaultSiweAbuseControlStore,
+  now = Date.now()
+): AbuseControlDecision {
+  return store.checkRateLimit(
+    [
+      {
+        key: `siwe:nonce:ip:${identity.ip}`,
+        limit: SIWE_NONCE_RATE_LIMIT.ipLimit,
+        windowMilliseconds: SIWE_NONCE_RATE_LIMIT.windowMilliseconds,
+        reason: "nonce_ip_rate_limited",
+      },
+      {
+        key: `siwe:nonce:ua:${identity.userAgentHash}`,
+        limit: SIWE_NONCE_RATE_LIMIT.userAgentLimit,
+        windowMilliseconds: SIWE_NONCE_RATE_LIMIT.windowMilliseconds,
+        reason: "nonce_user_agent_rate_limited",
+      },
+    ],
+    now
+  );
+}
+
+export function checkSiweLoginRequest(
+  identity: SiweRequestIdentity,
+  store = defaultSiweAbuseControlStore,
+  now = Date.now()
+): AbuseControlDecision {
+  return store.checkRateLimit(
+    [
+      {
+        key: `siwe:login:ip:${identity.ip}`,
+        limit: SIWE_LOGIN_RATE_LIMIT.ipLimit,
+        windowMilliseconds: SIWE_LOGIN_RATE_LIMIT.windowMilliseconds,
+        reason: "login_ip_rate_limited",
+      },
+      {
+        key: `siwe:login:ua:${identity.userAgentHash}`,
+        limit: SIWE_LOGIN_RATE_LIMIT.userAgentLimit,
+        windowMilliseconds: SIWE_LOGIN_RATE_LIMIT.windowMilliseconds,
+        reason: "login_user_agent_rate_limited",
+      },
+    ],
+    now
+  );
+}
+
+export function checkSiweLoginAddressRequest(
+  address: string | undefined,
+  store = defaultSiweAbuseControlStore,
+  now = Date.now()
+): AbuseControlDecision {
+  if (!address) {
+    return { allowed: true };
+  }
+
+  return store.checkRateLimit(
+    [
+      {
+        key: `siwe:login:address:${address.toLowerCase()}`,
+        limit: SIWE_LOGIN_RATE_LIMIT.addressLimit,
+        windowMilliseconds: SIWE_LOGIN_RATE_LIMIT.windowMilliseconds,
+        reason: "login_address_rate_limited",
+      },
+    ],
+    now
+  );
+}
+
+export function checkSiweLoginFailureBackoff(
+  identity: SiweRequestIdentity,
+  address?: string,
+  store = defaultSiweAbuseControlStore,
+  now = Date.now()
+): AbuseControlDecision {
+  return store.checkFailureBackoff(loginFailureKeys(identity, address), now);
+}
+
+export function recordSiweLoginFailure(
+  reason: string,
+  identity: SiweRequestIdentity,
+  address?: string,
+  store = defaultSiweAbuseControlStore,
+  now = Date.now()
+): AbuseControlDecision {
+  const bucket = store.recordLoginFailure(
+    loginFailureKeys(identity, address),
+    now
+  );
+
+  console.warn("siwe_login_failure", {
+    event: "siwe_login_failure",
+    reason,
+    ip: identity.ip,
+    userAgentHash: identity.userAgentHash,
+    address,
+    failures: bucket?.failures ?? 0,
+    lockedUntil: bucket?.lockedUntil
+      ? new Date(bucket.lockedUntil).toISOString()
+      : undefined,
+  });
+
+  return bucket?.lockedUntil && bucket.lockedUntil > now
+    ? {
+        allowed: false,
+        reason: "login_failure_backoff",
+        retryAfterSeconds: retryAfterSeconds(bucket.lockedUntil, now),
+      }
+    : { allowed: true };
+}
+
+export function resetSiweLoginFailures(
+  identity: SiweRequestIdentity,
+  address?: string,
+  store = defaultSiweAbuseControlStore
+): void {
+  store.resetLoginFailures(loginFailureKeys(identity, address));
+}
+
+export function logSiweThrottle(
+  event: "siwe_nonce_throttled" | "siwe_login_throttled",
+  identity: SiweRequestIdentity,
+  decision: AbuseControlDecision,
+  address?: string
+): void {
+  console.warn(event, {
+    event,
+    reason: decision.reason,
+    retryAfterSeconds: decision.retryAfterSeconds,
+    ip: identity.ip,
+    userAgentHash: identity.userAgentHash,
+    address,
+  });
+}
+
+function loginFailureKeys(
+  identity: SiweRequestIdentity,
+  address?: string
+): string[] {
+  const keys = [
+    `siwe:failure:ip:${identity.ip}`,
+    `siwe:failure:ua:${identity.userAgentHash}`,
+  ];
+
+  if (address) {
+    keys.push(`siwe:failure:address:${address.toLowerCase()}`);
+  }
+
+  return keys;
+}
+
+function retryAfterSeconds(targetTime: number, now: number): number {
+  return Math.max(1, Math.ceil((targetTime - now) / 1000));
+}
+
+function hashIdentityPart(value: string): string {
+  let hash = 5381;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 33) ^ value.charCodeAt(index);
+  }
+
+  return (hash >>> 0).toString(36);
+}

--- a/packages/web/src/app/api/common/siwe-abuse-controls.ts
+++ b/packages/web/src/app/api/common/siwe-abuse-controls.ts
@@ -1,3 +1,5 @@
+import { isIP } from "node:net";
+
 type HeaderReader = {
   get(name: string): string | null;
 };
@@ -22,6 +24,7 @@ type RateLimitBucket = {
 type FailedLoginBucket = {
   failures: number;
   lockedUntil?: number;
+  updatedAt: number;
 };
 
 type RateLimitRule = {
@@ -50,14 +53,24 @@ export const SIWE_LOGIN_FAILURE_BACKOFF = {
   maxLockMilliseconds: 15 * 60_000,
 } as const;
 
+export const SIWE_ABUSE_BUCKET_LIMITS = {
+  maxRateLimitBuckets: 2_000,
+  maxFailedLoginBuckets: 2_000,
+  failureStaleMilliseconds: 30 * 60_000,
+  cleanupIntervalMilliseconds: 60_000,
+} as const;
+
 export class SiweAbuseControlStore {
   private readonly rateLimitBuckets = new Map<string, RateLimitBucket>();
   private readonly failedLoginBuckets = new Map<string, FailedLoginBucket>();
+  private lastCleanupAt = 0;
 
   checkRateLimit(
     rules: RateLimitRule[],
     now = Date.now()
   ): AbuseControlDecision {
+    this.cleanup(now);
+
     for (const rule of rules) {
       const bucket = this.rateLimitBuckets.get(rule.key);
 
@@ -84,6 +97,8 @@ export class SiweAbuseControlStore {
       bucket.count += 1;
     }
 
+    this.enforceRateLimitBucketCap();
+
     return { allowed: true };
   }
 
@@ -91,6 +106,8 @@ export class SiweAbuseControlStore {
     keys: string[],
     now = Date.now()
   ): AbuseControlDecision {
+    this.cleanup(now);
+
     for (const key of keys) {
       const bucket = this.failedLoginBuckets.get(key);
 
@@ -110,11 +127,17 @@ export class SiweAbuseControlStore {
     keys: string[],
     now = Date.now()
   ): FailedLoginBucket | undefined {
+    this.cleanup(now);
+
     let strictestBucket: FailedLoginBucket | undefined;
 
     for (const key of keys) {
-      const bucket = this.failedLoginBuckets.get(key) ?? { failures: 0 };
+      const bucket = this.failedLoginBuckets.get(key) ?? {
+        failures: 0,
+        updatedAt: now,
+      };
       bucket.failures += 1;
+      bucket.updatedAt = now;
 
       if (bucket.failures >= SIWE_LOGIN_FAILURE_BACKOFF.threshold) {
         const lockMilliseconds = Math.min(
@@ -137,6 +160,8 @@ export class SiweAbuseControlStore {
       }
     }
 
+    this.enforceFailedLoginBucketCap();
+
     return strictestBucket;
   }
 
@@ -149,6 +174,73 @@ export class SiweAbuseControlStore {
   clear(): void {
     this.rateLimitBuckets.clear();
     this.failedLoginBuckets.clear();
+    this.lastCleanupAt = 0;
+  }
+
+  bucketCounts(): { rateLimit: number; failedLogin: number } {
+    return {
+      rateLimit: this.rateLimitBuckets.size,
+      failedLogin: this.failedLoginBuckets.size,
+    };
+  }
+
+  private cleanup(now: number): void {
+    if (
+      this.lastCleanupAt &&
+      now - this.lastCleanupAt < SIWE_ABUSE_BUCKET_LIMITS.cleanupIntervalMilliseconds
+    ) {
+      return;
+    }
+
+    this.lastCleanupAt = now;
+
+    for (const [key, bucket] of this.rateLimitBuckets) {
+      if (bucket.resetAt <= now) {
+        this.rateLimitBuckets.delete(key);
+      }
+    }
+
+    for (const [key, bucket] of this.failedLoginBuckets) {
+      const lockIsActive = !!bucket.lockedUntil && bucket.lockedUntil > now;
+      const stale =
+        bucket.updatedAt + SIWE_ABUSE_BUCKET_LIMITS.failureStaleMilliseconds <=
+        now;
+
+      if (!lockIsActive && stale) {
+        this.failedLoginBuckets.delete(key);
+      }
+    }
+
+    this.enforceRateLimitBucketCap();
+    this.enforceFailedLoginBucketCap();
+  }
+
+  private enforceRateLimitBucketCap(): void {
+    while (
+      this.rateLimitBuckets.size >
+      SIWE_ABUSE_BUCKET_LIMITS.maxRateLimitBuckets
+    ) {
+      const oldestKey = this.rateLimitBuckets.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+
+      this.rateLimitBuckets.delete(oldestKey);
+    }
+  }
+
+  private enforceFailedLoginBucketCap(): void {
+    while (
+      this.failedLoginBuckets.size >
+      SIWE_ABUSE_BUCKET_LIMITS.maxFailedLoginBuckets
+    ) {
+      const oldestKey = this.failedLoginBuckets.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+
+      this.failedLoginBuckets.delete(oldestKey);
+    }
   }
 }
 
@@ -157,11 +249,12 @@ const defaultSiweAbuseControlStore = new SiweAbuseControlStore();
 export function createSiweRequestIdentity(
   headers: HeaderReader
 ): SiweRequestIdentity {
-  const forwardedFor = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
   const ip =
-    forwardedFor ||
-    headers.get("x-real-ip")?.trim() ||
-    headers.get("cf-connecting-ip")?.trim() ||
+    normalizedSingleIp(headers.get("true-client-ip")) ||
+    normalizedSingleIp(headers.get("cf-connecting-ip")) ||
+    normalizedSingleIp(headers.get("x-real-ip")) ||
+    normalizedSingleIp(headers.get("x-vercel-forwarded-for")) ||
+    normalizedForwardedForIp(headers.get("x-forwarded-for")) ||
     "unknown";
   const userAgent = headers.get("user-agent")?.trim() || "unknown";
 
@@ -336,4 +429,40 @@ function hashIdentityPart(value: string): string {
   }
 
   return (hash >>> 0).toString(36);
+}
+
+function normalizedForwardedForIp(headerValue: string | null): string | null {
+  if (!headerValue) {
+    return null;
+  }
+
+  const candidates = headerValue.split(",").map((part) => part.trim());
+
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const normalizedIp = normalizedSingleIp(candidates[index]);
+    if (normalizedIp) {
+      return normalizedIp;
+    }
+  }
+
+  return null;
+}
+
+function normalizedSingleIp(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  let candidate = value.trim().toLowerCase();
+  if (!candidate) {
+    return null;
+  }
+
+  if (candidate.startsWith("[") && candidate.includes("]")) {
+    candidate = candidate.slice(1, candidate.indexOf("]"));
+  } else if (candidate.includes(":") && candidate.indexOf(":") === candidate.lastIndexOf(":")) {
+    candidate = candidate.split(":")[0] ?? "";
+  }
+
+  return isIP(candidate) ? candidate : null;
 }

--- a/packages/web/src/app/api/common/siwe-nonce-store.ts
+++ b/packages/web/src/app/api/common/siwe-nonce-store.ts
@@ -1,11 +1,9 @@
 import { databaseConnection } from "./database";
-import { SIWE_NONCE_COOKIE_MAX_AGE_SECONDS } from "./siwe-nonce";
-
-const SIWE_NONCE_TTL_MILLISECONDS = SIWE_NONCE_COOKIE_MAX_AGE_SECONDS * 1000;
+import { siweNonceExpiresAt } from "./siwe-nonce";
 
 export async function storeSiweNonce(nonce: string): Promise<void> {
   const sql = databaseConnection();
-  const expiresAt = new Date(Date.now() + SIWE_NONCE_TTL_MILLISECONDS);
+  const expiresAt = siweNonceExpiresAt();
 
   await sql`
     insert into d_siwe_nonce (nonce, expires_at)
@@ -22,10 +20,11 @@ export async function storeSiweNonce(nonce: string): Promise<void> {
 
 export async function consumeSiweNonce(nonce: string): Promise<boolean> {
   const sql = databaseConnection();
+  const now = new Date();
   const [storedNonce] = await sql`
     delete from d_siwe_nonce
     where nonce = ${nonce}
-      and expires_at > now()
+      and expires_at > ${now.toISOString()}
     returning nonce
   `;
 

--- a/packages/web/src/app/api/common/siwe-nonce-store.ts
+++ b/packages/web/src/app/api/common/siwe-nonce-store.ts
@@ -7,7 +7,7 @@ export async function storeSiweNonce(nonce: string): Promise<void> {
 
   await sql`
     insert into d_siwe_nonce (nonce, expires_at)
-    values (${nonce}, ${expiresAt.toISOString()})
+    values (${nonce}, ${expiresAt})
     on conflict (nonce) do update
     set expires_at = excluded.expires_at
   `;
@@ -20,11 +20,10 @@ export async function storeSiweNonce(nonce: string): Promise<void> {
 
 export async function consumeSiweNonce(nonce: string): Promise<boolean> {
   const sql = databaseConnection();
-  const now = new Date();
   const [storedNonce] = await sql`
     delete from d_siwe_nonce
     where nonce = ${nonce}
-      and expires_at > ${now.toISOString()}
+      and expires_at > now()
     returning nonce
   `;
 

--- a/packages/web/src/app/api/common/siwe-nonce.ts
+++ b/packages/web/src/app/api/common/siwe-nonce.ts
@@ -3,7 +3,16 @@ import { jwtVerify, SignJWT } from "jose";
 export const SIWE_NONCE_COOKIE_NAME = "degov_siwe_nonce";
 export const SIWE_NONCE_COOKIE_MAX_AGE_SECONDS = 180;
 
+const SIWE_NONCE_TTL_MILLISECONDS = SIWE_NONCE_COOKIE_MAX_AGE_SECONDS * 1000;
 const textEncoder = new TextEncoder();
+
+export function siweNonceExpiresAt(now = new Date()): Date {
+  return new Date(now.getTime() + SIWE_NONCE_TTL_MILLISECONDS);
+}
+
+export function siweNonceIsUsable(expiresAt: Date, now = new Date()): boolean {
+  return expiresAt.getTime() > now.getTime();
+}
 
 export async function signSiweNonceCookieValue(
   nonce: string,


### PR DESCRIPTION
## Problem

SIWE nonce generation and login verification did not have explicit abuse controls for repeated nonce requests, repeated login attempts, or repeated failed verification attempts. Failures also lacked structured signals that could be used to observe abnormal nonce/login spikes.

## Fix

- Added in-memory SIWE abuse controls keyed by hardened client IP identity and user agent for nonce and login requests.
- Apply address-based throttling/failure tracking only after SIWE signature verification succeeds, avoiding forged-payload lockout of victim addresses.
- Added temporary failed-login backoff keyed by IP/user agent and verified address where available, with `Retry-After` responses and no indefinite lockout.
- Added stale bucket eviction and hard caps to prevent unbounded abuse-control memory growth.
- Added structured `console.warn` signals for throttled nonce/login requests and failed login attempts.
- Kept DB-backed nonce consumption single-use and made expiry handling testable with shared nonce expiry helpers.

## Tests

- `node --test --experimental-strip-types packages/web/scripts/profile-auth.test.ts`
- `pnpm --filter @degov/web lint` (passes with one existing unrelated warning in `packages/web/src/app/_server/config-remote.ts` about import ordering)
- `pnpm --filter @degov/web build`

Closes #693.