### PR TITLE
Define canonical Postgres schema ownership for the Datalens indexer fresh initialization path.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ to a Datalens-native indexer. The documents below describe historical behavior
 or API/data-model reference material unless a newer document says otherwise.
 
 - [Datalens Rust technical conventions][datalens-rust-conventions]
+- [Datalens PostgreSQL schema ownership][datalens-postgres-schema]
 - [Developer guide](./guides/20260325__indexer_developer_guide.md)
 - [Accuracy diagnosis guide](./guides/20260331__indexer_accuracy_diagnosis.md)
 - [Accuracy research summary](./research/20260401__indexer_accuracy_research.md)
@@ -23,3 +24,4 @@ or API/data-model reference material unless a newer document says otherwise.
 - [Projection replay, reconciliation, and rollout](./plans/20260325__degov_projection_replay_reconciliation_rollout.md)
 
 [datalens-rust-conventions]: ./spec/datalens-rust-technical-conventions.md
+[datalens-postgres-schema]: ../packages/indexer/README.md#postgresql-schema-ownership

--- a/packages/indexer/README.md
+++ b/packages/indexer/README.md
@@ -13,6 +13,28 @@ The package intentionally has no indexer runtime right now. Its `build` and
 `test` scripts are placeholders so workspace commands can continue to run while
 the Datalens implementation is introduced in follow-up work.
 
+## PostgreSQL schema ownership
+
+`schema/postgres.sql` is the canonical PostgreSQL schema source for the
+Datalens-native DeGov indexer fresh initialization path. Future Rust repository
+code should initialize a fresh database by applying this file with `sqlx` and
+should keep checkpoint, projection, and reconcile writes inside explicit
+transaction boundaries.
+
+The Datalens indexer upgrade is a breaking indexer implementation change.
+Operators must reset or recreate the Postgres index database before adopting it
+and then run the Datalens-native indexer from the configured start block. Do not
+add historical in-place migrations for v3/v4 SQD/Subsquid index databases: a
+table-shape migration cannot recompute historical proposal state, votes,
+delegations, contributor power, or aggregate metrics under the new indexing
+semantics.
+
+`reference/schema.graphql` remains the compatibility reference for table and
+field names consumed by the current web and square GraphQL/API paths. Edit
+`schema/postgres.sql` for database initialization, Rust SQL models for typed
+access, and `reference/schema.graphql` only when a separate issue explicitly
+changes the API-visible contract.
+
 ## Reference artifacts
 
 The files under `reference/` are retained only as behavioral/API references for
@@ -26,4 +48,6 @@ shell.
 
 ```bash
 pnpm --filter @degov/indexer build
+pnpm --filter @degov/indexer test
+DEGOV_INDEXER_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/indexer pnpm --filter @degov/indexer run smoke:postgres-init
 ```

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -7,7 +7,7 @@
     "check:rust-conventions": "node ./scripts/check-rust-conventions.mjs",
     "check:postgres-schema": "node ./scripts/check-postgres-schema.mjs",
     "smoke:postgres-init": "node ./scripts/smoke-postgres-init.mjs",
-    "test": "pnpm run check:rust-conventions && pnpm run check:postgres-schema && node ./scripts/check-rust-conventions.test.mjs && node ./scripts/placeholder.mjs",
+    "test": "pnpm run check:rust-conventions && pnpm run check:postgres-schema && node ./scripts/check-rust-conventions.test.mjs && node ./scripts/smoke-postgres-init.test.mjs && node ./scripts/placeholder.mjs",
     "test-unit": "node ./scripts/placeholder.mjs"
   }
 }

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "build": "node ./scripts/placeholder.mjs",
     "check:rust-conventions": "node ./scripts/check-rust-conventions.mjs",
-    "test": "pnpm run check:rust-conventions && node ./scripts/check-rust-conventions.test.mjs && node ./scripts/placeholder.mjs",
+    "check:postgres-schema": "node ./scripts/check-postgres-schema.mjs",
+    "smoke:postgres-init": "node ./scripts/smoke-postgres-init.mjs",
+    "test": "pnpm run check:rust-conventions && pnpm run check:postgres-schema && node ./scripts/check-rust-conventions.test.mjs && node ./scripts/placeholder.mjs",
     "test-unit": "node ./scripts/placeholder.mjs"
   }
 }

--- a/packages/indexer/schema/postgres.sql
+++ b/packages/indexer/schema/postgres.sql
@@ -1,0 +1,852 @@
+-- Datalens-native DeGov indexer PostgreSQL schema.
+--
+-- Ownership:
+-- - This file is the canonical fresh index initialization schema.
+-- - The Rust Datalens indexer applies this schema to a clean Postgres database.
+-- - GraphQL/API-visible table compatibility is tracked against
+--   packages/indexer/reference/schema.graphql.
+-- - No historical in-place migration is supported from removed SQD/Subsquid
+--   v3/v4 index databases. Operators must reset or recreate the Postgres index
+--   database and run from the configured Datalens start block.
+--
+-- Large EVM uint256 vote and power values use NUMERIC(78, 0) to preserve
+-- precision without floating-point coercion.
+
+CREATE TABLE IF NOT EXISTS degov_indexer_checkpoint (
+  id TEXT PRIMARY KEY DEFAULT 'default',
+  chain_id INTEGER NOT NULL,
+  dao_code TEXT,
+  governor_address TEXT NOT NULL,
+  start_block_number NUMERIC(78, 0) NOT NULL,
+  next_block_number NUMERIC(78, 0) NOT NULL,
+  last_block_number NUMERIC(78, 0),
+  last_block_timestamp NUMERIC(78, 0),
+  last_transaction_hash TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT degov_indexer_checkpoint_singleton CHECK (id = 'default')
+);
+
+CREATE TABLE IF NOT EXISTS degov_indexer_reconcile_task (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER NOT NULL,
+  dao_code TEXT,
+  governor_address TEXT NOT NULL,
+  task_type TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  next_run_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  locked_at TIMESTAMPTZ,
+  locked_by TEXT,
+  processed_at TIMESTAMPTZ,
+  error TEXT,
+  first_seen_block_number NUMERIC(78, 0) NOT NULL,
+  last_seen_block_number NUMERIC(78, 0) NOT NULL,
+  last_seen_transaction_hash TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT degov_indexer_reconcile_task_unique_subject UNIQUE NULLS NOT DISTINCT (
+    chain_id,
+    governor_address,
+    task_type,
+    subject_id
+  )
+);
+
+CREATE INDEX IF NOT EXISTS degov_indexer_reconcile_task_status_idx
+  ON degov_indexer_reconcile_task (status, next_run_at);
+
+CREATE TABLE IF NOT EXISTS delegate_changed (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  delegator TEXT NOT NULL,
+  from_delegate TEXT NOT NULL,
+  to_delegate TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS delegate_changed_chain_governor_delegator_idx
+  ON delegate_changed (chain_id, governor_address, delegator);
+
+CREATE TABLE IF NOT EXISTS delegate_votes_changed (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  delegate TEXT NOT NULL,
+  previous_votes NUMERIC(78, 0) NOT NULL,
+  new_votes NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS delegate_votes_changed_chain_governor_delegate_idx
+  ON delegate_votes_changed (chain_id, governor_address, delegate);
+
+CREATE TABLE IF NOT EXISTS token_transfer (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  "from" TEXT NOT NULL,
+  "to" TEXT NOT NULL,
+  value NUMERIC(78, 0) NOT NULL,
+  standard TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS token_transfer_chain_governor_token_idx
+  ON token_transfer (chain_id, governor_address, token_address);
+CREATE INDEX IF NOT EXISTS token_transfer_transaction_hash_idx
+  ON token_transfer (transaction_hash);
+
+CREATE TABLE IF NOT EXISTS vote_power_checkpoint (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  account TEXT NOT NULL,
+  clock_mode TEXT NOT NULL,
+  timepoint NUMERIC(78, 0) NOT NULL,
+  previous_power NUMERIC(78, 0) NOT NULL,
+  new_power NUMERIC(78, 0) NOT NULL,
+  delta NUMERIC(78, 0) NOT NULL,
+  source TEXT,
+  cause TEXT NOT NULL,
+  delegator TEXT,
+  from_delegate TEXT,
+  to_delegate TEXT,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS vote_power_checkpoint_lookup_idx
+  ON vote_power_checkpoint (chain_id, governor_address, token_address, account, clock_mode, timepoint);
+
+CREATE TABLE IF NOT EXISTS token_balance_checkpoint (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  account TEXT NOT NULL,
+  previous_balance NUMERIC(78, 0) NOT NULL,
+  new_balance NUMERIC(78, 0) NOT NULL,
+  delta NUMERIC(78, 0) NOT NULL,
+  source TEXT NOT NULL,
+  cause TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS token_balance_checkpoint_lookup_idx
+  ON token_balance_checkpoint (chain_id, governor_address, token_address, account, block_number);
+
+CREATE TABLE IF NOT EXISTS onchain_refresh_task (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER NOT NULL,
+  dao_code TEXT,
+  governor_address TEXT NOT NULL,
+  token_address TEXT NOT NULL,
+  account TEXT NOT NULL,
+  refresh_balance BOOLEAN NOT NULL,
+  refresh_power BOOLEAN NOT NULL,
+  reason TEXT NOT NULL,
+  first_seen_block_number NUMERIC(78, 0) NOT NULL,
+  last_seen_block_number NUMERIC(78, 0) NOT NULL,
+  last_seen_block_timestamp NUMERIC(78, 0) NOT NULL,
+  last_seen_transaction_hash TEXT NOT NULL,
+  status TEXT NOT NULL,
+  attempts INTEGER NOT NULL,
+  next_run_at NUMERIC(78, 0) NOT NULL,
+  locked_at NUMERIC(78, 0),
+  locked_by TEXT,
+  processed_at NUMERIC(78, 0),
+  error TEXT,
+  pending_after_lock BOOLEAN NOT NULL,
+  pending_after_lock_block_number NUMERIC(78, 0),
+  pending_after_lock_block_timestamp NUMERIC(78, 0),
+  pending_after_lock_transaction_hash TEXT,
+  created_at NUMERIC(78, 0) NOT NULL,
+  updated_at NUMERIC(78, 0) NOT NULL,
+  CONSTRAINT onchain_refresh_task_account_unique UNIQUE NULLS NOT DISTINCT (
+    chain_id,
+    governor_address,
+    token_address,
+    account
+  )
+);
+
+CREATE INDEX IF NOT EXISTS onchain_refresh_task_status_idx
+  ON onchain_refresh_task (status, next_run_at);
+
+CREATE TABLE IF NOT EXISTS proposal_canceled (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_canceled_lookup_idx
+  ON proposal_canceled (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS proposal_created (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  proposer TEXT NOT NULL,
+  targets TEXT[] NOT NULL,
+  values TEXT[] NOT NULL,
+  signatures TEXT[] NOT NULL,
+  calldatas TEXT[] NOT NULL,
+  vote_start NUMERIC(78, 0) NOT NULL,
+  vote_end NUMERIC(78, 0) NOT NULL,
+  description TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_created_lookup_idx
+  ON proposal_created (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS proposal_executed (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_executed_lookup_idx
+  ON proposal_executed (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS proposal_queued (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  eta_seconds NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_queued_lookup_idx
+  ON proposal_queued (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS proposal_extended (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  extended_deadline NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_extended_lookup_idx
+  ON proposal_extended (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS voting_delay_set (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  old_voting_delay NUMERIC(78, 0) NOT NULL,
+  new_voting_delay NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS voting_delay_set_lookup_idx
+  ON voting_delay_set (chain_id, governor_address, block_number);
+
+CREATE TABLE IF NOT EXISTS voting_period_set (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  old_voting_period NUMERIC(78, 0) NOT NULL,
+  new_voting_period NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS voting_period_set_lookup_idx
+  ON voting_period_set (chain_id, governor_address, block_number);
+
+CREATE TABLE IF NOT EXISTS proposal_threshold_set (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  old_proposal_threshold NUMERIC(78, 0) NOT NULL,
+  new_proposal_threshold NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_threshold_set_lookup_idx
+  ON proposal_threshold_set (chain_id, governor_address, block_number);
+
+CREATE TABLE IF NOT EXISTS quorum_numerator_updated (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  old_quorum_numerator NUMERIC(78, 0) NOT NULL,
+  new_quorum_numerator NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS quorum_numerator_updated_lookup_idx
+  ON quorum_numerator_updated (chain_id, governor_address, block_number);
+
+CREATE TABLE IF NOT EXISTS late_quorum_vote_extension_set (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  old_late_quorum_vote_extension NUMERIC(78, 0) NOT NULL,
+  new_late_quorum_vote_extension NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS late_quorum_vote_extension_set_lookup_idx
+  ON late_quorum_vote_extension_set (chain_id, governor_address, block_number);
+
+CREATE TABLE IF NOT EXISTS timelock_change (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  old_timelock TEXT NOT NULL,
+  new_timelock TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS timelock_change_lookup_idx
+  ON timelock_change (chain_id, governor_address, block_number);
+
+CREATE TABLE IF NOT EXISTS vote_cast (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  voter TEXT NOT NULL,
+  proposal_id TEXT NOT NULL,
+  support INTEGER NOT NULL,
+  weight NUMERIC(78, 0) NOT NULL,
+  reason TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS vote_cast_lookup_idx
+  ON vote_cast (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS vote_cast_with_params (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  voter TEXT NOT NULL,
+  proposal_id TEXT NOT NULL,
+  support INTEGER NOT NULL,
+  weight NUMERIC(78, 0) NOT NULL,
+  reason TEXT NOT NULL,
+  params TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS vote_cast_with_params_lookup_idx
+  ON vote_cast_with_params (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS proposal (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  proposer TEXT NOT NULL,
+  targets TEXT[] NOT NULL,
+  values TEXT[] NOT NULL,
+  signatures TEXT[] NOT NULL,
+  calldatas TEXT[] NOT NULL,
+  vote_start NUMERIC(78, 0) NOT NULL,
+  vote_end NUMERIC(78, 0) NOT NULL,
+  description TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  metrics_votes_count INTEGER,
+  metrics_votes_with_params_count INTEGER,
+  metrics_votes_without_params_count INTEGER,
+  metrics_votes_weight_for_sum NUMERIC(78, 0),
+  metrics_votes_weight_against_sum NUMERIC(78, 0),
+  metrics_votes_weight_abstain_sum NUMERIC(78, 0),
+  title TEXT NOT NULL,
+  vote_start_timestamp NUMERIC(78, 0) NOT NULL,
+  vote_end_timestamp NUMERIC(78, 0) NOT NULL,
+  block_interval TEXT,
+  description_hash TEXT,
+  proposal_snapshot NUMERIC(78, 0),
+  proposal_deadline NUMERIC(78, 0),
+  proposal_eta NUMERIC(78, 0),
+  queue_ready_at NUMERIC(78, 0),
+  queue_expires_at NUMERIC(78, 0),
+  counting_mode TEXT,
+  timelock_address TEXT,
+  timelock_grace_period NUMERIC(78, 0),
+  clock_mode TEXT NOT NULL,
+  quorum NUMERIC(78, 0) NOT NULL,
+  decimals NUMERIC(78, 0) NOT NULL,
+  CONSTRAINT proposal_lookup_unique UNIQUE NULLS NOT DISTINCT (chain_id, governor_address, proposal_id)
+);
+
+CREATE INDEX IF NOT EXISTS proposal_lookup_idx
+  ON proposal (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS vote_cast_group (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL REFERENCES proposal (id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  voter TEXT NOT NULL,
+  ref_proposal_id TEXT NOT NULL,
+  support INTEGER NOT NULL,
+  weight NUMERIC(78, 0) NOT NULL,
+  reason TEXT NOT NULL,
+  params TEXT,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS vote_cast_group_lookup_idx
+  ON vote_cast_group (chain_id, governor_address, ref_proposal_id);
+
+CREATE TABLE IF NOT EXISTS proposal_action (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  proposal_ref TEXT NOT NULL REFERENCES proposal (id) ON DELETE CASCADE,
+  action_index INTEGER NOT NULL,
+  target TEXT NOT NULL,
+  value TEXT NOT NULL,
+  signature TEXT NOT NULL,
+  calldata TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_action_lookup_idx
+  ON proposal_action (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS proposal_state_epoch (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  proposal_ref TEXT NOT NULL REFERENCES proposal (id) ON DELETE CASCADE,
+  state TEXT NOT NULL,
+  start_timepoint NUMERIC(78, 0),
+  end_timepoint NUMERIC(78, 0),
+  start_block_number NUMERIC(78, 0),
+  start_block_timestamp NUMERIC(78, 0),
+  end_block_number NUMERIC(78, 0),
+  end_block_timestamp NUMERIC(78, 0),
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_state_epoch_lookup_idx
+  ON proposal_state_epoch (chain_id, governor_address, proposal_id, state);
+
+CREATE TABLE IF NOT EXISTS governance_parameter_checkpoint (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  event_name TEXT NOT NULL,
+  parameter_name TEXT NOT NULL,
+  value_type TEXT NOT NULL,
+  old_value TEXT,
+  new_value TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS governance_parameter_checkpoint_lookup_idx
+  ON governance_parameter_checkpoint (chain_id, governor_address, parameter_name);
+
+CREATE TABLE IF NOT EXISTS proposal_deadline_extension (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_id TEXT NOT NULL,
+  proposal_ref TEXT NOT NULL REFERENCES proposal (id) ON DELETE CASCADE,
+  previous_deadline NUMERIC(78, 0),
+  new_deadline NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS proposal_deadline_extension_lookup_idx
+  ON proposal_deadline_extension (chain_id, governor_address, proposal_id);
+
+CREATE TABLE IF NOT EXISTS timelock_operation (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  timelock_address TEXT NOT NULL,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposal_ref TEXT REFERENCES proposal (id) ON DELETE SET NULL,
+  proposal_id TEXT,
+  operation_id TEXT NOT NULL,
+  timelock_type TEXT NOT NULL,
+  predecessor TEXT,
+  salt TEXT,
+  state TEXT NOT NULL,
+  call_count INTEGER,
+  executed_call_count INTEGER,
+  delay_seconds NUMERIC(78, 0),
+  ready_at NUMERIC(78, 0),
+  expires_at NUMERIC(78, 0),
+  queued_block_number NUMERIC(78, 0),
+  queued_block_timestamp NUMERIC(78, 0),
+  queued_transaction_hash TEXT,
+  cancelled_block_number NUMERIC(78, 0),
+  cancelled_block_timestamp NUMERIC(78, 0),
+  cancelled_transaction_hash TEXT,
+  executed_block_number NUMERIC(78, 0),
+  executed_block_timestamp NUMERIC(78, 0),
+  executed_transaction_hash TEXT,
+  CONSTRAINT timelock_operation_lookup_unique UNIQUE NULLS NOT DISTINCT (
+    chain_id,
+    governor_address,
+    timelock_address,
+    proposal_id,
+    operation_id
+  )
+);
+
+CREATE INDEX IF NOT EXISTS timelock_operation_lookup_idx
+  ON timelock_operation (chain_id, governor_address, timelock_address, proposal_id, operation_id);
+
+CREATE TABLE IF NOT EXISTS timelock_call (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  timelock_address TEXT NOT NULL,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  operation_id TEXT NOT NULL,
+  operation_ref TEXT NOT NULL REFERENCES timelock_operation (id) ON DELETE CASCADE,
+  proposal_ref TEXT REFERENCES proposal (id) ON DELETE SET NULL,
+  proposal_id TEXT,
+  proposal_action_id TEXT,
+  proposal_action_index INTEGER,
+  action_index INTEGER NOT NULL,
+  target TEXT NOT NULL,
+  value TEXT NOT NULL,
+  data TEXT NOT NULL,
+  predecessor TEXT,
+  delay_seconds NUMERIC(78, 0),
+  state TEXT NOT NULL,
+  scheduled_block_number NUMERIC(78, 0),
+  scheduled_block_timestamp NUMERIC(78, 0),
+  scheduled_transaction_hash TEXT,
+  executed_block_number NUMERIC(78, 0),
+  executed_block_timestamp NUMERIC(78, 0),
+  executed_transaction_hash TEXT
+);
+
+CREATE INDEX IF NOT EXISTS timelock_call_lookup_idx
+  ON timelock_call (chain_id, governor_address, timelock_address, operation_id, action_index);
+
+CREATE TABLE IF NOT EXISTS timelock_role_event (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  timelock_address TEXT NOT NULL,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  event_name TEXT NOT NULL,
+  role TEXT NOT NULL,
+  role_label TEXT,
+  account TEXT,
+  sender TEXT,
+  previous_admin_role TEXT,
+  previous_admin_role_label TEXT,
+  new_admin_role TEXT,
+  new_admin_role_label TEXT,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS timelock_role_event_lookup_idx
+  ON timelock_role_event (chain_id, governor_address, timelock_address, role, event_name);
+
+CREATE TABLE IF NOT EXISTS timelock_min_delay_change (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  timelock_address TEXT NOT NULL,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  old_duration NUMERIC(78, 0) NOT NULL,
+  new_duration NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS timelock_min_delay_change_lookup_idx
+  ON timelock_min_delay_change (chain_id, governor_address, timelock_address, block_number);
+
+CREATE TABLE IF NOT EXISTS data_metric (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  proposals_count INTEGER,
+  votes_count INTEGER,
+  votes_with_params_count INTEGER,
+  votes_without_params_count INTEGER,
+  votes_weight_for_sum NUMERIC(78, 0),
+  votes_weight_against_sum NUMERIC(78, 0),
+  votes_weight_abstain_sum NUMERIC(78, 0),
+  power_sum NUMERIC(78, 0),
+  member_count INTEGER,
+  CONSTRAINT data_metric_lookup_unique UNIQUE NULLS NOT DISTINCT (
+    chain_id,
+    governor_address,
+    dao_code
+  )
+);
+
+CREATE INDEX IF NOT EXISTS data_metric_lookup_idx
+  ON data_metric (chain_id, governor_address, dao_code);
+
+CREATE TABLE IF NOT EXISTS delegate_rolling (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  delegator TEXT NOT NULL,
+  from_delegate TEXT NOT NULL,
+  to_delegate TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  from_previous_votes NUMERIC(78, 0),
+  from_new_votes NUMERIC(78, 0),
+  to_previous_votes NUMERIC(78, 0),
+  to_new_votes NUMERIC(78, 0)
+);
+
+CREATE INDEX IF NOT EXISTS delegate_rolling_delegator_idx
+  ON delegate_rolling (chain_id, governor_address, delegator);
+CREATE INDEX IF NOT EXISTS delegate_rolling_transaction_hash_idx
+  ON delegate_rolling (transaction_hash);
+
+CREATE TABLE IF NOT EXISTS delegate (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  from_delegate TEXT NOT NULL,
+  to_delegate TEXT NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  is_current BOOLEAN NOT NULL,
+  power NUMERIC(78, 0) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS delegate_lookup_idx
+  ON delegate (chain_id, governor_address, from_delegate, to_delegate);
+
+CREATE TABLE IF NOT EXISTS contributor (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  last_vote_block_number NUMERIC(78, 0),
+  last_vote_timestamp NUMERIC(78, 0),
+  power NUMERIC(78, 0) NOT NULL,
+  balance NUMERIC(78, 0),
+  delegates_count_all INTEGER NOT NULL,
+  delegates_count_effective INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS contributor_lookup_idx
+  ON contributor (chain_id, governor_address, id);
+
+CREATE TABLE IF NOT EXISTS delegate_mapping (
+  id TEXT PRIMARY KEY,
+  chain_id INTEGER,
+  dao_code TEXT,
+  governor_address TEXT,
+  token_address TEXT,
+  contract_address TEXT,
+  log_index INTEGER,
+  transaction_index INTEGER,
+  "from" TEXT NOT NULL,
+  "to" TEXT NOT NULL,
+  power NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  block_timestamp NUMERIC(78, 0) NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS delegate_mapping_lookup_idx
+  ON delegate_mapping (chain_id, governor_address, "from");

--- a/packages/indexer/scripts/check-postgres-schema.mjs
+++ b/packages/indexer/scripts/check-postgres-schema.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const root = path.resolve(import.meta.dirname, "..");
+const schemaPath = path.join(root, "schema", "postgres.sql");
+const readmePath = path.join(root, "README.md");
+const docsReadmePath = path.resolve(root, "..", "..", "docs", "README.md");
+
+const requiredTables = [
+  "degov_indexer_checkpoint",
+  "degov_indexer_reconcile_task",
+  "delegate_changed",
+  "delegate_votes_changed",
+  "token_transfer",
+  "vote_power_checkpoint",
+  "token_balance_checkpoint",
+  "onchain_refresh_task",
+  "proposal_canceled",
+  "proposal_created",
+  "proposal_executed",
+  "proposal_queued",
+  "proposal_extended",
+  "voting_delay_set",
+  "voting_period_set",
+  "proposal_threshold_set",
+  "quorum_numerator_updated",
+  "late_quorum_vote_extension_set",
+  "timelock_change",
+  "vote_cast",
+  "vote_cast_with_params",
+  "vote_cast_group",
+  "proposal",
+  "proposal_action",
+  "proposal_state_epoch",
+  "governance_parameter_checkpoint",
+  "proposal_deadline_extension",
+  "timelock_operation",
+  "timelock_call",
+  "timelock_role_event",
+  "timelock_min_delay_change",
+  "data_metric",
+  "delegate_rolling",
+  "delegate",
+  "contributor",
+  "delegate_mapping",
+];
+
+const requiredSchemaSnippets = [
+  /Datalens-native DeGov indexer PostgreSQL schema/i,
+  /fresh index initialization/i,
+  /reset or recreate/i,
+  /No historical in-place migration/i,
+  /NUMERIC\(78,\s*0\)/i,
+  /CREATE TABLE IF NOT EXISTS degov_indexer_checkpoint/i,
+  /CREATE TABLE IF NOT EXISTS degov_indexer_reconcile_task/i,
+  /UNIQUE NULLS NOT DISTINCT/i,
+  /CREATE INDEX IF NOT EXISTS/i,
+];
+
+const requiredReadmeSnippets = [
+  /schema\/postgres\.sql/,
+  /canonical PostgreSQL schema/i,
+  /reset or recreate/i,
+  /fresh initialization/i,
+  /reference\/schema\.graphql/,
+  /GraphQL/i,
+  /sqlx/i,
+];
+
+function tablePattern(tableName) {
+  return new RegExp(`CREATE\\s+TABLE\\s+IF\\s+NOT\\s+EXISTS\\s+${tableName}\\b`, "i");
+}
+
+async function main() {
+  const [schema, readme, docsReadme] = await Promise.all([
+    readFile(schemaPath, "utf8"),
+    readFile(readmePath, "utf8"),
+    readFile(docsReadmePath, "utf8"),
+  ]);
+
+  for (const pattern of requiredSchemaSnippets) {
+    assert.match(schema, pattern, `schema must include ${pattern}`);
+  }
+
+  for (const tableName of requiredTables) {
+    assert.match(schema, tablePattern(tableName), `schema must create ${tableName}`);
+  }
+
+  for (const pattern of requiredReadmeSnippets) {
+    assert.match(readme, pattern, `indexer README must include ${pattern}`);
+  }
+
+  assert.match(
+    docsReadme,
+    /Datalens PostgreSQL schema/i,
+    "docs README must route readers to the Datalens PostgreSQL schema owner",
+  );
+
+  console.log("Postgres schema ownership check passed");
+}
+
+await main();

--- a/packages/indexer/scripts/check-postgres-schema.mjs
+++ b/packages/indexer/scripts/check-postgres-schema.mjs
@@ -3,7 +3,6 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import process from "node:process";
 
 const root = path.resolve(import.meta.dirname, "..");
 const schemaPath = path.join(root, "schema", "postgres.sql");

--- a/packages/indexer/scripts/smoke-postgres-init.mjs
+++ b/packages/indexer/scripts/smoke-postgres-init.mjs
@@ -7,6 +7,7 @@ import process from "node:process";
 
 const schemaPath = path.resolve(import.meta.dirname, "..", "schema", "postgres.sql");
 const databaseUrl = process.env.DEGOV_INDEXER_DATABASE_URL;
+const isLinux = process.platform === "linux";
 
 if (!databaseUrl) {
   console.error("DEGOV_INDEXER_DATABASE_URL must point to a clean Postgres database");
@@ -34,15 +35,29 @@ const expectedTables = [
   "delegate_mapping",
 ];
 
+function dockerDatabaseUrl() {
+  if (isLinux) {
+    return databaseUrl;
+  }
+
+  const url = new URL(databaseUrl);
+
+  if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) {
+    url.hostname = "host.docker.internal";
+  }
+
+  return url.toString();
+}
+
 function runDockerPostgres(args, stdin) {
   return new Promise((resolve, reject) => {
+    const dockerNetworkArgs = isLinux ? ["--network", "host"] : [];
     const child = spawn(
       "docker",
       [
         "run",
         "--rm",
-        "--network",
-        "host",
+        ...dockerNetworkArgs,
         "-i",
         "postgres:17-alpine",
         ...args,
@@ -73,8 +88,37 @@ function runDockerPostgres(args, stdin) {
 
 async function main() {
   const schema = await readFile(schemaPath, "utf8");
+  const psqlDatabaseUrl = dockerDatabaseUrl();
+  const cleanDatabaseSql = [
+    "SELECT table_name",
+    "FROM information_schema.tables",
+    "WHERE table_schema = 'public'",
+    "ORDER BY table_name;",
+  ].join("\n");
+  const cleanDatabaseResult = await runDockerPostgres(
+    ["psql", psqlDatabaseUrl, "--tuples-only", "--no-align"],
+    cleanDatabaseSql,
+  );
+
+  if (cleanDatabaseResult.status !== 0) {
+    console.error(cleanDatabaseResult.stderr);
+    process.exit(cleanDatabaseResult.status ?? 1);
+  }
+
+  const existingTables = cleanDatabaseResult.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (existingTables.length > 0) {
+    console.error(
+      `DEGOV_INDEXER_DATABASE_URL must point to a clean Postgres database; public already contains: ${existingTables.join(", ")}`,
+    );
+    process.exit(1);
+  }
+
   const initResult = await runDockerPostgres(
-    ["psql", databaseUrl, "--set", "ON_ERROR_STOP=1"],
+    ["psql", psqlDatabaseUrl, "--set", "ON_ERROR_STOP=1"],
     schema,
   );
 
@@ -91,7 +135,7 @@ async function main() {
     "ORDER BY table_name;",
   ].join("\n");
   const verifyResult = await runDockerPostgres(
-    ["psql", databaseUrl, "--tuples-only", "--no-align"],
+    ["psql", psqlDatabaseUrl, "--tuples-only", "--no-align"],
     verifySql,
   );
 

--- a/packages/indexer/scripts/smoke-postgres-init.mjs
+++ b/packages/indexer/scripts/smoke-postgres-init.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const schemaPath = path.resolve(import.meta.dirname, "..", "schema", "postgres.sql");
+const databaseUrl = process.env.DEGOV_INDEXER_DATABASE_URL;
+
+if (!databaseUrl) {
+  console.error("DEGOV_INDEXER_DATABASE_URL must point to a clean Postgres database");
+  process.exit(1);
+}
+
+const expectedTables = [
+  "degov_indexer_checkpoint",
+  "degov_indexer_reconcile_task",
+  "proposal",
+  "proposal_action",
+  "proposal_state_epoch",
+  "vote_cast_group",
+  "vote_power_checkpoint",
+  "token_balance_checkpoint",
+  "onchain_refresh_task",
+  "timelock_operation",
+  "timelock_call",
+  "timelock_role_event",
+  "timelock_min_delay_change",
+  "data_metric",
+  "delegate_rolling",
+  "delegate",
+  "contributor",
+  "delegate_mapping",
+];
+
+function runDockerPostgres(args, stdin) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "docker",
+      [
+        "run",
+        "--rm",
+        "--network",
+        "host",
+        "-i",
+        "postgres:17-alpine",
+        ...args,
+      ],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status) => {
+      resolve({ status, stdout, stderr });
+    });
+
+    if (stdin) {
+      child.stdin.end(stdin);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+async function main() {
+  const schema = await readFile(schemaPath, "utf8");
+  const initResult = await runDockerPostgres(
+    ["psql", databaseUrl, "--set", "ON_ERROR_STOP=1"],
+    schema,
+  );
+
+  if (initResult.status !== 0) {
+    console.error(initResult.stderr);
+    process.exit(initResult.status ?? 1);
+  }
+
+  const verifySql = [
+    "SELECT table_name",
+    "FROM information_schema.tables",
+    "WHERE table_schema = 'public'",
+    `AND table_name = ANY (ARRAY[${expectedTables.map((name) => `'${name}'`).join(", ")}])`,
+    "ORDER BY table_name;",
+  ].join("\n");
+  const verifyResult = await runDockerPostgres(
+    ["psql", databaseUrl, "--tuples-only", "--no-align"],
+    verifySql,
+  );
+
+  if (verifyResult.status !== 0) {
+    console.error(verifyResult.stderr);
+    process.exit(verifyResult.status ?? 1);
+  }
+
+  const foundTables = new Set(
+    verifyResult.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+  const missingTables = expectedTables.filter((tableName) => !foundTables.has(tableName));
+
+  if (missingTables.length > 0) {
+    console.error(`Postgres schema smoke check missed tables: ${missingTables.join(", ")}`);
+    process.exit(1);
+  }
+
+  console.log("Postgres initialization smoke check passed");
+}
+
+await main();

--- a/packages/indexer/scripts/smoke-postgres-init.mjs
+++ b/packages/indexer/scripts/smoke-postgres-init.mjs
@@ -90,10 +90,22 @@ async function main() {
   const schema = await readFile(schemaPath, "utf8");
   const psqlDatabaseUrl = dockerDatabaseUrl();
   const cleanDatabaseSql = [
-    "SELECT table_name",
-    "FROM information_schema.tables",
-    "WHERE table_schema = 'public'",
-    "ORDER BY table_name;",
+    "SELECT",
+    "  CASE c.relkind",
+    "    WHEN 'r' THEN 'table'",
+    "    WHEN 'p' THEN 'partitioned table'",
+    "    WHEN 'v' THEN 'view'",
+    "    WHEN 'm' THEN 'materialized view'",
+    "    WHEN 'S' THEN 'sequence'",
+    "    WHEN 'f' THEN 'foreign table'",
+    "    WHEN 'i' THEN 'index'",
+    "    WHEN 'I' THEN 'partitioned index'",
+    "    ELSE c.relkind::text",
+    "  END || ':' || c.relname AS object_name",
+    "FROM pg_catalog.pg_class c",
+    "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace",
+    "WHERE n.nspname = 'public'",
+    "ORDER BY object_name;",
   ].join("\n");
   const cleanDatabaseResult = await runDockerPostgres(
     ["psql", psqlDatabaseUrl, "--tuples-only", "--no-align"],
@@ -105,14 +117,14 @@ async function main() {
     process.exit(cleanDatabaseResult.status ?? 1);
   }
 
-  const existingTables = cleanDatabaseResult.stdout
+  const existingObjects = cleanDatabaseResult.stdout
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean);
 
-  if (existingTables.length > 0) {
+  if (existingObjects.length > 0) {
     console.error(
-      `DEGOV_INDEXER_DATABASE_URL must point to a clean Postgres database; public already contains: ${existingTables.join(", ")}`,
+      `DEGOV_INDEXER_DATABASE_URL must point to a clean Postgres database; public already contains: ${existingObjects.join(", ")}`,
     );
     process.exit(1);
   }

--- a/packages/indexer/scripts/smoke-postgres-init.test.mjs
+++ b/packages/indexer/scripts/smoke-postgres-init.test.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import assert from "node:assert/strict";
+
+const scriptPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "smoke-postgres-init.mjs",
+);
+
+const script = await readFile(scriptPath, "utf8");
+
+assert.match(script, /const dockerNetworkArgs = isLinux \? \["--network", "host"\] : \[\]/);
+assert.match(script, /FROM pg_catalog\.pg_class/);
+assert.match(script, /pg_catalog\.pg_namespace/);
+assert.match(script, /n\.nspname = 'public'/);
+
+console.log("Postgres initialization smoke script tests passed");


### PR DESCRIPTION
## Summary
Define canonical Postgres schema ownership for the Datalens indexer fresh initialization path.

## Why
- Issue: [HBX-265](https://plane.kahub.in/endless/browse/HBX-265/)

## Changes
- Add packages/indexer/schema/postgres.sql as the canonical fresh Postgres schema for checkpoint, reconcile, proposal, vote, delegation, contributor, metric, and timelock tables.
- Document reset/recreate database requirements and GraphQL compatibility ownership in the indexer README and docs router.
- Add schema ownership and Postgres initialization smoke scripts to package verification commands.

## Impact
- docs/README.md
- packages/indexer/README.md
- packages/indexer/package.json
- packages/indexer/schema/postgres.sql
- packages/indexer/scripts/check-postgres-schema.mjs
- packages/indexer/scripts/smoke-postgres-init.mjs

## Verification
- pnpm --filter @degov/indexer test
- DEGOV_INDEXER_DATABASE_URL=postgresql://postgres:postgres@localhost:32768/indexer pnpm --filter @degov/indexer run smoke:postgres-init
- just web lint
- git diff --check

## Additional commits
- Repair Postgres initialization smoke script review findings.
- test(indexer): harden postgres init smoke repair
- Merge main compatibility preflight changes into the HBX-265 Postgres schema branch.

## Links
- Issue: [HBX-265](https://plane.kahub.in/endless/browse/HBX-265/)
- Related PR: https://github.com/ringecosystem/degov/pull/737
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov
  issue: HBX-265
  issue_url: "https://plane.kahub.in/endless/browse/HBX-265/"
  run_id: run-hbx-265-review-repair-1780368943808547029
  attempt_id: run-hbx-265-review-repair-1780368943808547029-attempt-1
  head_branch: fewensa/test/hbx-265-attempt-2/postgres-schema-init
  base_branch: main
  commit_id: da214764dfac0ea195996ed662584456bb40b0a5
  metadata_attempt_id: run-hbx-265-review-repair-1780368943808547029-attempt-1
  primary_commit_id: ec80c0927a6868e976684ebf9141a6af53ecd4fe
  primary_metadata_attempt_id: run-hbx-265-1780367088339168606-attempt-2
  attempt_result_recorded: true
  additional_commits:
    - commit_id: 5a5eba9c9b2320d39d0942b26814447115422e56
      attempt_id: run-hbx-265-review-repair-1780368208197358946-attempt-1
      summary: "Repair Postgres initialization smoke script review findings."
    - commit_id: 812af638ee2b3ed499f735af3dac1b8f303c994c
      attempt_id: run-hbx-265-review-repair-1780368526386265733-attempt-1
      summary: "test(indexer): harden postgres init smoke repair"
    - commit_id: da214764dfac0ea195996ed662584456bb40b0a5
      attempt_id: run-hbx-265-review-repair-1780368943808547029-attempt-1
      summary: "Merge main compatibility preflight changes into the HBX-265 Postgres schema branch."
  related_prs:
    - "https://github.com/ringecosystem/degov/pull/737"
  ```