### PR TITLE
HBX-250: Implement Datalens ABI event decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +144,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +169,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -269,6 +293,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,13 +401,15 @@ dependencies = [
  "anyhow",
  "clap",
  "datalens-sdk",
+ "ethabi",
  "figment",
+ "hex",
  "log",
  "serde",
  "serde_json",
  "sqlx",
  "temp-env",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing-log",
  "tracing-subscriber",
@@ -423,6 +476,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethabi"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+dependencies = [
+ "ethereum-types",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 1.0.69",
+ "uint",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +550,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.6",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +581,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -836,6 +951,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,7 +1034,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -939,6 +1092,30 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1064,6 +1241,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1357,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,7 +1414,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1209,7 +1436,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1243,6 +1470,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1322,6 +1555,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,10 +1637,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -1596,6 +1857,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,7 +1961,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1766,7 +2037,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -1776,6 +2047,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -1832,6 +2109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "temp-env"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,11 +2125,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1867,6 +2170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1939,6 +2251,36 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2059,6 +2401,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2447,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2526,6 +2886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,6 +2905,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yansi"

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -9,7 +9,9 @@ publish = false
 anyhow = "1.0.100"
 clap = { version = "4.6.1", features = ["derive"] }
 datalens-sdk = { git = "https://github.com/ringecosystem/datalens", rev = "1744283cd1547240e0bc290b5fa3c5d1c55e74d6" }
+ethabi = "18.0.0"
 figment = { version = "0.10.19", features = ["env"] }
+hex = "0.4.3"
 log = "0.4.30"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/apps/indexer/src/config.rs
+++ b/apps/indexer/src/config.rs
@@ -7,7 +7,7 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{ConfigError, DaoContractAddresses};
+use crate::{ConfigError, DaoContractAddresses, GovernanceTokenStandard};
 
 pub const DEFAULT_DATALENS_TIMEOUT_SECONDS: u64 = 60;
 pub const DEFAULT_DATALENS_FINALITY: DatalensFinality = DatalensFinality::DurableOnly;
@@ -160,6 +160,7 @@ struct RawDatalensConfig {
     datalens_query_row_limit: u32,
     datalens_governor_address: Option<String>,
     datalens_governor_token_address: Option<String>,
+    datalens_governor_token_standard: Option<String>,
     datalens_timelock_address: Option<String>,
 }
 
@@ -180,6 +181,7 @@ impl Default for RawDatalensConfig {
             datalens_query_row_limit: DEFAULT_DATALENS_QUERY_ROW_LIMIT,
             datalens_governor_address: None,
             datalens_governor_token_address: None,
+            datalens_governor_token_standard: None,
             datalens_timelock_address: None,
         }
     }
@@ -204,6 +206,7 @@ impl DatalensConfig {
                     "DATALENS_QUERY_ROW_LIMIT",
                     "DATALENS_GOVERNOR_ADDRESS",
                     "DATALENS_GOVERNOR_TOKEN_ADDRESS",
+                    "DATALENS_GOVERNOR_TOKEN_STANDARD",
                     "DATALENS_TIMELOCK_ADDRESS",
                 ]))
                 .extract()
@@ -272,6 +275,7 @@ impl TryFrom<RawDatalensConfig> for DatalensConfig {
             dao_contracts: dao_contract_addresses(
                 raw.datalens_governor_address,
                 raw.datalens_governor_token_address,
+                raw.datalens_governor_token_standard,
                 raw.datalens_timelock_address,
             )?,
         })
@@ -303,35 +307,53 @@ fn optional_non_empty(
 fn dao_contract_addresses(
     governor: Option<String>,
     governor_token: Option<String>,
+    governor_token_standard: Option<String>,
     timelock: Option<String>,
 ) -> Result<Option<DaoContractAddresses>, ConfigError> {
     let governor = optional_non_empty("DATALENS_GOVERNOR_ADDRESS", governor)?;
     let governor_token = optional_non_empty("DATALENS_GOVERNOR_TOKEN_ADDRESS", governor_token)?;
+    let governor_token_standard =
+        optional_non_empty("DATALENS_GOVERNOR_TOKEN_STANDARD", governor_token_standard)?
+            .map(|value| value.parse::<GovernanceTokenStandard>())
+            .transpose()?;
     let timelock = optional_non_empty("DATALENS_TIMELOCK_ADDRESS", timelock)?;
 
-    Ok(match (governor, governor_token, timelock) {
-        (Some(governor), Some(governor_token), Some(timelock)) => Some(DaoContractAddresses {
-            governor,
-            governor_token,
-            timelock,
-        }),
-        (None, None, None) => None,
-        (None, _, _) => {
-            return Err(ConfigError::MissingRequired {
-                field: "DATALENS_GOVERNOR_ADDRESS",
-            });
-        }
-        (_, None, _) => {
-            return Err(ConfigError::MissingRequired {
-                field: "DATALENS_GOVERNOR_TOKEN_ADDRESS",
-            });
-        }
-        (_, _, None) => {
-            return Err(ConfigError::MissingRequired {
-                field: "DATALENS_TIMELOCK_ADDRESS",
-            });
-        }
-    })
+    Ok(
+        match (governor, governor_token, governor_token_standard, timelock) {
+            (
+                Some(governor),
+                Some(governor_token),
+                Some(governor_token_standard),
+                Some(timelock),
+            ) => Some(DaoContractAddresses {
+                governor,
+                governor_token,
+                governor_token_standard,
+                timelock,
+            }),
+            (None, None, None, None) => None,
+            (None, _, _, _) => {
+                return Err(ConfigError::MissingRequired {
+                    field: "DATALENS_GOVERNOR_ADDRESS",
+                });
+            }
+            (_, None, _, _) => {
+                return Err(ConfigError::MissingRequired {
+                    field: "DATALENS_GOVERNOR_TOKEN_ADDRESS",
+                });
+            }
+            (_, _, None, _) => {
+                return Err(ConfigError::MissingRequired {
+                    field: "DATALENS_GOVERNOR_TOKEN_STANDARD",
+                });
+            }
+            (_, _, _, None) => {
+                return Err(ConfigError::MissingRequired {
+                    field: "DATALENS_TIMELOCK_ADDRESS",
+                });
+            }
+        },
+    )
 }
 
 #[cfg(test)]
@@ -365,6 +387,7 @@ mod tests {
                     "DATALENS_GOVERNOR_TOKEN_ADDRESS",
                     Some("0x2222222222222222222222222222222222222222"),
                 ),
+                ("DATALENS_GOVERNOR_TOKEN_STANDARD", Some("erc20")),
                 (
                     "DATALENS_TIMELOCK_ADDRESS",
                     Some("0x3333333333333333333333333333333333333333"),
@@ -397,6 +420,14 @@ mod tests {
                         .expect("contracts")
                         .governor_token,
                     "0x2222222222222222222222222222222222222222"
+                );
+                assert_eq!(
+                    config
+                        .dao_contracts
+                        .as_ref()
+                        .expect("contracts")
+                        .governor_token_standard,
+                    GovernanceTokenStandard::Erc20
                 );
                 assert_eq!(
                     config.dao_contracts.as_ref().expect("contracts").timelock,
@@ -454,6 +485,40 @@ mod tests {
                     error,
                     ConfigError::MissingRequired {
                         field: "DATALENS_ENDPOINT"
+                    }
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_from_env_rejects_invalid_governor_token_standard() {
+        with_datalens_env(
+            &[
+                ("DATALENS_ENDPOINT", Some("https://datalens.ringdao.com")),
+                ("DATALENS_APPLICATION", Some("degov-live")),
+                ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+                (
+                    "DATALENS_GOVERNOR_ADDRESS",
+                    Some("0x1111111111111111111111111111111111111111"),
+                ),
+                (
+                    "DATALENS_GOVERNOR_TOKEN_ADDRESS",
+                    Some("0x2222222222222222222222222222222222222222"),
+                ),
+                ("DATALENS_GOVERNOR_TOKEN_STANDARD", Some("erc1155")),
+                (
+                    "DATALENS_TIMELOCK_ADDRESS",
+                    Some("0x3333333333333333333333333333333333333333"),
+                ),
+            ],
+            || {
+                let error = DatalensConfig::from_env().expect_err("invalid token standard");
+
+                assert_eq!(
+                    error,
+                    ConfigError::InvalidTokenStandard {
+                        value: "erc1155".to_owned()
                     }
                 );
             },

--- a/apps/indexer/src/config.rs
+++ b/apps/indexer/src/config.rs
@@ -387,7 +387,7 @@ mod tests {
                     "DATALENS_GOVERNOR_TOKEN_ADDRESS",
                     Some("0x2222222222222222222222222222222222222222"),
                 ),
-                ("DATALENS_GOVERNOR_TOKEN_STANDARD", Some("erc20")),
+                ("DATALENS_GOVERNOR_TOKEN_STANDARD", Some("ERC20")),
                 (
                     "DATALENS_TIMELOCK_ADDRESS",
                     Some("0x3333333333333333333333333333333333333333"),
@@ -486,6 +486,42 @@ mod tests {
                     ConfigError::MissingRequired {
                         field: "DATALENS_ENDPOINT"
                     }
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_from_env_accepts_case_insensitive_governor_token_standard() {
+        with_datalens_env(
+            &[
+                ("DATALENS_ENDPOINT", Some("https://datalens.ringdao.com")),
+                ("DATALENS_APPLICATION", Some("degov-live")),
+                ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+                (
+                    "DATALENS_GOVERNOR_ADDRESS",
+                    Some("0x1111111111111111111111111111111111111111"),
+                ),
+                (
+                    "DATALENS_GOVERNOR_TOKEN_ADDRESS",
+                    Some("0x2222222222222222222222222222222222222222"),
+                ),
+                ("DATALENS_GOVERNOR_TOKEN_STANDARD", Some("ErC721")),
+                (
+                    "DATALENS_TIMELOCK_ADDRESS",
+                    Some("0x3333333333333333333333333333333333333333"),
+                ),
+            ],
+            || {
+                let config = DatalensConfig::from_env().expect("load config");
+
+                assert_eq!(
+                    config
+                        .dao_contracts
+                        .as_ref()
+                        .expect("contracts")
+                        .governor_token_standard,
+                    GovernanceTokenStandard::Erc721
                 );
             },
         );

--- a/apps/indexer/src/dao_event.rs
+++ b/apps/indexer/src/dao_event.rs
@@ -31,11 +31,13 @@ impl FromStr for GovernanceTokenStandard {
     type Err = ConfigError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.trim() {
+        let trimmed = value.trim();
+
+        match trimmed.to_ascii_lowercase().as_str() {
             "erc20" => Ok(Self::Erc20),
             "erc721" => Ok(Self::Erc721),
-            value => Err(ConfigError::InvalidTokenStandard {
-                value: value.to_owned(),
+            _ => Err(ConfigError::InvalidTokenStandard {
+                value: trimmed.to_owned(),
             }),
         }
     }

--- a/apps/indexer/src/dao_event.rs
+++ b/apps/indexer/src/dao_event.rs
@@ -1,0 +1,854 @@
+use std::str::FromStr;
+
+use ethabi::{ParamType, Token, decode};
+use thiserror::Error;
+
+use crate::{ConfigError, DaoLogSource, NormalizedEvmLog};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GovernanceTokenStandard {
+    Erc20,
+    Erc721,
+}
+
+impl GovernanceTokenStandard {
+    fn transfer_topic_count(self) -> usize {
+        match self {
+            Self::Erc20 => 3,
+            Self::Erc721 => 4,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Erc20 => "ERC20",
+            Self::Erc721 => "ERC721",
+        }
+    }
+}
+
+impl FromStr for GovernanceTokenStandard {
+    type Err = ConfigError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "erc20" => Ok(Self::Erc20),
+            "erc721" => Ok(Self::Erc721),
+            value => Err(ConfigError::InvalidTokenStandard {
+                value: value.to_owned(),
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DecodedDaoEvent {
+    Governor(DecodedGovernorEvent),
+    Token(DecodedTokenEvent),
+    Timelock(DecodedTimelockEvent),
+    UnsupportedTopic(UnsupportedTopicEvent),
+}
+
+impl DecodedDaoEvent {
+    pub fn as_governor(&self) -> Option<&DecodedGovernorEvent> {
+        match self {
+            Self::Governor(event) => Some(event),
+            _ => None,
+        }
+    }
+
+    pub fn as_token(&self) -> Option<&DecodedTokenEvent> {
+        match self {
+            Self::Token(event) => Some(event),
+            _ => None,
+        }
+    }
+
+    pub fn as_timelock(&self) -> Option<&DecodedTimelockEvent> {
+        match self {
+            Self::Timelock(event) => Some(event),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnsupportedTopicEvent {
+    pub dao_code: String,
+    pub source: DaoLogSource,
+    pub block_number: u64,
+    pub transaction_hash: String,
+    pub address: String,
+    pub topic0: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DecodedGovernorEvent {
+    ProposalCreated(ProposalCreatedEvent),
+    ProposalQueued(ProposalQueuedEvent),
+    ProposalExtended(ProposalExtendedEvent),
+    ProposalExecuted(ProposalIdEvent),
+    ProposalCanceled(ProposalIdEvent),
+    VotingDelaySet(ParameterChangeEvent),
+    VotingPeriodSet(ParameterChangeEvent),
+    ProposalThresholdSet(ParameterChangeEvent),
+    QuorumNumeratorUpdated(ParameterChangeEvent),
+    LateQuorumVoteExtensionSet(ParameterChangeEvent),
+    TimelockChange(TimelockChangeEvent),
+    VoteCast(VoteCastEvent),
+    VoteCastWithParams(VoteCastWithParamsEvent),
+}
+
+impl DecodedGovernorEvent {
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::ProposalCreated(_) => "ProposalCreated",
+            Self::ProposalQueued(_) => "ProposalQueued",
+            Self::ProposalExtended(_) => "ProposalExtended",
+            Self::ProposalExecuted(_) => "ProposalExecuted",
+            Self::ProposalCanceled(_) => "ProposalCanceled",
+            Self::VotingDelaySet(_) => "VotingDelaySet",
+            Self::VotingPeriodSet(_) => "VotingPeriodSet",
+            Self::ProposalThresholdSet(_) => "ProposalThresholdSet",
+            Self::QuorumNumeratorUpdated(_) => "QuorumNumeratorUpdated",
+            Self::LateQuorumVoteExtensionSet(_) => "LateQuorumVoteExtensionSet",
+            Self::TimelockChange(_) => "TimelockChange",
+            Self::VoteCast(_) => "VoteCast",
+            Self::VoteCastWithParams(_) => "VoteCastWithParams",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalCreatedEvent {
+    pub proposal_id: String,
+    pub proposer: String,
+    pub targets: Vec<String>,
+    pub values: Vec<String>,
+    pub signatures: Vec<String>,
+    pub calldatas: Vec<String>,
+    pub vote_start: String,
+    pub vote_end: String,
+    pub description: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalQueuedEvent {
+    pub proposal_id: String,
+    pub eta_seconds: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalExtendedEvent {
+    pub proposal_id: String,
+    pub extended_deadline: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalIdEvent {
+    pub proposal_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParameterChangeEvent {
+    pub old_value: String,
+    pub new_value: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockChangeEvent {
+    pub old_timelock: String,
+    pub new_timelock: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VoteCastEvent {
+    pub voter: String,
+    pub proposal_id: String,
+    pub support: u8,
+    pub weight: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VoteCastWithParamsEvent {
+    pub voter: String,
+    pub proposal_id: String,
+    pub support: u8,
+    pub weight: String,
+    pub reason: String,
+    pub params: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DecodedTokenEvent {
+    DelegateChanged(DelegateChangedEvent),
+    DelegateVotesChanged(DelegateVotesChangedEvent),
+    Transfer(TokenTransferEvent),
+}
+
+impl DecodedTokenEvent {
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::DelegateChanged(_) => "DelegateChanged",
+            Self::DelegateVotesChanged(_) => "DelegateVotesChanged",
+            Self::Transfer(_) => "Transfer",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateChangedEvent {
+    pub delegator: String,
+    pub from_delegate: String,
+    pub to_delegate: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateVotesChangedEvent {
+    pub delegate: String,
+    pub previous_votes: String,
+    pub new_votes: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenTransferEvent {
+    pub from: String,
+    pub to: String,
+    pub value: String,
+    pub standard: GovernanceTokenStandard,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DecodedTimelockEvent {
+    CallScheduled(CallScheduledEvent),
+    CallExecuted(CallExecutedEvent),
+    CallSalt(CallSaltEvent),
+    Cancelled(TimelockOperationIdEvent),
+    MinDelayChange(ParameterChangeEvent),
+    RoleGranted(RoleAccountEvent),
+    RoleRevoked(RoleAccountEvent),
+    RoleAdminChanged(RoleAdminChangedEvent),
+}
+
+impl DecodedTimelockEvent {
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::CallScheduled(_) => "CallScheduled",
+            Self::CallExecuted(_) => "CallExecuted",
+            Self::CallSalt(_) => "CallSalt",
+            Self::Cancelled(_) => "Cancelled",
+            Self::MinDelayChange(_) => "MinDelayChange",
+            Self::RoleGranted(_) => "RoleGranted",
+            Self::RoleRevoked(_) => "RoleRevoked",
+            Self::RoleAdminChanged(_) => "RoleAdminChanged",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CallScheduledEvent {
+    pub id: String,
+    pub index: String,
+    pub target: String,
+    pub value: String,
+    pub data: String,
+    pub predecessor: String,
+    pub delay: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CallExecutedEvent {
+    pub id: String,
+    pub index: String,
+    pub target: String,
+    pub value: String,
+    pub data: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CallSaltEvent {
+    pub id: String,
+    pub salt: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockOperationIdEvent {
+    pub id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleAccountEvent {
+    pub role: String,
+    pub account: String,
+    pub sender: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleAdminChangedEvent {
+    pub role: String,
+    pub previous_admin_role: String,
+    pub new_admin_role: String,
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error(
+    "failed to decode DAO {dao_code} log at block {block_number}, tx {transaction_hash}, address {address}, topic0 {topic0}: {reason}"
+)]
+pub struct DaoEventDecodeError {
+    pub dao_code: Box<str>,
+    pub block_number: u64,
+    pub transaction_hash: Box<str>,
+    pub address: Box<str>,
+    pub topic0: Box<str>,
+    pub reason: Box<str>,
+}
+
+pub fn decode_dao_log(
+    dao_code: &str,
+    source: DaoLogSource,
+    token_standard: Option<GovernanceTokenStandard>,
+    log: &NormalizedEvmLog,
+) -> Result<DecodedDaoEvent, DaoEventDecodeError> {
+    let context = DecodeContext::new(dao_code, log);
+    let topic0 = context.topic0()?;
+
+    match source {
+        DaoLogSource::Governor => decode_governor_event(&context, topic0),
+        DaoLogSource::GovernorToken => decode_token_event(&context, topic0, token_standard),
+        DaoLogSource::Timelock => decode_timelock_event(&context, topic0),
+    }
+}
+
+fn decode_governor_event(
+    context: &DecodeContext<'_>,
+    topic0: &str,
+) -> Result<DecodedDaoEvent, DaoEventDecodeError> {
+    let event = match topic0 {
+        PROPOSAL_CREATED => {
+            context.expect_topic_count(1)?;
+            let tokens = context.decode_data(&[
+                ParamType::Uint(256),
+                ParamType::Address,
+                ParamType::Array(Box::new(ParamType::Address)),
+                ParamType::Array(Box::new(ParamType::Uint(256))),
+                ParamType::Array(Box::new(ParamType::String)),
+                ParamType::Array(Box::new(ParamType::Bytes)),
+                ParamType::Uint(256),
+                ParamType::Uint(256),
+                ParamType::String,
+            ])?;
+            DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: token_uint(&tokens[0], context)?,
+                proposer: token_address(&tokens[1], context)?,
+                targets: token_address_array(&tokens[2], context)?,
+                values: token_uint_array(&tokens[3], context)?,
+                signatures: token_string_array(&tokens[4], context)?,
+                calldatas: token_bytes_array(&tokens[5], context)?,
+                vote_start: token_uint(&tokens[6], context)?,
+                vote_end: token_uint(&tokens[7], context)?,
+                description: token_string(&tokens[8], context)?,
+            })
+        }
+        PROPOSAL_QUEUED => {
+            context.expect_topic_count(1)?;
+            let tokens = context.decode_data(&[ParamType::Uint(256), ParamType::Uint(256)])?;
+            DecodedGovernorEvent::ProposalQueued(ProposalQueuedEvent {
+                proposal_id: token_uint(&tokens[0], context)?,
+                eta_seconds: token_uint(&tokens[1], context)?,
+            })
+        }
+        PROPOSAL_EXTENDED => {
+            context.expect_topic_count(2)?;
+            let tokens = context.decode_data(&[ParamType::Uint(64)])?;
+            DecodedGovernorEvent::ProposalExtended(ProposalExtendedEvent {
+                proposal_id: context.topic_uint(1)?,
+                extended_deadline: token_uint(&tokens[0], context)?,
+            })
+        }
+        PROPOSAL_EXECUTED => {
+            context.expect_topic_count(1)?;
+            DecodedGovernorEvent::ProposalExecuted(decode_proposal_id_event(context)?)
+        }
+        PROPOSAL_CANCELED => {
+            context.expect_topic_count(1)?;
+            DecodedGovernorEvent::ProposalCanceled(decode_proposal_id_event(context)?)
+        }
+        VOTING_DELAY_SET => decode_parameter_change(context, "VotingDelaySet")?,
+        VOTING_PERIOD_SET => decode_parameter_change(context, "VotingPeriodSet")?,
+        PROPOSAL_THRESHOLD_SET => decode_parameter_change(context, "ProposalThresholdSet")?,
+        QUORUM_NUMERATOR_UPDATED => decode_parameter_change(context, "QuorumNumeratorUpdated")?,
+        LATE_QUORUM_VOTE_EXTENSION_SET => {
+            context.expect_topic_count(1)?;
+            let tokens = context.decode_data(&[ParamType::Uint(64), ParamType::Uint(64)])?;
+            DecodedGovernorEvent::LateQuorumVoteExtensionSet(ParameterChangeEvent {
+                old_value: token_uint(&tokens[0], context)?,
+                new_value: token_uint(&tokens[1], context)?,
+            })
+        }
+        TIMELOCK_CHANGE => {
+            context.expect_topic_count(1)?;
+            let tokens = context.decode_data(&[ParamType::Address, ParamType::Address])?;
+            DecodedGovernorEvent::TimelockChange(TimelockChangeEvent {
+                old_timelock: token_address(&tokens[0], context)?,
+                new_timelock: token_address(&tokens[1], context)?,
+            })
+        }
+        VOTE_CAST => {
+            context.expect_topic_count(2)?;
+            let tokens = context.decode_data(&[
+                ParamType::Uint(256),
+                ParamType::Uint(8),
+                ParamType::Uint(256),
+                ParamType::String,
+            ])?;
+            DecodedGovernorEvent::VoteCast(VoteCastEvent {
+                voter: context.topic_address(1)?,
+                proposal_id: token_uint(&tokens[0], context)?,
+                support: token_u8(&tokens[1], context)?,
+                weight: token_uint(&tokens[2], context)?,
+                reason: token_string(&tokens[3], context)?,
+            })
+        }
+        VOTE_CAST_WITH_PARAMS => {
+            context.expect_topic_count(2)?;
+            let tokens = context.decode_data(&[
+                ParamType::Uint(256),
+                ParamType::Uint(8),
+                ParamType::Uint(256),
+                ParamType::String,
+                ParamType::Bytes,
+            ])?;
+            DecodedGovernorEvent::VoteCastWithParams(VoteCastWithParamsEvent {
+                voter: context.topic_address(1)?,
+                proposal_id: token_uint(&tokens[0], context)?,
+                support: token_u8(&tokens[1], context)?,
+                weight: token_uint(&tokens[2], context)?,
+                reason: token_string(&tokens[3], context)?,
+                params: token_bytes(&tokens[4], context)?,
+            })
+        }
+        _ => return Ok(context.unsupported(DaoLogSource::Governor)),
+    };
+
+    Ok(DecodedDaoEvent::Governor(event))
+}
+
+fn decode_token_event(
+    context: &DecodeContext<'_>,
+    topic0: &str,
+    token_standard: Option<GovernanceTokenStandard>,
+) -> Result<DecodedDaoEvent, DaoEventDecodeError> {
+    let event = match topic0 {
+        DELEGATE_CHANGED => {
+            context.expect_topic_count(4)?;
+            DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: context.topic_address(1)?,
+                from_delegate: context.topic_address(2)?,
+                to_delegate: context.topic_address(3)?,
+            })
+        }
+        DELEGATE_VOTES_CHANGED => {
+            context.expect_topic_count(2)?;
+            let tokens = context.decode_data(&[ParamType::Uint(256), ParamType::Uint(256)])?;
+            DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                delegate: context.topic_address(1)?,
+                previous_votes: token_uint(&tokens[0], context)?,
+                new_votes: token_uint(&tokens[1], context)?,
+            })
+        }
+        TRANSFER => {
+            let standard = token_standard.ok_or_else(|| {
+                context.error("token standard is required to decode Transfer events".to_owned())
+            })?;
+            let expected = standard.transfer_topic_count();
+            if context.log.topics.len() != expected {
+                return Err(context.error(format!(
+                    "expected {} Transfer topic count {expected}, observed {}",
+                    standard.label(),
+                    context.log.topics.len()
+                )));
+            }
+            DecodedTokenEvent::Transfer(match standard {
+                GovernanceTokenStandard::Erc20 => {
+                    let tokens = context.decode_data(&[ParamType::Uint(256)])?;
+                    TokenTransferEvent {
+                        from: context.topic_address(1)?,
+                        to: context.topic_address(2)?,
+                        value: token_uint(&tokens[0], context)?,
+                        standard,
+                    }
+                }
+                GovernanceTokenStandard::Erc721 => TokenTransferEvent {
+                    from: context.topic_address(1)?,
+                    to: context.topic_address(2)?,
+                    value: context.topic_uint(3)?,
+                    standard,
+                },
+            })
+        }
+        _ => return Ok(context.unsupported(DaoLogSource::GovernorToken)),
+    };
+
+    Ok(DecodedDaoEvent::Token(event))
+}
+
+fn decode_timelock_event(
+    context: &DecodeContext<'_>,
+    topic0: &str,
+) -> Result<DecodedDaoEvent, DaoEventDecodeError> {
+    let event = match topic0 {
+        CALL_SCHEDULED => {
+            context.expect_topic_count(3)?;
+            let tokens = context.decode_data(&[
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Bytes,
+                ParamType::FixedBytes(32),
+                ParamType::Uint(256),
+            ])?;
+            DecodedTimelockEvent::CallScheduled(CallScheduledEvent {
+                id: context.topic_bytes32(1)?,
+                index: context.topic_uint(2)?,
+                target: token_address(&tokens[0], context)?,
+                value: token_uint(&tokens[1], context)?,
+                data: token_bytes(&tokens[2], context)?,
+                predecessor: token_fixed_bytes(&tokens[3], context)?,
+                delay: token_uint(&tokens[4], context)?,
+            })
+        }
+        CALL_EXECUTED => {
+            context.expect_topic_count(3)?;
+            let tokens = context.decode_data(&[
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Bytes,
+            ])?;
+            DecodedTimelockEvent::CallExecuted(CallExecutedEvent {
+                id: context.topic_bytes32(1)?,
+                index: context.topic_uint(2)?,
+                target: token_address(&tokens[0], context)?,
+                value: token_uint(&tokens[1], context)?,
+                data: token_bytes(&tokens[2], context)?,
+            })
+        }
+        CALL_SALT => {
+            context.expect_topic_count(2)?;
+            let tokens = context.decode_data(&[ParamType::FixedBytes(32)])?;
+            DecodedTimelockEvent::CallSalt(CallSaltEvent {
+                id: context.topic_bytes32(1)?,
+                salt: token_fixed_bytes(&tokens[0], context)?,
+            })
+        }
+        CANCELLED => {
+            context.expect_topic_count(2)?;
+            DecodedTimelockEvent::Cancelled(TimelockOperationIdEvent {
+                id: context.topic_bytes32(1)?,
+            })
+        }
+        MIN_DELAY_CHANGE => {
+            context.expect_topic_count(1)?;
+            let tokens = context.decode_data(&[ParamType::Uint(256), ParamType::Uint(256)])?;
+            DecodedTimelockEvent::MinDelayChange(ParameterChangeEvent {
+                old_value: token_uint(&tokens[0], context)?,
+                new_value: token_uint(&tokens[1], context)?,
+            })
+        }
+        ROLE_GRANTED => {
+            context.expect_topic_count(4)?;
+            DecodedTimelockEvent::RoleGranted(RoleAccountEvent {
+                role: context.topic_bytes32(1)?,
+                account: context.topic_address(2)?,
+                sender: context.topic_address(3)?,
+            })
+        }
+        ROLE_REVOKED => {
+            context.expect_topic_count(4)?;
+            DecodedTimelockEvent::RoleRevoked(RoleAccountEvent {
+                role: context.topic_bytes32(1)?,
+                account: context.topic_address(2)?,
+                sender: context.topic_address(3)?,
+            })
+        }
+        ROLE_ADMIN_CHANGED => {
+            context.expect_topic_count(4)?;
+            DecodedTimelockEvent::RoleAdminChanged(RoleAdminChangedEvent {
+                role: context.topic_bytes32(1)?,
+                previous_admin_role: context.topic_bytes32(2)?,
+                new_admin_role: context.topic_bytes32(3)?,
+            })
+        }
+        _ => return Ok(context.unsupported(DaoLogSource::Timelock)),
+    };
+
+    Ok(DecodedDaoEvent::Timelock(event))
+}
+
+fn decode_proposal_id_event(
+    context: &DecodeContext<'_>,
+) -> Result<ProposalIdEvent, DaoEventDecodeError> {
+    let tokens = context.decode_data(&[ParamType::Uint(256)])?;
+    Ok(ProposalIdEvent {
+        proposal_id: token_uint(&tokens[0], context)?,
+    })
+}
+
+fn decode_parameter_change(
+    context: &DecodeContext<'_>,
+    event_name: &str,
+) -> Result<DecodedGovernorEvent, DaoEventDecodeError> {
+    context.expect_topic_count(1)?;
+    let tokens = context.decode_data(&[ParamType::Uint(256), ParamType::Uint(256)])?;
+    let event = ParameterChangeEvent {
+        old_value: token_uint(&tokens[0], context)?,
+        new_value: token_uint(&tokens[1], context)?,
+    };
+
+    Ok(match event_name {
+        "VotingDelaySet" => DecodedGovernorEvent::VotingDelaySet(event),
+        "VotingPeriodSet" => DecodedGovernorEvent::VotingPeriodSet(event),
+        "ProposalThresholdSet" => DecodedGovernorEvent::ProposalThresholdSet(event),
+        "QuorumNumeratorUpdated" => DecodedGovernorEvent::QuorumNumeratorUpdated(event),
+        _ => unreachable!("unsupported parameter change event"),
+    })
+}
+
+struct DecodeContext<'a> {
+    dao_code: &'a str,
+    log: &'a NormalizedEvmLog,
+}
+
+impl<'a> DecodeContext<'a> {
+    fn new(dao_code: &'a str, log: &'a NormalizedEvmLog) -> Self {
+        Self { dao_code, log }
+    }
+
+    fn topic0(&self) -> Result<&str, DaoEventDecodeError> {
+        self.log
+            .topics
+            .first()
+            .map(String::as_str)
+            .ok_or_else(|| self.error("missing topic0".to_owned()))
+    }
+
+    fn expect_topic_count(&self, expected: usize) -> Result<(), DaoEventDecodeError> {
+        let observed = self.log.topics.len();
+        if observed != expected {
+            return Err(self.error(format!(
+                "expected topic count {expected}, observed {observed}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn decode_data(&self, params: &[ParamType]) -> Result<Vec<Token>, DaoEventDecodeError> {
+        let data = decode_hex(&self.log.data).map_err(|error| self.error(error))?;
+        decode(params, &data).map_err(|error| self.error(error.to_string()))
+    }
+
+    fn topic_address(&self, index: usize) -> Result<String, DaoEventDecodeError> {
+        let bytes = self.topic_bytes(index)?;
+        Ok(format!("0x{}", hex::encode(&bytes[12..32])))
+    }
+
+    fn topic_uint(&self, index: usize) -> Result<String, DaoEventDecodeError> {
+        let bytes = self.topic_bytes(index)?;
+        Ok(ethabi::Uint::from_big_endian(&bytes).to_string())
+    }
+
+    fn topic_bytes32(&self, index: usize) -> Result<String, DaoEventDecodeError> {
+        let bytes = self.topic_bytes(index)?;
+        Ok(format!("0x{}", hex::encode(bytes)))
+    }
+
+    fn topic_bytes(&self, index: usize) -> Result<[u8; 32], DaoEventDecodeError> {
+        let topic = self
+            .log
+            .topics
+            .get(index)
+            .ok_or_else(|| self.error(format!("missing topic at index {index}")))?;
+        let bytes = decode_hex(topic).map_err(|error| self.error(error))?;
+        bytes.try_into().map_err(|bytes: Vec<u8>| {
+            self.error(format!("topic has {} bytes, expected 32", bytes.len()))
+        })
+    }
+
+    fn unsupported(&self, source: DaoLogSource) -> DecodedDaoEvent {
+        DecodedDaoEvent::UnsupportedTopic(UnsupportedTopicEvent {
+            dao_code: self.dao_code.to_owned(),
+            source,
+            block_number: self.log.block_number,
+            transaction_hash: self.log.transaction_hash.clone(),
+            address: self.log.address.clone(),
+            topic0: self.log.topics.first().cloned().unwrap_or_default(),
+        })
+    }
+
+    fn error(&self, reason: String) -> DaoEventDecodeError {
+        DaoEventDecodeError {
+            dao_code: self.dao_code.into(),
+            block_number: self.log.block_number,
+            transaction_hash: self.log.transaction_hash.clone().into_boxed_str(),
+            address: self.log.address.clone().into_boxed_str(),
+            topic0: self
+                .log
+                .topics
+                .first()
+                .cloned()
+                .unwrap_or_default()
+                .into_boxed_str(),
+            reason: reason.into_boxed_str(),
+        }
+    }
+}
+
+fn decode_hex(value: &str) -> Result<Vec<u8>, String> {
+    let value = value.strip_prefix("0x").unwrap_or(value);
+    if value.is_empty() {
+        return Ok(Vec::new());
+    }
+    hex::decode(value).map_err(|error| format!("invalid hex data: {error}"))
+}
+
+fn token_uint(token: &Token, context: &DecodeContext<'_>) -> Result<String, DaoEventDecodeError> {
+    match token {
+        Token::Uint(value) => Ok(value.to_string()),
+        token => Err(context.error(format!("expected uint token, got {token:?}"))),
+    }
+}
+
+fn token_u8(token: &Token, context: &DecodeContext<'_>) -> Result<u8, DaoEventDecodeError> {
+    match token {
+        Token::Uint(value) => value
+            .as_u32()
+            .try_into()
+            .map_err(|_| context.error(format!("uint token {value} does not fit u8"))),
+        token => Err(context.error(format!("expected uint8 token, got {token:?}"))),
+    }
+}
+
+fn token_address(
+    token: &Token,
+    context: &DecodeContext<'_>,
+) -> Result<String, DaoEventDecodeError> {
+    match token {
+        Token::Address(value) => Ok(format!("0x{}", hex::encode(value.as_bytes()))),
+        token => Err(context.error(format!("expected address token, got {token:?}"))),
+    }
+}
+
+fn token_string(token: &Token, context: &DecodeContext<'_>) -> Result<String, DaoEventDecodeError> {
+    match token {
+        Token::String(value) => Ok(value.clone()),
+        token => Err(context.error(format!("expected string token, got {token:?}"))),
+    }
+}
+
+fn token_bytes(token: &Token, context: &DecodeContext<'_>) -> Result<String, DaoEventDecodeError> {
+    match token {
+        Token::Bytes(value) => Ok(format!("0x{}", hex::encode(value))),
+        token => Err(context.error(format!("expected bytes token, got {token:?}"))),
+    }
+}
+
+fn token_fixed_bytes(
+    token: &Token,
+    context: &DecodeContext<'_>,
+) -> Result<String, DaoEventDecodeError> {
+    match token {
+        Token::FixedBytes(value) if value.len() == 32 => Ok(format!("0x{}", hex::encode(value))),
+        Token::FixedBytes(value) => {
+            Err(context.error(format!("expected bytes32 token, got {} bytes", value.len())))
+        }
+        token => Err(context.error(format!("expected bytes32 token, got {token:?}"))),
+    }
+}
+
+fn token_address_array(
+    token: &Token,
+    context: &DecodeContext<'_>,
+) -> Result<Vec<String>, DaoEventDecodeError> {
+    match token {
+        Token::Array(values) => values
+            .iter()
+            .map(|value| token_address(value, context))
+            .collect(),
+        token => Err(context.error(format!("expected address array token, got {token:?}"))),
+    }
+}
+
+fn token_uint_array(
+    token: &Token,
+    context: &DecodeContext<'_>,
+) -> Result<Vec<String>, DaoEventDecodeError> {
+    match token {
+        Token::Array(values) => values
+            .iter()
+            .map(|value| token_uint(value, context))
+            .collect(),
+        token => Err(context.error(format!("expected uint array token, got {token:?}"))),
+    }
+}
+
+fn token_string_array(
+    token: &Token,
+    context: &DecodeContext<'_>,
+) -> Result<Vec<String>, DaoEventDecodeError> {
+    match token {
+        Token::Array(values) => values
+            .iter()
+            .map(|value| token_string(value, context))
+            .collect(),
+        token => Err(context.error(format!("expected string array token, got {token:?}"))),
+    }
+}
+
+fn token_bytes_array(
+    token: &Token,
+    context: &DecodeContext<'_>,
+) -> Result<Vec<String>, DaoEventDecodeError> {
+    match token {
+        Token::Array(values) => values
+            .iter()
+            .map(|value| token_bytes(value, context))
+            .collect(),
+        token => Err(context.error(format!("expected bytes array token, got {token:?}"))),
+    }
+}
+
+const PROPOSAL_CREATED: &str = "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0";
+const PROPOSAL_QUEUED: &str = "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892";
+const PROPOSAL_EXTENDED: &str =
+    "0x541f725fb9f7c98a30cc9c0ff32fbb14358cd7159c847a3aa20a2bdc442ba511";
+const PROPOSAL_EXECUTED: &str =
+    "0x712ae1383f79ac853f8d882153778e0260ef8f03b504e2866e0593e04d2b291f";
+const PROPOSAL_CANCELED: &str =
+    "0x789cf55be980739dad1d0699b93b58e806b51c9d96619bfa8fe0a28abaa7b30c";
+const VOTING_DELAY_SET: &str = "0xc565b045403dc03c2eea82b81a0465edad9e2e7fc4d97e11421c209da93d7a93";
+const VOTING_PERIOD_SET: &str =
+    "0x7e3f7f0708a84de9203036abaa450dccc85ad5ff52f78c170f3edb55cf5e8828";
+const PROPOSAL_THRESHOLD_SET: &str =
+    "0xccb45da8d5717e6c4544694297c4ba5cf151d455c9bb0ed4fc7a38411bc05461";
+const QUORUM_NUMERATOR_UPDATED: &str =
+    "0x0553476bf02ef2726e8ce5ced78d63e26e602e4a2257b1f559418e24b4633997";
+const LATE_QUORUM_VOTE_EXTENSION_SET: &str =
+    "0x7ca4ac117ed3cdce75c1161d8207c440389b1a15d69d096831664657c07dafc2";
+const TIMELOCK_CHANGE: &str = "0x08f74ea46ef7894f65eabfb5e6e695de773a000b47c529ab559178069b226401";
+const VOTE_CAST: &str = "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4";
+const VOTE_CAST_WITH_PARAMS: &str =
+    "0xe2babfbac5889a709b63bb7f598b324e08bc5a4fb9ec647fb3cbc9ec07eb8712";
+
+const TRANSFER: &str = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const DELEGATE_CHANGED: &str = "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f";
+const DELEGATE_VOTES_CHANGED: &str =
+    "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724";
+
+const CALL_SCHEDULED: &str = "0x4cf4410cc57040e44862ef0f45f3dd5a5e02db8eb8add648d4b0e236f1d07dca";
+const CALL_EXECUTED: &str = "0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58";
+const CALL_SALT: &str = "0x20fda5fd27a1ea7bf5b9567f143ac5470bb059374a27e8f67cb44f946f6d0387";
+const CANCELLED: &str = "0xbaa1eb22f2a492ba1a5fea61b8df4d27c6c8b5f3971e63bb58fa14ff72eedb70";
+const MIN_DELAY_CHANGE: &str = "0x11c24f4ead16507c69ac467fbd5e4eed5fb5c699626d2cc6d66421df253886d5";
+const ROLE_GRANTED: &str = "0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d";
+const ROLE_REVOKED: &str = "0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b";
+const ROLE_ADMIN_CHANGED: &str =
+    "0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff";

--- a/apps/indexer/src/error.rs
+++ b/apps/indexer/src/error.rs
@@ -20,6 +20,9 @@ pub enum ConfigError {
     #[error("invalid Datalens chain family {value}")]
     InvalidChainFamily { value: String },
 
+    #[error("invalid Datalens governor token standard {value}")]
+    InvalidTokenStandard { value: String },
+
     #[error("failed to load Datalens configuration: {0}")]
     Load(String),
 }

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod checkpoint;
 pub mod config;
+pub mod dao_event;
 pub mod datalens;
 pub mod error;
 pub mod evm_log;
@@ -12,6 +13,14 @@ pub use checkpoint::{
 pub use config::{
     ChainFamily, ChainIdentityConfig, DatalensConfig, DatalensFinality, DatasetKeyConfig,
     QueryLimitConfig, SecretString,
+};
+pub use dao_event::{
+    CallExecutedEvent, CallSaltEvent, CallScheduledEvent, DaoEventDecodeError, DecodedDaoEvent,
+    DecodedGovernorEvent, DecodedTimelockEvent, DecodedTokenEvent, DelegateChangedEvent,
+    DelegateVotesChangedEvent, GovernanceTokenStandard, ParameterChangeEvent, ProposalCreatedEvent,
+    ProposalExtendedEvent, ProposalIdEvent, ProposalQueuedEvent, RoleAccountEvent,
+    RoleAdminChangedEvent, TimelockChangeEvent, TimelockOperationIdEvent, TokenTransferEvent,
+    UnsupportedTopicEvent, VoteCastEvent, VoteCastWithParamsEvent, decode_dao_log,
 };
 pub use datalens::{
     DatalensNativeClient, DatalensNativeReader, ServiceReadiness, verify_datalens_service,

--- a/apps/indexer/src/planner.rs
+++ b/apps/indexer/src/planner.rs
@@ -4,12 +4,13 @@ use datalens_sdk::native::{
     QuerySelectorInput, SelectorKindInput,
 };
 
-use crate::{DatalensConfig, DatalensError};
+use crate::{DatalensConfig, DatalensError, GovernanceTokenStandard};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DaoContractAddresses {
     pub governor: String,
     pub governor_token: String,
+    pub governor_token_standard: GovernanceTokenStandard,
     pub timelock: String,
 }
 
@@ -439,6 +440,7 @@ mod tests {
         DaoContractAddresses {
             governor: "0x1111111111111111111111111111111111111111".to_owned(),
             governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+            governor_token_standard: GovernanceTokenStandard::Erc20,
             timelock: "0x3333333333333333333333333333333333333333".to_owned(),
         }
     }

--- a/apps/indexer/tests/dao_event_decode.rs
+++ b/apps/indexer/tests/dao_event_decode.rs
@@ -1,0 +1,526 @@
+use degov_datalens_indexer::{
+    DaoLogSource, DecodedDaoEvent, GovernanceTokenStandard, NormalizedEvmLog, decode_dao_log,
+};
+use ethabi::{Token, encode};
+use serde_json::json;
+
+#[test]
+fn test_decode_governor_event_family_decodes_every_configured_topic() {
+    let cases = vec![
+        (
+            proposal_created_log(),
+            "ProposalCreated",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                11,
+                GOVERNOR,
+                vec![PROPOSAL_QUEUED],
+                encode(&[uint(42), uint(123)]),
+            ),
+            "ProposalQueued",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                12,
+                GOVERNOR,
+                vec![PROPOSAL_EXTENDED, topic_uint(42).as_str()],
+                encode(&[uint(456)]),
+            ),
+            "ProposalExtended",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(13, GOVERNOR, vec![PROPOSAL_EXECUTED], encode(&[uint(42)])),
+            "ProposalExecuted",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(14, GOVERNOR, vec![PROPOSAL_CANCELED], encode(&[uint(42)])),
+            "ProposalCanceled",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                15,
+                GOVERNOR,
+                vec![VOTING_DELAY_SET],
+                encode(&[uint(1), uint(2)]),
+            ),
+            "VotingDelaySet",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                16,
+                GOVERNOR,
+                vec![VOTING_PERIOD_SET],
+                encode(&[uint(3), uint(4)]),
+            ),
+            "VotingPeriodSet",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                17,
+                GOVERNOR,
+                vec![PROPOSAL_THRESHOLD_SET],
+                encode(&[uint(5), uint(6)]),
+            ),
+            "ProposalThresholdSet",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                18,
+                GOVERNOR,
+                vec![QUORUM_NUMERATOR_UPDATED],
+                encode(&[uint(7), uint(8)]),
+            ),
+            "QuorumNumeratorUpdated",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                19,
+                GOVERNOR,
+                vec![LATE_QUORUM_VOTE_EXTENSION_SET],
+                encode(&[uint(9), uint(10)]),
+            ),
+            "LateQuorumVoteExtensionSet",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                20,
+                GOVERNOR,
+                vec![TIMELOCK_CHANGE],
+                encode(&[
+                    address("0000000000000000000000000000000000000001"),
+                    address(TIMELOCK),
+                ]),
+            ),
+            "TimelockChange",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                21,
+                GOVERNOR,
+                vec![
+                    VOTE_CAST,
+                    topic_address("0000000000000000000000000000000000000a11").as_str(),
+                ],
+                encode(&[
+                    uint(42),
+                    Token::Uint(1.into()),
+                    uint(99),
+                    Token::String("aye".to_owned()),
+                ]),
+            ),
+            "VoteCast",
+            DecodedDaoEvent::as_governor,
+        ),
+        (
+            log(
+                22,
+                GOVERNOR,
+                vec![
+                    VOTE_CAST_WITH_PARAMS,
+                    topic_address("0000000000000000000000000000000000000a12").as_str(),
+                ],
+                encode(&[
+                    uint(42),
+                    Token::Uint(2.into()),
+                    uint(100),
+                    Token::String("reason".to_owned()),
+                    Token::Bytes(vec![0xde, 0xad]),
+                ]),
+            ),
+            "VoteCastWithParams",
+            DecodedDaoEvent::as_governor,
+        ),
+    ];
+
+    for (log, expected_name, accessor) in cases {
+        let event = decode_dao_log("unit-dao", DaoLogSource::Governor, None, &log)
+            .expect("decode governor event");
+        let governor = accessor(&event).expect("governor event");
+
+        assert_eq!(governor.event_name(), expected_name);
+    }
+}
+
+#[test]
+fn test_decode_token_event_family_decodes_delegation_and_erc20_transfer() {
+    let delegate_changed = decode_dao_log(
+        "unit-dao",
+        DaoLogSource::GovernorToken,
+        Some(GovernanceTokenStandard::Erc20),
+        &log(
+            30,
+            TOKEN,
+            vec![
+                DELEGATE_CHANGED,
+                topic_address("0000000000000000000000000000000000000b01").as_str(),
+                topic_address("0000000000000000000000000000000000000b02").as_str(),
+                topic_address("0000000000000000000000000000000000000b03").as_str(),
+            ],
+            vec![],
+        ),
+    )
+    .expect("decode DelegateChanged");
+    assert_eq!(
+        delegate_changed
+            .as_token()
+            .expect("token event")
+            .event_name(),
+        "DelegateChanged"
+    );
+
+    let votes_changed = decode_dao_log(
+        "unit-dao",
+        DaoLogSource::GovernorToken,
+        Some(GovernanceTokenStandard::Erc20),
+        &log(
+            31,
+            TOKEN,
+            vec![
+                DELEGATE_VOTES_CHANGED,
+                topic_address("0000000000000000000000000000000000000b04").as_str(),
+            ],
+            encode(&[uint(11), uint(12)]),
+        ),
+    )
+    .expect("decode DelegateVotesChanged");
+    assert_eq!(
+        votes_changed.as_token().expect("token event").event_name(),
+        "DelegateVotesChanged"
+    );
+
+    let transfer = decode_dao_log(
+        "unit-dao",
+        DaoLogSource::GovernorToken,
+        Some(GovernanceTokenStandard::Erc20),
+        &erc20_transfer_log(32),
+    )
+    .expect("decode ERC20 Transfer");
+
+    match transfer.as_token().expect("token event") {
+        degov_datalens_indexer::DecodedTokenEvent::Transfer(event) => {
+            assert_eq!(event.standard, GovernanceTokenStandard::Erc20);
+            assert_eq!(event.value, "500");
+        }
+        event => panic!("expected Transfer, got {event:?}"),
+    }
+}
+
+#[test]
+fn test_decode_erc721_transfer_reads_token_id_from_topic() {
+    let decoded = decode_dao_log(
+        "unit-dao",
+        DaoLogSource::GovernorToken,
+        Some(GovernanceTokenStandard::Erc721),
+        &erc721_transfer_log(40),
+    )
+    .expect("decode ERC721 Transfer");
+
+    match decoded.as_token().expect("token event") {
+        degov_datalens_indexer::DecodedTokenEvent::Transfer(event) => {
+            assert_eq!(event.standard, GovernanceTokenStandard::Erc721);
+            assert_eq!(event.value, "777");
+        }
+        event => panic!("expected Transfer, got {event:?}"),
+    }
+}
+
+#[test]
+fn test_decode_token_transfer_rejects_bad_standard_topic_count_mismatch() {
+    let error = decode_dao_log(
+        "unit-dao",
+        DaoLogSource::GovernorToken,
+        Some(GovernanceTokenStandard::Erc20),
+        &erc721_transfer_log(41),
+    )
+    .expect_err("ERC20 decoder must reject ERC721 transfer shape");
+
+    let message = error.to_string();
+    assert!(message.contains("unit-dao"));
+    assert!(message.contains("block 41"));
+    assert!(message.contains("tx 0xtx41"));
+    assert!(message.contains(TOKEN));
+    assert!(message.contains(TRANSFER));
+    assert!(message.contains("expected ERC20 Transfer topic count 3, observed 4"));
+}
+
+#[test]
+fn test_decode_timelock_event_family_decodes_every_configured_topic() {
+    let cases = vec![
+        (
+            log(
+                50,
+                TIMELOCK,
+                vec![
+                    CALL_SCHEDULED,
+                    topic_bytes32(1).as_str(),
+                    topic_uint(0).as_str(),
+                ],
+                encode(&[
+                    address("0000000000000000000000000000000000000c01"),
+                    uint(99),
+                    Token::Bytes(vec![0xaa]),
+                    bytes32(2),
+                    uint(60),
+                ]),
+            ),
+            "CallScheduled",
+        ),
+        (
+            log(
+                51,
+                TIMELOCK,
+                vec![
+                    CALL_EXECUTED,
+                    topic_bytes32(1).as_str(),
+                    topic_uint(0).as_str(),
+                ],
+                encode(&[
+                    address("0000000000000000000000000000000000000c01"),
+                    uint(99),
+                    Token::Bytes(vec![0xaa]),
+                ]),
+            ),
+            "CallExecuted",
+        ),
+        (
+            log(
+                52,
+                TIMELOCK,
+                vec![CALL_SALT, topic_bytes32(1).as_str()],
+                encode(&[bytes32(3)]),
+            ),
+            "CallSalt",
+        ),
+        (
+            log(
+                53,
+                TIMELOCK,
+                vec![CANCELLED, topic_bytes32(1).as_str()],
+                vec![],
+            ),
+            "Cancelled",
+        ),
+        (
+            log(
+                54,
+                TIMELOCK,
+                vec![MIN_DELAY_CHANGE],
+                encode(&[uint(60), uint(120)]),
+            ),
+            "MinDelayChange",
+        ),
+        (
+            log(
+                55,
+                TIMELOCK,
+                vec![
+                    ROLE_GRANTED,
+                    topic_bytes32(4).as_str(),
+                    topic_address("0000000000000000000000000000000000000d01").as_str(),
+                    topic_address("0000000000000000000000000000000000000d02").as_str(),
+                ],
+                vec![],
+            ),
+            "RoleGranted",
+        ),
+        (
+            log(
+                56,
+                TIMELOCK,
+                vec![
+                    ROLE_REVOKED,
+                    topic_bytes32(4).as_str(),
+                    topic_address("0000000000000000000000000000000000000d01").as_str(),
+                    topic_address("0000000000000000000000000000000000000d02").as_str(),
+                ],
+                vec![],
+            ),
+            "RoleRevoked",
+        ),
+        (
+            log(
+                57,
+                TIMELOCK,
+                vec![
+                    ROLE_ADMIN_CHANGED,
+                    topic_bytes32(4).as_str(),
+                    topic_bytes32(5).as_str(),
+                    topic_bytes32(6).as_str(),
+                ],
+                vec![],
+            ),
+            "RoleAdminChanged",
+        ),
+    ];
+
+    for (log, expected_name) in cases {
+        let decoded = decode_dao_log("unit-dao", DaoLogSource::Timelock, None, &log)
+            .expect("decode timelock event");
+        assert_eq!(
+            decoded.as_timelock().expect("timelock event").event_name(),
+            expected_name
+        );
+    }
+}
+
+#[test]
+fn test_decode_marks_unsupported_topic_explicitly() {
+    let decoded = decode_dao_log(
+        "unit-dao",
+        DaoLogSource::Governor,
+        None,
+        &log(70, GOVERNOR, vec![UNKNOWN_TOPIC], vec![]),
+    )
+    .expect("unsupported topic result");
+
+    match decoded {
+        DecodedDaoEvent::UnsupportedTopic(event) => {
+            assert_eq!(event.dao_code, "unit-dao");
+            assert_eq!(event.source, DaoLogSource::Governor);
+            assert_eq!(event.topic0, UNKNOWN_TOPIC);
+        }
+        event => panic!("expected unsupported topic, got {event:?}"),
+    }
+}
+
+fn proposal_created_log() -> NormalizedEvmLog {
+    log(
+        10,
+        GOVERNOR,
+        vec![PROPOSAL_CREATED],
+        encode(&[
+            uint(42),
+            address("0000000000000000000000000000000000000a01"),
+            Token::Array(vec![address("0000000000000000000000000000000000000a02")]),
+            Token::Array(vec![uint(1)]),
+            Token::Array(vec![Token::String("upgrade()".to_owned())]),
+            Token::Array(vec![Token::Bytes(vec![0x12, 0x34])]),
+            uint(100),
+            uint(200),
+            Token::String("Proposal title".to_owned()),
+        ]),
+    )
+}
+
+fn erc20_transfer_log(block_number: u64) -> NormalizedEvmLog {
+    log(
+        block_number,
+        TOKEN,
+        vec![
+            TRANSFER,
+            topic_address("0000000000000000000000000000000000000e01").as_str(),
+            topic_address("0000000000000000000000000000000000000e02").as_str(),
+        ],
+        encode(&[uint(500)]),
+    )
+}
+
+fn erc721_transfer_log(block_number: u64) -> NormalizedEvmLog {
+    log(
+        block_number,
+        TOKEN,
+        vec![
+            TRANSFER,
+            topic_address("0000000000000000000000000000000000000e01").as_str(),
+            topic_address("0000000000000000000000000000000000000e02").as_str(),
+            topic_uint(777).as_str(),
+        ],
+        vec![],
+    )
+}
+
+fn log(block_number: u64, address: &str, topics: Vec<&str>, data: Vec<u8>) -> NormalizedEvmLog {
+    NormalizedEvmLog {
+        id: format!("evm:46:{block_number}:0xtx{block_number}:0:0"),
+        chain_id: 46,
+        block_number,
+        block_hash: format!("0xblock{block_number}"),
+        block_timestamp_ms: Some(block_number * 1_000),
+        transaction_hash: format!("0xtx{block_number}"),
+        transaction_index: 0,
+        log_index: 0,
+        address: address.to_owned(),
+        topics: topics.into_iter().map(str::to_owned).collect(),
+        data: format!("0x{}", hex::encode(data)),
+        removed: false,
+        raw_payload: json!({}),
+    }
+}
+
+fn uint(value: u64) -> Token {
+    Token::Uint(value.into())
+}
+
+fn address(value: &str) -> Token {
+    Token::Address(value.parse().expect("address"))
+}
+
+fn bytes32(value: u8) -> Token {
+    Token::FixedBytes(vec![value; 32])
+}
+
+fn topic_address(value: &str) -> String {
+    format!("0x{value:0>64}")
+}
+
+fn topic_uint(value: u64) -> String {
+    format!("0x{value:064x}")
+}
+
+fn topic_bytes32(value: u8) -> String {
+    format!("0x{}", hex::encode(vec![value; 32]))
+}
+
+const GOVERNOR: &str = "0x1111111111111111111111111111111111111111";
+const TOKEN: &str = "0x2222222222222222222222222222222222222222";
+const TIMELOCK: &str = "0x3333333333333333333333333333333333333333";
+const UNKNOWN_TOPIC: &str = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+const PROPOSAL_CREATED: &str = "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0";
+const PROPOSAL_QUEUED: &str = "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892";
+const PROPOSAL_EXTENDED: &str =
+    "0x541f725fb9f7c98a30cc9c0ff32fbb14358cd7159c847a3aa20a2bdc442ba511";
+const PROPOSAL_EXECUTED: &str =
+    "0x712ae1383f79ac853f8d882153778e0260ef8f03b504e2866e0593e04d2b291f";
+const PROPOSAL_CANCELED: &str =
+    "0x789cf55be980739dad1d0699b93b58e806b51c9d96619bfa8fe0a28abaa7b30c";
+const VOTING_DELAY_SET: &str = "0xc565b045403dc03c2eea82b81a0465edad9e2e7fc4d97e11421c209da93d7a93";
+const VOTING_PERIOD_SET: &str =
+    "0x7e3f7f0708a84de9203036abaa450dccc85ad5ff52f78c170f3edb55cf5e8828";
+const PROPOSAL_THRESHOLD_SET: &str =
+    "0xccb45da8d5717e6c4544694297c4ba5cf151d455c9bb0ed4fc7a38411bc05461";
+const QUORUM_NUMERATOR_UPDATED: &str =
+    "0x0553476bf02ef2726e8ce5ced78d63e26e602e4a2257b1f559418e24b4633997";
+const LATE_QUORUM_VOTE_EXTENSION_SET: &str =
+    "0x7ca4ac117ed3cdce75c1161d8207c440389b1a15d69d096831664657c07dafc2";
+const TIMELOCK_CHANGE: &str = "0x08f74ea46ef7894f65eabfb5e6e695de773a000b47c529ab559178069b226401";
+const VOTE_CAST: &str = "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4";
+const VOTE_CAST_WITH_PARAMS: &str =
+    "0xe2babfbac5889a709b63bb7f598b324e08bc5a4fb9ec647fb3cbc9ec07eb8712";
+
+const TRANSFER: &str = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const DELEGATE_CHANGED: &str = "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f";
+const DELEGATE_VOTES_CHANGED: &str =
+    "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724";
+
+const CALL_SCHEDULED: &str = "0x4cf4410cc57040e44862ef0f45f3dd5a5e02db8eb8add648d4b0e236f1d07dca";
+const CALL_EXECUTED: &str = "0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58";
+const CALL_SALT: &str = "0x20fda5fd27a1ea7bf5b9567f143ac5470bb059374a27e8f67cb44f946f6d0387";
+const CANCELLED: &str = "0xbaa1eb22f2a492ba1a5fea61b8df4d27c6c8b5f3971e63bb58fa14ff72eedb70";
+const MIN_DELAY_CHANGE: &str = "0x11c24f4ead16507c69ac467fbd5e4eed5fb5c699626d2cc6d66421df253886d5";
+const ROLE_GRANTED: &str = "0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d";
+const ROLE_REVOKED: &str = "0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b";
+const ROLE_ADMIN_CHANGED: &str =
+    "0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff";


### PR DESCRIPTION
## Summary

Implements HBX-250 by adding a Datalens-native ABI decoding layer for normalized EVM logs. It decodes governance, token, and timelock event families into typed domain events without writing business tables.

## Scope

- Adds typed decode output for governor, token, and timelock logs.
- Supports ERC20 and ERC721 Transfer semantics via explicit token standard.
- Preserves fail-fast errors with DAO code, block, tx, address, and topic0 context.
- Marks unsupported topics explicitly instead of silently skipping configured decode failures.
- Adds config parsing for `DATALENS_GOVERNOR_TOKEN_STANDARD`.

## Verification

- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://datalens:datalens@localhost:5432/datalens_test just test`
- `cargo clippy --locked -p degov-datalens-indexer --all-targets -- -D warnings`
- `git diff --check`

Plane: HBX-250