### PR TITLE
HBX-254: Implement Datalens timelock projection pipeline

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -8,6 +8,7 @@ pub mod evm_log;
 pub mod planner;
 pub mod power_reconcile;
 pub mod proposal_projection;
+pub mod timelock_projection;
 pub mod vote_projection;
 
 pub use chain_tool::{
@@ -54,6 +55,13 @@ pub use proposal_projection::{
     ProposalProjectionEvent, ProposalProjectionRepository, ProposalQueuedWrite,
     ProposalRepositoryWriteError, ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite,
     project_proposal_events,
+};
+pub use timelock_projection::{
+    InMemoryTimelockProjectionRepository, TIMELOCK_POSTGRES_ADAPTER_GAP, TimelockCallWrite,
+    TimelockEventCommon, TimelockMinDelayChangeWrite, TimelockOperationHintWrite,
+    TimelockOperationWrite, TimelockProjectionBatch, TimelockProjectionContext,
+    TimelockProjectionError, TimelockProjectionEvent, TimelockProjectionRepository,
+    TimelockRepositoryWriteError, TimelockRoleEventWrite, project_timelock_events,
 };
 pub use vote_projection::{
     ContributorVoteSignalWrite, DataMetricVoteDelta, InMemoryVoteProjectionRepository,

--- a/apps/indexer/src/timelock_projection.rs
+++ b/apps/indexer/src/timelock_projection.rs
@@ -255,14 +255,44 @@ impl TimelockProjectionRepository for InMemoryTimelockProjectionRepository {
     type Error = TimelockRepositoryWriteError;
 
     fn apply(&mut self, batch: &TimelockProjectionBatch) -> Result<(), Self::Error> {
-        extend_map(
-            &mut self.timelock_operations,
-            &batch.timelock_operations,
-            |row| row.id.clone(),
-        );
-        extend_map(&mut self.timelock_calls, &batch.timelock_calls, |row| {
-            row.id.clone()
-        });
+        for operation in &batch.timelock_operations {
+            self.timelock_operations
+                .entry(operation.id.clone())
+                .and_modify(|stored| stored.merge(operation))
+                .or_insert_with(|| operation.clone());
+        }
+        for call in &batch.timelock_calls {
+            self.timelock_calls
+                .entry(call.id.clone())
+                .and_modify(|stored| stored.merge(call))
+                .or_insert_with(|| call.clone());
+        }
+        for operation in self.timelock_operations.values_mut() {
+            let call_count = self
+                .timelock_calls
+                .values()
+                .filter(|call| {
+                    call.operation_ref == operation.id && call.scheduled_block_number.is_some()
+                })
+                .count();
+            let executed_call_count = self
+                .timelock_calls
+                .values()
+                .filter(|call| {
+                    call.operation_ref == operation.id && call.executed_block_number.is_some()
+                })
+                .count();
+            operation.call_count = if call_count > 0 {
+                Some(call_count)
+            } else {
+                None
+            };
+            operation.executed_call_count = if executed_call_count > 0 {
+                Some(executed_call_count)
+            } else {
+                None
+            };
+        }
         extend_map(
             &mut self.timelock_role_events,
             &batch.timelock_role_events,
@@ -851,7 +881,7 @@ fn operation_ref(common: &TimelockEventCommon, operation_id: &str) -> String {
 }
 
 fn call_ref(operation_ref: &str, index: &str) -> String {
-    format!("{operation_ref}:call:{}", parse_usize(index))
+    format!("{operation_ref}:call:{index}")
 }
 
 fn normalize_identifier(value: &str) -> String {
@@ -863,7 +893,38 @@ fn parse_usize(value: &str) -> usize {
 }
 
 fn add_decimal_strings(left: &str, right: &str) -> Option<String> {
-    Some((left.parse::<u128>().ok()? + right.parse::<u128>().ok()?).to_string())
+    if left.is_empty()
+        || right.is_empty()
+        || !left.bytes().all(|byte| byte.is_ascii_digit())
+        || !right.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let mut carry = 0;
+    let mut digits = Vec::with_capacity(left.len().max(right.len()) + 1);
+    let mut left = left.bytes().rev();
+    let mut right = right.bytes().rev();
+
+    loop {
+        let left_digit = left.next().map(|byte| byte - b'0');
+        let right_digit = right.next().map(|byte| byte - b'0');
+        if left_digit.is_none() && right_digit.is_none() && carry == 0 {
+            break;
+        }
+
+        let sum = left_digit.unwrap_or_default() + right_digit.unwrap_or_default() + carry;
+        digits.push(char::from(b'0' + (sum % 10)));
+        carry = sum / 10;
+    }
+
+    let value = digits.into_iter().rev().collect::<String>();
+    let value = value.trim_start_matches('0');
+    Some(if value.is_empty() {
+        "0".to_owned()
+    } else {
+        value.to_owned()
+    })
 }
 
 fn merge_sum(left: Option<usize>, right: Option<usize>) -> Option<usize> {
@@ -931,13 +992,13 @@ fn role_label(role: &str) -> Option<&'static str> {
         "0x0000000000000000000000000000000000000000000000000000000000000000" => {
             Some("DEFAULT_ADMIN_ROLE")
         }
-        "0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1dca736082b6819cc1c" => {
+        "0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc1" => {
             Some("PROPOSER_ROLE")
         }
         "0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469e63" => {
             Some("EXECUTOR_ROLE")
         }
-        "0x5f58e31ab30a808bd595a1846dfacf36fb5398db601a2c1f9395392a042330a0" => {
+        "0x5f58e3a2316349923ce3780f8d587db2d72378aed66a8261c916544fa6846ca5" => {
             Some("TIMELOCK_ADMIN_ROLE")
         }
         _ => None,

--- a/apps/indexer/src/timelock_projection.rs
+++ b/apps/indexer/src/timelock_projection.rs
@@ -1,0 +1,951 @@
+use std::collections::BTreeMap;
+
+use crate::{
+    BatchReadPlanConfig, CallExecutedEvent, CallScheduledEvent, ChainContracts,
+    ChainReadExecutionReport, ChainReadMethod, ChainReadPlan, ChainReadPlanBuilder,
+    ChainReadReason, ChainReadValue, DecodedTimelockEvent, NormalizedEvmLog, ParameterChangeEvent,
+    RoleAccountEvent, RoleAdminChangedEvent,
+};
+
+pub const TIMELOCK_POSTGRES_ADAPTER_GAP: &str = "Timelock projection write models and repository boundary are implemented; the concrete Postgres adapter is intentionally deferred.";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockProjectionContext {
+    pub dao_code: String,
+    pub governor_address: String,
+    pub timelock_address: String,
+    pub contracts: ChainContracts,
+    pub read_plan_config: BatchReadPlanConfig,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TimelockProjectionEvent {
+    pub log: NormalizedEvmLog,
+    pub event: DecodedTimelockEvent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockProjectionBatch {
+    pub event_order: Vec<String>,
+    pub timelock_operations: Vec<TimelockOperationWrite>,
+    pub timelock_calls: Vec<TimelockCallWrite>,
+    pub timelock_role_events: Vec<TimelockRoleEventWrite>,
+    pub timelock_min_delay_changes: Vec<TimelockMinDelayChangeWrite>,
+    pub timelock_operation_hints: Vec<TimelockOperationHintWrite>,
+    pub chain_read_plan: ChainReadPlan,
+}
+
+impl TimelockProjectionBatch {
+    pub fn apply_chain_read_execution_report(&mut self, report: &ChainReadExecutionReport) {
+        let operation_indexes = self
+            .timelock_operations
+            .iter()
+            .enumerate()
+            .map(|(index, operation)| {
+                (
+                    (
+                        operation.chain_id,
+                        normalize_identifier(&operation.timelock_address),
+                        normalize_identifier(&operation.operation_id),
+                    ),
+                    index,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let mut results = report.results.iter().collect::<Vec<_>>();
+        results.sort_by_key(|result| {
+            (
+                result.key.chain_id,
+                result.key.contract_address.clone(),
+                result.key.method,
+                result.key.args.clone(),
+                result.read_index,
+            )
+        });
+
+        for result in results {
+            let Some(operation_id) = result.key.args.first() else {
+                continue;
+            };
+            let key = (
+                result.key.chain_id,
+                normalize_identifier(&result.key.contract_address),
+                normalize_identifier(operation_id),
+            );
+            let Some(index) = operation_indexes.get(&key).copied() else {
+                continue;
+            };
+            if result.key.method == ChainReadMethod::TimelockOperationState
+                && let Some(state) = chain_read_operation_state(&result.value)
+            {
+                self.timelock_operations[index].state = state;
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TimelockProjectionError {
+    MixedChainIds {
+        expected: i32,
+        actual: i32,
+        log_id: String,
+    },
+    ConflictingDuplicateLog {
+        log_id: String,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockEventCommon {
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub timelock_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub block_number: String,
+    pub block_timestamp: Option<String>,
+    pub transaction_hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockOperationWrite {
+    pub id: String,
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub timelock_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub proposal_ref: Option<String>,
+    pub proposal_id: Option<String>,
+    pub operation_id: String,
+    pub timelock_type: String,
+    pub predecessor: Option<String>,
+    pub salt: Option<String>,
+    pub state: String,
+    pub call_count: Option<usize>,
+    pub executed_call_count: Option<usize>,
+    pub delay_seconds: Option<String>,
+    pub ready_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub queued_block_number: Option<String>,
+    pub queued_block_timestamp: Option<String>,
+    pub queued_transaction_hash: Option<String>,
+    pub cancelled_block_number: Option<String>,
+    pub cancelled_block_timestamp: Option<String>,
+    pub cancelled_transaction_hash: Option<String>,
+    pub executed_block_number: Option<String>,
+    pub executed_block_timestamp: Option<String>,
+    pub executed_transaction_hash: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockCallWrite {
+    pub id: String,
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub timelock_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub operation_id: String,
+    pub operation_ref: String,
+    pub proposal_ref: Option<String>,
+    pub proposal_id: Option<String>,
+    pub proposal_action_id: Option<String>,
+    pub proposal_action_index: Option<usize>,
+    pub action_index: usize,
+    pub target: String,
+    pub value: String,
+    pub data: String,
+    pub predecessor: Option<String>,
+    pub delay_seconds: Option<String>,
+    pub state: String,
+    pub scheduled_block_number: Option<String>,
+    pub scheduled_block_timestamp: Option<String>,
+    pub scheduled_transaction_hash: Option<String>,
+    pub executed_block_number: Option<String>,
+    pub executed_block_timestamp: Option<String>,
+    pub executed_transaction_hash: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockRoleEventWrite {
+    pub id: String,
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub timelock_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub event_name: String,
+    pub role: String,
+    pub role_label: Option<String>,
+    pub account: Option<String>,
+    pub sender: Option<String>,
+    pub previous_admin_role: Option<String>,
+    pub previous_admin_role_label: Option<String>,
+    pub new_admin_role: Option<String>,
+    pub new_admin_role_label: Option<String>,
+    pub block_number: String,
+    pub block_timestamp: Option<String>,
+    pub transaction_hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockMinDelayChangeWrite {
+    pub id: String,
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub timelock_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub old_duration: String,
+    pub new_duration: String,
+    pub block_number: String,
+    pub block_timestamp: Option<String>,
+    pub transaction_hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockOperationHintWrite {
+    pub id: String,
+    pub common: TimelockEventCommon,
+    pub operation_id: String,
+    pub event_name: String,
+}
+
+pub trait TimelockProjectionRepository {
+    type Error;
+
+    fn apply(&mut self, batch: &TimelockProjectionBatch) -> Result<(), Self::Error>;
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct InMemoryTimelockProjectionRepository {
+    timelock_operations: BTreeMap<String, TimelockOperationWrite>,
+    timelock_calls: BTreeMap<String, TimelockCallWrite>,
+    timelock_role_events: BTreeMap<String, TimelockRoleEventWrite>,
+    timelock_min_delay_changes: BTreeMap<String, TimelockMinDelayChangeWrite>,
+    timelock_operation_hints: BTreeMap<String, TimelockOperationHintWrite>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TimelockRepositoryWriteError {}
+
+impl InMemoryTimelockProjectionRepository {
+    pub fn timelock_operations(&self) -> &BTreeMap<String, TimelockOperationWrite> {
+        &self.timelock_operations
+    }
+
+    pub fn timelock_calls(&self) -> &BTreeMap<String, TimelockCallWrite> {
+        &self.timelock_calls
+    }
+}
+
+impl TimelockProjectionRepository for InMemoryTimelockProjectionRepository {
+    type Error = TimelockRepositoryWriteError;
+
+    fn apply(&mut self, batch: &TimelockProjectionBatch) -> Result<(), Self::Error> {
+        extend_map(
+            &mut self.timelock_operations,
+            &batch.timelock_operations,
+            |row| row.id.clone(),
+        );
+        extend_map(&mut self.timelock_calls, &batch.timelock_calls, |row| {
+            row.id.clone()
+        });
+        extend_map(
+            &mut self.timelock_role_events,
+            &batch.timelock_role_events,
+            |row| row.id.clone(),
+        );
+        extend_map(
+            &mut self.timelock_min_delay_changes,
+            &batch.timelock_min_delay_changes,
+            |row| row.id.clone(),
+        );
+        extend_map(
+            &mut self.timelock_operation_hints,
+            &batch.timelock_operation_hints,
+            |row| row.id.clone(),
+        );
+
+        Ok(())
+    }
+}
+
+pub fn project_timelock_events(
+    context: &TimelockProjectionContext,
+    events: Vec<TimelockProjectionEvent>,
+) -> Result<TimelockProjectionBatch, TimelockProjectionError> {
+    let governor_address = normalize_identifier(&context.governor_address);
+    let timelock_address = normalize_identifier(&context.timelock_address);
+    let chain_id = validate_chain_ids(&events)?;
+    let mut builder = ChainReadPlanBuilder::new(
+        chain_id,
+        context.contracts.clone(),
+        context.read_plan_config,
+    );
+    let mut deduped: BTreeMap<String, TimelockProjectionEvent> = BTreeMap::new();
+
+    for event in events {
+        if let Some(stored) = deduped.get(&event.log.id) {
+            if stored != &event {
+                return Err(TimelockProjectionError::ConflictingDuplicateLog {
+                    log_id: event.log.id,
+                });
+            }
+            continue;
+        }
+        deduped.insert(event.log.id.clone(), event);
+    }
+
+    let mut event_order = Vec::new();
+    let mut operations = BTreeMap::new();
+    let mut calls = BTreeMap::new();
+    let mut role_events = BTreeMap::new();
+    let mut min_delay_changes = BTreeMap::new();
+    let mut operation_hints = BTreeMap::new();
+
+    let mut ordered = deduped.into_values().collect::<Vec<_>>();
+    ordered.sort_by_key(|event| {
+        (
+            event.log.block_number,
+            event.log.transaction_index,
+            event.log.log_index,
+            event.log.id.clone(),
+        )
+    });
+
+    for input in ordered {
+        event_order.push(input.log.id.clone());
+        let common = common(context, &governor_address, &timelock_address, &input.log);
+        if let Some(operation_id) = operation_id(&input.event) {
+            builder.add_timelock_operation_refresh(
+                operation_id,
+                input.log.block_number,
+                ChainReadReason::TimelockLifecycleRefresh,
+            );
+            operation_hints.insert(
+                format!("{}:hint:{}", input.log.id, input.event.event_name()),
+                operation_hint_write(&input.log.id, common.clone(), operation_id, &input.event),
+            );
+        }
+
+        match &input.event {
+            DecodedTimelockEvent::CallScheduled(event) => {
+                let operation_id = normalize_identifier(&event.id);
+                let operation_ref = operation_ref(&common, &operation_id);
+                let call = scheduled_call_write(&common, &operation_ref, event);
+                calls
+                    .entry(call.id.clone())
+                    .and_modify(|stored: &mut TimelockCallWrite| stored.merge(&call))
+                    .or_insert(call);
+                let operation = scheduled_operation_write(&common, event);
+                operations
+                    .entry(operation.id.clone())
+                    .and_modify(|stored: &mut TimelockOperationWrite| stored.merge(&operation))
+                    .or_insert(operation);
+            }
+            DecodedTimelockEvent::CallExecuted(event) => {
+                let operation_id = normalize_identifier(&event.id);
+                let operation_ref = operation_ref(&common, &operation_id);
+                let call = executed_call_write(&common, &operation_ref, event);
+                calls
+                    .entry(call.id.clone())
+                    .and_modify(|stored: &mut TimelockCallWrite| stored.merge(&call))
+                    .or_insert(call);
+                let operation = terminal_operation_write(&common, &operation_id, "Executed");
+                operations
+                    .entry(operation.id.clone())
+                    .and_modify(|stored: &mut TimelockOperationWrite| stored.merge(&operation))
+                    .or_insert(operation);
+            }
+            DecodedTimelockEvent::CallSalt(event) => {
+                let operation_id = normalize_identifier(&event.id);
+                let operation = salt_operation_write(&common, &operation_id, &event.salt);
+                operations
+                    .entry(operation.id.clone())
+                    .and_modify(|stored: &mut TimelockOperationWrite| stored.merge(&operation))
+                    .or_insert(operation);
+            }
+            DecodedTimelockEvent::Cancelled(event) => {
+                let operation_id = normalize_identifier(&event.id);
+                let operation = terminal_operation_write(&common, &operation_id, "Cancelled");
+                operations
+                    .entry(operation.id.clone())
+                    .and_modify(|stored: &mut TimelockOperationWrite| stored.merge(&operation))
+                    .or_insert(operation);
+            }
+            DecodedTimelockEvent::RoleGranted(event) => {
+                let row = role_account_write(&input.log.id, &common, "RoleGranted", event);
+                role_events.insert(row.id.clone(), row);
+            }
+            DecodedTimelockEvent::RoleRevoked(event) => {
+                let row = role_account_write(&input.log.id, &common, "RoleRevoked", event);
+                role_events.insert(row.id.clone(), row);
+            }
+            DecodedTimelockEvent::RoleAdminChanged(event) => {
+                let row = role_admin_changed_write(&input.log.id, &common, event);
+                role_events.insert(row.id.clone(), row);
+            }
+            DecodedTimelockEvent::MinDelayChange(event) => {
+                let row = min_delay_change_write(&input.log.id, &common, event);
+                min_delay_changes.insert(row.id.clone(), row);
+            }
+        }
+    }
+
+    Ok(TimelockProjectionBatch {
+        event_order,
+        timelock_operations: operations.into_values().collect(),
+        timelock_calls: calls.into_values().collect(),
+        timelock_role_events: role_events.into_values().collect(),
+        timelock_min_delay_changes: min_delay_changes.into_values().collect(),
+        timelock_operation_hints: operation_hints.into_values().collect(),
+        chain_read_plan: builder.build(),
+    })
+}
+
+fn common(
+    context: &TimelockProjectionContext,
+    governor_address: &str,
+    timelock_address: &str,
+    log: &NormalizedEvmLog,
+) -> TimelockEventCommon {
+    TimelockEventCommon {
+        chain_id: log.chain_id,
+        dao_code: context.dao_code.clone(),
+        governor_address: governor_address.to_owned(),
+        timelock_address: timelock_address.to_owned(),
+        contract_address: normalize_identifier(&log.address),
+        log_index: log.log_index,
+        transaction_index: log.transaction_index,
+        block_number: log.block_number.to_string(),
+        block_timestamp: log
+            .block_timestamp_ms
+            .map(|timestamp| (timestamp / 1_000).to_string()),
+        transaction_hash: normalize_identifier(&log.transaction_hash),
+    }
+}
+
+fn scheduled_operation_write(
+    common: &TimelockEventCommon,
+    event: &CallScheduledEvent,
+) -> TimelockOperationWrite {
+    let operation_id = normalize_identifier(&event.id);
+    let ready_at = common
+        .block_timestamp
+        .as_deref()
+        .and_then(|timestamp| add_decimal_strings(timestamp, &event.delay));
+
+    TimelockOperationWrite {
+        id: operation_ref(common, &operation_id),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        timelock_address: common.timelock_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        proposal_ref: None,
+        proposal_id: None,
+        operation_id,
+        timelock_type: "TimelockController".to_owned(),
+        predecessor: Some(normalize_identifier(&event.predecessor)),
+        salt: None,
+        state: "Queued".to_owned(),
+        call_count: Some(1),
+        executed_call_count: None,
+        delay_seconds: Some(event.delay.clone()),
+        ready_at,
+        expires_at: None,
+        queued_block_number: Some(common.block_number.clone()),
+        queued_block_timestamp: common.block_timestamp.clone(),
+        queued_transaction_hash: Some(common.transaction_hash.clone()),
+        cancelled_block_number: None,
+        cancelled_block_timestamp: None,
+        cancelled_transaction_hash: None,
+        executed_block_number: None,
+        executed_block_timestamp: None,
+        executed_transaction_hash: None,
+    }
+}
+
+fn salt_operation_write(
+    common: &TimelockEventCommon,
+    operation_id: &str,
+    salt: &str,
+) -> TimelockOperationWrite {
+    let mut operation = operation_stub(common, operation_id, "Queued");
+    operation.salt = Some(normalize_identifier(salt));
+    operation
+}
+
+fn terminal_operation_write(
+    common: &TimelockEventCommon,
+    operation_id: &str,
+    state: &str,
+) -> TimelockOperationWrite {
+    let mut operation = operation_stub(common, operation_id, state);
+    match state {
+        "Executed" => {
+            operation.executed_call_count = Some(1);
+            operation.executed_block_number = Some(common.block_number.clone());
+            operation.executed_block_timestamp = common.block_timestamp.clone();
+            operation.executed_transaction_hash = Some(common.transaction_hash.clone());
+        }
+        "Cancelled" => {
+            operation.cancelled_block_number = Some(common.block_number.clone());
+            operation.cancelled_block_timestamp = common.block_timestamp.clone();
+            operation.cancelled_transaction_hash = Some(common.transaction_hash.clone());
+        }
+        _ => {}
+    }
+    operation
+}
+
+fn operation_stub(
+    common: &TimelockEventCommon,
+    operation_id: &str,
+    state: &str,
+) -> TimelockOperationWrite {
+    TimelockOperationWrite {
+        id: operation_ref(common, operation_id),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        timelock_address: common.timelock_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        proposal_ref: None,
+        proposal_id: None,
+        operation_id: normalize_identifier(operation_id),
+        timelock_type: "TimelockController".to_owned(),
+        predecessor: None,
+        salt: None,
+        state: state.to_owned(),
+        call_count: None,
+        executed_call_count: None,
+        delay_seconds: None,
+        ready_at: None,
+        expires_at: None,
+        queued_block_number: None,
+        queued_block_timestamp: None,
+        queued_transaction_hash: None,
+        cancelled_block_number: None,
+        cancelled_block_timestamp: None,
+        cancelled_transaction_hash: None,
+        executed_block_number: None,
+        executed_block_timestamp: None,
+        executed_transaction_hash: None,
+    }
+}
+
+fn scheduled_call_write(
+    common: &TimelockEventCommon,
+    operation_ref: &str,
+    event: &CallScheduledEvent,
+) -> TimelockCallWrite {
+    TimelockCallWrite {
+        id: call_ref(operation_ref, &event.index),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        timelock_address: common.timelock_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        operation_id: normalize_identifier(&event.id),
+        operation_ref: operation_ref.to_owned(),
+        proposal_ref: None,
+        proposal_id: None,
+        proposal_action_id: None,
+        proposal_action_index: None,
+        action_index: parse_usize(&event.index),
+        target: normalize_identifier(&event.target),
+        value: event.value.clone(),
+        data: event.data.clone(),
+        predecessor: Some(normalize_identifier(&event.predecessor)),
+        delay_seconds: Some(event.delay.clone()),
+        state: "Scheduled".to_owned(),
+        scheduled_block_number: Some(common.block_number.clone()),
+        scheduled_block_timestamp: common.block_timestamp.clone(),
+        scheduled_transaction_hash: Some(common.transaction_hash.clone()),
+        executed_block_number: None,
+        executed_block_timestamp: None,
+        executed_transaction_hash: None,
+    }
+}
+
+fn executed_call_write(
+    common: &TimelockEventCommon,
+    operation_ref: &str,
+    event: &CallExecutedEvent,
+) -> TimelockCallWrite {
+    TimelockCallWrite {
+        id: call_ref(operation_ref, &event.index),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        timelock_address: common.timelock_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        operation_id: normalize_identifier(&event.id),
+        operation_ref: operation_ref.to_owned(),
+        proposal_ref: None,
+        proposal_id: None,
+        proposal_action_id: None,
+        proposal_action_index: None,
+        action_index: parse_usize(&event.index),
+        target: normalize_identifier(&event.target),
+        value: event.value.clone(),
+        data: event.data.clone(),
+        predecessor: None,
+        delay_seconds: None,
+        state: "Executed".to_owned(),
+        scheduled_block_number: None,
+        scheduled_block_timestamp: None,
+        scheduled_transaction_hash: None,
+        executed_block_number: Some(common.block_number.clone()),
+        executed_block_timestamp: common.block_timestamp.clone(),
+        executed_transaction_hash: Some(common.transaction_hash.clone()),
+    }
+}
+
+fn role_account_write(
+    log_id: &str,
+    common: &TimelockEventCommon,
+    event_name: &str,
+    event: &RoleAccountEvent,
+) -> TimelockRoleEventWrite {
+    let role = normalize_identifier(&event.role);
+    TimelockRoleEventWrite {
+        id: log_id.to_owned(),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        timelock_address: common.timelock_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        event_name: event_name.to_owned(),
+        role: role.clone(),
+        role_label: role_label(&role).map(str::to_owned),
+        account: Some(normalize_identifier(&event.account)),
+        sender: Some(normalize_identifier(&event.sender)),
+        previous_admin_role: None,
+        previous_admin_role_label: None,
+        new_admin_role: None,
+        new_admin_role_label: None,
+        block_number: common.block_number.clone(),
+        block_timestamp: common.block_timestamp.clone(),
+        transaction_hash: common.transaction_hash.clone(),
+    }
+}
+
+fn role_admin_changed_write(
+    log_id: &str,
+    common: &TimelockEventCommon,
+    event: &RoleAdminChangedEvent,
+) -> TimelockRoleEventWrite {
+    let role = normalize_identifier(&event.role);
+    let previous_admin_role = normalize_identifier(&event.previous_admin_role);
+    let new_admin_role = normalize_identifier(&event.new_admin_role);
+
+    TimelockRoleEventWrite {
+        id: log_id.to_owned(),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        timelock_address: common.timelock_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        event_name: "RoleAdminChanged".to_owned(),
+        role: role.clone(),
+        role_label: role_label(&role).map(str::to_owned),
+        account: None,
+        sender: None,
+        previous_admin_role: Some(previous_admin_role.clone()),
+        previous_admin_role_label: role_label(&previous_admin_role).map(str::to_owned),
+        new_admin_role: Some(new_admin_role.clone()),
+        new_admin_role_label: role_label(&new_admin_role).map(str::to_owned),
+        block_number: common.block_number.clone(),
+        block_timestamp: common.block_timestamp.clone(),
+        transaction_hash: common.transaction_hash.clone(),
+    }
+}
+
+fn min_delay_change_write(
+    log_id: &str,
+    common: &TimelockEventCommon,
+    event: &ParameterChangeEvent,
+) -> TimelockMinDelayChangeWrite {
+    TimelockMinDelayChangeWrite {
+        id: log_id.to_owned(),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        timelock_address: common.timelock_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        old_duration: event.old_value.clone(),
+        new_duration: event.new_value.clone(),
+        block_number: common.block_number.clone(),
+        block_timestamp: common.block_timestamp.clone(),
+        transaction_hash: common.transaction_hash.clone(),
+    }
+}
+
+fn operation_hint_write(
+    log_id: &str,
+    common: TimelockEventCommon,
+    operation_id: &str,
+    event: &DecodedTimelockEvent,
+) -> TimelockOperationHintWrite {
+    TimelockOperationHintWrite {
+        id: format!("{log_id}:operation-hint"),
+        common,
+        operation_id: normalize_identifier(operation_id),
+        event_name: event.event_name().to_owned(),
+    }
+}
+
+impl TimelockOperationWrite {
+    fn merge(&mut self, next: &Self) {
+        self.contract_address = next.contract_address.clone();
+        self.log_index = next.log_index;
+        self.transaction_index = next.transaction_index;
+        self.predecessor = next.predecessor.clone().or(self.predecessor.clone());
+        self.salt = next.salt.clone().or(self.salt.clone());
+        self.state = merge_operation_state(&self.state, &next.state);
+        self.call_count = merge_sum(self.call_count, next.call_count);
+        self.executed_call_count = merge_sum(self.executed_call_count, next.executed_call_count);
+        self.delay_seconds = next.delay_seconds.clone().or(self.delay_seconds.clone());
+        self.ready_at = next.ready_at.clone().or(self.ready_at.clone());
+        self.expires_at = next.expires_at.clone().or(self.expires_at.clone());
+        self.queued_block_number = next
+            .queued_block_number
+            .clone()
+            .or(self.queued_block_number.clone());
+        self.queued_block_timestamp = next
+            .queued_block_timestamp
+            .clone()
+            .or(self.queued_block_timestamp.clone());
+        self.queued_transaction_hash = next
+            .queued_transaction_hash
+            .clone()
+            .or(self.queued_transaction_hash.clone());
+        self.cancelled_block_number = next
+            .cancelled_block_number
+            .clone()
+            .or(self.cancelled_block_number.clone());
+        self.cancelled_block_timestamp = next
+            .cancelled_block_timestamp
+            .clone()
+            .or(self.cancelled_block_timestamp.clone());
+        self.cancelled_transaction_hash = next
+            .cancelled_transaction_hash
+            .clone()
+            .or(self.cancelled_transaction_hash.clone());
+        self.executed_block_number = next
+            .executed_block_number
+            .clone()
+            .or(self.executed_block_number.clone());
+        self.executed_block_timestamp = next
+            .executed_block_timestamp
+            .clone()
+            .or(self.executed_block_timestamp.clone());
+        self.executed_transaction_hash = next
+            .executed_transaction_hash
+            .clone()
+            .or(self.executed_transaction_hash.clone());
+    }
+}
+
+impl TimelockCallWrite {
+    fn merge(&mut self, next: &Self) {
+        self.contract_address = next.contract_address.clone();
+        self.log_index = next.log_index;
+        self.transaction_index = next.transaction_index;
+        self.target = next.target.clone();
+        self.value = next.value.clone();
+        self.data = next.data.clone();
+        self.predecessor = next.predecessor.clone().or(self.predecessor.clone());
+        self.delay_seconds = next.delay_seconds.clone().or(self.delay_seconds.clone());
+        self.state = merge_call_state(&self.state, &next.state);
+        self.scheduled_block_number = next
+            .scheduled_block_number
+            .clone()
+            .or(self.scheduled_block_number.clone());
+        self.scheduled_block_timestamp = next
+            .scheduled_block_timestamp
+            .clone()
+            .or(self.scheduled_block_timestamp.clone());
+        self.scheduled_transaction_hash = next
+            .scheduled_transaction_hash
+            .clone()
+            .or(self.scheduled_transaction_hash.clone());
+        self.executed_block_number = next
+            .executed_block_number
+            .clone()
+            .or(self.executed_block_number.clone());
+        self.executed_block_timestamp = next
+            .executed_block_timestamp
+            .clone()
+            .or(self.executed_block_timestamp.clone());
+        self.executed_transaction_hash = next
+            .executed_transaction_hash
+            .clone()
+            .or(self.executed_transaction_hash.clone());
+    }
+}
+
+fn validate_chain_ids(events: &[TimelockProjectionEvent]) -> Result<i32, TimelockProjectionError> {
+    let Some(first) = events.first() else {
+        return Ok(0);
+    };
+    for event in events.iter().skip(1) {
+        if event.log.chain_id != first.log.chain_id {
+            return Err(TimelockProjectionError::MixedChainIds {
+                expected: first.log.chain_id,
+                actual: event.log.chain_id,
+                log_id: event.log.id.clone(),
+            });
+        }
+    }
+    Ok(first.log.chain_id)
+}
+
+fn operation_id(event: &DecodedTimelockEvent) -> Option<&str> {
+    match event {
+        DecodedTimelockEvent::CallScheduled(event) => Some(&event.id),
+        DecodedTimelockEvent::CallExecuted(event) => Some(&event.id),
+        DecodedTimelockEvent::CallSalt(event) => Some(&event.id),
+        DecodedTimelockEvent::Cancelled(event) => Some(&event.id),
+        _ => None,
+    }
+}
+
+fn operation_ref(common: &TimelockEventCommon, operation_id: &str) -> String {
+    format!(
+        "timelock-operation:{}:{}:{}:{}",
+        common.chain_id,
+        common.governor_address,
+        common.timelock_address,
+        normalize_identifier(operation_id)
+    )
+}
+
+fn call_ref(operation_ref: &str, index: &str) -> String {
+    format!("{operation_ref}:call:{}", parse_usize(index))
+}
+
+fn normalize_identifier(value: &str) -> String {
+    value.to_ascii_lowercase()
+}
+
+fn parse_usize(value: &str) -> usize {
+    value.parse::<usize>().unwrap_or_default()
+}
+
+fn add_decimal_strings(left: &str, right: &str) -> Option<String> {
+    Some((left.parse::<u128>().ok()? + right.parse::<u128>().ok()?).to_string())
+}
+
+fn merge_sum(left: Option<usize>, right: Option<usize>) -> Option<usize> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left + right),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn merge_operation_state(left: &str, right: &str) -> String {
+    if operation_state_rank(right) >= operation_state_rank(left) {
+        right.to_owned()
+    } else {
+        left.to_owned()
+    }
+}
+
+fn operation_state_rank(state: &str) -> u8 {
+    match state {
+        "Unset" => 0,
+        "Waiting" | "Queued" => 1,
+        "Ready" => 2,
+        "Done" | "Executed" => 3,
+        "Cancelled" => 4,
+        _ => 0,
+    }
+}
+
+fn merge_call_state(left: &str, right: &str) -> String {
+    if call_state_rank(right) >= call_state_rank(left) {
+        right.to_owned()
+    } else {
+        left.to_owned()
+    }
+}
+
+fn call_state_rank(state: &str) -> u8 {
+    match state {
+        "Scheduled" => 1,
+        "Executed" => 2,
+        _ => 0,
+    }
+}
+
+fn chain_read_operation_state(value: &ChainReadValue) -> Option<String> {
+    match value {
+        ChainReadValue::Integer(value) => Some(
+            match value.as_str() {
+                "0" => "Unset",
+                "1" => "Waiting",
+                "2" => "Ready",
+                "3" => "Done",
+                state => state,
+            }
+            .to_owned(),
+        ),
+        ChainReadValue::String(value) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn role_label(role: &str) -> Option<&'static str> {
+    match role {
+        "0x0000000000000000000000000000000000000000000000000000000000000000" => {
+            Some("DEFAULT_ADMIN_ROLE")
+        }
+        "0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1dca736082b6819cc1c" => {
+            Some("PROPOSER_ROLE")
+        }
+        "0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469e63" => {
+            Some("EXECUTOR_ROLE")
+        }
+        "0x5f58e31ab30a808bd595a1846dfacf36fb5398db601a2c1f9395392a042330a0" => {
+            Some("TIMELOCK_ADMIN_ROLE")
+        }
+        _ => None,
+    }
+}
+
+fn extend_map<T: Clone>(map: &mut BTreeMap<String, T>, rows: &[T], key: impl Fn(&T) -> String) {
+    for row in rows {
+        map.insert(key(row), row.clone());
+    }
+}

--- a/apps/indexer/tests/timelock_projection.rs
+++ b/apps/indexer/tests/timelock_projection.rs
@@ -7,6 +7,7 @@ use degov_datalens_indexer::{
     project_timelock_events,
 };
 use serde_json::json;
+use sha3::{Digest, Keccak256};
 
 #[test]
 fn test_project_timelock_scheduled_executed_and_cancelled_operations() {
@@ -189,6 +190,199 @@ fn test_project_timelock_role_and_min_delay_events() {
     assert_eq!(delay.old_duration, "3600");
     assert_eq!(delay.new_duration, "7200");
     assert_eq!(delay.block_number, "22");
+}
+
+#[test]
+fn test_project_timelock_role_labels_use_openzeppelin_hashes() {
+    let proposer_role = role_hash("PROPOSER_ROLE");
+    let executor_role = role_hash("EXECUTOR_ROLE");
+    let admin_role = role_hash("TIMELOCK_ADMIN_ROLE");
+    let batch = project_timelock_events(
+        &context(),
+        vec![
+            TimelockProjectionEvent {
+                log: log(20, 0, 0),
+                event: DecodedTimelockEvent::RoleGranted(RoleAccountEvent {
+                    role: proposer_role.clone(),
+                    account: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+                    sender: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD".to_owned(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: log(21, 0, 0),
+                event: DecodedTimelockEvent::RoleAdminChanged(RoleAdminChangedEvent {
+                    role: proposer_role.clone(),
+                    previous_admin_role: admin_role.clone(),
+                    new_admin_role: executor_role.clone(),
+                }),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    let granted = &batch.timelock_role_events[0];
+    assert_eq!(granted.role, proposer_role);
+    assert_eq!(granted.role_label.as_deref(), Some("PROPOSER_ROLE"));
+
+    let admin_changed = &batch.timelock_role_events[1];
+    assert_eq!(
+        admin_changed.previous_admin_role.as_deref(),
+        Some(admin_role.as_str())
+    );
+    assert_eq!(
+        admin_changed.previous_admin_role_label.as_deref(),
+        Some("TIMELOCK_ADMIN_ROLE")
+    );
+    assert_eq!(
+        admin_changed.new_admin_role.as_deref(),
+        Some(executor_role.as_str())
+    );
+    assert_eq!(
+        admin_changed.new_admin_role_label.as_deref(),
+        Some("EXECUTOR_ROLE")
+    );
+}
+
+#[test]
+fn test_project_timelock_call_ids_preserve_decimal_index_strings() {
+    let large_index = "18446744073709551616".to_owned();
+    let leading_zero_index = "00018446744073709551616".to_owned();
+    let batch = project_timelock_events(
+        &context(),
+        vec![
+            TimelockProjectionEvent {
+                log: log(10, 0, 0),
+                event: DecodedTimelockEvent::CallScheduled(CallScheduledEvent {
+                    id: operation_id(),
+                    index: large_index.clone(),
+                    target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                    value: "0".to_owned(),
+                    data: "0x".to_owned(),
+                    predecessor: predecessor_id(),
+                    delay: "60".to_owned(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: log(10, 0, 1),
+                event: DecodedTimelockEvent::CallScheduled(CallScheduledEvent {
+                    id: operation_id(),
+                    index: leading_zero_index.clone(),
+                    target: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD".to_owned(),
+                    value: "0".to_owned(),
+                    data: "0x".to_owned(),
+                    predecessor: predecessor_id(),
+                    delay: "60".to_owned(),
+                }),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(batch.timelock_calls.len(), 2);
+    assert!(
+        batch
+            .timelock_calls
+            .iter()
+            .any(|call| call.id.ends_with(&format!(":call:{large_index}")))
+    );
+    assert!(
+        batch
+            .timelock_calls
+            .iter()
+            .any(|call| call.id.ends_with(&format!(":call:{leading_zero_index}")))
+    );
+}
+
+#[test]
+fn test_project_timelock_ready_at_adds_uint256_sized_decimal_strings() {
+    let delay = "115792089237316195423570985008687907853269984665640564039457584007913129639000";
+    let batch = project_timelock_events(
+        &context(),
+        vec![TimelockProjectionEvent {
+            log: log(10, 0, 0),
+            event: DecodedTimelockEvent::CallScheduled(CallScheduledEvent {
+                id: operation_id(),
+                index: "0".to_owned(),
+                target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                value: "0".to_owned(),
+                data: "0x".to_owned(),
+                predecessor: predecessor_id(),
+                delay: delay.to_owned(),
+            }),
+        }],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(
+        batch.timelock_operations[0].ready_at.as_deref(),
+        Some("115792089237316195423570985008687907853269984665640564039457584007914829639000")
+    );
+}
+
+#[test]
+fn test_project_timelock_repository_merges_incremental_operation_and_call_state() {
+    let mut repository = degov_datalens_indexer::InMemoryTimelockProjectionRepository::default();
+    let scheduled_batch = project_timelock_events(
+        &context(),
+        vec![TimelockProjectionEvent {
+            log: log(10, 0, 0),
+            event: DecodedTimelockEvent::CallScheduled(CallScheduledEvent {
+                id: operation_id(),
+                index: "0".to_owned(),
+                target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                value: "0".to_owned(),
+                data: "0x".to_owned(),
+                predecessor: predecessor_id(),
+                delay: "60".to_owned(),
+            }),
+        }],
+    )
+    .expect("scheduled projection succeeds");
+    let executed_batch = project_timelock_events(
+        &context(),
+        vec![TimelockProjectionEvent {
+            log: log(11, 0, 0),
+            event: DecodedTimelockEvent::CallExecuted(CallExecutedEvent {
+                id: operation_id(),
+                index: "0".to_owned(),
+                target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                value: "0".to_owned(),
+                data: "0x".to_owned(),
+            }),
+        }],
+    )
+    .expect("executed projection succeeds");
+
+    repository
+        .apply(&scheduled_batch)
+        .expect("scheduled write succeeds");
+    repository
+        .apply(&executed_batch)
+        .expect("executed write succeeds");
+    repository
+        .apply(&executed_batch)
+        .expect("executed replay succeeds");
+
+    let operation = repository
+        .timelock_operations()
+        .values()
+        .next()
+        .expect("operation");
+    assert_eq!(operation.state, "Executed");
+    assert_eq!(operation.call_count, Some(1));
+    assert_eq!(operation.executed_call_count, Some(1));
+    assert_eq!(
+        operation.predecessor.as_deref(),
+        Some(predecessor_id().as_str())
+    );
+    assert_eq!(operation.ready_at.as_deref(), Some("1700000060"));
+    assert_eq!(operation.queued_block_number.as_deref(), Some("10"));
+    assert_eq!(operation.executed_block_number.as_deref(), Some("11"));
+
+    let call = repository.timelock_calls().values().next().expect("call");
+    assert_eq!(call.state, "Executed");
+    assert_eq!(call.scheduled_block_number.as_deref(), Some("10"));
+    assert_eq!(call.executed_block_number.as_deref(), Some("11"));
 }
 
 #[test]
@@ -397,7 +591,7 @@ fn salt_id() -> String {
 }
 
 fn proposer_role() -> String {
-    "0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1dca736082b6819cc1c".to_owned()
+    "0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc1".to_owned()
 }
 
 fn executor_role() -> String {
@@ -405,5 +599,9 @@ fn executor_role() -> String {
 }
 
 fn admin_role() -> String {
-    "0x5f58e31ab30a808bd595a1846dfacf36fb5398db601a2c1f9395392a042330a0".to_owned()
+    "0x5f58e3a2316349923ce3780f8d587db2d72378aed66a8261c916544fa6846ca5".to_owned()
+}
+
+fn role_hash(role: &str) -> String {
+    format!("0x{}", hex::encode(Keccak256::digest(role.as_bytes())))
 }

--- a/apps/indexer/tests/timelock_projection.rs
+++ b/apps/indexer/tests/timelock_projection.rs
@@ -1,0 +1,409 @@
+use degov_datalens_indexer::{
+    BatchReadPlanConfig, CallExecutedEvent, CallSaltEvent, CallScheduledEvent, ChainContracts,
+    ChainReadExecutionReport, ChainReadKey, ChainReadMethod, ChainReadResult, ChainReadValue,
+    DecodedTimelockEvent, NormalizedEvmLog, ParameterChangeEvent, ReadRequirement,
+    RoleAccountEvent, RoleAdminChangedEvent, TimelockOperationIdEvent, TimelockProjectionContext,
+    TimelockProjectionError, TimelockProjectionEvent, TimelockProjectionRepository,
+    project_timelock_events,
+};
+use serde_json::json;
+
+#[test]
+fn test_project_timelock_scheduled_executed_and_cancelled_operations() {
+    let batch = project_timelock_events(
+        &context(),
+        vec![
+            TimelockProjectionEvent {
+                log: log(10, 0, 2),
+                event: DecodedTimelockEvent::CallScheduled(CallScheduledEvent {
+                    id: operation_id(),
+                    index: "0".to_owned(),
+                    target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                    value: "100".to_owned(),
+                    data: "0x1234".to_owned(),
+                    predecessor: predecessor_id(),
+                    delay: "3600".to_owned(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: log(10, 0, 1),
+                event: DecodedTimelockEvent::CallSalt(CallSaltEvent {
+                    id: operation_id(),
+                    salt: salt_id(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: log(11, 1, 0),
+                event: DecodedTimelockEvent::CallExecuted(CallExecutedEvent {
+                    id: operation_id(),
+                    index: "0".to_owned(),
+                    target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                    value: "100".to_owned(),
+                    data: "0x1234".to_owned(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: log(12, 0, 0),
+                event: DecodedTimelockEvent::Cancelled(TimelockOperationIdEvent {
+                    id: operation_id(),
+                }),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(
+        batch.event_order,
+        vec![
+            "evm:1:10:0xtx10:0:1".to_owned(),
+            "evm:1:10:0xtx10:0:2".to_owned(),
+            "evm:1:11:0xtx11:1:0".to_owned(),
+            "evm:1:12:0xtx12:0:0".to_owned(),
+        ]
+    );
+    assert_eq!(batch.timelock_operations.len(), 1);
+    assert_eq!(batch.timelock_calls.len(), 1);
+    assert_eq!(batch.timelock_operation_hints.len(), 4);
+
+    let operation = &batch.timelock_operations[0];
+    assert_eq!(
+        operation.id,
+        format!(
+            "timelock-operation:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:0x2222222222222222222222222222222222222222:{}",
+            operation_id()
+        )
+    );
+    assert_eq!(operation.operation_id, operation_id());
+    assert_eq!(operation.timelock_type, "TimelockController");
+    assert_eq!(
+        operation.predecessor.as_deref(),
+        Some(predecessor_id().as_str())
+    );
+    assert_eq!(operation.salt.as_deref(), Some(salt_id().as_str()));
+    assert_eq!(operation.state, "Cancelled");
+    assert_eq!(operation.call_count, Some(1));
+    assert_eq!(operation.executed_call_count, Some(1));
+    assert_eq!(operation.delay_seconds.as_deref(), Some("3600"));
+    assert_eq!(operation.ready_at.as_deref(), Some("1700003600"));
+    assert_eq!(operation.queued_block_number.as_deref(), Some("10"));
+    assert_eq!(operation.executed_block_number.as_deref(), Some("11"));
+    assert_eq!(operation.cancelled_block_number.as_deref(), Some("12"));
+
+    let call = &batch.timelock_calls[0];
+    assert_eq!(call.id, format!("{}:call:0", operation.id));
+    assert_eq!(call.operation_ref, operation.id);
+    assert_eq!(call.action_index, 0);
+    assert_eq!(call.target, "0xcccccccccccccccccccccccccccccccccccccccc");
+    assert_eq!(call.value, "100");
+    assert_eq!(call.data, "0x1234");
+    assert_eq!(call.state, "Executed");
+    assert_eq!(call.scheduled_block_number.as_deref(), Some("10"));
+    assert_eq!(call.executed_block_number.as_deref(), Some("11"));
+
+    assert_eq!(batch.chain_read_plan.metrics.requested_reads, 4);
+    assert_eq!(batch.chain_read_plan.metrics.deduped_reads, 3);
+    assert_eq!(batch.chain_read_plan.reads.len(), 1);
+    assert_eq!(
+        batch.chain_read_plan.reads[0].requirement,
+        ReadRequirement::Required
+    );
+    assert_eq!(
+        batch.chain_read_plan.reads[0].key.method,
+        ChainReadMethod::TimelockOperationState
+    );
+    assert_eq!(
+        batch.chain_read_plan.reads[0].key.args,
+        vec![operation_id()]
+    );
+    assert_eq!(
+        batch.chain_read_plan.reads[0].metadata.operation_ids,
+        [operation_id()].into()
+    );
+    assert_eq!(
+        batch.chain_read_plan.reads[0].activity_blocks,
+        vec![10, 11, 12]
+    );
+}
+
+#[test]
+fn test_project_timelock_role_and_min_delay_events() {
+    let batch = project_timelock_events(
+        &context(),
+        vec![
+            TimelockProjectionEvent {
+                log: log(20, 0, 0),
+                event: DecodedTimelockEvent::RoleGranted(RoleAccountEvent {
+                    role: proposer_role(),
+                    account: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+                    sender: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD".to_owned(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: log(21, 0, 0),
+                event: DecodedTimelockEvent::RoleAdminChanged(RoleAdminChangedEvent {
+                    role: proposer_role(),
+                    previous_admin_role: admin_role(),
+                    new_admin_role: executor_role(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: log(22, 0, 0),
+                event: DecodedTimelockEvent::MinDelayChange(ParameterChangeEvent {
+                    old_value: "3600".to_owned(),
+                    new_value: "7200".to_owned(),
+                }),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(batch.timelock_role_events.len(), 2);
+    assert_eq!(batch.timelock_min_delay_changes.len(), 1);
+    assert!(batch.chain_read_plan.reads.is_empty());
+
+    let granted = &batch.timelock_role_events[0];
+    assert_eq!(granted.event_name, "RoleGranted");
+    assert_eq!(granted.role, proposer_role());
+    assert_eq!(granted.role_label.as_deref(), Some("PROPOSER_ROLE"));
+    assert_eq!(
+        granted.account.as_deref(),
+        Some("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    );
+    assert_eq!(
+        granted.sender.as_deref(),
+        Some("0xdddddddddddddddddddddddddddddddddddddddd")
+    );
+
+    let admin_changed = &batch.timelock_role_events[1];
+    assert_eq!(admin_changed.event_name, "RoleAdminChanged");
+    assert_eq!(
+        admin_changed.previous_admin_role_label.as_deref(),
+        Some("TIMELOCK_ADMIN_ROLE")
+    );
+    assert_eq!(
+        admin_changed.new_admin_role_label.as_deref(),
+        Some("EXECUTOR_ROLE")
+    );
+
+    let delay = &batch.timelock_min_delay_changes[0];
+    assert_eq!(delay.old_duration, "3600");
+    assert_eq!(delay.new_duration, "7200");
+    assert_eq!(delay.block_number, "22");
+}
+
+#[test]
+fn test_project_timelock_events_replays_idempotently() {
+    let mut events = vec![
+        TimelockProjectionEvent {
+            log: log(10, 0, 0),
+            event: DecodedTimelockEvent::CallScheduled(CallScheduledEvent {
+                id: operation_id(),
+                index: "0".to_owned(),
+                target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                value: "0".to_owned(),
+                data: "0x".to_owned(),
+                predecessor: predecessor_id(),
+                delay: "60".to_owned(),
+            }),
+        },
+        TimelockProjectionEvent {
+            log: log(11, 0, 0),
+            event: DecodedTimelockEvent::CallExecuted(CallExecutedEvent {
+                id: operation_id(),
+                index: "0".to_owned(),
+                target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                value: "0".to_owned(),
+                data: "0x".to_owned(),
+            }),
+        },
+    ];
+    events.push(events[0].clone());
+    events.push(events[1].clone());
+
+    let batch = project_timelock_events(&context(), events).expect("projection succeeds");
+    let mut repository = degov_datalens_indexer::InMemoryTimelockProjectionRepository::default();
+
+    repository
+        .apply(&batch)
+        .expect("first projection write succeeds");
+    repository
+        .apply(&batch)
+        .expect("replay projection write succeeds");
+
+    assert_eq!(batch.timelock_operations.len(), 1);
+    assert_eq!(batch.timelock_calls.len(), 1);
+    assert_eq!(repository.timelock_operations().len(), 1);
+    assert_eq!(repository.timelock_calls().len(), 1);
+    assert_eq!(
+        repository
+            .timelock_operations()
+            .values()
+            .next()
+            .expect("operation")
+            .state,
+        "Executed"
+    );
+}
+
+#[test]
+fn test_project_timelock_events_rejects_mixed_chain_input() {
+    let mut second = log(11, 0, 0);
+    second.chain_id = 2;
+
+    let err = project_timelock_events(
+        &context(),
+        vec![
+            TimelockProjectionEvent {
+                log: log(10, 0, 0),
+                event: DecodedTimelockEvent::Cancelled(TimelockOperationIdEvent {
+                    id: operation_id(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: second,
+                event: DecodedTimelockEvent::Cancelled(TimelockOperationIdEvent {
+                    id: operation_id(),
+                }),
+            },
+        ],
+    )
+    .expect_err("mixed chain input is rejected");
+
+    assert_eq!(
+        err,
+        TimelockProjectionError::MixedChainIds {
+            expected: 1,
+            actual: 2,
+            log_id: "evm:1:11:0xtx11:0:0".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_project_timelock_events_rejects_duplicate_log_id_with_conflicting_metadata() {
+    let mut duplicate = log(10, 0, 0);
+    duplicate.transaction_hash = "0xdifferent".to_owned();
+
+    let err = project_timelock_events(
+        &context(),
+        vec![
+            TimelockProjectionEvent {
+                log: log(10, 0, 0),
+                event: DecodedTimelockEvent::Cancelled(TimelockOperationIdEvent {
+                    id: operation_id(),
+                }),
+            },
+            TimelockProjectionEvent {
+                log: duplicate,
+                event: DecodedTimelockEvent::Cancelled(TimelockOperationIdEvent {
+                    id: operation_id(),
+                }),
+            },
+        ],
+    )
+    .expect_err("conflicting duplicate log metadata is rejected");
+
+    assert_eq!(
+        err,
+        TimelockProjectionError::ConflictingDuplicateLog {
+            log_id: "evm:1:10:0xtx10:0:0".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_apply_chain_read_execution_report_updates_operation_state() {
+    let mut batch = project_timelock_events(
+        &context(),
+        vec![TimelockProjectionEvent {
+            log: log(10, 0, 0),
+            event: DecodedTimelockEvent::CallScheduled(CallScheduledEvent {
+                id: operation_id(),
+                index: "0".to_owned(),
+                target: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned(),
+                value: "0".to_owned(),
+                data: "0x".to_owned(),
+                predecessor: predecessor_id(),
+                delay: "60".to_owned(),
+            }),
+        }],
+    )
+    .expect("projection succeeds");
+    let report = ChainReadExecutionReport {
+        results: vec![ChainReadResult {
+            read_index: 0,
+            key: ChainReadKey {
+                chain_id: 1,
+                contract_address: "0x2222222222222222222222222222222222222222".to_owned(),
+                method: ChainReadMethod::TimelockOperationState,
+                args: vec![operation_id()],
+                block_mode: degov_datalens_indexer::BlockReadMode::Fresh,
+            },
+            value: ChainReadValue::Integer("2".to_owned()),
+        }],
+        ..ChainReadExecutionReport::default()
+    };
+
+    batch.apply_chain_read_execution_report(&report);
+
+    assert_eq!(batch.timelock_operations[0].state, "Ready");
+}
+
+fn context() -> TimelockProjectionContext {
+    TimelockProjectionContext {
+        dao_code: "unit-dao".to_owned(),
+        governor_address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned(),
+        timelock_address: "0x2222222222222222222222222222222222222222".to_owned(),
+        contracts: ChainContracts {
+            governor: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned(),
+            governor_token: "0x1111111111111111111111111111111111111111".to_owned(),
+            timelock: "0x2222222222222222222222222222222222222222".to_owned(),
+        },
+        read_plan_config: BatchReadPlanConfig {
+            max_concurrency: 4,
+            multicall_batch_size: 10,
+        },
+    }
+}
+
+fn log(block_number: u64, transaction_index: u64, log_index: u64) -> NormalizedEvmLog {
+    NormalizedEvmLog {
+        id: format!("evm:1:{block_number}:0xtx{block_number}:{transaction_index}:{log_index}"),
+        chain_id: 1,
+        block_number,
+        block_hash: format!("0xblock{block_number}"),
+        block_timestamp_ms: Some(1_700_000_000_000 + block_number),
+        transaction_hash: format!("0xtx{block_number}"),
+        transaction_index,
+        log_index,
+        address: "0x2222222222222222222222222222222222222222".to_owned(),
+        topics: vec![],
+        data: "0x".to_owned(),
+        removed: false,
+        raw_payload: json!({ "blockNumber": block_number }),
+    }
+}
+
+fn operation_id() -> String {
+    "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0".to_owned()
+}
+
+fn predecessor_id() -> String {
+    "0x0000000000000000000000000000000000000000000000000000000000000000".to_owned()
+}
+
+fn salt_id() -> String {
+    "0x1111111111111111111111111111111111111111111111111111111111111111".to_owned()
+}
+
+fn proposer_role() -> String {
+    "0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1dca736082b6819cc1c".to_owned()
+}
+
+fn executor_role() -> String {
+    "0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469e63".to_owned()
+}
+
+fn admin_role() -> String {
+    "0x5f58e31ab30a808bd595a1846dfacf36fb5398db601a2c1f9395392a042330a0".to_owned()
+}


### PR DESCRIPTION
## Summary
- Adds a Datalens-native timelock projection module for TimelockController events.
- Produces schema-relevant write models for timelock operations, calls, role events, min-delay changes, and operation lifecycle hints.
- Adds deterministic ordering, duplicate conflict checks, idempotent in-memory repository replay, and ChainTool operation refresh scheduling.

## Verification
- 
running 6 tests
test test_project_timelock_events_rejects_duplicate_log_id_with_conflicting_metadata ... ok
test test_project_timelock_scheduled_executed_and_cancelled_operations ... ok
test test_project_timelock_events_rejects_mixed_chain_input ... ok
test test_project_timelock_role_and_min_delay_events ... ok
test test_project_timelock_events_replays_idempotently ... ok
test test_apply_chain_read_execution_report_updates_operation_state ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
running 18 tests
test checkpoint::tests::test_plan_next_checkpoint_range_limits_to_target_height ... ok
test checkpoint::tests::test_plan_next_checkpoint_range_returns_none_when_checkpoint_caught_up ... ok
test config::tests::test_secret_string_never_formats_secret ... ok
test config::tests::test_from_env_requires_application_and_token_for_startup ... ok
test datalens::tests::test_verify_datalens_service_rejects_mocked_unready_client ... ok
test planner::tests::test_fetch_dao_log_pages_retries_errors_before_returning_page ... ok
test planner::tests::test_fetch_dao_log_pages_treats_empty_rows_as_successful_page ... ok
test planner::tests::test_fetch_dao_log_pages_stops_without_later_pages_when_retries_are_exhausted ... ok
test config::tests::test_endpoint_must_be_service_base_url ... ok
test config::tests::test_from_env_requires_endpoint_for_startup ... ok
test planner::tests::test_plan_dao_log_queries_uses_configured_finality ... ok
test planner::tests::test_plan_dao_log_queries_rejects_zero_chunk_limit ... ok
test planner::tests::test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelock ... ok
test datalens::tests::test_verify_datalens_service_accepts_mocked_ready_client ... ok
test planner::tests::test_plan_dao_log_queries_chunks_ranges_by_config_limit ... ok
test config::tests::test_from_env_rejects_invalid_governor_token_standard ... ok
test config::tests::test_from_env_accepts_case_insensitive_governor_token_standard ... ok
test config::tests::test_from_env_with_required_datalens_fields_builds_sdk_graphql_endpoint ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test test_capability_plan_covers_required_governor_token_and_timelock_reads ... ok
test test_read_execution_report_carries_lossless_read_values ... ok
test test_read_plan_clamps_zero_batch_config_to_valid_minimums ... ok
test test_read_plan_groups_required_reads_into_bounded_multicall_batches ... ok
test test_read_plan_dedupes_same_rpc_read_across_semantic_metadata ... ok
test test_read_plan_keeps_distinct_power_reads_when_block_semantics_differ ... ok
test test_read_plan_dedupes_repeated_account_power_reads_in_large_datalens_batch ... ok
test test_read_plan_dedupes_repeated_account_proposal_and_operation_activity ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s


running 6 tests
test test_decode_marks_unsupported_topic_explicitly ... ok
test test_decode_erc721_transfer_reads_token_id_from_topic ... ok
test test_decode_token_transfer_rejects_bad_standard_topic_count_mismatch ... ok
test test_decode_token_event_family_decodes_delegation_and_erc20_transfer ... ok
test test_decode_timelock_event_family_decodes_every_configured_topic ... ok
test test_decode_governor_event_family_decodes_every_configured_topic ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
test test_normalize_evm_log_rows_converts_timestamps_and_lowercases_addresses ... ok
test test_normalize_evm_log_rows_deduplicates_duplicate_raw_logs_by_stable_event_id ... ok
test test_normalize_evm_log_rows_rejects_timestamp_overflow ... ok
test test_normalize_evm_log_rows_rejects_conflicting_duplicate_ids ... ok
test test_normalize_evm_log_rows_keeps_missing_timestamp_as_none ... ok
test test_normalize_evm_log_rows_sorts_mixed_blocks_and_transactions_deterministically ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test test_plan_power_reconcile_can_emit_current_votes_fallback_reads ... ok
test test_plan_power_reconcile_does_not_write_log_derived_power ... ok
test test_plan_power_reconcile_is_fresh_when_processor_is_past_target_height ... ok
test test_plan_power_reconcile_emits_chaintool_get_votes_reads ... ok
test test_plan_power_reconcile_skips_zero_addresses_from_transfer_and_delegate_changes ... ok
test test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons ... ok
test test_plan_power_reconcile_uses_same_block_log_position_for_latest_status ... ok
test test_plan_power_reconcile_dedupes_large_batch_before_chain_reads ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 13 tests
test test_project_proposal_events_rejects_conflicting_duplicate_log_id ... ok
test test_project_proposal_events_accepts_empty_input ... ok
test test_project_proposal_events_rejects_duplicate_log_id_with_conflicting_metadata ... ok
test test_project_proposal_created_rejects_action_length_mismatch ... ok
test test_project_proposal_events_rejects_mixed_chain_input ... ok
test test_project_proposal_created_builds_aggregate_actions_and_chain_reads ... ok
test test_apply_chain_read_execution_report_updates_proposal_reads ... ok
test test_description_heading_single_newline_and_no_heading ... ok
test test_proposal_extended_updates_deadline_and_previous_deadline_when_known ... ok
test test_project_proposal_events_replays_idempotently_and_sorts_by_log_position ... ok
test test_proposal_extended_id_includes_stable_log_identity ... ok
test test_project_proposal_lifecycle_events_builds_metadata_and_state_epochs ... ok
test test_repository_preserves_lifecycle_metadata_when_identity_arrives_later ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
test test_project_timelock_events_rejects_duplicate_log_id_with_conflicting_metadata ... ok
test test_apply_chain_read_execution_report_updates_operation_state ... ok
test test_project_timelock_events_rejects_mixed_chain_input ... ok
test test_project_timelock_role_and_min_delay_events ... ok
test test_project_timelock_scheduled_executed_and_cancelled_operations ... ok
test test_project_timelock_events_replays_idempotently ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
- 
- 
- Rust convention check passed
- Postgres schema ownership check passed

## Notes
- This is the projection/write-model/repository-boundary slice; the concrete Postgres adapter remains a storage integration follow-up.