### PR TITLE
HBX-266: Define ChainTool onchain read planning

### DIFF
--- a/apps/indexer/src/chain_tool.rs
+++ b/apps/indexer/src/chain_tool.rs
@@ -23,6 +23,15 @@ impl Default for BatchReadPlanConfig {
     }
 }
 
+impl BatchReadPlanConfig {
+    pub fn validated(self) -> Self {
+        Self {
+            max_concurrency: self.max_concurrency.max(1),
+            multicall_batch_size: self.multicall_batch_size.max(1),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum BlockReadMode {
     Fresh,
@@ -74,15 +83,20 @@ pub struct ChainReadKey {
     pub method: ChainReadMethod,
     pub args: Vec<String>,
     pub block_mode: BlockReadMode,
-    pub account: Option<String>,
-    pub proposal_id: Option<String>,
-    pub operation_id: Option<String>,
-    pub reason: ChainReadReason,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ChainReadMetadata {
+    pub accounts: BTreeSet<String>,
+    pub proposal_ids: BTreeSet<String>,
+    pub operation_ids: BTreeSet<String>,
+    pub reasons: BTreeSet<ChainReadReason>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChainReadRequest {
     pub key: ChainReadKey,
+    pub metadata: ChainReadMetadata,
     pub requirement: ReadRequirement,
     pub activity_blocks: Vec<u64>,
 }
@@ -195,7 +209,26 @@ pub trait ChainTool {
 pub struct ChainReadExecutionReport {
     pub metrics: ChainReadMetrics,
     pub capabilities: Vec<ChainReadCapability>,
+    pub results: Vec<ChainReadResult>,
     pub partial_failures: PartialChainReadFailureReport,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainReadResult {
+    pub read_index: usize,
+    pub key: ChainReadKey,
+    pub value: ChainReadValue,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChainReadValue {
+    Null,
+    Bool(bool),
+    Integer(String),
+    String(String),
+    Bytes(String),
+    Array(Vec<ChainReadValue>),
+    Object(BTreeMap<String, ChainReadValue>),
 }
 
 pub struct ChainReadPlanBuilder {
@@ -211,7 +244,7 @@ impl ChainReadPlanBuilder {
         Self {
             chain_id,
             contracts: normalize_contracts(contracts),
-            config,
+            config: config.validated(),
             requested_reads: 0,
             reads: BTreeMap::new(),
         }
@@ -441,6 +474,7 @@ impl ChainReadPlanBuilder {
 
     fn add_read(&mut self, draft: ChainReadDraft, requirement: ReadRequirement) {
         self.requested_reads += 1;
+        let metadata = ChainReadMetadata::from_draft(&draft);
         let key = ChainReadKey {
             chain_id: self.chain_id,
             contract_address: normalize_identifier(&draft.contract_address),
@@ -451,10 +485,6 @@ impl ChainReadPlanBuilder {
                 .map(|arg| normalize_identifier(&arg))
                 .collect(),
             block_mode: draft.block_mode,
-            account: draft.account,
-            proposal_id: draft.proposal_id,
-            operation_id: draft.operation_id,
-            reason: draft.reason,
         };
 
         self.reads
@@ -464,8 +494,9 @@ impl ChainReadPlanBuilder {
                 if let Some(activity_block) = draft.activity_block {
                     read.activity_blocks.insert(activity_block);
                 }
+                read.metadata.merge(metadata.clone());
             })
-            .or_insert_with(|| PendingChainRead::new(requirement, draft.activity_block));
+            .or_insert_with(|| PendingChainRead::new(requirement, draft.activity_block, metadata));
     }
 }
 
@@ -484,13 +515,19 @@ struct ChainReadDraft {
 
 #[derive(Clone, Debug)]
 struct PendingChainRead {
+    metadata: ChainReadMetadata,
     requirement: ReadRequirement,
     activity_blocks: BTreeSet<u64>,
 }
 
 impl PendingChainRead {
-    fn new(requirement: ReadRequirement, activity_block: Option<u64>) -> Self {
+    fn new(
+        requirement: ReadRequirement,
+        activity_block: Option<u64>,
+        metadata: ChainReadMetadata,
+    ) -> Self {
         Self {
+            metadata,
             requirement,
             activity_blocks: activity_block.into_iter().collect(),
         }
@@ -499,9 +536,28 @@ impl PendingChainRead {
     fn into_request(self, key: ChainReadKey) -> ChainReadRequest {
         ChainReadRequest {
             key,
+            metadata: self.metadata,
             requirement: self.requirement,
             activity_blocks: self.activity_blocks.into_iter().collect(),
         }
+    }
+}
+
+impl ChainReadMetadata {
+    fn from_draft(draft: &ChainReadDraft) -> Self {
+        let mut metadata = Self::default();
+        metadata.accounts.extend(draft.account.clone());
+        metadata.proposal_ids.extend(draft.proposal_id.clone());
+        metadata.operation_ids.extend(draft.operation_id.clone());
+        metadata.reasons.insert(draft.reason);
+        metadata
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.accounts.extend(other.accounts);
+        self.proposal_ids.extend(other.proposal_ids);
+        self.operation_ids.extend(other.operation_ids);
+        self.reasons.extend(other.reasons);
     }
 }
 

--- a/apps/indexer/src/chain_tool.rs
+++ b/apps/indexer/src/chain_tool.rs
@@ -1,0 +1,563 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainContracts {
+    pub governor: String,
+    pub governor_token: String,
+    pub timelock: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BatchReadPlanConfig {
+    pub max_concurrency: usize,
+    pub multicall_batch_size: usize,
+}
+
+impl Default for BatchReadPlanConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrency: 8,
+            multicall_batch_size: 50,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum BlockReadMode {
+    Fresh,
+    Latest,
+    Safe,
+    Finalized,
+    AtBlock(u64),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum ChainReadMethod {
+    CountingMode,
+    ClockMode,
+    Decimals,
+    Delegates,
+    BalanceOf,
+    GetVotes,
+    CurrentVotes,
+    GetPastVotes,
+    GetPriorVotes,
+    ProposalSnapshot,
+    ProposalDeadline,
+    State,
+    Quorum,
+    TimelockEta,
+    TimelockOperationState,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum ChainReadReason {
+    CapabilityDetection,
+    TokenActivityPowerRefresh,
+    ProposalSnapshotPower,
+    ProposalLifecycleRefresh,
+    TimelockLifecycleRefresh,
+    OptionalEnrichment,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReadRequirement {
+    Required,
+    Optional,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ChainReadKey {
+    pub chain_id: i32,
+    pub contract_address: String,
+    pub method: ChainReadMethod,
+    pub args: Vec<String>,
+    pub block_mode: BlockReadMode,
+    pub account: Option<String>,
+    pub proposal_id: Option<String>,
+    pub operation_id: Option<String>,
+    pub reason: ChainReadReason,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainReadRequest {
+    pub key: ChainReadKey,
+    pub requirement: ReadRequirement,
+    pub activity_blocks: Vec<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MulticallReadGroup {
+    pub chain_id: i32,
+    pub contract_address: String,
+    pub block_mode: BlockReadMode,
+    pub read_indexes: Vec<usize>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainReadExecutionPlan {
+    pub max_concurrency: usize,
+    pub multicall_groups: Vec<MulticallReadGroup>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainReadPlan {
+    pub reads: Vec<ChainReadRequest>,
+    pub execution: ChainReadExecutionPlan,
+    pub metrics: ChainReadMetrics,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ChainReadMetrics {
+    pub requested_reads: usize,
+    pub deduped_reads: usize,
+    pub executed_rpc_calls: usize,
+    pub multicall_batch_size: usize,
+    pub failures: usize,
+    pub retries: usize,
+    pub latency_ms: u128,
+    pub cache_hits: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ChainReadRetryPolicy {
+    pub max_attempts: u32,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+    pub request_timeout: Duration,
+}
+
+impl Default for ChainReadRetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(250),
+            max_backoff: Duration::from_secs(5),
+            request_timeout: Duration::from_secs(15),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChainReadFailureKind {
+    Timeout,
+    RateLimited,
+    Transport,
+    Reverted,
+    Unsupported,
+    Decode,
+    Internal,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainReadFailure {
+    pub key: ChainReadKey,
+    pub kind: ChainReadFailureKind,
+    pub retryable: bool,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PartialChainReadFailureReport {
+    pub required_failures: Vec<ChainReadFailure>,
+    pub optional_failures: Vec<ChainReadFailure>,
+}
+
+impl PartialChainReadFailureReport {
+    pub fn can_commit_projection_writes(&self) -> bool {
+        self.required_failures.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChainReadCapability {
+    Supported {
+        method: ChainReadMethod,
+    },
+    Unsupported {
+        method: ChainReadMethod,
+    },
+    Fallback {
+        requested: ChainReadMethod,
+        fallback: ChainReadMethod,
+    },
+}
+
+pub trait ChainTool {
+    fn execute_read_plan(
+        &self,
+        plan: &ChainReadPlan,
+    ) -> Result<ChainReadExecutionReport, PartialChainReadFailureReport>;
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ChainReadExecutionReport {
+    pub metrics: ChainReadMetrics,
+    pub capabilities: Vec<ChainReadCapability>,
+    pub partial_failures: PartialChainReadFailureReport,
+}
+
+pub struct ChainReadPlanBuilder {
+    chain_id: i32,
+    contracts: ChainContracts,
+    config: BatchReadPlanConfig,
+    requested_reads: usize,
+    reads: BTreeMap<ChainReadKey, PendingChainRead>,
+}
+
+impl ChainReadPlanBuilder {
+    pub fn new(chain_id: i32, contracts: ChainContracts, config: BatchReadPlanConfig) -> Self {
+        Self {
+            chain_id,
+            contracts: normalize_contracts(contracts),
+            config,
+            requested_reads: 0,
+            reads: BTreeMap::new(),
+        }
+    }
+
+    pub fn capability_detection_plan(
+        chain_id: i32,
+        contracts: ChainContracts,
+        config: BatchReadPlanConfig,
+    ) -> ChainReadPlan {
+        let mut builder = Self::new(chain_id, contracts, config);
+        builder.add_governor_capability(ChainReadMethod::CountingMode, vec![]);
+        builder.add_governor_capability(ChainReadMethod::ClockMode, vec![]);
+        builder.add_governor_capability(ChainReadMethod::ProposalSnapshot, vec!["0"]);
+        builder.add_governor_capability(ChainReadMethod::ProposalDeadline, vec!["0"]);
+        builder.add_governor_capability(ChainReadMethod::State, vec!["0"]);
+        builder.add_governor_capability(ChainReadMethod::Quorum, vec!["0"]);
+        builder.add_token_capability(ChainReadMethod::Decimals, vec![]);
+        builder.add_token_capability(
+            ChainReadMethod::Delegates,
+            vec!["0x0000000000000000000000000000000000000000"],
+        );
+        builder.add_token_capability(
+            ChainReadMethod::BalanceOf,
+            vec!["0x0000000000000000000000000000000000000000"],
+        );
+        builder.add_token_capability(
+            ChainReadMethod::GetVotes,
+            vec!["0x0000000000000000000000000000000000000000"],
+        );
+        builder.add_token_capability(
+            ChainReadMethod::CurrentVotes,
+            vec!["0x0000000000000000000000000000000000000000"],
+        );
+        builder.add_token_capability(
+            ChainReadMethod::GetPastVotes,
+            vec!["0x0000000000000000000000000000000000000000", "0"],
+        );
+        builder.add_token_capability(
+            ChainReadMethod::GetPriorVotes,
+            vec!["0x0000000000000000000000000000000000000000", "0"],
+        );
+        builder.add_timelock_capability(ChainReadMethod::TimelockEta, vec!["0x00"]);
+        builder.add_timelock_capability(ChainReadMethod::TimelockOperationState, vec!["0x00"]);
+        builder.add_timelock_capability(ChainReadMethod::TimelockEta, vec!["0x00"]);
+        builder.build()
+    }
+
+    pub fn add_account_power_refresh(
+        &mut self,
+        account: &str,
+        activity_block: u64,
+        reason: ChainReadReason,
+    ) {
+        let account = normalize_identifier(account);
+        self.add_required_read(ChainReadDraft {
+            contract_address: self.contracts.governor_token.clone(),
+            method: ChainReadMethod::GetVotes,
+            args: vec![account.clone()],
+            block_mode: BlockReadMode::Fresh,
+            account: Some(account),
+            proposal_id: None,
+            operation_id: None,
+            reason,
+            activity_block: Some(activity_block),
+        });
+    }
+
+    pub fn add_account_past_power(
+        &mut self,
+        account: &str,
+        snapshot_block: u64,
+        reason: ChainReadReason,
+    ) {
+        let account = normalize_identifier(account);
+        self.add_required_read(ChainReadDraft {
+            contract_address: self.contracts.governor_token.clone(),
+            method: ChainReadMethod::GetPastVotes,
+            args: vec![account.clone(), snapshot_block.to_string()],
+            block_mode: BlockReadMode::AtBlock(snapshot_block),
+            account: Some(account),
+            proposal_id: None,
+            operation_id: None,
+            reason,
+            activity_block: Some(snapshot_block),
+        });
+    }
+
+    pub fn add_proposal_refresh(
+        &mut self,
+        proposal_id: &str,
+        activity_block: u64,
+        reason: ChainReadReason,
+    ) {
+        let proposal_id = normalize_identifier(proposal_id);
+        for method in [
+            ChainReadMethod::ProposalSnapshot,
+            ChainReadMethod::ProposalDeadline,
+            ChainReadMethod::State,
+        ] {
+            self.add_required_read(ChainReadDraft {
+                contract_address: self.contracts.governor.clone(),
+                method,
+                args: vec![proposal_id.clone()],
+                block_mode: BlockReadMode::Fresh,
+                account: None,
+                proposal_id: Some(proposal_id.clone()),
+                operation_id: None,
+                reason,
+                activity_block: Some(activity_block),
+            });
+        }
+    }
+
+    pub fn add_timelock_operation_refresh(
+        &mut self,
+        operation_id: &str,
+        activity_block: u64,
+        reason: ChainReadReason,
+    ) {
+        let operation_id = normalize_identifier(operation_id);
+        self.add_required_read(ChainReadDraft {
+            contract_address: self.contracts.timelock.clone(),
+            method: ChainReadMethod::TimelockOperationState,
+            args: vec![operation_id.clone()],
+            block_mode: BlockReadMode::Fresh,
+            account: None,
+            proposal_id: None,
+            operation_id: Some(operation_id),
+            reason,
+            activity_block: Some(activity_block),
+        });
+    }
+
+    pub fn add_optional_enrichment_read(
+        &mut self,
+        contract_address: String,
+        method: ChainReadMethod,
+        args: Vec<String>,
+        block_mode: BlockReadMode,
+    ) {
+        self.add_read(
+            ChainReadDraft {
+                contract_address,
+                method,
+                args,
+                block_mode,
+                account: None,
+                proposal_id: None,
+                operation_id: None,
+                reason: ChainReadReason::OptionalEnrichment,
+                activity_block: None,
+            },
+            ReadRequirement::Optional,
+        );
+    }
+
+    pub fn build(self) -> ChainReadPlan {
+        let reads = self
+            .reads
+            .into_iter()
+            .map(|(key, read)| read.into_request(key))
+            .collect::<Vec<_>>();
+        let execution = ChainReadExecutionPlan {
+            max_concurrency: self.config.max_concurrency,
+            multicall_groups: build_multicall_groups(&reads, self.config.multicall_batch_size),
+        };
+        let metrics = ChainReadMetrics {
+            requested_reads: self.requested_reads,
+            deduped_reads: self.requested_reads.saturating_sub(reads.len()),
+            multicall_batch_size: self.config.multicall_batch_size,
+            ..ChainReadMetrics::default()
+        };
+
+        ChainReadPlan {
+            reads,
+            execution,
+            metrics,
+        }
+    }
+
+    fn add_governor_capability(&mut self, method: ChainReadMethod, args: Vec<&str>) {
+        self.add_required_read(ChainReadDraft {
+            contract_address: self.contracts.governor.clone(),
+            method,
+            args: args.into_iter().map(str::to_owned).collect(),
+            block_mode: BlockReadMode::Fresh,
+            account: None,
+            proposal_id: Some("0".to_owned()),
+            operation_id: None,
+            reason: ChainReadReason::CapabilityDetection,
+            activity_block: None,
+        });
+    }
+
+    fn add_token_capability(&mut self, method: ChainReadMethod, args: Vec<&str>) {
+        self.add_required_read(ChainReadDraft {
+            contract_address: self.contracts.governor_token.clone(),
+            method,
+            args: args.into_iter().map(str::to_owned).collect(),
+            block_mode: BlockReadMode::Fresh,
+            account: None,
+            proposal_id: None,
+            operation_id: None,
+            reason: ChainReadReason::CapabilityDetection,
+            activity_block: None,
+        });
+    }
+
+    fn add_timelock_capability(&mut self, method: ChainReadMethod, args: Vec<&str>) {
+        self.add_required_read(ChainReadDraft {
+            contract_address: self.contracts.timelock.clone(),
+            method,
+            args: args.into_iter().map(str::to_owned).collect(),
+            block_mode: BlockReadMode::Fresh,
+            account: None,
+            proposal_id: None,
+            operation_id: Some("0x00".to_owned()),
+            reason: ChainReadReason::CapabilityDetection,
+            activity_block: None,
+        });
+    }
+
+    fn add_required_read(&mut self, draft: ChainReadDraft) {
+        self.add_read(draft, ReadRequirement::Required);
+    }
+
+    fn add_read(&mut self, draft: ChainReadDraft, requirement: ReadRequirement) {
+        self.requested_reads += 1;
+        let key = ChainReadKey {
+            chain_id: self.chain_id,
+            contract_address: normalize_identifier(&draft.contract_address),
+            method: draft.method,
+            args: draft
+                .args
+                .into_iter()
+                .map(|arg| normalize_identifier(&arg))
+                .collect(),
+            block_mode: draft.block_mode,
+            account: draft.account,
+            proposal_id: draft.proposal_id,
+            operation_id: draft.operation_id,
+            reason: draft.reason,
+        };
+
+        self.reads
+            .entry(key)
+            .and_modify(|read| {
+                read.requirement = merge_requirement(read.requirement, requirement);
+                if let Some(activity_block) = draft.activity_block {
+                    read.activity_blocks.insert(activity_block);
+                }
+            })
+            .or_insert_with(|| PendingChainRead::new(requirement, draft.activity_block));
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ChainReadDraft {
+    contract_address: String,
+    method: ChainReadMethod,
+    args: Vec<String>,
+    block_mode: BlockReadMode,
+    account: Option<String>,
+    proposal_id: Option<String>,
+    operation_id: Option<String>,
+    reason: ChainReadReason,
+    activity_block: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+struct PendingChainRead {
+    requirement: ReadRequirement,
+    activity_blocks: BTreeSet<u64>,
+}
+
+impl PendingChainRead {
+    fn new(requirement: ReadRequirement, activity_block: Option<u64>) -> Self {
+        Self {
+            requirement,
+            activity_blocks: activity_block.into_iter().collect(),
+        }
+    }
+
+    fn into_request(self, key: ChainReadKey) -> ChainReadRequest {
+        ChainReadRequest {
+            key,
+            requirement: self.requirement,
+            activity_blocks: self.activity_blocks.into_iter().collect(),
+        }
+    }
+}
+
+fn build_multicall_groups(
+    reads: &[ChainReadRequest],
+    multicall_batch_size: usize,
+) -> Vec<MulticallReadGroup> {
+    if multicall_batch_size == 0 {
+        return Vec::new();
+    }
+
+    let mut grouped = BTreeMap::<(i32, String, BlockReadMode), Vec<usize>>::new();
+    for (index, read) in reads.iter().enumerate() {
+        grouped
+            .entry((
+                read.key.chain_id,
+                read.key.contract_address.clone(),
+                read.key.block_mode,
+            ))
+            .or_default()
+            .push(index);
+    }
+
+    grouped
+        .into_iter()
+        .flat_map(|((chain_id, contract_address, block_mode), indexes)| {
+            indexes
+                .chunks(multicall_batch_size)
+                .map(move |chunk| MulticallReadGroup {
+                    chain_id,
+                    contract_address: contract_address.clone(),
+                    block_mode,
+                    read_indexes: chunk.to_vec(),
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn merge_requirement(left: ReadRequirement, right: ReadRequirement) -> ReadRequirement {
+    match (left, right) {
+        (ReadRequirement::Required, _) | (_, ReadRequirement::Required) => {
+            ReadRequirement::Required
+        }
+        (ReadRequirement::Optional, ReadRequirement::Optional) => ReadRequirement::Optional,
+    }
+}
+
+fn normalize_contracts(contracts: ChainContracts) -> ChainContracts {
+    ChainContracts {
+        governor: normalize_identifier(&contracts.governor),
+        governor_token: normalize_identifier(&contracts.governor_token),
+        timelock: normalize_identifier(&contracts.timelock),
+    }
+}
+
+fn normalize_identifier(value: &str) -> String {
+    value.to_ascii_lowercase()
+}

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -9,9 +9,9 @@ pub mod planner;
 pub use chain_tool::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadCapability,
     ChainReadExecutionPlan, ChainReadExecutionReport, ChainReadFailure, ChainReadFailureKind,
-    ChainReadKey, ChainReadMethod, ChainReadMetrics, ChainReadPlan, ChainReadPlanBuilder,
-    ChainReadReason, ChainReadRequest, ChainReadRetryPolicy, ChainTool, MulticallReadGroup,
-    PartialChainReadFailureReport, ReadRequirement,
+    ChainReadKey, ChainReadMetadata, ChainReadMethod, ChainReadMetrics, ChainReadPlan,
+    ChainReadPlanBuilder, ChainReadReason, ChainReadRequest, ChainReadResult, ChainReadRetryPolicy,
+    ChainReadValue, ChainTool, MulticallReadGroup, PartialChainReadFailureReport, ReadRequirement,
 };
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod chain_tool;
 pub mod checkpoint;
 pub mod config;
 pub mod datalens;
@@ -5,6 +6,13 @@ pub mod error;
 pub mod evm_log;
 pub mod planner;
 
+pub use chain_tool::{
+    BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadCapability,
+    ChainReadExecutionPlan, ChainReadExecutionReport, ChainReadFailure, ChainReadFailureKind,
+    ChainReadKey, ChainReadMethod, ChainReadMetrics, ChainReadPlan, ChainReadPlanBuilder,
+    ChainReadReason, ChainReadRequest, ChainReadRetryPolicy, ChainTool, MulticallReadGroup,
+    PartialChainReadFailureReport, ReadRequirement,
+};
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
     plan_next_checkpoint_range,

--- a/apps/indexer/tests/chain_tool_read_plan.rs
+++ b/apps/indexer/tests/chain_tool_read_plan.rs
@@ -1,6 +1,6 @@
 use degov_datalens_indexer::{
-    BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadMethod, ChainReadPlanBuilder,
-    ChainReadReason, ReadRequirement,
+    BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadExecutionReport, ChainReadMethod,
+    ChainReadPlanBuilder, ChainReadReason, ChainReadResult, ChainReadValue, ReadRequirement,
 };
 
 #[test]
@@ -31,15 +31,60 @@ fn test_read_plan_dedupes_repeated_account_power_reads_in_large_datalens_batch()
     );
     assert_eq!(plan.reads[0].key.block_mode, BlockReadMode::Fresh);
     assert_eq!(
-        plan.reads[0].key.account.as_deref(),
-        Some("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        plan.reads[0].metadata.accounts,
+        ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned()].into()
     );
     assert_eq!(
-        plan.reads[0].key.reason,
-        ChainReadReason::TokenActivityPowerRefresh
+        plan.reads[0].metadata.reasons,
+        [ChainReadReason::TokenActivityPowerRefresh].into()
     );
     assert_eq!(plan.reads[0].requirement, ReadRequirement::Required);
     assert_eq!(plan.reads[0].activity_blocks.len(), 10_000);
+}
+
+#[test]
+fn test_read_plan_dedupes_same_rpc_read_across_semantic_metadata() {
+    let contracts = contracts();
+    let mut builder =
+        ChainReadPlanBuilder::new(1, contracts.clone(), BatchReadPlanConfig::default());
+
+    builder.add_account_power_refresh(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        100,
+        ChainReadReason::TokenActivityPowerRefresh,
+    );
+    builder.add_account_power_refresh(
+        "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        101,
+        ChainReadReason::ProposalSnapshotPower,
+    );
+    builder.add_optional_enrichment_read(
+        contracts.governor_token.clone(),
+        ChainReadMethod::GetVotes,
+        vec!["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned()],
+        BlockReadMode::Fresh,
+    );
+
+    let plan = builder.build();
+
+    assert_eq!(plan.metrics.requested_reads, 3);
+    assert_eq!(plan.metrics.deduped_reads, 2);
+    assert_eq!(plan.reads.len(), 1);
+    assert_eq!(plan.reads[0].requirement, ReadRequirement::Required);
+    assert_eq!(plan.reads[0].activity_blocks, vec![100, 101]);
+    assert_eq!(
+        plan.reads[0].metadata.accounts,
+        ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned()].into()
+    );
+    assert_eq!(
+        plan.reads[0].metadata.reasons,
+        [
+            ChainReadReason::OptionalEnrichment,
+            ChainReadReason::ProposalSnapshotPower,
+            ChainReadReason::TokenActivityPowerRefresh,
+        ]
+        .into()
+    );
 }
 
 #[test]
@@ -73,22 +118,24 @@ fn test_read_plan_dedupes_repeated_account_proposal_and_operation_activity() {
     assert_eq!(
         plan.reads
             .iter()
-            .filter(|read| read.key.account.as_deref()
-                == Some("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+            .filter(|read| read
+                .metadata
+                .accounts
+                .contains("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
             .count(),
         1
     );
     assert_eq!(
         plan.reads
             .iter()
-            .filter(|read| read.key.proposal_id.as_deref() == Some("42"))
+            .filter(|read| read.metadata.proposal_ids.contains("42"))
             .count(),
         3
     );
     assert_eq!(
         plan.reads
             .iter()
-            .filter(|read| read.key.operation_id.as_deref() == Some("0xffff"))
+            .filter(|read| read.metadata.operation_ids.contains("0xffff"))
             .count(),
         1
     );
@@ -119,7 +166,13 @@ fn test_read_plan_keeps_distinct_power_reads_when_block_semantics_differ() {
     let keys = plan
         .reads
         .iter()
-        .map(|read| (&read.key.method, &read.key.block_mode, &read.key.reason))
+        .map(|read| {
+            (
+                &read.key.method,
+                &read.key.block_mode,
+                &read.metadata.reasons,
+            )
+        })
         .collect::<Vec<_>>();
 
     assert_eq!(plan.metrics.requested_reads, 3);
@@ -128,17 +181,17 @@ fn test_read_plan_keeps_distinct_power_reads_when_block_semantics_differ() {
     assert!(keys.contains(&(
         &ChainReadMethod::GetVotes,
         &BlockReadMode::Fresh,
-        &ChainReadReason::TokenActivityPowerRefresh,
+        &[ChainReadReason::TokenActivityPowerRefresh].into(),
     )));
     assert!(keys.contains(&(
         &ChainReadMethod::GetPastVotes,
         &BlockReadMode::AtBlock(100),
-        &ChainReadReason::ProposalSnapshotPower,
+        &[ChainReadReason::ProposalSnapshotPower].into(),
     )));
     assert!(keys.contains(&(
         &ChainReadMethod::GetPastVotes,
         &BlockReadMode::AtBlock(101),
-        &ChainReadReason::ProposalSnapshotPower,
+        &[ChainReadReason::ProposalSnapshotPower].into(),
     )));
 }
 
@@ -227,6 +280,59 @@ fn test_read_plan_groups_required_reads_into_bounded_multicall_batches() {
             .map(|group| group.read_indexes.len())
             .collect::<Vec<_>>(),
         vec![2, 2, 1]
+    );
+}
+
+#[test]
+fn test_read_plan_clamps_zero_batch_config_to_valid_minimums() {
+    let contracts = contracts();
+    let mut builder = ChainReadPlanBuilder::new(
+        1,
+        contracts,
+        BatchReadPlanConfig {
+            max_concurrency: 0,
+            multicall_batch_size: 0,
+        },
+    );
+
+    builder.add_account_power_refresh(
+        "0x0000000000000000000000000000000000000001",
+        200,
+        ChainReadReason::TokenActivityPowerRefresh,
+    );
+
+    let plan = builder.build();
+
+    assert_eq!(plan.execution.max_concurrency, 1);
+    assert_eq!(plan.metrics.multicall_batch_size, 1);
+    assert_eq!(plan.execution.multicall_groups.len(), 1);
+    assert_eq!(plan.execution.multicall_groups[0].read_indexes, vec![0]);
+}
+
+#[test]
+fn test_read_execution_report_carries_lossless_read_values() {
+    let contracts = contracts();
+    let mut builder = ChainReadPlanBuilder::new(1, contracts, BatchReadPlanConfig::default());
+    builder.add_account_power_refresh(
+        "0x0000000000000000000000000000000000000001",
+        200,
+        ChainReadReason::TokenActivityPowerRefresh,
+    );
+    let plan = builder.build();
+
+    let report = ChainReadExecutionReport {
+        results: vec![ChainReadResult {
+            read_index: 0,
+            key: plan.reads[0].key.clone(),
+            value: ChainReadValue::Integer("340282366920938463463374607431768211455".to_owned()),
+        }],
+        ..ChainReadExecutionReport::default()
+    };
+
+    assert_eq!(report.results[0].read_index, 0);
+    assert_eq!(
+        report.results[0].value,
+        ChainReadValue::Integer("340282366920938463463374607431768211455".to_owned())
     );
 }
 

--- a/apps/indexer/tests/chain_tool_read_plan.rs
+++ b/apps/indexer/tests/chain_tool_read_plan.rs
@@ -1,0 +1,254 @@
+use degov_datalens_indexer::{
+    BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadMethod, ChainReadPlanBuilder,
+    ChainReadReason, ReadRequirement,
+};
+
+#[test]
+fn test_read_plan_dedupes_repeated_account_power_reads_in_large_datalens_batch() {
+    let contracts = contracts();
+    let mut builder =
+        ChainReadPlanBuilder::new(1, contracts.clone(), BatchReadPlanConfig::default());
+
+    for block_number in 10_000..20_000 {
+        builder.add_account_power_refresh(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            block_number,
+            ChainReadReason::TokenActivityPowerRefresh,
+        );
+    }
+
+    let plan = builder.build();
+
+    assert_eq!(plan.metrics.requested_reads, 10_000);
+    assert_eq!(plan.metrics.deduped_reads, 9_999);
+    assert_eq!(plan.reads.len(), 1);
+    assert_eq!(plan.reads[0].key.chain_id, 1);
+    assert_eq!(plan.reads[0].key.contract_address, contracts.governor_token);
+    assert_eq!(plan.reads[0].key.method, ChainReadMethod::GetVotes);
+    assert_eq!(
+        plan.reads[0].key.args,
+        vec!["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+    );
+    assert_eq!(plan.reads[0].key.block_mode, BlockReadMode::Fresh);
+    assert_eq!(
+        plan.reads[0].key.account.as_deref(),
+        Some("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    );
+    assert_eq!(
+        plan.reads[0].key.reason,
+        ChainReadReason::TokenActivityPowerRefresh
+    );
+    assert_eq!(plan.reads[0].requirement, ReadRequirement::Required);
+    assert_eq!(plan.reads[0].activity_blocks.len(), 10_000);
+}
+
+#[test]
+fn test_read_plan_dedupes_repeated_account_proposal_and_operation_activity() {
+    let contracts = contracts();
+    let mut builder = ChainReadPlanBuilder::new(1, contracts, BatchReadPlanConfig::default());
+
+    for block_number in 30_000..40_000 {
+        builder.add_account_power_refresh(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            block_number,
+            ChainReadReason::TokenActivityPowerRefresh,
+        );
+        builder.add_proposal_refresh(
+            "42",
+            block_number,
+            ChainReadReason::ProposalLifecycleRefresh,
+        );
+        builder.add_timelock_operation_refresh(
+            "0xffff",
+            block_number,
+            ChainReadReason::TimelockLifecycleRefresh,
+        );
+    }
+
+    let plan = builder.build();
+
+    assert_eq!(plan.metrics.requested_reads, 50_000);
+    assert_eq!(plan.metrics.deduped_reads, 49_995);
+    assert_eq!(plan.reads.len(), 5);
+    assert_eq!(
+        plan.reads
+            .iter()
+            .filter(|read| read.key.account.as_deref()
+                == Some("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        plan.reads
+            .iter()
+            .filter(|read| read.key.proposal_id.as_deref() == Some("42"))
+            .count(),
+        3
+    );
+    assert_eq!(
+        plan.reads
+            .iter()
+            .filter(|read| read.key.operation_id.as_deref() == Some("0xffff"))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn test_read_plan_keeps_distinct_power_reads_when_block_semantics_differ() {
+    let contracts = contracts();
+    let mut builder = ChainReadPlanBuilder::new(1, contracts, BatchReadPlanConfig::default());
+
+    builder.add_account_power_refresh(
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        100,
+        ChainReadReason::TokenActivityPowerRefresh,
+    );
+    builder.add_account_past_power(
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        100,
+        ChainReadReason::ProposalSnapshotPower,
+    );
+    builder.add_account_past_power(
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        101,
+        ChainReadReason::ProposalSnapshotPower,
+    );
+
+    let plan = builder.build();
+    let keys = plan
+        .reads
+        .iter()
+        .map(|read| (&read.key.method, &read.key.block_mode, &read.key.reason))
+        .collect::<Vec<_>>();
+
+    assert_eq!(plan.metrics.requested_reads, 3);
+    assert_eq!(plan.metrics.deduped_reads, 0);
+    assert_eq!(keys.len(), 3);
+    assert!(keys.contains(&(
+        &ChainReadMethod::GetVotes,
+        &BlockReadMode::Fresh,
+        &ChainReadReason::TokenActivityPowerRefresh,
+    )));
+    assert!(keys.contains(&(
+        &ChainReadMethod::GetPastVotes,
+        &BlockReadMode::AtBlock(100),
+        &ChainReadReason::ProposalSnapshotPower,
+    )));
+    assert!(keys.contains(&(
+        &ChainReadMethod::GetPastVotes,
+        &BlockReadMode::AtBlock(101),
+        &ChainReadReason::ProposalSnapshotPower,
+    )));
+}
+
+#[test]
+fn test_capability_plan_covers_required_governor_token_and_timelock_reads() {
+    let contracts = contracts();
+    let plan = ChainReadPlanBuilder::capability_detection_plan(
+        1,
+        contracts.clone(),
+        BatchReadPlanConfig::default(),
+    );
+
+    assert_eq!(plan.metrics.requested_reads, 16);
+    assert!(plan.metrics.deduped_reads > 0);
+    assert_required(&plan, &contracts.governor, ChainReadMethod::CountingMode);
+    assert_required(&plan, &contracts.governor, ChainReadMethod::ClockMode);
+    assert_required(
+        &plan,
+        &contracts.governor,
+        ChainReadMethod::ProposalSnapshot,
+    );
+    assert_required(
+        &plan,
+        &contracts.governor,
+        ChainReadMethod::ProposalDeadline,
+    );
+    assert_required(&plan, &contracts.governor, ChainReadMethod::State);
+    assert_required(&plan, &contracts.governor, ChainReadMethod::Quorum);
+    assert_required(&plan, &contracts.governor_token, ChainReadMethod::Decimals);
+    assert_required(&plan, &contracts.governor_token, ChainReadMethod::Delegates);
+    assert_required(&plan, &contracts.governor_token, ChainReadMethod::BalanceOf);
+    assert_required(&plan, &contracts.governor_token, ChainReadMethod::GetVotes);
+    assert_required(
+        &plan,
+        &contracts.governor_token,
+        ChainReadMethod::CurrentVotes,
+    );
+    assert_required(
+        &plan,
+        &contracts.governor_token,
+        ChainReadMethod::GetPastVotes,
+    );
+    assert_required(
+        &plan,
+        &contracts.governor_token,
+        ChainReadMethod::GetPriorVotes,
+    );
+    assert_required(&plan, &contracts.timelock, ChainReadMethod::TimelockEta);
+    assert_required(
+        &plan,
+        &contracts.timelock,
+        ChainReadMethod::TimelockOperationState,
+    );
+}
+
+#[test]
+fn test_read_plan_groups_required_reads_into_bounded_multicall_batches() {
+    let contracts = contracts();
+    let mut builder = ChainReadPlanBuilder::new(
+        1,
+        contracts,
+        BatchReadPlanConfig {
+            max_concurrency: 3,
+            multicall_batch_size: 2,
+        },
+    );
+
+    for account in [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000003",
+        "0x0000000000000000000000000000000000000004",
+        "0x0000000000000000000000000000000000000005",
+    ] {
+        builder.add_account_power_refresh(account, 200, ChainReadReason::TokenActivityPowerRefresh);
+    }
+
+    let plan = builder.build();
+
+    assert_eq!(plan.execution.max_concurrency, 3);
+    assert_eq!(plan.execution.multicall_groups.len(), 3);
+    assert_eq!(
+        plan.execution
+            .multicall_groups
+            .iter()
+            .map(|group| group.read_indexes.len())
+            .collect::<Vec<_>>(),
+        vec![2, 2, 1]
+    );
+}
+
+fn assert_required(
+    plan: &degov_datalens_indexer::ChainReadPlan,
+    address: &str,
+    method: ChainReadMethod,
+) {
+    assert!(
+        plan.reads.iter().any(|read| {
+            read.key.contract_address == address
+                && read.key.method == method
+                && read.requirement == ReadRequirement::Required
+        }),
+        "missing required read {method:?} for {address}",
+    );
+}
+
+fn contracts() -> ChainContracts {
+    ChainContracts {
+        governor: "0x1111111111111111111111111111111111111111".to_owned(),
+        governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+        timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+    }
+}


### PR DESCRIPTION
## Summary

Implements HBX-266 by adding a ChainTool/read-plan abstraction for Datalens-native indexing. The abstraction defines supported onchain read families, stable dedupe keys, required vs optional reads, batch grouping, retry/failure policy types, and metrics counters without wiring live RPC execution or business projections.

## Scope

- Adds ChainTool read planning and dedupe APIs.
- Covers governor, token, timelock, and power read request kinds.
- Keeps final contributor/delegate power as onchain-read truth only.
- Adds tests for large-window dedupe, block-tag semantics, capability coverage, required/optional reads, and batch grouping.

## Verification

- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://datalens:datalens@localhost:5432/datalens_test just test`
- `cargo clippy --locked -p degov-datalens-indexer --all-targets -- -D warnings`
- `git diff --check`

Plane: HBX-266