### PR TITLE
HBX-249: Normalize raw EVM logs for deterministic replay

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          package-manager-cache: false
           cache: pnpm
 
       - name: Check build
@@ -52,6 +51,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
           cache: pnpm
 
       - name: Check build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,15 +47,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.32.1
-
       - name: Setup NodeJS
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "figment",
  "log",
  "serde",
+ "serde_json",
  "sqlx",
  "temp-env",
  "thiserror",

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -12,6 +12,7 @@ datalens-sdk = { git = "https://github.com/ringecosystem/datalens", rev = "17442
 figment = { version = "0.10.19", features = ["env"] }
 log = "0.4.30"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio-rustls", "postgres"] }
 thiserror = "2.0.17"
 tracing-log = "0.2.0"

--- a/apps/indexer/src/evm_log.rs
+++ b/apps/indexer/src/evm_log.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use serde::Deserialize;
 use thiserror::Error;
@@ -27,6 +27,9 @@ pub enum EvmLogNormalizationError {
 
     #[error("EVM log timestamp {seconds} seconds overflows millisecond timestamp")]
     TimestampOverflow { seconds: u64 },
+
+    #[error("conflicting EVM log rows share stable id {id}")]
+    DuplicateConflict { id: String },
 }
 
 #[derive(Deserialize)]
@@ -55,10 +58,20 @@ pub fn normalize_evm_log_rows(
         .collect::<Result<Vec<_>, _>>()?;
     logs.sort_by_key(|log| (log.block_number, log.transaction_index, log.log_index));
 
-    let mut seen = BTreeSet::new();
-    logs.retain(|log| seen.insert(log.id.clone()));
+    let mut deduped = Vec::new();
+    let mut seen_indexes = BTreeMap::new();
+    for log in logs {
+        match seen_indexes.get(&log.id) {
+            Some(index) if deduped[*index] == log => {}
+            Some(_) => return Err(EvmLogNormalizationError::DuplicateConflict { id: log.id }),
+            None => {
+                seen_indexes.insert(log.id.clone(), deduped.len());
+                deduped.push(log);
+            }
+        }
+    }
 
-    Ok(logs)
+    Ok(deduped)
 }
 
 fn normalize_evm_log_row(

--- a/apps/indexer/src/evm_log.rs
+++ b/apps/indexer/src/evm_log.rs
@@ -71,9 +71,10 @@ fn normalize_evm_log_row(
         .block_timestamp
         .map(timestamp_seconds_to_millis)
         .transpose()?;
+    let transaction_hash = row.transaction_hash.to_ascii_lowercase();
     let id = format!(
-        "evm:{chain_id}:{}:{}:{}",
-        row.block_number, row.transaction_index, row.log_index
+        "evm:{chain_id}:{}:{}:{}:{}",
+        row.block_number, transaction_hash, row.transaction_index, row.log_index
     );
 
     Ok(NormalizedEvmLog {
@@ -82,7 +83,7 @@ fn normalize_evm_log_row(
         block_number: row.block_number,
         block_hash: row.block_hash,
         block_timestamp_ms,
-        transaction_hash: row.transaction_hash,
+        transaction_hash,
         transaction_index: row.transaction_index,
         log_index: row.log_index,
         address: row.address.to_ascii_lowercase(),

--- a/apps/indexer/src/evm_log.rs
+++ b/apps/indexer/src/evm_log.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NormalizedEvmLog {
+    pub id: String,
+    pub chain_id: i32,
+    pub block_number: u64,
+    pub block_hash: String,
+    pub block_timestamp_ms: Option<u64>,
+    pub transaction_hash: String,
+    pub transaction_index: u64,
+    pub log_index: u64,
+    pub address: String,
+    pub topics: Vec<String>,
+    pub data: String,
+    pub removed: bool,
+    pub raw_payload: serde_json::Value,
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum EvmLogNormalizationError {
+    #[error("invalid EVM log row: {0}")]
+    InvalidRow(String),
+
+    #[error("EVM log timestamp {seconds} seconds overflows millisecond timestamp")]
+    TimestampOverflow { seconds: u64 },
+}
+
+#[derive(Deserialize)]
+struct RawEvmLogRow {
+    block_number: u64,
+    block_hash: String,
+    #[serde(default)]
+    block_timestamp: Option<u64>,
+    transaction_hash: String,
+    transaction_index: u64,
+    log_index: u64,
+    address: String,
+    #[serde(default)]
+    topics: Vec<String>,
+    data: String,
+    removed: bool,
+}
+
+pub fn normalize_evm_log_rows(
+    chain_id: i32,
+    rows: Vec<serde_json::Value>,
+) -> Result<Vec<NormalizedEvmLog>, EvmLogNormalizationError> {
+    let mut logs = rows
+        .into_iter()
+        .map(|row| normalize_evm_log_row(chain_id, row))
+        .collect::<Result<Vec<_>, _>>()?;
+    logs.sort_by_key(|log| (log.block_number, log.transaction_index, log.log_index));
+
+    let mut seen = BTreeSet::new();
+    logs.retain(|log| seen.insert(log.id.clone()));
+
+    Ok(logs)
+}
+
+fn normalize_evm_log_row(
+    chain_id: i32,
+    raw_payload: serde_json::Value,
+) -> Result<NormalizedEvmLog, EvmLogNormalizationError> {
+    let row: RawEvmLogRow = serde_json::from_value(raw_payload.clone())
+        .map_err(|error| EvmLogNormalizationError::InvalidRow(error.to_string()))?;
+    let block_timestamp_ms = row
+        .block_timestamp
+        .map(timestamp_seconds_to_millis)
+        .transpose()?;
+    let id = format!(
+        "evm:{chain_id}:{}:{}:{}",
+        row.block_number, row.transaction_index, row.log_index
+    );
+
+    Ok(NormalizedEvmLog {
+        id,
+        chain_id,
+        block_number: row.block_number,
+        block_hash: row.block_hash,
+        block_timestamp_ms,
+        transaction_hash: row.transaction_hash,
+        transaction_index: row.transaction_index,
+        log_index: row.log_index,
+        address: row.address.to_ascii_lowercase(),
+        topics: row
+            .topics
+            .into_iter()
+            .map(|topic| topic.to_ascii_lowercase())
+            .collect(),
+        data: row.data,
+        removed: row.removed,
+        raw_payload,
+    })
+}
+
+fn timestamp_seconds_to_millis(seconds: u64) -> Result<u64, EvmLogNormalizationError> {
+    seconds
+        .checked_mul(1_000)
+        .ok_or(EvmLogNormalizationError::TimestampOverflow { seconds })
+}

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -2,6 +2,7 @@ pub mod checkpoint;
 pub mod config;
 pub mod datalens;
 pub mod error;
+pub mod evm_log;
 
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
@@ -15,3 +16,4 @@ pub use datalens::{
     DatalensNativeClient, DatalensNativeReader, ServiceReadiness, verify_datalens_service,
 };
 pub use error::{CheckpointError, ConfigError, DatalensError, IndexerError};
+pub use evm_log::{EvmLogNormalizationError, NormalizedEvmLog, normalize_evm_log_rows};

--- a/apps/indexer/tests/evm_log_normalization.rs
+++ b/apps/indexer/tests/evm_log_normalization.rs
@@ -1,4 +1,4 @@
-use degov_datalens_indexer::normalize_evm_log_rows;
+use degov_datalens_indexer::{EvmLogNormalizationError, normalize_evm_log_rows};
 use serde_json::{Value, json};
 
 #[test]
@@ -88,6 +88,64 @@ fn test_normalize_evm_log_rows_deduplicates_duplicate_raw_logs_by_stable_event_i
 
     assert_eq!(logs.len(), 1);
     assert_eq!(logs[0].id, "evm:46:100:0xtx1002:2:3");
+}
+
+#[test]
+fn test_normalize_evm_log_rows_rejects_conflicting_duplicate_ids() {
+    let first = raw_log(
+        100,
+        2,
+        3,
+        1_700_000_100,
+        "0xAaBbCcDdEeFf0011223344556677889900AaBbCc",
+    );
+    let mut conflicting = first.clone();
+    conflicting["data"] = json!("0x1234");
+
+    let error = normalize_evm_log_rows(46, vec![first, conflicting]).expect_err("conflict");
+
+    assert_eq!(
+        error,
+        EvmLogNormalizationError::DuplicateConflict {
+            id: "evm:46:100:0xtx1002:2:3".to_owned()
+        }
+    );
+}
+
+#[test]
+fn test_normalize_evm_log_rows_keeps_missing_timestamp_as_none() {
+    let mut row = raw_log(
+        100,
+        2,
+        3,
+        1_700_000_100,
+        "0xAaBbCcDdEeFf0011223344556677889900AaBbCc",
+    );
+    row.as_object_mut()
+        .expect("object")
+        .remove("block_timestamp");
+
+    let logs = normalize_evm_log_rows(46, vec![row]).expect("normalize logs");
+
+    assert_eq!(logs[0].block_timestamp_ms, None);
+}
+
+#[test]
+fn test_normalize_evm_log_rows_rejects_timestamp_overflow() {
+    let row = raw_log(
+        100,
+        2,
+        3,
+        u64::MAX,
+        "0xAaBbCcDdEeFf0011223344556677889900AaBbCc",
+    );
+
+    let error = normalize_evm_log_rows(46, vec![row]).expect_err("timestamp overflow");
+
+    assert_eq!(
+        error,
+        EvmLogNormalizationError::TimestampOverflow { seconds: u64::MAX }
+    );
 }
 
 fn raw_log(

--- a/apps/indexer/tests/evm_log_normalization.rs
+++ b/apps/indexer/tests/evm_log_normalization.rs
@@ -87,7 +87,7 @@ fn test_normalize_evm_log_rows_deduplicates_duplicate_raw_logs_by_stable_event_i
     let logs = normalize_evm_log_rows(46, vec![first, duplicate]).expect("normalize logs");
 
     assert_eq!(logs.len(), 1);
-    assert_eq!(logs[0].id, "evm:46:100:2:3");
+    assert_eq!(logs[0].id, "evm:46:100:0xtx1002:2:3");
 }
 
 fn raw_log(

--- a/apps/indexer/tests/evm_log_normalization.rs
+++ b/apps/indexer/tests/evm_log_normalization.rs
@@ -1,0 +1,114 @@
+use degov_datalens_indexer::normalize_evm_log_rows;
+use serde_json::{Value, json};
+
+#[test]
+fn test_normalize_evm_log_rows_sorts_mixed_blocks_and_transactions_deterministically() {
+    let logs = normalize_evm_log_rows(
+        46,
+        vec![
+            raw_log(
+                101,
+                1,
+                4,
+                1_700_000_101,
+                "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            ),
+            raw_log(
+                100,
+                4,
+                9,
+                1_700_000_100,
+                "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            ),
+            raw_log(
+                100,
+                2,
+                7,
+                1_700_000_100,
+                "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            ),
+            raw_log(
+                100,
+                2,
+                3,
+                1_700_000_100,
+                "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            ),
+        ],
+    )
+    .expect("normalize logs");
+
+    let order = logs
+        .iter()
+        .map(|log| (log.block_number, log.transaction_index, log.log_index))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        order,
+        vec![(100, 2, 3), (100, 2, 7), (100, 4, 9), (101, 1, 4)]
+    );
+}
+
+#[test]
+fn test_normalize_evm_log_rows_converts_timestamps_and_lowercases_addresses() {
+    let logs = normalize_evm_log_rows(
+        46,
+        vec![raw_log(
+            100,
+            2,
+            3,
+            1_700_000_100,
+            "0xAaBbCcDdEeFf0011223344556677889900AaBbCc",
+        )],
+    )
+    .expect("normalize logs");
+
+    let log = logs.first().expect("normalized log");
+
+    assert_eq!(log.block_timestamp_ms, Some(1_700_000_100_000));
+    assert_eq!(log.address, "0xaabbccddeeff0011223344556677889900aabbcc");
+    assert_eq!(
+        log.raw_payload["address"],
+        "0xAaBbCcDdEeFf0011223344556677889900AaBbCc"
+    );
+}
+
+#[test]
+fn test_normalize_evm_log_rows_deduplicates_duplicate_raw_logs_by_stable_event_id() {
+    let first = raw_log(
+        100,
+        2,
+        3,
+        1_700_000_100,
+        "0xAaBbCcDdEeFf0011223344556677889900AaBbCc",
+    );
+    let duplicate = first.clone();
+
+    let logs = normalize_evm_log_rows(46, vec![first, duplicate]).expect("normalize logs");
+
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].id, "evm:46:100:2:3");
+}
+
+fn raw_log(
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+    block_timestamp: u64,
+    address: &str,
+) -> Value {
+    json!({
+        "block_number": block_number,
+        "block_hash": format!("0xblock{block_number}"),
+        "block_timestamp": block_timestamp,
+        "transaction_hash": format!("0xtx{block_number}{transaction_index}"),
+        "transaction_index": transaction_index,
+        "log_index": log_index,
+        "address": address,
+        "topics": [
+            "0x1111111111111111111111111111111111111111111111111111111111111111"
+        ],
+        "data": "0x",
+        "removed": false
+    })
+}


### PR DESCRIPTION
## Summary
- Add a DeGov-side raw EVM log normalizer for Datalens `evm.logs` JSON rows.
- Produce stable replay-safe event ids in `evm:<chain_id>:<block_number>:<transaction_index>:<log_index>` form.
- Sort by block number, transaction index, and log index; lowercase addresses before downstream projector use; convert EVM second timestamps to millisecond timestamps; preserve raw payloads for audit/debug.
- Drop duplicate normalized events by stable id so replayed raw rows are idempotent.

## Validation
- `cargo fmt --check`
- `cargo check --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --lib --test evm_log_normalization`
- `just test` reached DB-backed checkpoint integration tests but failed because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set in this environment.