### PR TITLE
HBX-251: Implement Datalens proposal projection pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "sha3",
  "sqlx",
  "temp-env",
  "thiserror 2.0.18",

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -15,6 +15,7 @@ hex = "0.4.3"
 log = "0.4.30"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
+sha3 = "0.10.9"
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio-rustls", "postgres"] }
 thiserror = "2.0.17"
 tracing-log = "0.2.0"

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -49,7 +49,8 @@ pub use power_reconcile::{
 pub use proposal_projection::{
     InMemoryProposalProjectionRepository, ProposalActionWrite, ProposalCreatedWrite,
     ProposalDeadlineExtensionWrite, ProposalEventCommon, ProposalExtendedWrite, ProposalIdWrite,
-    ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionEvent,
-    ProposalProjectionRepository, ProposalQueuedWrite, ProposalRepositoryWriteError,
-    ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite, project_proposal_events,
+    ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionError,
+    ProposalProjectionEvent, ProposalProjectionRepository, ProposalQueuedWrite,
+    ProposalRepositoryWriteError, ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite,
+    project_proposal_events,
 };

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod evm_log;
 pub mod planner;
 pub mod power_reconcile;
+pub mod proposal_projection;
 
 pub use chain_tool::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadCapability,
@@ -44,4 +45,11 @@ pub use power_reconcile::{
     PowerActivityReason, PowerFreshnessState, PowerReconcileCandidate, PowerReconcileContext,
     PowerReconcileEvent, PowerReconcileMetrics, PowerReconcilePlan, PowerRefreshReadSource,
     PowerRefreshStatus, PowerRefreshStatusRecord, plan_power_reconcile,
+};
+pub use proposal_projection::{
+    InMemoryProposalProjectionRepository, ProposalActionWrite, ProposalCreatedWrite,
+    ProposalDeadlineExtensionWrite, ProposalEventCommon, ProposalExtendedWrite, ProposalIdWrite,
+    ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionEvent,
+    ProposalProjectionRepository, ProposalQueuedWrite, ProposalRepositoryWriteError,
+    ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite, project_proposal_events,
 };

--- a/apps/indexer/src/proposal_projection.rs
+++ b/apps/indexer/src/proposal_projection.rs
@@ -3,9 +3,9 @@ use std::collections::BTreeMap;
 use sha3::{Digest, Keccak256};
 
 use crate::{
-    BatchReadPlanConfig, ChainContracts, ChainReadPlan, ChainReadPlanBuilder, ChainReadReason,
-    DecodedGovernorEvent, NormalizedEvmLog, ProposalCreatedEvent, ProposalExtendedEvent,
-    ProposalQueuedEvent,
+    BatchReadPlanConfig, ChainContracts, ChainReadExecutionReport, ChainReadMethod, ChainReadPlan,
+    ChainReadPlanBuilder, ChainReadReason, ChainReadValue, DecodedGovernorEvent, NormalizedEvmLog,
+    ProposalCreatedEvent, ProposalExtendedEvent, ProposalQueuedEvent,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -35,6 +35,88 @@ pub struct ProposalProjectionBatch {
     pub proposal_state_epochs: Vec<ProposalStateEpochWrite>,
     pub proposal_deadline_extensions: Vec<ProposalDeadlineExtensionWrite>,
     pub chain_read_plan: ChainReadPlan,
+}
+
+impl ProposalProjectionBatch {
+    pub fn apply_chain_read_execution_report(&mut self, report: &ChainReadExecutionReport) {
+        let proposal_indexes = self
+            .proposals
+            .iter()
+            .enumerate()
+            .map(|(index, proposal)| {
+                (
+                    (
+                        proposal.chain_id,
+                        normalize_identifier(&proposal.governor_address),
+                        normalize_identifier(&proposal.proposal_id),
+                    ),
+                    index,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let mut results = report.results.iter().collect::<Vec<_>>();
+        results.sort_by_key(|result| {
+            (
+                result.key.chain_id,
+                result.key.contract_address.clone(),
+                result.key.method,
+                result.key.args.clone(),
+                result.read_index,
+            )
+        });
+
+        for result in results {
+            let Some(proposal_id) = result.key.args.first() else {
+                continue;
+            };
+            let key = (
+                result.key.chain_id,
+                normalize_identifier(&result.key.contract_address),
+                normalize_identifier(proposal_id),
+            );
+            let Some(index) = proposal_indexes.get(&key).copied() else {
+                continue;
+            };
+            let proposal = &mut self.proposals[index];
+            match result.key.method {
+                ChainReadMethod::ProposalSnapshot => {
+                    if let Some(value) = chain_read_scalar(&result.value) {
+                        proposal.proposal_snapshot = Some(value);
+                    }
+                }
+                ChainReadMethod::ProposalDeadline => {
+                    if let Some(value) = chain_read_scalar(&result.value) {
+                        proposal.proposal_deadline = Some(value);
+                    }
+                }
+                ChainReadMethod::State => {
+                    if let Some(value) = chain_read_state(&result.value) {
+                        proposal.current_state = Some(value);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalProjectionError {
+    MixedChainIds {
+        expected: i32,
+        actual: i32,
+        log_id: String,
+    },
+    ConflictingDuplicateLog {
+        log_id: String,
+    },
+    ActionLengthMismatch {
+        proposal_id: String,
+        targets: usize,
+        values: usize,
+        signatures: usize,
+        calldatas: usize,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -110,6 +192,8 @@ pub struct ProposalWrite {
     pub title: String,
     pub description_body: String,
     pub description_hash: String,
+    pub proposal_snapshot: Option<String>,
+    pub proposal_deadline: Option<String>,
     pub block_number: String,
     pub block_timestamp: Option<String>,
     pub transaction_hash: String,
@@ -275,17 +359,26 @@ impl ProposalProjectionRepository for InMemoryProposalProjectionRepository {
 pub fn project_proposal_events(
     context: &ProposalProjectionContext,
     events: Vec<ProposalProjectionEvent>,
-) -> ProposalProjectionBatch {
+) -> Result<ProposalProjectionBatch, ProposalProjectionError> {
     let governor_address = normalize_identifier(&context.governor_address);
+    let chain_id = validate_chain_ids(&events)?;
     let mut builder = ChainReadPlanBuilder::new(
-        first_chain_id(&events),
+        chain_id,
         context.contracts.clone(),
         context.read_plan_config,
     );
-    let mut deduped = BTreeMap::new();
+    let mut deduped: BTreeMap<String, ProposalProjectionEvent> = BTreeMap::new();
 
     for event in events {
-        deduped.entry(event.log.id.clone()).or_insert(event);
+        if let Some(stored) = deduped.get(&event.log.id) {
+            if stored.event != event.event {
+                return Err(ProposalProjectionError::ConflictingDuplicateLog {
+                    log_id: event.log.id,
+                });
+            }
+            continue;
+        }
+        deduped.insert(event.log.id.clone(), event);
     }
 
     let mut event_order = Vec::new();
@@ -323,6 +416,7 @@ pub fn project_proposal_events(
 
         match &input.event {
             DecodedGovernorEvent::ProposalCreated(event) => {
+                validate_action_lengths(event)?;
                 let common = common(context, &governor_address, &input.log, &event.proposal_id);
                 let row = proposal_created_write(&input.log.id, common.clone(), event);
                 proposal_created.insert(row.id.clone(), row);
@@ -401,8 +495,26 @@ pub fn project_proposal_events(
                 let common = common(context, &governor_address, &input.log, &event.proposal_id);
                 let row = proposal_extended_write(&input.log.id, common.clone(), event);
                 proposal_extended.insert(row.id.clone(), row);
-                let extension = deadline_extension_write(&common, event);
+                let proposal_ref = proposal_ref(
+                    &common.governor_address,
+                    &common.proposal_id,
+                    common.chain_id,
+                );
+                let previous_deadline = proposals
+                    .get(&proposal_ref)
+                    .and_then(|proposal: &ProposalWrite| proposal.proposal_deadline.clone());
+                let extension = deadline_extension_write(&common, event, previous_deadline);
                 proposal_deadline_extensions.insert(extension.id.clone(), extension);
+                proposals
+                    .entry(proposal_ref)
+                    .and_modify(|proposal: &mut ProposalWrite| {
+                        proposal.proposal_deadline = Some(event.extended_deadline.clone());
+                    })
+                    .or_insert_with(|| {
+                        let mut proposal = lifecycle_stub(&common, "Pending");
+                        proposal.proposal_deadline = Some(event.extended_deadline.clone());
+                        proposal
+                    });
             }
             DecodedGovernorEvent::ProposalExecuted(event) => {
                 let common = common(context, &governor_address, &input.log, &event.proposal_id);
@@ -447,7 +559,7 @@ pub fn project_proposal_events(
         )
     });
 
-    ProposalProjectionBatch {
+    Ok(ProposalProjectionBatch {
         event_order,
         proposal_created: proposal_created.into_values().collect(),
         proposal_queued: proposal_queued.into_values().collect(),
@@ -459,7 +571,7 @@ pub fn project_proposal_events(
         proposal_state_epochs,
         proposal_deadline_extensions: proposal_deadline_extensions.into_values().collect(),
         chain_read_plan: builder.build(),
-    }
+    })
 }
 
 fn write_terminal_state(
@@ -629,6 +741,8 @@ fn proposal_write(common: ProposalEventCommon, event: &ProposalCreatedEvent) -> 
         title,
         description_body,
         description_hash: description_hash(&event.description),
+        proposal_snapshot: Some(event.vote_start.clone()),
+        proposal_deadline: Some(event.vote_end.clone()),
         block_number: common.block_number.clone(),
         block_timestamp: common.block_timestamp.clone(),
         transaction_hash: common.transaction_hash.clone(),
@@ -719,6 +833,7 @@ fn state_epoch_write(
 fn deadline_extension_write(
     common: &ProposalEventCommon,
     event: &ProposalExtendedEvent,
+    previous_deadline: Option<String>,
 ) -> ProposalDeadlineExtensionWrite {
     let proposal_ref = proposal_ref(
         &common.governor_address,
@@ -727,7 +842,10 @@ fn deadline_extension_write(
     );
 
     ProposalDeadlineExtensionWrite {
-        id: format!("{}:deadline-extension:{}", proposal_ref, common.log_index),
+        id: format!(
+            "{}:deadline-extension:{}:{}:{}",
+            proposal_ref, common.block_number, common.transaction_hash, common.log_index
+        ),
         chain_id: common.chain_id,
         dao_code: common.dao_code.clone(),
         governor_address: common.governor_address.clone(),
@@ -736,7 +854,7 @@ fn deadline_extension_write(
         transaction_index: common.transaction_index,
         proposal_ref,
         proposal_id: common.proposal_id.clone(),
-        previous_deadline: None,
+        previous_deadline,
         new_deadline: event.extended_deadline.clone(),
         block_number: common.block_number.clone(),
         block_timestamp: common.block_timestamp.clone(),
@@ -769,6 +887,8 @@ fn lifecycle_stub(common: &ProposalEventCommon, state: &str) -> ProposalWrite {
         title: String::new(),
         description_body: String::new(),
         description_hash: description_hash(""),
+        proposal_snapshot: None,
+        proposal_deadline: None,
         block_number: common.block_number.clone(),
         block_timestamp: common.block_timestamp.clone(),
         transaction_hash: common.transaction_hash.clone(),
@@ -791,6 +911,8 @@ impl ProposalWrite {
         if !next.proposer.is_empty() {
             let mut merged = next.clone();
             merged.current_state = self.current_state.clone().or(merged.current_state);
+            merged.proposal_snapshot = self.proposal_snapshot.clone().or(merged.proposal_snapshot);
+            merged.proposal_deadline = self.proposal_deadline.clone().or(merged.proposal_deadline);
             merged.proposal_eta = self.proposal_eta.clone().or(merged.proposal_eta);
             merged.queued_block_number = self
                 .queued_block_number
@@ -831,6 +953,14 @@ impl ProposalWrite {
             *self = merged;
         } else {
             self.current_state = next.current_state.clone().or(self.current_state.clone());
+            self.proposal_snapshot = next
+                .proposal_snapshot
+                .clone()
+                .or(self.proposal_snapshot.clone());
+            self.proposal_deadline = next
+                .proposal_deadline
+                .clone()
+                .or(self.proposal_deadline.clone());
             self.proposal_eta = next.proposal_eta.clone().or(self.proposal_eta.clone());
             self.queued_block_number = next
                 .queued_block_number
@@ -872,11 +1002,37 @@ impl ProposalWrite {
     }
 }
 
-fn first_chain_id(events: &[ProposalProjectionEvent]) -> i32 {
-    events
-        .first()
-        .map(|event| event.log.chain_id)
-        .unwrap_or_default()
+fn validate_chain_ids(events: &[ProposalProjectionEvent]) -> Result<i32, ProposalProjectionError> {
+    let Some(first) = events.first() else {
+        return Ok(0);
+    };
+    for event in events.iter().skip(1) {
+        if event.log.chain_id != first.log.chain_id {
+            return Err(ProposalProjectionError::MixedChainIds {
+                expected: first.log.chain_id,
+                actual: event.log.chain_id,
+                log_id: event.log.id.clone(),
+            });
+        }
+    }
+    Ok(first.log.chain_id)
+}
+
+fn validate_action_lengths(event: &ProposalCreatedEvent) -> Result<(), ProposalProjectionError> {
+    if event.targets.len() == event.values.len()
+        && event.targets.len() == event.signatures.len()
+        && event.targets.len() == event.calldatas.len()
+    {
+        return Ok(());
+    }
+
+    Err(ProposalProjectionError::ActionLengthMismatch {
+        proposal_id: event.proposal_id.clone(),
+        targets: event.targets.len(),
+        values: event.values.len(),
+        signatures: event.signatures.len(),
+        calldatas: event.calldatas.len(),
+    })
 }
 
 fn proposal_id(event: &DecodedGovernorEvent) -> Option<&str> {
@@ -924,7 +1080,7 @@ fn proposal_ref(governor_address: &str, proposal_id: &str, chain_id: i32) -> Str
 fn split_description(description: &str) -> (String, String) {
     let trimmed = description.trim();
     if let Some(rest) = trimmed.strip_prefix("# ") {
-        let mut parts = rest.splitn(2, "\n\n");
+        let mut parts = rest.splitn(2, '\n');
         let title = parts.next().unwrap_or_default().trim().to_owned();
         let body = parts.next().unwrap_or_default().trim().to_owned();
         return (title, body);
@@ -947,6 +1103,34 @@ fn description_hash(description: &str) -> String {
 
 fn normalize_identifier(value: &str) -> String {
     value.to_ascii_lowercase()
+}
+
+fn chain_read_scalar(value: &ChainReadValue) -> Option<String> {
+    match value {
+        ChainReadValue::Integer(value) | ChainReadValue::String(value) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn chain_read_state(value: &ChainReadValue) -> Option<String> {
+    match value {
+        ChainReadValue::Integer(value) => Some(
+            match value.as_str() {
+                "0" => "Pending",
+                "1" => "Active",
+                "2" => "Canceled",
+                "3" => "Defeated",
+                "4" => "Succeeded",
+                "5" => "Queued",
+                "6" => "Expired",
+                "7" => "Executed",
+                state => state,
+            }
+            .to_owned(),
+        ),
+        ChainReadValue::String(value) => Some(value.clone()),
+        _ => None,
+    }
 }
 
 fn extend_map<T: Clone>(map: &mut BTreeMap<String, T>, rows: &[T], key: impl Fn(&T) -> String) {

--- a/apps/indexer/src/proposal_projection.rs
+++ b/apps/indexer/src/proposal_projection.rs
@@ -371,7 +371,7 @@ pub fn project_proposal_events(
 
     for event in events {
         if let Some(stored) = deduped.get(&event.log.id) {
-            if stored.event != event.event {
+            if stored != &event {
                 return Err(ProposalProjectionError::ConflictingDuplicateLog {
                     log_id: event.log.id,
                 });

--- a/apps/indexer/src/proposal_projection.rs
+++ b/apps/indexer/src/proposal_projection.rs
@@ -1,0 +1,956 @@
+use std::collections::BTreeMap;
+
+use sha3::{Digest, Keccak256};
+
+use crate::{
+    BatchReadPlanConfig, ChainContracts, ChainReadPlan, ChainReadPlanBuilder, ChainReadReason,
+    DecodedGovernorEvent, NormalizedEvmLog, ProposalCreatedEvent, ProposalExtendedEvent,
+    ProposalQueuedEvent,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalProjectionContext {
+    pub dao_code: String,
+    pub governor_address: String,
+    pub contracts: ChainContracts,
+    pub read_plan_config: BatchReadPlanConfig,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProposalProjectionEvent {
+    pub log: NormalizedEvmLog,
+    pub event: DecodedGovernorEvent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalProjectionBatch {
+    pub event_order: Vec<String>,
+    pub proposal_created: Vec<ProposalCreatedWrite>,
+    pub proposal_queued: Vec<ProposalQueuedWrite>,
+    pub proposal_extended: Vec<ProposalExtendedWrite>,
+    pub proposal_executed: Vec<ProposalIdWrite>,
+    pub proposal_canceled: Vec<ProposalIdWrite>,
+    pub proposals: Vec<ProposalWrite>,
+    pub proposal_actions: Vec<ProposalActionWrite>,
+    pub proposal_state_epochs: Vec<ProposalStateEpochWrite>,
+    pub proposal_deadline_extensions: Vec<ProposalDeadlineExtensionWrite>,
+    pub chain_read_plan: ChainReadPlan,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalCreatedWrite {
+    pub id: String,
+    pub common: ProposalEventCommon,
+    pub proposal_id: String,
+    pub proposer: String,
+    pub targets: Vec<String>,
+    pub values: Vec<String>,
+    pub signatures: Vec<String>,
+    pub calldatas: Vec<String>,
+    pub vote_start: String,
+    pub vote_end: String,
+    pub description: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalQueuedWrite {
+    pub id: String,
+    pub common: ProposalEventCommon,
+    pub proposal_id: String,
+    pub eta_seconds: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalExtendedWrite {
+    pub id: String,
+    pub common: ProposalEventCommon,
+    pub proposal_id: String,
+    pub extended_deadline: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalIdWrite {
+    pub id: String,
+    pub common: ProposalEventCommon,
+    pub proposal_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalEventCommon {
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub proposal_id: String,
+    pub block_number: String,
+    pub block_timestamp: Option<String>,
+    pub transaction_hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalWrite {
+    pub id: String,
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub proposal_id: String,
+    pub proposer: String,
+    pub targets: Vec<String>,
+    pub values: Vec<String>,
+    pub signatures: Vec<String>,
+    pub calldatas: Vec<String>,
+    pub vote_start: String,
+    pub vote_end: String,
+    pub description: String,
+    pub title: String,
+    pub description_body: String,
+    pub description_hash: String,
+    pub block_number: String,
+    pub block_timestamp: Option<String>,
+    pub transaction_hash: String,
+    pub current_state: Option<String>,
+    pub proposal_eta: Option<String>,
+    pub queued_block_number: Option<String>,
+    pub queued_block_timestamp: Option<String>,
+    pub queued_transaction_hash: Option<String>,
+    pub executed_block_number: Option<String>,
+    pub executed_block_timestamp: Option<String>,
+    pub executed_transaction_hash: Option<String>,
+    pub canceled_block_number: Option<String>,
+    pub canceled_block_timestamp: Option<String>,
+    pub canceled_transaction_hash: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalActionWrite {
+    pub id: String,
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub proposal_ref: String,
+    pub proposal_id: String,
+    pub action_index: usize,
+    pub target: String,
+    pub value: String,
+    pub signature: String,
+    pub calldata: String,
+    pub block_number: String,
+    pub block_timestamp: Option<String>,
+    pub transaction_hash: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum ProposalStateWriteKind {
+    Pending,
+    Queued,
+    Executed,
+    Canceled,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalStateEpochWrite {
+    pub id: String,
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub proposal_ref: String,
+    pub proposal_id: String,
+    pub kind: ProposalStateWriteKind,
+    pub state: String,
+    pub start_timepoint: Option<String>,
+    pub end_timepoint: Option<String>,
+    pub start_block_number: Option<String>,
+    pub start_block_timestamp: Option<String>,
+    pub end_block_number: Option<String>,
+    pub end_block_timestamp: Option<String>,
+    pub transaction_hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalDeadlineExtensionWrite {
+    pub id: String,
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub proposal_ref: String,
+    pub proposal_id: String,
+    pub previous_deadline: Option<String>,
+    pub new_deadline: String,
+    pub block_number: String,
+    pub block_timestamp: Option<String>,
+    pub transaction_hash: String,
+}
+
+pub trait ProposalProjectionRepository {
+    type Error;
+
+    fn apply(&mut self, batch: &ProposalProjectionBatch) -> Result<(), Self::Error>;
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct InMemoryProposalProjectionRepository {
+    proposal_created: BTreeMap<String, ProposalCreatedWrite>,
+    proposal_queued: BTreeMap<String, ProposalQueuedWrite>,
+    proposal_extended: BTreeMap<String, ProposalExtendedWrite>,
+    proposal_executed: BTreeMap<String, ProposalIdWrite>,
+    proposal_canceled: BTreeMap<String, ProposalIdWrite>,
+    proposals: BTreeMap<String, ProposalWrite>,
+    proposal_actions: BTreeMap<String, ProposalActionWrite>,
+    proposal_state_epochs: BTreeMap<String, ProposalStateEpochWrite>,
+    proposal_deadline_extensions: BTreeMap<String, ProposalDeadlineExtensionWrite>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalRepositoryWriteError {}
+
+impl InMemoryProposalProjectionRepository {
+    pub fn proposals(&self) -> &BTreeMap<String, ProposalWrite> {
+        &self.proposals
+    }
+}
+
+impl ProposalProjectionRepository for InMemoryProposalProjectionRepository {
+    type Error = ProposalRepositoryWriteError;
+
+    fn apply(&mut self, batch: &ProposalProjectionBatch) -> Result<(), Self::Error> {
+        extend_map(&mut self.proposal_created, &batch.proposal_created, |row| {
+            row.id.clone()
+        });
+        extend_map(&mut self.proposal_queued, &batch.proposal_queued, |row| {
+            row.id.clone()
+        });
+        extend_map(
+            &mut self.proposal_extended,
+            &batch.proposal_extended,
+            |row| row.id.clone(),
+        );
+        extend_map(
+            &mut self.proposal_executed,
+            &batch.proposal_executed,
+            |row| row.id.clone(),
+        );
+        extend_map(
+            &mut self.proposal_canceled,
+            &batch.proposal_canceled,
+            |row| row.id.clone(),
+        );
+        extend_map(&mut self.proposal_actions, &batch.proposal_actions, |row| {
+            row.id.clone()
+        });
+        extend_map(
+            &mut self.proposal_state_epochs,
+            &batch.proposal_state_epochs,
+            |row| row.id.clone(),
+        );
+        extend_map(
+            &mut self.proposal_deadline_extensions,
+            &batch.proposal_deadline_extensions,
+            |row| row.id.clone(),
+        );
+        for proposal in &batch.proposals {
+            self.proposals
+                .entry(proposal.id.clone())
+                .and_modify(|stored| stored.merge(proposal))
+                .or_insert_with(|| proposal.clone());
+        }
+
+        Ok(())
+    }
+}
+
+pub fn project_proposal_events(
+    context: &ProposalProjectionContext,
+    events: Vec<ProposalProjectionEvent>,
+) -> ProposalProjectionBatch {
+    let governor_address = normalize_identifier(&context.governor_address);
+    let mut builder = ChainReadPlanBuilder::new(
+        first_chain_id(&events),
+        context.contracts.clone(),
+        context.read_plan_config,
+    );
+    let mut deduped = BTreeMap::new();
+
+    for event in events {
+        deduped.entry(event.log.id.clone()).or_insert(event);
+    }
+
+    let mut event_order = Vec::new();
+    let mut proposal_created = BTreeMap::new();
+    let mut proposal_queued = BTreeMap::new();
+    let mut proposal_extended = BTreeMap::new();
+    let mut proposal_executed = BTreeMap::new();
+    let mut proposal_canceled = BTreeMap::new();
+    let mut proposals = BTreeMap::new();
+    let mut proposal_actions = BTreeMap::new();
+    let mut proposal_state_epochs = BTreeMap::new();
+    let mut proposal_deadline_extensions = BTreeMap::new();
+
+    let mut ordered = deduped.into_values().collect::<Vec<_>>();
+    ordered.sort_by_key(|event| {
+        (
+            event.log.block_number,
+            event.log.transaction_index,
+            event.log.log_index,
+            event.log.id.clone(),
+        )
+    });
+
+    for input in ordered {
+        let proposal_id = proposal_id(&input.event);
+        let Some(proposal_id) = proposal_id else {
+            continue;
+        };
+        event_order.push(input.log.id.clone());
+        builder.add_proposal_refresh(
+            proposal_id,
+            input.log.block_number,
+            ChainReadReason::ProposalLifecycleRefresh,
+        );
+
+        match &input.event {
+            DecodedGovernorEvent::ProposalCreated(event) => {
+                let common = common(context, &governor_address, &input.log, &event.proposal_id);
+                let row = proposal_created_write(&input.log.id, common.clone(), event);
+                proposal_created.insert(row.id.clone(), row);
+
+                let proposal = proposal_write(common.clone(), event);
+                for action in proposal_action_writes(&common, &proposal, event) {
+                    proposal_actions.insert(action.id.clone(), action);
+                }
+                proposal_state_epochs.insert(
+                    state_epoch_id(&proposal.id, ProposalStateWriteKind::Pending, &input.log),
+                    state_epoch_write(
+                        &common,
+                        &proposal.id,
+                        ProposalStateWriteKind::Pending,
+                        "Pending",
+                        Some(event.vote_start.clone()),
+                    ),
+                );
+                proposals
+                    .entry(proposal.id.clone())
+                    .and_modify(|stored: &mut ProposalWrite| stored.merge(&proposal))
+                    .or_insert(proposal);
+            }
+            DecodedGovernorEvent::ProposalQueued(event) => {
+                let common = common(context, &governor_address, &input.log, &event.proposal_id);
+                let row = proposal_queued_write(&input.log.id, common.clone(), event);
+                proposal_queued.insert(row.id.clone(), row);
+                proposal_state_epochs.insert(
+                    state_epoch_id(
+                        &proposal_ref(
+                            &common.governor_address,
+                            &common.proposal_id,
+                            common.chain_id,
+                        ),
+                        ProposalStateWriteKind::Queued,
+                        &input.log,
+                    ),
+                    state_epoch_write(
+                        &common,
+                        &proposal_ref(
+                            &common.governor_address,
+                            &common.proposal_id,
+                            common.chain_id,
+                        ),
+                        ProposalStateWriteKind::Queued,
+                        "Queued",
+                        Some(event.eta_seconds.clone()),
+                    ),
+                );
+                proposals
+                    .entry(proposal_ref(
+                        &common.governor_address,
+                        &common.proposal_id,
+                        common.chain_id,
+                    ))
+                    .and_modify(|proposal: &mut ProposalWrite| {
+                        proposal.current_state = Some("Queued".to_owned());
+                        proposal.proposal_eta = Some(event.eta_seconds.clone());
+                        proposal.queued_block_number = Some(common.block_number.clone());
+                        proposal.queued_block_timestamp = common.block_timestamp.clone();
+                        proposal.queued_transaction_hash = Some(common.transaction_hash.clone());
+                    })
+                    .or_insert_with(|| lifecycle_stub(&common, "Queued"));
+                if let Some(proposal) = proposals.get_mut(&proposal_ref(
+                    &common.governor_address,
+                    &common.proposal_id,
+                    common.chain_id,
+                )) {
+                    proposal.proposal_eta = Some(event.eta_seconds.clone());
+                    proposal.queued_block_number = Some(common.block_number.clone());
+                    proposal.queued_block_timestamp = common.block_timestamp.clone();
+                    proposal.queued_transaction_hash = Some(common.transaction_hash.clone());
+                }
+            }
+            DecodedGovernorEvent::ProposalExtended(event) => {
+                let common = common(context, &governor_address, &input.log, &event.proposal_id);
+                let row = proposal_extended_write(&input.log.id, common.clone(), event);
+                proposal_extended.insert(row.id.clone(), row);
+                let extension = deadline_extension_write(&common, event);
+                proposal_deadline_extensions.insert(extension.id.clone(), extension);
+            }
+            DecodedGovernorEvent::ProposalExecuted(event) => {
+                let common = common(context, &governor_address, &input.log, &event.proposal_id);
+                let row = proposal_id_write(&input.log.id, common.clone());
+                proposal_executed.insert(row.id.clone(), row);
+                write_terminal_state(
+                    &mut proposals,
+                    &mut proposal_state_epochs,
+                    &common,
+                    &input.log,
+                    ProposalStateWriteKind::Executed,
+                    "Executed",
+                );
+            }
+            DecodedGovernorEvent::ProposalCanceled(event) => {
+                let common = common(context, &governor_address, &input.log, &event.proposal_id);
+                let row = proposal_id_write(&input.log.id, common.clone());
+                proposal_canceled.insert(row.id.clone(), row);
+                write_terminal_state(
+                    &mut proposals,
+                    &mut proposal_state_epochs,
+                    &common,
+                    &input.log,
+                    ProposalStateWriteKind::Canceled,
+                    "Canceled",
+                );
+            }
+            _ => {}
+        }
+    }
+
+    let mut proposal_state_epochs = proposal_state_epochs.into_values().collect::<Vec<_>>();
+    proposal_state_epochs.sort_by_key(|row| {
+        (
+            row.start_block_number
+                .as_deref()
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or_default(),
+            row.transaction_index,
+            row.log_index,
+            row.kind,
+        )
+    });
+
+    ProposalProjectionBatch {
+        event_order,
+        proposal_created: proposal_created.into_values().collect(),
+        proposal_queued: proposal_queued.into_values().collect(),
+        proposal_extended: proposal_extended.into_values().collect(),
+        proposal_executed: proposal_executed.into_values().collect(),
+        proposal_canceled: proposal_canceled.into_values().collect(),
+        proposals: proposals.into_values().collect(),
+        proposal_actions: proposal_actions.into_values().collect(),
+        proposal_state_epochs,
+        proposal_deadline_extensions: proposal_deadline_extensions.into_values().collect(),
+        chain_read_plan: builder.build(),
+    }
+}
+
+fn write_terminal_state(
+    proposals: &mut BTreeMap<String, ProposalWrite>,
+    proposal_state_epochs: &mut BTreeMap<String, ProposalStateEpochWrite>,
+    common: &ProposalEventCommon,
+    log: &NormalizedEvmLog,
+    kind: ProposalStateWriteKind,
+    state: &str,
+) {
+    let proposal_ref = proposal_ref(
+        &common.governor_address,
+        &common.proposal_id,
+        common.chain_id,
+    );
+    proposal_state_epochs.insert(
+        state_epoch_id(&proposal_ref, kind, log),
+        state_epoch_write(common, &proposal_ref, kind, state, None),
+    );
+    proposals
+        .entry(proposal_ref)
+        .and_modify(|proposal| {
+            proposal.current_state = Some(state.to_owned());
+            match kind {
+                ProposalStateWriteKind::Executed => {
+                    proposal.executed_block_number = Some(common.block_number.clone());
+                    proposal.executed_block_timestamp = common.block_timestamp.clone();
+                    proposal.executed_transaction_hash = Some(common.transaction_hash.clone());
+                }
+                ProposalStateWriteKind::Canceled => {
+                    proposal.canceled_block_number = Some(common.block_number.clone());
+                    proposal.canceled_block_timestamp = common.block_timestamp.clone();
+                    proposal.canceled_transaction_hash = Some(common.transaction_hash.clone());
+                }
+                _ => {}
+            }
+        })
+        .or_insert_with(|| {
+            let mut proposal = lifecycle_stub(common, state);
+            match kind {
+                ProposalStateWriteKind::Executed => {
+                    proposal.executed_block_number = Some(common.block_number.clone());
+                    proposal.executed_block_timestamp = common.block_timestamp.clone();
+                    proposal.executed_transaction_hash = Some(common.transaction_hash.clone());
+                }
+                ProposalStateWriteKind::Canceled => {
+                    proposal.canceled_block_number = Some(common.block_number.clone());
+                    proposal.canceled_block_timestamp = common.block_timestamp.clone();
+                    proposal.canceled_transaction_hash = Some(common.transaction_hash.clone());
+                }
+                _ => {}
+            }
+            proposal
+        });
+}
+
+fn common(
+    context: &ProposalProjectionContext,
+    governor_address: &str,
+    log: &NormalizedEvmLog,
+    proposal_id: &str,
+) -> ProposalEventCommon {
+    ProposalEventCommon {
+        chain_id: log.chain_id,
+        dao_code: context.dao_code.clone(),
+        governor_address: governor_address.to_owned(),
+        contract_address: normalize_identifier(&log.address),
+        log_index: log.log_index,
+        transaction_index: log.transaction_index,
+        proposal_id: proposal_id.to_owned(),
+        block_number: log.block_number.to_string(),
+        block_timestamp: log
+            .block_timestamp_ms
+            .map(|timestamp| (timestamp / 1_000).to_string()),
+        transaction_hash: normalize_identifier(&log.transaction_hash),
+    }
+}
+
+fn proposal_created_write(
+    log_id: &str,
+    common: ProposalEventCommon,
+    event: &ProposalCreatedEvent,
+) -> ProposalCreatedWrite {
+    ProposalCreatedWrite {
+        id: log_id.to_owned(),
+        common,
+        proposal_id: event.proposal_id.clone(),
+        proposer: normalize_identifier(&event.proposer),
+        targets: event
+            .targets
+            .iter()
+            .map(|target| normalize_identifier(target))
+            .collect(),
+        values: event.values.clone(),
+        signatures: event.signatures.clone(),
+        calldatas: event.calldatas.clone(),
+        vote_start: event.vote_start.clone(),
+        vote_end: event.vote_end.clone(),
+        description: event.description.clone(),
+    }
+}
+
+fn proposal_queued_write(
+    log_id: &str,
+    common: ProposalEventCommon,
+    event: &ProposalQueuedEvent,
+) -> ProposalQueuedWrite {
+    ProposalQueuedWrite {
+        id: log_id.to_owned(),
+        common,
+        proposal_id: event.proposal_id.clone(),
+        eta_seconds: event.eta_seconds.clone(),
+    }
+}
+
+fn proposal_extended_write(
+    log_id: &str,
+    common: ProposalEventCommon,
+    event: &ProposalExtendedEvent,
+) -> ProposalExtendedWrite {
+    ProposalExtendedWrite {
+        id: log_id.to_owned(),
+        common,
+        proposal_id: event.proposal_id.clone(),
+        extended_deadline: event.extended_deadline.clone(),
+    }
+}
+
+fn proposal_id_write(log_id: &str, common: ProposalEventCommon) -> ProposalIdWrite {
+    let proposal_id = common.proposal_id.clone();
+
+    ProposalIdWrite {
+        id: log_id.to_owned(),
+        common,
+        proposal_id,
+    }
+}
+
+fn proposal_write(common: ProposalEventCommon, event: &ProposalCreatedEvent) -> ProposalWrite {
+    let (title, description_body) = split_description(&event.description);
+
+    ProposalWrite {
+        id: proposal_ref(
+            &common.governor_address,
+            &event.proposal_id,
+            common.chain_id,
+        ),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        proposal_id: event.proposal_id.clone(),
+        proposer: normalize_identifier(&event.proposer),
+        targets: event
+            .targets
+            .iter()
+            .map(|target| normalize_identifier(target))
+            .collect(),
+        values: event.values.clone(),
+        signatures: event.signatures.clone(),
+        calldatas: event.calldatas.clone(),
+        vote_start: event.vote_start.clone(),
+        vote_end: event.vote_end.clone(),
+        description: event.description.clone(),
+        title,
+        description_body,
+        description_hash: description_hash(&event.description),
+        block_number: common.block_number.clone(),
+        block_timestamp: common.block_timestamp.clone(),
+        transaction_hash: common.transaction_hash.clone(),
+        current_state: Some("Pending".to_owned()),
+        proposal_eta: None,
+        queued_block_number: None,
+        queued_block_timestamp: None,
+        queued_transaction_hash: None,
+        executed_block_number: None,
+        executed_block_timestamp: None,
+        executed_transaction_hash: None,
+        canceled_block_number: None,
+        canceled_block_timestamp: None,
+        canceled_transaction_hash: None,
+    }
+}
+
+fn proposal_action_writes(
+    common: &ProposalEventCommon,
+    proposal: &ProposalWrite,
+    event: &ProposalCreatedEvent,
+) -> Vec<ProposalActionWrite> {
+    event
+        .targets
+        .iter()
+        .zip(event.values.iter())
+        .zip(event.signatures.iter())
+        .zip(event.calldatas.iter())
+        .enumerate()
+        .map(
+            |(action_index, (((target, value), signature), calldata))| ProposalActionWrite {
+                id: format!("{}:action:{action_index}", proposal.id),
+                chain_id: common.chain_id,
+                dao_code: common.dao_code.clone(),
+                governor_address: common.governor_address.clone(),
+                contract_address: common.contract_address.clone(),
+                log_index: common.log_index,
+                transaction_index: common.transaction_index,
+                proposal_ref: proposal.id.clone(),
+                proposal_id: common.proposal_id.clone(),
+                action_index,
+                target: normalize_identifier(target),
+                value: value.clone(),
+                signature: signature.clone(),
+                calldata: calldata.clone(),
+                block_number: common.block_number.clone(),
+                block_timestamp: common.block_timestamp.clone(),
+                transaction_hash: common.transaction_hash.clone(),
+            },
+        )
+        .collect()
+}
+
+fn state_epoch_write(
+    common: &ProposalEventCommon,
+    proposal_ref: &str,
+    kind: ProposalStateWriteKind,
+    state: &str,
+    start_timepoint: Option<String>,
+) -> ProposalStateEpochWrite {
+    ProposalStateEpochWrite {
+        id: format!(
+            "{proposal_ref}:state:{}:{}:{}",
+            state.to_ascii_lowercase(),
+            common.block_number,
+            common.log_index
+        ),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        proposal_ref: proposal_ref.to_owned(),
+        proposal_id: common.proposal_id.clone(),
+        kind,
+        state: state.to_owned(),
+        start_timepoint,
+        end_timepoint: None,
+        start_block_number: Some(common.block_number.clone()),
+        start_block_timestamp: common.block_timestamp.clone(),
+        end_block_number: None,
+        end_block_timestamp: None,
+        transaction_hash: common.transaction_hash.clone(),
+    }
+}
+
+fn deadline_extension_write(
+    common: &ProposalEventCommon,
+    event: &ProposalExtendedEvent,
+) -> ProposalDeadlineExtensionWrite {
+    let proposal_ref = proposal_ref(
+        &common.governor_address,
+        &common.proposal_id,
+        common.chain_id,
+    );
+
+    ProposalDeadlineExtensionWrite {
+        id: format!("{}:deadline-extension:{}", proposal_ref, common.log_index),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        proposal_ref,
+        proposal_id: common.proposal_id.clone(),
+        previous_deadline: None,
+        new_deadline: event.extended_deadline.clone(),
+        block_number: common.block_number.clone(),
+        block_timestamp: common.block_timestamp.clone(),
+        transaction_hash: common.transaction_hash.clone(),
+    }
+}
+
+fn lifecycle_stub(common: &ProposalEventCommon, state: &str) -> ProposalWrite {
+    ProposalWrite {
+        id: proposal_ref(
+            &common.governor_address,
+            &common.proposal_id,
+            common.chain_id,
+        ),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        proposal_id: common.proposal_id.clone(),
+        proposer: String::new(),
+        targets: Vec::new(),
+        values: Vec::new(),
+        signatures: Vec::new(),
+        calldatas: Vec::new(),
+        vote_start: "0".to_owned(),
+        vote_end: "0".to_owned(),
+        description: String::new(),
+        title: String::new(),
+        description_body: String::new(),
+        description_hash: description_hash(""),
+        block_number: common.block_number.clone(),
+        block_timestamp: common.block_timestamp.clone(),
+        transaction_hash: common.transaction_hash.clone(),
+        current_state: Some(state.to_owned()),
+        proposal_eta: None,
+        queued_block_number: None,
+        queued_block_timestamp: None,
+        queued_transaction_hash: None,
+        executed_block_number: None,
+        executed_block_timestamp: None,
+        executed_transaction_hash: None,
+        canceled_block_number: None,
+        canceled_block_timestamp: None,
+        canceled_transaction_hash: None,
+    }
+}
+
+impl ProposalWrite {
+    fn merge(&mut self, next: &Self) {
+        if !next.proposer.is_empty() {
+            let mut merged = next.clone();
+            merged.current_state = self.current_state.clone().or(merged.current_state);
+            merged.proposal_eta = self.proposal_eta.clone().or(merged.proposal_eta);
+            merged.queued_block_number = self
+                .queued_block_number
+                .clone()
+                .or(merged.queued_block_number);
+            merged.queued_block_timestamp = self
+                .queued_block_timestamp
+                .clone()
+                .or(merged.queued_block_timestamp);
+            merged.queued_transaction_hash = self
+                .queued_transaction_hash
+                .clone()
+                .or(merged.queued_transaction_hash);
+            merged.executed_block_number = self
+                .executed_block_number
+                .clone()
+                .or(merged.executed_block_number);
+            merged.executed_block_timestamp = self
+                .executed_block_timestamp
+                .clone()
+                .or(merged.executed_block_timestamp);
+            merged.executed_transaction_hash = self
+                .executed_transaction_hash
+                .clone()
+                .or(merged.executed_transaction_hash);
+            merged.canceled_block_number = self
+                .canceled_block_number
+                .clone()
+                .or(merged.canceled_block_number);
+            merged.canceled_block_timestamp = self
+                .canceled_block_timestamp
+                .clone()
+                .or(merged.canceled_block_timestamp);
+            merged.canceled_transaction_hash = self
+                .canceled_transaction_hash
+                .clone()
+                .or(merged.canceled_transaction_hash);
+            *self = merged;
+        } else {
+            self.current_state = next.current_state.clone().or(self.current_state.clone());
+            self.proposal_eta = next.proposal_eta.clone().or(self.proposal_eta.clone());
+            self.queued_block_number = next
+                .queued_block_number
+                .clone()
+                .or(self.queued_block_number.clone());
+            self.queued_block_timestamp = next
+                .queued_block_timestamp
+                .clone()
+                .or(self.queued_block_timestamp.clone());
+            self.queued_transaction_hash = next
+                .queued_transaction_hash
+                .clone()
+                .or(self.queued_transaction_hash.clone());
+            self.executed_block_number = next
+                .executed_block_number
+                .clone()
+                .or(self.executed_block_number.clone());
+            self.executed_block_timestamp = next
+                .executed_block_timestamp
+                .clone()
+                .or(self.executed_block_timestamp.clone());
+            self.executed_transaction_hash = next
+                .executed_transaction_hash
+                .clone()
+                .or(self.executed_transaction_hash.clone());
+            self.canceled_block_number = next
+                .canceled_block_number
+                .clone()
+                .or(self.canceled_block_number.clone());
+            self.canceled_block_timestamp = next
+                .canceled_block_timestamp
+                .clone()
+                .or(self.canceled_block_timestamp.clone());
+            self.canceled_transaction_hash = next
+                .canceled_transaction_hash
+                .clone()
+                .or(self.canceled_transaction_hash.clone());
+        }
+    }
+}
+
+fn first_chain_id(events: &[ProposalProjectionEvent]) -> i32 {
+    events
+        .first()
+        .map(|event| event.log.chain_id)
+        .unwrap_or_default()
+}
+
+fn proposal_id(event: &DecodedGovernorEvent) -> Option<&str> {
+    match event {
+        DecodedGovernorEvent::ProposalCreated(event) => Some(&event.proposal_id),
+        DecodedGovernorEvent::ProposalQueued(event) => Some(&event.proposal_id),
+        DecodedGovernorEvent::ProposalExtended(event) => Some(&event.proposal_id),
+        DecodedGovernorEvent::ProposalExecuted(event) => Some(&event.proposal_id),
+        DecodedGovernorEvent::ProposalCanceled(event) => Some(&event.proposal_id),
+        _ => None,
+    }
+}
+
+fn state_epoch_id(
+    proposal_ref: &str,
+    kind: ProposalStateWriteKind,
+    log: &NormalizedEvmLog,
+) -> String {
+    format!(
+        "{proposal_ref}:state:{}:{}:{}",
+        kind.as_str().to_ascii_lowercase(),
+        log.block_number,
+        log.log_index
+    )
+}
+
+impl ProposalStateWriteKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "Pending",
+            Self::Queued => "Queued",
+            Self::Executed => "Executed",
+            Self::Canceled => "Canceled",
+        }
+    }
+}
+
+fn proposal_ref(governor_address: &str, proposal_id: &str, chain_id: i32) -> String {
+    format!(
+        "proposal:{chain_id}:{}:{proposal_id}",
+        normalize_identifier(governor_address)
+    )
+}
+
+fn split_description(description: &str) -> (String, String) {
+    let trimmed = description.trim();
+    if let Some(rest) = trimmed.strip_prefix("# ") {
+        let mut parts = rest.splitn(2, "\n\n");
+        let title = parts.next().unwrap_or_default().trim().to_owned();
+        let body = parts.next().unwrap_or_default().trim().to_owned();
+        return (title, body);
+    }
+
+    let mut lines = trimmed.lines();
+    let title = lines
+        .next()
+        .unwrap_or_default()
+        .trim_start_matches('#')
+        .trim();
+    let body = lines.collect::<Vec<_>>().join("\n").trim().to_owned();
+    (title.to_owned(), body)
+}
+
+fn description_hash(description: &str) -> String {
+    let hash = Keccak256::digest(description.as_bytes());
+    format!("0x{}", hex::encode(hash))
+}
+
+fn normalize_identifier(value: &str) -> String {
+    value.to_ascii_lowercase()
+}
+
+fn extend_map<T: Clone>(map: &mut BTreeMap<String, T>, rows: &[T], key: impl Fn(&T) -> String) {
+    for row in rows {
+        map.insert(key(row), row.clone());
+    }
+}

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -333,6 +333,34 @@ fn test_project_proposal_events_rejects_conflicting_duplicate_log_id() {
 }
 
 #[test]
+fn test_project_proposal_events_rejects_duplicate_log_id_with_conflicting_metadata() {
+    let mut duplicate = log(10, 0, 1);
+    duplicate.transaction_hash = "0xdifferent".to_owned();
+
+    let err = project_proposal_events(
+        &context(),
+        vec![
+            ProposalProjectionEvent {
+                log: log(10, 0, 1),
+                event: proposal_created("42", "# Title\nBody"),
+            },
+            ProposalProjectionEvent {
+                log: duplicate,
+                event: proposal_created("42", "# Title\nBody"),
+            },
+        ],
+    )
+    .expect_err("conflicting duplicate log metadata is rejected");
+
+    assert_eq!(
+        err,
+        ProposalProjectionError::ConflictingDuplicateLog {
+            log_id: "evm:1:10:0xtx10:0:1".to_owned(),
+        }
+    );
+}
+
+#[test]
 fn test_project_proposal_created_rejects_action_length_mismatch() {
     let err = project_proposal_events(
         &context(),

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -1,8 +1,9 @@
 use degov_datalens_indexer::{
-    BatchReadPlanConfig, ChainContracts, ChainReadMethod, DecodedGovernorEvent, NormalizedEvmLog,
+    BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadExecutionReport, ChainReadKey,
+    ChainReadMethod, ChainReadResult, ChainReadValue, DecodedGovernorEvent, NormalizedEvmLog,
     ProposalCreatedEvent, ProposalExtendedEvent, ProposalIdEvent, ProposalProjectionContext,
-    ProposalProjectionEvent, ProposalProjectionRepository, ProposalQueuedEvent,
-    ProposalStateWriteKind, ReadRequirement, project_proposal_events,
+    ProposalProjectionError, ProposalProjectionEvent, ProposalProjectionRepository,
+    ProposalQueuedEvent, ProposalStateWriteKind, ReadRequirement, project_proposal_events,
 };
 use serde_json::json;
 
@@ -27,7 +28,8 @@ fn test_project_proposal_created_builds_aggregate_actions_and_chain_reads() {
                 description: "# Proposal title\n\nProposal body".to_owned(),
             }),
         }],
-    );
+    )
+    .expect("projection succeeds");
 
     assert_eq!(batch.proposal_created.len(), 1);
     assert_eq!(batch.proposals.len(), 1);
@@ -51,6 +53,8 @@ fn test_project_proposal_created_builds_aggregate_actions_and_chain_reads() {
         "0x3bec3dfa58e028fdf10e56bebf69d18a3170b2897a2381164179670dd2fa0193"
     );
     assert_eq!(proposal.current_state.as_deref(), Some("Pending"));
+    assert_eq!(proposal.proposal_snapshot.as_deref(), Some("20"));
+    assert_eq!(proposal.proposal_deadline.as_deref(), Some("40"));
     assert_eq!(proposal.block_timestamp, Some("1700000000".to_owned()));
 
     assert_eq!(batch.proposal_actions[0].action_index, 0);
@@ -114,7 +118,8 @@ fn test_project_proposal_lifecycle_events_builds_metadata_and_state_epochs() {
                 }),
             },
         ],
-    );
+    )
+    .expect("projection succeeds");
 
     assert_eq!(batch.proposal_queued.len(), 1);
     assert_eq!(batch.proposal_extended.len(), 1);
@@ -176,7 +181,7 @@ fn test_project_proposal_events_replays_idempotently_and_sorts_by_log_position()
     events.push(events[0].clone());
     events.push(events[1].clone());
 
-    let batch = project_proposal_events(&context(), events);
+    let batch = project_proposal_events(&context(), events).expect("projection succeeds");
     let mut repository = degov_datalens_indexer::InMemoryProposalProjectionRepository::default();
 
     repository
@@ -218,7 +223,8 @@ fn test_repository_preserves_lifecycle_metadata_when_identity_arrives_later() {
                 eta_seconds: "1700000400".to_owned(),
             }),
         }],
-    );
+    )
+    .expect("projection succeeds");
     let identity_batch = project_proposal_events(
         &context(),
         vec![ProposalProjectionEvent {
@@ -235,7 +241,8 @@ fn test_repository_preserves_lifecycle_metadata_when_identity_arrives_later() {
                 description: "Plain title".to_owned(),
             }),
         }],
-    );
+    )
+    .expect("projection succeeds");
     let mut repository = degov_datalens_indexer::InMemoryProposalProjectionRepository::default();
 
     repository
@@ -256,6 +263,228 @@ fn test_repository_preserves_lifecycle_metadata_when_identity_arrives_later() {
     );
     assert_eq!(proposal.current_state.as_deref(), Some("Queued"));
     assert_eq!(proposal.proposal_eta.as_deref(), Some("1700000400"));
+}
+
+#[test]
+fn test_project_proposal_events_accepts_empty_input() {
+    let batch = project_proposal_events(&context(), vec![]).expect("empty projection succeeds");
+
+    assert!(batch.event_order.is_empty());
+    assert!(batch.proposals.is_empty());
+    assert!(batch.chain_read_plan.reads.is_empty());
+}
+
+#[test]
+fn test_project_proposal_events_rejects_mixed_chain_input() {
+    let mut second = log(11, 0, 1);
+    second.chain_id = 2;
+
+    let err = project_proposal_events(
+        &context(),
+        vec![
+            ProposalProjectionEvent {
+                log: log(10, 0, 1),
+                event: proposal_created("42", "# Title\nBody"),
+            },
+            ProposalProjectionEvent {
+                log: second,
+                event: proposal_created("43", "# Other\nBody"),
+            },
+        ],
+    )
+    .expect_err("mixed chain input is rejected");
+
+    assert_eq!(
+        err,
+        ProposalProjectionError::MixedChainIds {
+            expected: 1,
+            actual: 2,
+            log_id: "evm:1:11:0xtx11:0:1".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_project_proposal_events_rejects_conflicting_duplicate_log_id() {
+    let mut duplicate = log(10, 0, 1);
+    duplicate.block_number = 11;
+
+    let err = project_proposal_events(
+        &context(),
+        vec![
+            ProposalProjectionEvent {
+                log: log(10, 0, 1),
+                event: proposal_created("42", "# Title\nBody"),
+            },
+            ProposalProjectionEvent {
+                log: duplicate,
+                event: proposal_created("43", "# Other\nBody"),
+            },
+        ],
+    )
+    .expect_err("conflicting duplicate log is rejected");
+
+    assert_eq!(
+        err,
+        ProposalProjectionError::ConflictingDuplicateLog {
+            log_id: "evm:1:10:0xtx10:0:1".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_project_proposal_created_rejects_action_length_mismatch() {
+    let err = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: log(10, 0, 1),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "42".to_owned(),
+                proposer: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+                targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+                values: vec![],
+                signatures: vec!["".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "20".to_owned(),
+                vote_end: "40".to_owned(),
+                description: "# Title\nBody".to_owned(),
+            }),
+        }],
+    )
+    .expect_err("mismatched action vectors are rejected");
+
+    assert_eq!(
+        err,
+        ProposalProjectionError::ActionLengthMismatch {
+            proposal_id: "42".to_owned(),
+            targets: 1,
+            values: 0,
+            signatures: 1,
+            calldatas: 1,
+        }
+    );
+}
+
+#[test]
+fn test_proposal_extended_updates_deadline_and_previous_deadline_when_known() {
+    let batch = project_proposal_events(
+        &context(),
+        vec![
+            ProposalProjectionEvent {
+                log: log(10, 0, 1),
+                event: proposal_created("42", "# Title\nBody"),
+            },
+            ProposalProjectionEvent {
+                log: log(11, 0, 1),
+                event: DecodedGovernorEvent::ProposalExtended(ProposalExtendedEvent {
+                    proposal_id: "42".to_owned(),
+                    extended_deadline: "55".to_owned(),
+                }),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(batch.proposals[0].proposal_deadline.as_deref(), Some("55"));
+    assert_eq!(
+        batch.proposal_deadline_extensions[0]
+            .previous_deadline
+            .as_deref(),
+        Some("40")
+    );
+}
+
+#[test]
+fn test_proposal_extended_id_includes_stable_log_identity() {
+    let batch = project_proposal_events(
+        &context(),
+        vec![
+            ProposalProjectionEvent {
+                log: log(11, 0, 1),
+                event: DecodedGovernorEvent::ProposalExtended(ProposalExtendedEvent {
+                    proposal_id: "42".to_owned(),
+                    extended_deadline: "55".to_owned(),
+                }),
+            },
+            ProposalProjectionEvent {
+                log: log(12, 0, 1),
+                event: DecodedGovernorEvent::ProposalExtended(ProposalExtendedEvent {
+                    proposal_id: "42".to_owned(),
+                    extended_deadline: "60".to_owned(),
+                }),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(batch.proposal_deadline_extensions.len(), 2);
+    assert_ne!(
+        batch.proposal_deadline_extensions[0].id,
+        batch.proposal_deadline_extensions[1].id
+    );
+}
+
+#[test]
+fn test_apply_chain_read_execution_report_updates_proposal_reads() {
+    let mut batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: log(10, 0, 1),
+            event: proposal_created("42", "# Title\nBody"),
+        }],
+    )
+    .expect("projection succeeds");
+    let report = ChainReadExecutionReport {
+        results: vec![
+            read_result(
+                ChainReadMethod::ProposalSnapshot,
+                "42",
+                ChainReadValue::Integer("21".to_owned()),
+            ),
+            read_result(
+                ChainReadMethod::ProposalDeadline,
+                "42",
+                ChainReadValue::Integer("41".to_owned()),
+            ),
+            read_result(
+                ChainReadMethod::State,
+                "42",
+                ChainReadValue::Integer("1".to_owned()),
+            ),
+        ],
+        ..ChainReadExecutionReport::default()
+    };
+
+    batch.apply_chain_read_execution_report(&report);
+
+    assert_eq!(batch.proposals[0].proposal_snapshot.as_deref(), Some("21"));
+    assert_eq!(batch.proposals[0].proposal_deadline.as_deref(), Some("41"));
+    assert_eq!(batch.proposals[0].current_state.as_deref(), Some("Active"));
+}
+
+#[test]
+fn test_description_heading_single_newline_and_no_heading() {
+    let heading = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: log(10, 0, 1),
+            event: proposal_created("42", "# Title\nBody"),
+        }],
+    )
+    .expect("projection succeeds");
+    let plain = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: log(11, 0, 1),
+            event: proposal_created("43", "Plain title\nPlain body"),
+        }],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(heading.proposals[0].title, "Title");
+    assert_eq!(heading.proposals[0].description_body, "Body");
+    assert_eq!(plain.proposals[0].title, "Plain title");
+    assert_eq!(plain.proposals[0].description_body, "Plain body");
 }
 
 fn context() -> ProposalProjectionContext {
@@ -289,5 +518,37 @@ fn log(block_number: u64, transaction_index: u64, log_index: u64) -> NormalizedE
         data: "0x".to_owned(),
         removed: false,
         raw_payload: json!({ "blockNumber": block_number }),
+    }
+}
+
+fn proposal_created(proposal_id: &str, description: &str) -> DecodedGovernorEvent {
+    DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+        proposal_id: proposal_id.to_owned(),
+        proposer: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+        targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+        values: vec!["0".to_owned()],
+        signatures: vec!["".to_owned()],
+        calldatas: vec!["0x".to_owned()],
+        vote_start: "20".to_owned(),
+        vote_end: "40".to_owned(),
+        description: description.to_owned(),
+    })
+}
+
+fn read_result(
+    method: ChainReadMethod,
+    proposal_id: &str,
+    value: ChainReadValue,
+) -> ChainReadResult {
+    ChainReadResult {
+        read_index: 0,
+        key: ChainReadKey {
+            chain_id: 1,
+            contract_address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+            method,
+            args: vec![proposal_id.to_owned()],
+            block_mode: BlockReadMode::Fresh,
+        },
+        value,
     }
 }

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -1,0 +1,293 @@
+use degov_datalens_indexer::{
+    BatchReadPlanConfig, ChainContracts, ChainReadMethod, DecodedGovernorEvent, NormalizedEvmLog,
+    ProposalCreatedEvent, ProposalExtendedEvent, ProposalIdEvent, ProposalProjectionContext,
+    ProposalProjectionEvent, ProposalProjectionRepository, ProposalQueuedEvent,
+    ProposalStateWriteKind, ReadRequirement, project_proposal_events,
+};
+use serde_json::json;
+
+#[test]
+fn test_project_proposal_created_builds_aggregate_actions_and_chain_reads() {
+    let batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: log(10, 2, 7),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "42".to_owned(),
+                proposer: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+                targets: vec![
+                    "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                    "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD".to_owned(),
+                ],
+                values: vec!["100".to_owned(), "0".to_owned()],
+                signatures: vec!["setFoo(uint256)".to_owned(), "".to_owned()],
+                calldatas: vec!["0x1234".to_owned(), "0xabcd".to_owned()],
+                vote_start: "20".to_owned(),
+                vote_end: "40".to_owned(),
+                description: "# Proposal title\n\nProposal body".to_owned(),
+            }),
+        }],
+    );
+
+    assert_eq!(batch.proposal_created.len(), 1);
+    assert_eq!(batch.proposals.len(), 1);
+    assert_eq!(batch.proposal_actions.len(), 2);
+    assert_eq!(batch.proposal_state_epochs.len(), 1);
+
+    let proposal = &batch.proposals[0];
+    assert_eq!(
+        proposal.id,
+        "proposal:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:42"
+    );
+    assert_eq!(proposal.proposal_id, "42");
+    assert_eq!(
+        proposal.proposer,
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    );
+    assert_eq!(proposal.title, "Proposal title");
+    assert_eq!(proposal.description_body, "Proposal body");
+    assert_eq!(
+        proposal.description_hash,
+        "0x3bec3dfa58e028fdf10e56bebf69d18a3170b2897a2381164179670dd2fa0193"
+    );
+    assert_eq!(proposal.current_state.as_deref(), Some("Pending"));
+    assert_eq!(proposal.block_timestamp, Some("1700000000".to_owned()));
+
+    assert_eq!(batch.proposal_actions[0].action_index, 0);
+    assert_eq!(
+        batch.proposal_actions[0].target,
+        "0xcccccccccccccccccccccccccccccccccccccccc"
+    );
+    assert_eq!(batch.proposal_actions[1].action_index, 1);
+    assert_eq!(batch.proposal_state_epochs[0].state, "Pending");
+
+    let methods = batch
+        .chain_read_plan
+        .reads
+        .iter()
+        .map(|read| {
+            assert_eq!(read.requirement, ReadRequirement::Required);
+            assert_eq!(read.metadata.proposal_ids, ["42".to_owned()].into());
+            assert_eq!(read.activity_blocks, vec![10]);
+            read.key.method
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        methods,
+        vec![
+            ChainReadMethod::ProposalSnapshot,
+            ChainReadMethod::ProposalDeadline,
+            ChainReadMethod::State,
+        ]
+    );
+}
+
+#[test]
+fn test_project_proposal_lifecycle_events_builds_metadata_and_state_epochs() {
+    let batch = project_proposal_events(
+        &context(),
+        vec![
+            ProposalProjectionEvent {
+                log: log(13, 0, 1),
+                event: DecodedGovernorEvent::ProposalQueued(ProposalQueuedEvent {
+                    proposal_id: "42".to_owned(),
+                    eta_seconds: "1700000400".to_owned(),
+                }),
+            },
+            ProposalProjectionEvent {
+                log: log(14, 0, 1),
+                event: DecodedGovernorEvent::ProposalExtended(ProposalExtendedEvent {
+                    proposal_id: "42".to_owned(),
+                    extended_deadline: "55".to_owned(),
+                }),
+            },
+            ProposalProjectionEvent {
+                log: log(15, 0, 1),
+                event: DecodedGovernorEvent::ProposalExecuted(ProposalIdEvent {
+                    proposal_id: "42".to_owned(),
+                }),
+            },
+            ProposalProjectionEvent {
+                log: log(16, 0, 1),
+                event: DecodedGovernorEvent::ProposalCanceled(ProposalIdEvent {
+                    proposal_id: "43".to_owned(),
+                }),
+            },
+        ],
+    );
+
+    assert_eq!(batch.proposal_queued.len(), 1);
+    assert_eq!(batch.proposal_extended.len(), 1);
+    assert_eq!(batch.proposal_executed.len(), 1);
+    assert_eq!(batch.proposal_canceled.len(), 1);
+    assert_eq!(batch.proposal_deadline_extensions.len(), 1);
+
+    let states = batch
+        .proposal_state_epochs
+        .iter()
+        .map(|state| (state.proposal_id.as_str(), state.kind, state.state.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        states,
+        vec![
+            ("42", ProposalStateWriteKind::Queued, "Queued"),
+            ("42", ProposalStateWriteKind::Executed, "Executed"),
+            ("43", ProposalStateWriteKind::Canceled, "Canceled"),
+        ]
+    );
+
+    let queued = &batch.proposal_queued[0];
+    assert_eq!(queued.proposal_id, "42");
+    assert_eq!(queued.eta_seconds, "1700000400");
+
+    let extension = &batch.proposal_deadline_extensions[0];
+    assert_eq!(extension.proposal_id, "42");
+    assert_eq!(extension.new_deadline, "55");
+
+    assert_eq!(batch.chain_read_plan.metrics.requested_reads, 12);
+    assert_eq!(batch.chain_read_plan.reads.len(), 6);
+}
+
+#[test]
+fn test_project_proposal_events_replays_idempotently_and_sorts_by_log_position() {
+    let mut events = vec![
+        ProposalProjectionEvent {
+            log: log(12, 0, 1),
+            event: DecodedGovernorEvent::ProposalQueued(ProposalQueuedEvent {
+                proposal_id: "42".to_owned(),
+                eta_seconds: "1700000400".to_owned(),
+            }),
+        },
+        ProposalProjectionEvent {
+            log: log(11, 0, 1),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "42".to_owned(),
+                proposer: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+                targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "20".to_owned(),
+                vote_end: "40".to_owned(),
+                description: "Plain title".to_owned(),
+            }),
+        },
+    ];
+    events.push(events[0].clone());
+    events.push(events[1].clone());
+
+    let batch = project_proposal_events(&context(), events);
+    let mut repository = degov_datalens_indexer::InMemoryProposalProjectionRepository::default();
+
+    repository
+        .apply(&batch)
+        .expect("first projection write succeeds");
+    repository
+        .apply(&batch)
+        .expect("replay projection write succeeds");
+
+    assert_eq!(batch.proposal_created.len(), 1);
+    assert_eq!(batch.proposal_queued.len(), 1);
+    assert_eq!(
+        batch.event_order,
+        vec![
+            "evm:1:11:0xtx11:0:1".to_owned(),
+            "evm:1:12:0xtx12:0:1".to_owned()
+        ]
+    );
+    assert_eq!(repository.proposals().len(), 1);
+    assert_eq!(
+        repository
+            .proposals()
+            .get("proposal:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:42")
+            .expect("proposal")
+            .current_state
+            .as_deref(),
+        Some("Queued")
+    );
+}
+
+#[test]
+fn test_repository_preserves_lifecycle_metadata_when_identity_arrives_later() {
+    let lifecycle_batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: log(12, 0, 1),
+            event: DecodedGovernorEvent::ProposalQueued(ProposalQueuedEvent {
+                proposal_id: "42".to_owned(),
+                eta_seconds: "1700000400".to_owned(),
+            }),
+        }],
+    );
+    let identity_batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: log(11, 0, 1),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "42".to_owned(),
+                proposer: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+                targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "20".to_owned(),
+                vote_end: "40".to_owned(),
+                description: "Plain title".to_owned(),
+            }),
+        }],
+    );
+    let mut repository = degov_datalens_indexer::InMemoryProposalProjectionRepository::default();
+
+    repository
+        .apply(&lifecycle_batch)
+        .expect("lifecycle write succeeds");
+    repository
+        .apply(&identity_batch)
+        .expect("identity write succeeds");
+
+    let proposal = repository
+        .proposals()
+        .get("proposal:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:42")
+        .expect("proposal");
+
+    assert_eq!(
+        proposal.proposer,
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    );
+    assert_eq!(proposal.current_state.as_deref(), Some("Queued"));
+    assert_eq!(proposal.proposal_eta.as_deref(), Some("1700000400"));
+}
+
+fn context() -> ProposalProjectionContext {
+    ProposalProjectionContext {
+        dao_code: "unit-dao".to_owned(),
+        governor_address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned(),
+        contracts: ChainContracts {
+            governor: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned(),
+            governor_token: "0x1111111111111111111111111111111111111111".to_owned(),
+            timelock: "0x2222222222222222222222222222222222222222".to_owned(),
+        },
+        read_plan_config: BatchReadPlanConfig {
+            max_concurrency: 4,
+            multicall_batch_size: 10,
+        },
+    }
+}
+
+fn log(block_number: u64, transaction_index: u64, log_index: u64) -> NormalizedEvmLog {
+    NormalizedEvmLog {
+        id: format!("evm:1:{block_number}:0xtx{block_number}:{transaction_index}:{log_index}"),
+        chain_id: 1,
+        block_number,
+        block_hash: format!("0xblock{block_number}"),
+        block_timestamp_ms: Some(1_700_000_000_000 + block_number),
+        transaction_hash: format!("0xtx{block_number}"),
+        transaction_index,
+        log_index,
+        address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+        topics: vec![],
+        data: "0x".to_owned(),
+        removed: false,
+        raw_payload: json!({ "blockNumber": block_number }),
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Datalens-native proposal projection model for decoded Governor lifecycle events.
- Produces deterministic write models for proposal creation, lifecycle events, aggregate proposals, proposal actions, state epochs, and deadline extensions.
- Adds an in-memory repository boundary to validate idempotent replay behavior before Postgres write integration.
- Schedules proposal lifecycle ChainTool reads through the shared read-plan path.

## Verification
- 
running 4 tests
test test_project_proposal_created_builds_aggregate_actions_and_chain_reads ... ok
test test_project_proposal_lifecycle_events_builds_metadata_and_state_epochs ... ok
test test_project_proposal_events_replays_idempotently_and_sorts_by_log_position ... ok
test test_repository_preserves_lifecycle_metadata_when_identity_arrives_later ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
- 
- 
- Rust convention check passed
- Postgres schema ownership check passed

## Notes
- This implements the concrete projection/repository boundary slice; Postgres persistence can build on the exported write models.