### PR TITLE
chore(release): bump packages to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "degov",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "private": true,
   "packageManager": "pnpm@10.32.1",
   "pnpm": {

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@degov/indexer",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "codegen:abi": "squid-evm-typegen src/abi ./abi/*.json",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@degov/web",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "postinstall": "prisma generate",


### PR DESCRIPTION
## Summary

Bump all DeGov workspace package versions to `2.0.0` for the upcoming major release.

Updated packages:

- `degov`: `2.0.0`
- `@degov/indexer`: `2.0.0`
- `@degov/web`: `2.0.0`

## Release Notes

### DeGov 2.0.0

This is a **breaking major release** for DeGov indexing and deployment operations.

#### Breaking changes

- The indexer schema and indexing behavior changed for v2 onchain power support.
- Existing indexer databases from the previous release line should not be migrated in place.
- Operators must reset/recreate indexer databases and perform a fresh sync after deploying this release.

#### New deployment requirement

This release adds a new runtime service:

- `onchain-refresh-worker`

Deployments must run this worker alongside the existing indexer service. The worker is responsible for refreshing current onchain token balances/voting power and reconciling stale delegate power while the processor continues indexing historical events.

For Docker Compose users, `docker-compose.yml` now includes the `onchain-refresh-worker` service and the related environment variables in `.env.example`.

For Kubernetes/GitOps deployments, make sure the equivalent worker Deployment/container is included when rolling out this release.

#### Operational upgrade notes

1. Build and publish the `2.0.0` images/packages.
2. Update deployment manifests to include the new `onchain-refresh-worker` service.
3. Reset/recreate v2 indexer databases instead of relying on historical in-place migration.
4. Start the indexer and worker from a clean database.
5. Monitor processor sync height, `onchain_refresh_task` processing, delegate power, and `data_metric.global.power_sum` after the fresh sync begins.

## Validation

- Ran `pnpm install --lockfile-only --ignore-scripts`; no lockfile changes were required.
- Ran `pnpm --filter @degov/indexer run build` successfully.
