### PR TITLE
HBX-255: Integrate Datalens onchain power refresh

### DIFF
--- a/apps/indexer/src/chain_tool.rs
+++ b/apps/indexer/src/chain_tool.rs
@@ -299,10 +299,25 @@ impl ChainReadPlanBuilder {
         activity_block: u64,
         reason: ChainReadReason,
     ) {
+        self.add_account_power_refresh_with_method(
+            account,
+            activity_block,
+            reason,
+            ChainReadMethod::GetVotes,
+        );
+    }
+
+    pub fn add_account_power_refresh_with_method(
+        &mut self,
+        account: &str,
+        activity_block: u64,
+        reason: ChainReadReason,
+        method: ChainReadMethod,
+    ) {
         let account = normalize_identifier(account);
         self.add_required_read(ChainReadDraft {
             contract_address: self.contracts.governor_token.clone(),
-            method: ChainReadMethod::GetVotes,
+            method,
             args: vec![account.clone()],
             block_mode: BlockReadMode::Fresh,
             account: Some(account),

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -6,6 +6,7 @@ pub mod datalens;
 pub mod error;
 pub mod evm_log;
 pub mod planner;
+pub mod power_reconcile;
 
 pub use chain_tool::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadCapability,
@@ -38,4 +39,9 @@ pub use evm_log::{EvmLogNormalizationError, NormalizedEvmLog, normalize_evm_log_
 pub use planner::{
     DaoContractAddresses, DaoLogQueryPlan, DaoLogSource, DatalensLogPage, DatalensLogQueryReader,
     fetch_dao_log_pages, plan_dao_log_queries,
+};
+pub use power_reconcile::{
+    PowerActivityReason, PowerFreshnessState, PowerReconcileCandidate, PowerReconcileContext,
+    PowerReconcileEvent, PowerReconcileMetrics, PowerReconcilePlan, PowerRefreshReadSource,
+    PowerRefreshStatus, PowerRefreshStatusRecord, plan_power_reconcile,
 };

--- a/apps/indexer/src/power_reconcile.rs
+++ b/apps/indexer/src/power_reconcile.rs
@@ -1,0 +1,291 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    BatchReadPlanConfig, ChainContracts, ChainReadPlan, ChainReadPlanBuilder, ChainReadReason,
+    DecodedDaoEvent, DecodedGovernorEvent, DecodedTokenEvent,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PowerReconcileContext {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub contracts: ChainContracts,
+    pub from_block: u64,
+    pub to_block: u64,
+    pub target_height: Option<u64>,
+    pub read_plan_config: BatchReadPlanConfig,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PowerReconcileEvent {
+    pub block_number: u64,
+    pub transaction_hash: String,
+    pub event: DecodedDaoEvent,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum PowerActivityReason {
+    DelegateChanged,
+    DelegateVotesChanged,
+    Transfer,
+    VoteCast,
+}
+
+impl PowerActivityReason {
+    fn label(self) -> &'static str {
+        match self {
+            Self::DelegateChanged => "delegate_changed",
+            Self::DelegateVotesChanged => "delegate_votes_changed",
+            Self::Transfer => "transfer",
+            Self::VoteCast => "vote_cast",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PowerRefreshReadSource {
+    OnchainRpc,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PowerRefreshStatus {
+    Pending,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PowerRefreshStatusRecord {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub governor: String,
+    pub governor_token: String,
+    pub account: String,
+    pub source: PowerRefreshReadSource,
+    pub status: PowerRefreshStatus,
+    pub refresh_balance: bool,
+    pub refresh_power: bool,
+    pub reason: String,
+    pub first_seen_activity_block: u64,
+    pub last_seen_activity_block: u64,
+    pub last_seen_transaction_hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PowerReconcileCandidate {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub governor: String,
+    pub governor_token: String,
+    pub account: String,
+    pub latest_activity_block: u64,
+    pub reasons: BTreeSet<PowerActivityReason>,
+    pub observed_log_power: Option<String>,
+    pub status: PowerRefreshStatusRecord,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PowerFreshnessState {
+    Fresh,
+    SyncLag { lag_blocks: u64 },
+    UnknownTarget,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PowerReconcileMetrics {
+    pub candidate_count: usize,
+    pub deduped_count: usize,
+    pub read_count: usize,
+    pub processed_count: usize,
+    pub failed_count: usize,
+    pub sync_lag_blocks: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PowerReconcilePlan {
+    pub context: PowerReconcileContext,
+    pub candidates: Vec<PowerReconcileCandidate>,
+    pub chain_read_plan: ChainReadPlan,
+    pub freshness_state: PowerFreshnessState,
+    pub metrics: PowerReconcileMetrics,
+}
+
+pub fn plan_power_reconcile(
+    context: &PowerReconcileContext,
+    events: &[PowerReconcileEvent],
+) -> PowerReconcilePlan {
+    let mut candidate_count = 0;
+    let mut candidates = BTreeMap::<String, PendingPowerCandidate>::new();
+
+    for event in events {
+        for (account, reason) in affected_accounts(&event.event) {
+            if is_zero_address(&account) {
+                continue;
+            }
+
+            candidate_count += 1;
+            let normalized_account = normalize_identifier(&account);
+            candidates
+                .entry(normalized_account.clone())
+                .and_modify(|candidate| {
+                    candidate.first_seen_activity_block =
+                        candidate.first_seen_activity_block.min(event.block_number);
+                    if event.block_number >= candidate.latest_activity_block {
+                        candidate.latest_activity_block = event.block_number;
+                        candidate.last_seen_transaction_hash = event.transaction_hash.clone();
+                    }
+                    candidate.reasons.insert(reason);
+                })
+                .or_insert_with(|| PendingPowerCandidate {
+                    account: normalized_account,
+                    first_seen_activity_block: event.block_number,
+                    latest_activity_block: event.block_number,
+                    last_seen_transaction_hash: event.transaction_hash.clone(),
+                    reasons: [reason].into(),
+                });
+        }
+    }
+
+    let mut read_plan_builder = ChainReadPlanBuilder::new(
+        context.chain_id,
+        context.contracts.clone(),
+        context.read_plan_config,
+    );
+    let candidates = candidates
+        .into_values()
+        .map(|candidate| {
+            read_plan_builder.add_account_power_refresh(
+                &candidate.account,
+                candidate.latest_activity_block,
+                ChainReadReason::TokenActivityPowerRefresh,
+            );
+            candidate.into_reconcile_candidate(context)
+        })
+        .collect::<Vec<_>>();
+    let chain_read_plan = read_plan_builder.build();
+    let freshness_state = freshness_state(context);
+    let sync_lag_blocks = match freshness_state {
+        PowerFreshnessState::SyncLag { lag_blocks } => Some(lag_blocks),
+        PowerFreshnessState::Fresh | PowerFreshnessState::UnknownTarget => None,
+    };
+
+    PowerReconcilePlan {
+        context: context.clone(),
+        metrics: PowerReconcileMetrics {
+            candidate_count,
+            deduped_count: candidate_count.saturating_sub(candidates.len()),
+            read_count: chain_read_plan.reads.len(),
+            processed_count: 0,
+            failed_count: 0,
+            sync_lag_blocks,
+        },
+        candidates,
+        chain_read_plan,
+        freshness_state,
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PendingPowerCandidate {
+    account: String,
+    first_seen_activity_block: u64,
+    latest_activity_block: u64,
+    last_seen_transaction_hash: String,
+    reasons: BTreeSet<PowerActivityReason>,
+}
+
+impl PendingPowerCandidate {
+    fn into_reconcile_candidate(self, context: &PowerReconcileContext) -> PowerReconcileCandidate {
+        let governor = normalize_identifier(&context.contracts.governor);
+        let governor_token = normalize_identifier(&context.contracts.governor_token);
+        let reason = reason_label(&self.reasons);
+
+        PowerReconcileCandidate {
+            dao_code: context.dao_code.clone(),
+            chain_id: context.chain_id,
+            governor: governor.clone(),
+            governor_token: governor_token.clone(),
+            account: self.account.clone(),
+            latest_activity_block: self.latest_activity_block,
+            reasons: self.reasons,
+            observed_log_power: None,
+            status: PowerRefreshStatusRecord {
+                dao_code: context.dao_code.clone(),
+                chain_id: context.chain_id,
+                governor,
+                governor_token,
+                account: self.account,
+                source: PowerRefreshReadSource::OnchainRpc,
+                status: PowerRefreshStatus::Pending,
+                refresh_balance: false,
+                refresh_power: true,
+                reason,
+                first_seen_activity_block: self.first_seen_activity_block,
+                last_seen_activity_block: self.latest_activity_block,
+                last_seen_transaction_hash: self.last_seen_transaction_hash,
+            },
+        }
+    }
+}
+
+fn affected_accounts(event: &DecodedDaoEvent) -> Vec<(String, PowerActivityReason)> {
+    match event {
+        DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(event)) => vec![
+            (event.from.clone(), PowerActivityReason::Transfer),
+            (event.to.clone(), PowerActivityReason::Transfer),
+        ],
+        DecodedDaoEvent::Token(DecodedTokenEvent::DelegateChanged(event)) => vec![
+            (
+                event.delegator.clone(),
+                PowerActivityReason::DelegateChanged,
+            ),
+            (
+                event.from_delegate.clone(),
+                PowerActivityReason::DelegateChanged,
+            ),
+            (
+                event.to_delegate.clone(),
+                PowerActivityReason::DelegateChanged,
+            ),
+        ],
+        DecodedDaoEvent::Token(DecodedTokenEvent::DelegateVotesChanged(event)) => {
+            vec![(
+                event.delegate.clone(),
+                PowerActivityReason::DelegateVotesChanged,
+            )]
+        }
+        DecodedDaoEvent::Governor(DecodedGovernorEvent::VoteCast(event)) => {
+            vec![(event.voter.clone(), PowerActivityReason::VoteCast)]
+        }
+        DecodedDaoEvent::Governor(DecodedGovernorEvent::VoteCastWithParams(event)) => {
+            vec![(event.voter.clone(), PowerActivityReason::VoteCast)]
+        }
+        DecodedDaoEvent::Governor(_)
+        | DecodedDaoEvent::Timelock(_)
+        | DecodedDaoEvent::UnsupportedTopic(_) => Vec::new(),
+    }
+}
+
+fn freshness_state(context: &PowerReconcileContext) -> PowerFreshnessState {
+    match context.target_height {
+        Some(target_height) if context.to_block >= target_height => PowerFreshnessState::Fresh,
+        Some(target_height) => PowerFreshnessState::SyncLag {
+            lag_blocks: target_height - context.to_block,
+        },
+        None => PowerFreshnessState::UnknownTarget,
+    }
+}
+
+fn reason_label(reasons: &BTreeSet<PowerActivityReason>) -> String {
+    reasons
+        .iter()
+        .map(|reason| reason.label())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn is_zero_address(account: &str) -> bool {
+    normalize_identifier(account) == "0x0000000000000000000000000000000000000000"
+}
+
+fn normalize_identifier(value: &str) -> String {
+    value.to_ascii_lowercase()
+}

--- a/apps/indexer/src/power_reconcile.rs
+++ b/apps/indexer/src/power_reconcile.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
-    BatchReadPlanConfig, ChainContracts, ChainReadPlan, ChainReadPlanBuilder, ChainReadReason,
-    DecodedDaoEvent, DecodedGovernorEvent, DecodedTokenEvent,
+    BatchReadPlanConfig, ChainContracts, ChainReadMethod, ChainReadPlan, ChainReadPlanBuilder,
+    ChainReadReason, DecodedDaoEvent, DecodedTokenEvent,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -14,12 +14,16 @@ pub struct PowerReconcileContext {
     pub to_block: u64,
     pub target_height: Option<u64>,
     pub read_plan_config: BatchReadPlanConfig,
+    pub current_power_method: ChainReadMethod,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PowerReconcileEvent {
     pub block_number: u64,
+    pub block_timestamp_ms: Option<u64>,
     pub transaction_hash: String,
+    pub transaction_index: u64,
+    pub log_index: u64,
     pub event: DecodedDaoEvent,
 }
 
@@ -28,16 +32,14 @@ pub enum PowerActivityReason {
     DelegateChanged,
     DelegateVotesChanged,
     Transfer,
-    VoteCast,
 }
 
 impl PowerActivityReason {
     fn label(self) -> &'static str {
         match self {
-            Self::DelegateChanged => "delegate_changed",
-            Self::DelegateVotesChanged => "delegate_votes_changed",
+            Self::DelegateChanged => "delegate-change",
+            Self::DelegateVotesChanged => "delegate-votes-changed",
             Self::Transfer => "transfer",
-            Self::VoteCast => "vote_cast",
         }
     }
 }
@@ -66,7 +68,10 @@ pub struct PowerRefreshStatusRecord {
     pub reason: String,
     pub first_seen_activity_block: u64,
     pub last_seen_activity_block: u64,
+    pub last_seen_block_timestamp_ms: Option<u64>,
     pub last_seen_transaction_hash: String,
+    pub last_seen_transaction_index: u64,
+    pub last_seen_log_index: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -77,6 +82,8 @@ pub struct PowerReconcileCandidate {
     pub governor_token: String,
     pub account: String,
     pub latest_activity_block: u64,
+    pub latest_transaction_index: u64,
+    pub latest_log_index: u64,
     pub reasons: BTreeSet<PowerActivityReason>,
     pub observed_log_power: Option<String>,
     pub status: PowerRefreshStatusRecord,
@@ -128,8 +135,11 @@ pub fn plan_power_reconcile(
                 .and_modify(|candidate| {
                     candidate.first_seen_activity_block =
                         candidate.first_seen_activity_block.min(event.block_number);
-                    if event.block_number >= candidate.latest_activity_block {
+                    if event.log_position() >= candidate.latest_position() {
                         candidate.latest_activity_block = event.block_number;
+                        candidate.latest_transaction_index = event.transaction_index;
+                        candidate.latest_log_index = event.log_index;
+                        candidate.last_seen_block_timestamp_ms = event.block_timestamp_ms;
                         candidate.last_seen_transaction_hash = event.transaction_hash.clone();
                     }
                     candidate.reasons.insert(reason);
@@ -138,6 +148,9 @@ pub fn plan_power_reconcile(
                     account: normalized_account,
                     first_seen_activity_block: event.block_number,
                     latest_activity_block: event.block_number,
+                    latest_transaction_index: event.transaction_index,
+                    latest_log_index: event.log_index,
+                    last_seen_block_timestamp_ms: event.block_timestamp_ms,
                     last_seen_transaction_hash: event.transaction_hash.clone(),
                     reasons: [reason].into(),
                 });
@@ -152,10 +165,11 @@ pub fn plan_power_reconcile(
     let candidates = candidates
         .into_values()
         .map(|candidate| {
-            read_plan_builder.add_account_power_refresh(
+            read_plan_builder.add_account_power_refresh_with_method(
                 &candidate.account,
                 candidate.latest_activity_block,
                 ChainReadReason::TokenActivityPowerRefresh,
+                context.current_power_method,
             );
             candidate.into_reconcile_candidate(context)
         })
@@ -188,6 +202,9 @@ struct PendingPowerCandidate {
     account: String,
     first_seen_activity_block: u64,
     latest_activity_block: u64,
+    latest_transaction_index: u64,
+    latest_log_index: u64,
+    last_seen_block_timestamp_ms: Option<u64>,
     last_seen_transaction_hash: String,
     reasons: BTreeSet<PowerActivityReason>,
 }
@@ -205,6 +222,8 @@ impl PendingPowerCandidate {
             governor_token: governor_token.clone(),
             account: self.account.clone(),
             latest_activity_block: self.latest_activity_block,
+            latest_transaction_index: self.latest_transaction_index,
+            latest_log_index: self.latest_log_index,
             reasons: self.reasons,
             observed_log_power: None,
             status: PowerRefreshStatusRecord {
@@ -220,9 +239,20 @@ impl PendingPowerCandidate {
                 reason,
                 first_seen_activity_block: self.first_seen_activity_block,
                 last_seen_activity_block: self.latest_activity_block,
+                last_seen_block_timestamp_ms: self.last_seen_block_timestamp_ms,
                 last_seen_transaction_hash: self.last_seen_transaction_hash,
+                last_seen_transaction_index: self.latest_transaction_index,
+                last_seen_log_index: self.latest_log_index,
             },
         }
+    }
+
+    fn latest_position(&self) -> (u64, u64, u64) {
+        (
+            self.latest_activity_block,
+            self.latest_transaction_index,
+            self.latest_log_index,
+        )
     }
 }
 
@@ -252,12 +282,6 @@ fn affected_accounts(event: &DecodedDaoEvent) -> Vec<(String, PowerActivityReaso
                 PowerActivityReason::DelegateVotesChanged,
             )]
         }
-        DecodedDaoEvent::Governor(DecodedGovernorEvent::VoteCast(event)) => {
-            vec![(event.voter.clone(), PowerActivityReason::VoteCast)]
-        }
-        DecodedDaoEvent::Governor(DecodedGovernorEvent::VoteCastWithParams(event)) => {
-            vec![(event.voter.clone(), PowerActivityReason::VoteCast)]
-        }
         DecodedDaoEvent::Governor(_)
         | DecodedDaoEvent::Timelock(_)
         | DecodedDaoEvent::UnsupportedTopic(_) => Vec::new(),
@@ -279,7 +303,7 @@ fn reason_label(reasons: &BTreeSet<PowerActivityReason>) -> String {
         .iter()
         .map(|reason| reason.label())
         .collect::<Vec<_>>()
-        .join(",")
+        .join("+")
 }
 
 fn is_zero_address(account: &str) -> bool {
@@ -288,4 +312,10 @@ fn is_zero_address(account: &str) -> bool {
 
 fn normalize_identifier(value: &str) -> String {
     value.to_ascii_lowercase()
+}
+
+impl PowerReconcileEvent {
+    fn log_position(&self) -> (u64, u64, u64) {
+        (self.block_number, self.transaction_index, self.log_index)
+    }
 }

--- a/apps/indexer/tests/power_reconcile.rs
+++ b/apps/indexer/tests/power_reconcile.rs
@@ -1,9 +1,8 @@
 use degov_datalens_indexer::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadMethod, ChainReadReason,
-    DecodedDaoEvent, DecodedGovernorEvent, DecodedTokenEvent, DelegateChangedEvent,
-    DelegateVotesChangedEvent, PowerActivityReason, PowerFreshnessState, PowerReconcileContext,
-    PowerReconcileEvent, PowerRefreshReadSource, PowerRefreshStatus, TokenTransferEvent,
-    VoteCastEvent, plan_power_reconcile,
+    DecodedDaoEvent, DecodedTokenEvent, DelegateChangedEvent, DelegateVotesChangedEvent,
+    PowerActivityReason, PowerFreshnessState, PowerReconcileContext, PowerReconcileEvent,
+    PowerRefreshReadSource, PowerRefreshStatus, TokenTransferEvent, plan_power_reconcile,
 };
 
 #[test]
@@ -11,7 +10,10 @@ fn test_plan_power_reconcile_dedupes_large_batch_before_chain_reads() {
     let events = (100_000..110_000)
         .map(|block_number| PowerReconcileEvent {
             block_number,
+            block_timestamp_ms: Some(block_number * 1_000),
             transaction_hash: format!("0xtx{block_number}"),
+            transaction_index: 0,
+            log_index: 0,
             event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
                 from: account("aaaa"),
                 to: account("bbbb"),
@@ -43,7 +45,10 @@ fn test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons() {
     let events = vec![
         PowerReconcileEvent {
             block_number: 100,
+            block_timestamp_ms: Some(100_000),
             transaction_hash: "0xtx100".to_owned(),
+            transaction_index: 0,
+            log_index: 0,
             event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
                 from: acct.clone(),
                 to: account("bbbb"),
@@ -53,7 +58,10 @@ fn test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons() {
         },
         PowerReconcileEvent {
             block_number: 103,
+            block_timestamp_ms: Some(103_000),
             transaction_hash: "0xtx103".to_owned(),
+            transaction_index: 0,
+            log_index: 0,
             event: DecodedDaoEvent::Token(DecodedTokenEvent::DelegateChanged(
                 DelegateChangedEvent {
                     delegator: acct.clone(),
@@ -64,25 +72,19 @@ fn test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons() {
         },
         PowerReconcileEvent {
             block_number: 101,
+            block_timestamp_ms: Some(101_000),
             transaction_hash: "0xtx101".to_owned(),
-            event: DecodedDaoEvent::Governor(DecodedGovernorEvent::VoteCast(VoteCastEvent {
-                voter: acct.clone(),
-                proposal_id: "42".to_owned(),
-                support: 1,
-                weight: "999999".to_owned(),
-                reason: "from log, not final power".to_owned(),
-            })),
+            transaction_index: 0,
+            log_index: 0,
+            event: DecodedDaoEvent::Token(DecodedTokenEvent::DelegateVotesChanged(
+                DelegateVotesChangedEvent {
+                    delegate: acct.clone(),
+                    previous_votes: "1".to_owned(),
+                    new_votes: "999999".to_owned(),
+                },
+            )),
         },
-        PowerReconcileEvent {
-            block_number: 99,
-            transaction_hash: "0xtx99".to_owned(),
-            event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
-                from: acct.clone(),
-                to: account("eeee"),
-                value: "1".to_owned(),
-                standard: degov_datalens_indexer::GovernanceTokenStandard::Erc20,
-            })),
-        },
+        transfer_event(99, 0, 0, "0xtx99", &acct, &account("eeee")),
     ];
 
     let plan = plan_power_reconcile(&context(99, 103, Some(103)), &events);
@@ -97,8 +99,8 @@ fn test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons() {
         candidate.reasons,
         [
             PowerActivityReason::DelegateChanged,
+            PowerActivityReason::DelegateVotesChanged,
             PowerActivityReason::Transfer,
-            PowerActivityReason::VoteCast,
         ]
         .into()
     );
@@ -106,10 +108,13 @@ fn test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons() {
     assert_eq!(candidate.status.source, PowerRefreshReadSource::OnchainRpc);
     assert_eq!(candidate.status.first_seen_activity_block, 99);
     assert_eq!(candidate.status.last_seen_activity_block, 103);
+    assert_eq!(candidate.status.last_seen_block_timestamp_ms, Some(103_000));
     assert_eq!(candidate.status.last_seen_transaction_hash, "0xtx103");
+    assert_eq!(candidate.status.last_seen_transaction_index, 0);
+    assert_eq!(candidate.status.last_seen_log_index, 0);
     assert_eq!(
         candidate.status.reason,
-        "delegate_changed,transfer,vote_cast"
+        "delegate-change+delegate-votes-changed+transfer"
     );
 }
 
@@ -118,7 +123,10 @@ fn test_plan_power_reconcile_does_not_write_log_derived_power() {
     let acct = account("aaaa");
     let events = vec![PowerReconcileEvent {
         block_number: 100,
+        block_timestamp_ms: Some(100_000),
         transaction_hash: "0xtx100".to_owned(),
+        transaction_index: 0,
+        log_index: 0,
         event: DecodedDaoEvent::Token(DecodedTokenEvent::DelegateVotesChanged(
             DelegateVotesChangedEvent {
                 delegate: acct.clone(),
@@ -147,7 +155,10 @@ fn test_plan_power_reconcile_emits_chaintool_get_votes_reads() {
     let acct = account("aaaa");
     let events = vec![PowerReconcileEvent {
         block_number: 200,
+        block_timestamp_ms: Some(200_000),
         transaction_hash: "0xtx200".to_owned(),
+        transaction_index: 0,
+        log_index: 0,
         event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
             from: acct.clone(),
             to: account("bbbb"),
@@ -179,6 +190,100 @@ fn test_plan_power_reconcile_emits_chaintool_get_votes_reads() {
     assert_eq!(read.activity_blocks, vec![200]);
 }
 
+#[test]
+fn test_plan_power_reconcile_uses_same_block_log_position_for_latest_status() {
+    let acct = account("aaaa");
+    let events = vec![
+        transfer_event(300, 2, 1, "0xtx300b", &acct, &account("bbbb")),
+        transfer_event(300, 1, 9, "0xtx300a", &acct, &account("cccc")),
+        transfer_event(300, 2, 5, "0xtx300c", &acct, &account("dddd")),
+    ];
+
+    let plan = plan_power_reconcile(&context(300, 300, Some(300)), &events);
+    let candidate = plan
+        .candidates
+        .iter()
+        .find(|candidate| candidate.account == acct)
+        .expect("candidate");
+
+    assert_eq!(candidate.latest_activity_block, 300);
+    assert_eq!(candidate.latest_transaction_index, 2);
+    assert_eq!(candidate.latest_log_index, 5);
+    assert_eq!(candidate.status.last_seen_transaction_hash, "0xtx300c");
+}
+
+#[test]
+fn test_plan_power_reconcile_skips_zero_addresses_from_transfer_and_delegate_changes() {
+    let zero = "0x0000000000000000000000000000000000000000".to_owned();
+    let acct = account("aaaa");
+    let events = vec![
+        transfer_event(400, 0, 0, "0xtx400", &zero, &acct),
+        PowerReconcileEvent {
+            block_number: 401,
+            block_timestamp_ms: Some(401_000),
+            transaction_hash: "0xtx401".to_owned(),
+            transaction_index: 0,
+            log_index: 0,
+            event: DecodedDaoEvent::Token(DecodedTokenEvent::DelegateChanged(
+                DelegateChangedEvent {
+                    delegator: acct.clone(),
+                    from_delegate: zero.clone(),
+                    to_delegate: acct.clone(),
+                },
+            )),
+        },
+    ];
+
+    let plan = plan_power_reconcile(&context(400, 401, Some(401)), &events);
+
+    assert!(
+        !plan
+            .candidates
+            .iter()
+            .any(|candidate| candidate.account == zero)
+    );
+    assert!(
+        plan.candidates
+            .iter()
+            .any(|candidate| candidate.account == acct)
+    );
+}
+
+#[test]
+fn test_plan_power_reconcile_can_emit_current_votes_fallback_reads() {
+    let acct = account("aaaa");
+    let mut context = context(500, 500, Some(500));
+    context.current_power_method = ChainReadMethod::CurrentVotes;
+
+    let plan = plan_power_reconcile(
+        &context,
+        &[transfer_event(
+            500,
+            0,
+            0,
+            "0xtx500",
+            &acct,
+            &account("bbbb"),
+        )],
+    );
+    let read = plan
+        .chain_read_plan
+        .reads
+        .iter()
+        .find(|read| read.metadata.accounts.contains(&acct))
+        .expect("account read");
+
+    assert_eq!(read.key.method, ChainReadMethod::CurrentVotes);
+}
+
+#[test]
+fn test_plan_power_reconcile_is_fresh_when_processor_is_past_target_height() {
+    let plan = plan_power_reconcile(&context(600, 610, Some(600)), &[]);
+
+    assert_eq!(plan.freshness_state, PowerFreshnessState::Fresh);
+    assert_eq!(plan.metrics.sync_lag_blocks, None);
+}
+
 fn context(from_block: u64, to_block: u64, target_height: Option<u64>) -> PowerReconcileContext {
     PowerReconcileContext {
         dao_code: "unit-dao".to_owned(),
@@ -192,9 +297,33 @@ fn context(from_block: u64, to_block: u64, target_height: Option<u64>) -> PowerR
         to_block,
         target_height,
         read_plan_config: BatchReadPlanConfig::default(),
+        current_power_method: ChainReadMethod::GetVotes,
     }
 }
 
 fn account(suffix: &str) -> String {
     format!("0x{suffix:0>40}")
+}
+
+fn transfer_event(
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+    transaction_hash: &str,
+    from: &str,
+    to: &str,
+) -> PowerReconcileEvent {
+    PowerReconcileEvent {
+        block_number,
+        block_timestamp_ms: Some(block_number * 1_000),
+        transaction_hash: transaction_hash.to_owned(),
+        transaction_index,
+        log_index,
+        event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
+            from: from.to_owned(),
+            to: to.to_owned(),
+            value: "1".to_owned(),
+            standard: degov_datalens_indexer::GovernanceTokenStandard::Erc20,
+        })),
+    }
 }

--- a/apps/indexer/tests/power_reconcile.rs
+++ b/apps/indexer/tests/power_reconcile.rs
@@ -1,0 +1,200 @@
+use degov_datalens_indexer::{
+    BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadMethod, ChainReadReason,
+    DecodedDaoEvent, DecodedGovernorEvent, DecodedTokenEvent, DelegateChangedEvent,
+    DelegateVotesChangedEvent, PowerActivityReason, PowerFreshnessState, PowerReconcileContext,
+    PowerReconcileEvent, PowerRefreshReadSource, PowerRefreshStatus, TokenTransferEvent,
+    VoteCastEvent, plan_power_reconcile,
+};
+
+#[test]
+fn test_plan_power_reconcile_dedupes_large_batch_before_chain_reads() {
+    let events = (100_000..110_000)
+        .map(|block_number| PowerReconcileEvent {
+            block_number,
+            transaction_hash: format!("0xtx{block_number}"),
+            event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
+                from: account("aaaa"),
+                to: account("bbbb"),
+                value: block_number.to_string(),
+                standard: degov_datalens_indexer::GovernanceTokenStandard::Erc20,
+            })),
+        })
+        .collect::<Vec<_>>();
+
+    let plan = plan_power_reconcile(&context(100_000, 110_000, Some(110_010)), &events);
+
+    assert_eq!(plan.metrics.candidate_count, 20_000);
+    assert_eq!(plan.metrics.deduped_count, 19_998);
+    assert_eq!(plan.metrics.read_count, 2);
+    assert_eq!(plan.metrics.processed_count, 0);
+    assert_eq!(plan.metrics.failed_count, 0);
+    assert_eq!(plan.metrics.sync_lag_blocks, Some(10));
+    assert_eq!(
+        plan.freshness_state,
+        PowerFreshnessState::SyncLag { lag_blocks: 10 }
+    );
+    assert_eq!(plan.candidates.len(), 2);
+    assert_eq!(plan.chain_read_plan.reads.len(), 2);
+}
+
+#[test]
+fn test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons() {
+    let acct = account("aaaa");
+    let events = vec![
+        PowerReconcileEvent {
+            block_number: 100,
+            transaction_hash: "0xtx100".to_owned(),
+            event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
+                from: acct.clone(),
+                to: account("bbbb"),
+                value: "10".to_owned(),
+                standard: degov_datalens_indexer::GovernanceTokenStandard::Erc20,
+            })),
+        },
+        PowerReconcileEvent {
+            block_number: 103,
+            transaction_hash: "0xtx103".to_owned(),
+            event: DecodedDaoEvent::Token(DecodedTokenEvent::DelegateChanged(
+                DelegateChangedEvent {
+                    delegator: acct.clone(),
+                    from_delegate: account("cccc"),
+                    to_delegate: account("dddd"),
+                },
+            )),
+        },
+        PowerReconcileEvent {
+            block_number: 101,
+            transaction_hash: "0xtx101".to_owned(),
+            event: DecodedDaoEvent::Governor(DecodedGovernorEvent::VoteCast(VoteCastEvent {
+                voter: acct.clone(),
+                proposal_id: "42".to_owned(),
+                support: 1,
+                weight: "999999".to_owned(),
+                reason: "from log, not final power".to_owned(),
+            })),
+        },
+        PowerReconcileEvent {
+            block_number: 99,
+            transaction_hash: "0xtx99".to_owned(),
+            event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
+                from: acct.clone(),
+                to: account("eeee"),
+                value: "1".to_owned(),
+                standard: degov_datalens_indexer::GovernanceTokenStandard::Erc20,
+            })),
+        },
+    ];
+
+    let plan = plan_power_reconcile(&context(99, 103, Some(103)), &events);
+    let candidate = plan
+        .candidates
+        .iter()
+        .find(|candidate| candidate.account == acct)
+        .expect("candidate");
+
+    assert_eq!(candidate.latest_activity_block, 103);
+    assert_eq!(
+        candidate.reasons,
+        [
+            PowerActivityReason::DelegateChanged,
+            PowerActivityReason::Transfer,
+            PowerActivityReason::VoteCast,
+        ]
+        .into()
+    );
+    assert_eq!(candidate.status.status, PowerRefreshStatus::Pending);
+    assert_eq!(candidate.status.source, PowerRefreshReadSource::OnchainRpc);
+    assert_eq!(candidate.status.first_seen_activity_block, 99);
+    assert_eq!(candidate.status.last_seen_activity_block, 103);
+    assert_eq!(candidate.status.last_seen_transaction_hash, "0xtx103");
+    assert_eq!(
+        candidate.status.reason,
+        "delegate_changed,transfer,vote_cast"
+    );
+}
+
+#[test]
+fn test_plan_power_reconcile_does_not_write_log_derived_power() {
+    let acct = account("aaaa");
+    let events = vec![PowerReconcileEvent {
+        block_number: 100,
+        transaction_hash: "0xtx100".to_owned(),
+        event: DecodedDaoEvent::Token(DecodedTokenEvent::DelegateVotesChanged(
+            DelegateVotesChangedEvent {
+                delegate: acct.clone(),
+                previous_votes: "1".to_owned(),
+                new_votes: "999999".to_owned(),
+            },
+        )),
+    }];
+
+    let plan = plan_power_reconcile(&context(100, 100, Some(100)), &events);
+    let candidate = plan.candidates.first().expect("candidate");
+
+    assert_eq!(candidate.account, acct);
+    assert_eq!(candidate.observed_log_power, None);
+    assert_eq!(candidate.status.status, PowerRefreshStatus::Pending);
+    assert!(candidate.status.refresh_power);
+    assert!(!candidate.status.refresh_balance);
+    assert_eq!(
+        candidate.reasons,
+        [PowerActivityReason::DelegateVotesChanged].into()
+    );
+}
+
+#[test]
+fn test_plan_power_reconcile_emits_chaintool_get_votes_reads() {
+    let acct = account("aaaa");
+    let events = vec![PowerReconcileEvent {
+        block_number: 200,
+        transaction_hash: "0xtx200".to_owned(),
+        event: DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(TokenTransferEvent {
+            from: acct.clone(),
+            to: account("bbbb"),
+            value: "1".to_owned(),
+            standard: degov_datalens_indexer::GovernanceTokenStandard::Erc20,
+        })),
+    }];
+
+    let plan = plan_power_reconcile(&context(200, 200, Some(200)), &events);
+    let read = plan
+        .chain_read_plan
+        .reads
+        .iter()
+        .find(|read| read.metadata.accounts.contains(&acct))
+        .expect("account read");
+
+    assert_eq!(read.key.chain_id, 1);
+    assert_eq!(
+        read.key.contract_address,
+        "0x2222222222222222222222222222222222222222"
+    );
+    assert_eq!(read.key.method, ChainReadMethod::GetVotes);
+    assert_eq!(read.key.block_mode, BlockReadMode::Fresh);
+    assert_eq!(read.key.args, vec![acct]);
+    assert_eq!(
+        read.metadata.reasons,
+        [ChainReadReason::TokenActivityPowerRefresh].into()
+    );
+    assert_eq!(read.activity_blocks, vec![200]);
+}
+
+fn context(from_block: u64, to_block: u64, target_height: Option<u64>) -> PowerReconcileContext {
+    PowerReconcileContext {
+        dao_code: "unit-dao".to_owned(),
+        chain_id: 1,
+        contracts: ChainContracts {
+            governor: "0x1111111111111111111111111111111111111111".to_owned(),
+            governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+            timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+        },
+        from_block,
+        to_block,
+        target_height,
+        read_plan_config: BatchReadPlanConfig::default(),
+    }
+}
+
+fn account(suffix: &str) -> String {
+    format!("0x{suffix:0>40}")
+}


### PR DESCRIPTION
## Summary
- Adds a Datalens-native power reconcile planner for large historical log batches.
- Aggregates affected accounts across a checkpoint/window and dedupes them before scheduling ChainTool reads.
- Keeps final voting power onchain-truth only: logs produce reconcile candidates, not stored power values.
- Models pending refresh status records, freshness state, and metrics needed for later repository/write integration.

## Verification
- 
running 18 tests
test checkpoint::tests::test_plan_next_checkpoint_range_limits_to_target_height ... ok
test checkpoint::tests::test_plan_next_checkpoint_range_returns_none_when_checkpoint_caught_up ... ok
test config::tests::test_secret_string_never_formats_secret ... ok
test datalens::tests::test_verify_datalens_service_accepts_mocked_ready_client ... ok
test config::tests::test_endpoint_must_be_service_base_url ... ok
test datalens::tests::test_verify_datalens_service_rejects_mocked_unready_client ... ok
test planner::tests::test_fetch_dao_log_pages_stops_without_later_pages_when_retries_are_exhausted ... ok
test planner::tests::test_fetch_dao_log_pages_retries_errors_before_returning_page ... ok
test planner::tests::test_plan_dao_log_queries_rejects_zero_chunk_limit ... ok
test planner::tests::test_plan_dao_log_queries_uses_configured_finality ... ok
test config::tests::test_from_env_accepts_case_insensitive_governor_token_standard ... ok
test planner::tests::test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelock ... ok
test planner::tests::test_fetch_dao_log_pages_treats_empty_rows_as_successful_page ... ok
test planner::tests::test_plan_dao_log_queries_chunks_ranges_by_config_limit ... ok
test config::tests::test_from_env_requires_application_and_token_for_startup ... ok
test config::tests::test_from_env_rejects_invalid_governor_token_standard ... ok
test config::tests::test_from_env_requires_endpoint_for_startup ... ok
test config::tests::test_from_env_with_required_datalens_fields_builds_sdk_graphql_endpoint ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test test_read_execution_report_carries_lossless_read_values ... ok
test test_capability_plan_covers_required_governor_token_and_timelock_reads ... ok
test test_read_plan_clamps_zero_batch_config_to_valid_minimums ... ok
test test_read_plan_dedupes_same_rpc_read_across_semantic_metadata ... ok
test test_read_plan_keeps_distinct_power_reads_when_block_semantics_differ ... ok
test test_read_plan_groups_required_reads_into_bounded_multicall_batches ... ok
test test_read_plan_dedupes_repeated_account_power_reads_in_large_datalens_batch ... ok
test test_read_plan_dedupes_repeated_account_proposal_and_operation_activity ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s


running 6 tests
test test_decode_erc721_transfer_reads_token_id_from_topic ... ok
test test_decode_marks_unsupported_topic_explicitly ... ok
test test_decode_token_transfer_rejects_bad_standard_topic_count_mismatch ... ok
test test_decode_token_event_family_decodes_delegation_and_erc20_transfer ... ok
test test_decode_timelock_event_family_decodes_every_configured_topic ... ok
test test_decode_governor_event_family_decodes_every_configured_topic ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
test test_normalize_evm_log_rows_converts_timestamps_and_lowercases_addresses ... ok
test test_normalize_evm_log_rows_deduplicates_duplicate_raw_logs_by_stable_event_id ... ok
test test_normalize_evm_log_rows_keeps_missing_timestamp_as_none ... ok
test test_normalize_evm_log_rows_rejects_conflicting_duplicate_ids ... ok
test test_normalize_evm_log_rows_sorts_mixed_blocks_and_transactions_deterministically ... ok
test test_normalize_evm_log_rows_rejects_timestamp_overflow ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test test_plan_power_reconcile_does_not_write_log_derived_power ... ok
test test_plan_power_reconcile_emits_chaintool_get_votes_reads ... ok
test test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons ... ok
test test_plan_power_reconcile_dedupes_large_batch_before_chain_reads ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
- 
- 
- 
- Rust convention check passed
- Postgres schema ownership check passed

## Notes
- Full 
running 18 tests
test checkpoint::tests::test_plan_next_checkpoint_range_limits_to_target_height ... ok
test checkpoint::tests::test_plan_next_checkpoint_range_returns_none_when_checkpoint_caught_up ... ok
test datalens::tests::test_verify_datalens_service_accepts_mocked_ready_client ... ok
test datalens::tests::test_verify_datalens_service_rejects_mocked_unready_client ... ok
test config::tests::test_secret_string_never_formats_secret ... ok
test planner::tests::test_plan_dao_log_queries_rejects_zero_chunk_limit ... ok
test planner::tests::test_plan_dao_log_queries_chunks_ranges_by_config_limit ... ok
test planner::tests::test_plan_dao_log_queries_uses_configured_finality ... ok
test planner::tests::test_fetch_dao_log_pages_treats_empty_rows_as_successful_page ... ok
test planner::tests::test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelock ... ok
test planner::tests::test_fetch_dao_log_pages_retries_errors_before_returning_page ... ok
test config::tests::test_from_env_accepts_case_insensitive_governor_token_standard ... ok
test planner::tests::test_fetch_dao_log_pages_stops_without_later_pages_when_retries_are_exhausted ... ok
test config::tests::test_from_env_requires_application_and_token_for_startup ... ok
test config::tests::test_endpoint_must_be_service_base_url ... ok
test config::tests::test_from_env_requires_endpoint_for_startup ... ok
test config::tests::test_from_env_rejects_invalid_governor_token_standard ... ok
test config::tests::test_from_env_with_required_datalens_fields_builds_sdk_graphql_endpoint ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test test_read_execution_report_carries_lossless_read_values ... ok
test test_capability_plan_covers_required_governor_token_and_timelock_reads ... ok
test test_read_plan_clamps_zero_batch_config_to_valid_minimums ... ok
test test_read_plan_dedupes_same_rpc_read_across_semantic_metadata ... ok
test test_read_plan_groups_required_reads_into_bounded_multicall_batches ... ok
test test_read_plan_keeps_distinct_power_reads_when_block_semantics_differ ... ok
test test_read_plan_dedupes_repeated_account_power_reads_in_large_datalens_batch ... ok
test test_read_plan_dedupes_repeated_account_proposal_and_operation_activity ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s


running 4 tests
test test_checkpoint_restart_resumes_from_committed_next_block ... FAILED
test test_checkpoint_commit_advances_with_business_writes ... FAILED
test test_checkpoint_rollback_keeps_previous_state ... FAILED
test test_checkpoint_duplicate_range_replay_is_idempotent ... FAILED

failures:

---- test_checkpoint_restart_resumes_from_committed_next_block stdout ----
Error: "DEGOV_INDEXER_TEST_DATABASE_URL is required"

---- test_checkpoint_commit_advances_with_business_writes stdout ----
Error: "DEGOV_INDEXER_TEST_DATABASE_URL is required"

---- test_checkpoint_rollback_keeps_previous_state stdout ----
Error: "DEGOV_INDEXER_TEST_DATABASE_URL is required"

---- test_checkpoint_duplicate_range_replay_is_idempotent stdout ----
Error: "DEGOV_INDEXER_TEST_DATABASE_URL is required"


failures:
    test_checkpoint_commit_advances_with_business_writes
    test_checkpoint_duplicate_range_replay_is_idempotent
    test_checkpoint_restart_resumes_from_committed_next_block
    test_checkpoint_rollback_keeps_previous_state

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s still requires  for DB-backed checkpoint repository tests.