### PR TITLE
HBX-253: Implement Datalens token projection pipeline

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -9,6 +9,7 @@ pub mod planner;
 pub mod power_reconcile;
 pub mod proposal_projection;
 pub mod timelock_projection;
+pub mod token_projection;
 pub mod vote_projection;
 
 pub use chain_tool::{
@@ -62,6 +63,13 @@ pub use timelock_projection::{
     TimelockOperationWrite, TimelockProjectionBatch, TimelockProjectionContext,
     TimelockProjectionError, TimelockProjectionEvent, TimelockProjectionRepository,
     TimelockRepositoryWriteError, TimelockRoleEventWrite, project_timelock_events,
+};
+pub use token_projection::{
+    ContributorWrite, DataMetricTokenDelta, DelegateChangedWrite, DelegateMappingWrite,
+    DelegateRollingWrite, DelegateVotesChangedWrite, DelegateWrite,
+    InMemoryTokenProjectionRepository, TokenEventCommon, TokenProjectionBatch,
+    TokenProjectionContext, TokenProjectionError, TokenProjectionEvent, TokenProjectionOperation,
+    TokenProjectionRepository, TokenRepositoryWriteError, TokenTransferWrite, project_token_events,
 };
 pub use vote_projection::{
     ContributorVoteSignalWrite, DataMetricVoteDelta, InMemoryVoteProjectionRepository,

--- a/apps/indexer/src/token_projection.rs
+++ b/apps/indexer/src/token_projection.rs
@@ -334,10 +334,6 @@ impl InMemoryTokenProjectionRepository {
         };
         self.delegate_mappings
             .insert(mapping.id.clone(), mapping.clone());
-
-        if !(from_delegate == zero_address() && delegator == to_delegate) {
-            self.upsert_delegate_snapshot(common, delegator, to_delegate, true, &mapping.power);
-        }
     }
 
     fn apply_delegate_votes_changed(
@@ -367,10 +363,7 @@ impl InMemoryTokenProjectionRepository {
             }
         }
         let (from_delegate, to_delegate) = match side {
-            RollingSide::From if rolling.delegator == rolling.to_delegate => {
-                (rolling.delegator.clone(), rolling.from_delegate.clone())
-            }
-            RollingSide::From => (rolling.from_delegate.clone(), rolling.delegator.clone()),
+            RollingSide::From => (rolling.delegator.clone(), rolling.from_delegate.clone()),
             RollingSide::To => (rolling.delegator.clone(), rolling.to_delegate.clone()),
         };
         self.apply_delegate_delta(common, &from_delegate, &to_delegate, &delta);
@@ -441,6 +434,10 @@ impl InMemoryTokenProjectionRepository {
             return;
         }
         let id = delegate_ref(from_delegate, to_delegate);
+        if is_current && !is_nonzero_decimal(power) {
+            self.delegates.remove(&id);
+            return;
+        }
         let row = DelegateWrite {
             id: id.clone(),
             common: common.clone(),

--- a/apps/indexer/src/token_projection.rs
+++ b/apps/indexer/src/token_projection.rs
@@ -1,0 +1,887 @@
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    BatchReadPlanConfig, ChainContracts, ChainReadMethod, DecodedDaoEvent, DecodedTokenEvent,
+    DelegateChangedEvent, DelegateVotesChangedEvent, GovernanceTokenStandard, NormalizedEvmLog,
+    PowerReconcileContext, PowerReconcileEvent, PowerReconcilePlan, TokenTransferEvent,
+    plan_power_reconcile,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenProjectionContext {
+    pub dao_code: String,
+    pub governor_address: String,
+    pub token_address: String,
+    pub contracts: ChainContracts,
+    pub token_standard: GovernanceTokenStandard,
+    pub from_block: u64,
+    pub to_block: u64,
+    pub target_height: Option<u64>,
+    pub read_plan_config: BatchReadPlanConfig,
+    pub current_power_method: ChainReadMethod,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TokenProjectionEvent {
+    pub log: NormalizedEvmLog,
+    pub event: DecodedTokenEvent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenProjectionBatch {
+    pub event_order: Vec<String>,
+    pub delegate_changed: Vec<DelegateChangedWrite>,
+    pub delegate_votes_changed: Vec<DelegateVotesChangedWrite>,
+    pub token_transfers: Vec<TokenTransferWrite>,
+    pub delegate_rollings: Vec<DelegateRollingWrite>,
+    pub operations: Vec<TokenProjectionOperation>,
+    pub reconcile_plan: PowerReconcilePlan,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TokenProjectionError {
+    MixedChainIds {
+        expected: i32,
+        actual: i32,
+        log_id: String,
+    },
+    ConflictingDuplicateLog {
+        log_id: String,
+    },
+    MismatchedTokenStandard {
+        expected: GovernanceTokenStandard,
+        actual: GovernanceTokenStandard,
+        log_id: String,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenEventCommon {
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+    pub token_address: String,
+    pub contract_address: String,
+    pub log_index: u64,
+    pub transaction_index: u64,
+    pub block_number: String,
+    pub block_timestamp: Option<String>,
+    pub transaction_hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateChangedWrite {
+    pub id: String,
+    pub common: TokenEventCommon,
+    pub delegator: String,
+    pub from_delegate: String,
+    pub to_delegate: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateVotesChangedWrite {
+    pub id: String,
+    pub common: TokenEventCommon,
+    pub delegate: String,
+    pub previous_votes: String,
+    pub new_votes: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenTransferWrite {
+    pub id: String,
+    pub common: TokenEventCommon,
+    pub from: String,
+    pub to: String,
+    pub value: String,
+    pub standard: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateRollingWrite {
+    pub id: String,
+    pub common: TokenEventCommon,
+    pub delegator: String,
+    pub from_delegate: String,
+    pub to_delegate: String,
+    pub from_previous_votes: Option<String>,
+    pub from_new_votes: Option<String>,
+    pub to_previous_votes: Option<String>,
+    pub to_new_votes: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateWrite {
+    pub id: String,
+    pub common: TokenEventCommon,
+    pub from_delegate: String,
+    pub to_delegate: String,
+    pub is_current: bool,
+    pub power: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContributorWrite {
+    pub id: String,
+    pub common: TokenEventCommon,
+    pub last_vote_block_number: Option<String>,
+    pub last_vote_timestamp: Option<String>,
+    pub power: String,
+    pub balance: Option<String>,
+    pub delegates_count_all: i64,
+    pub delegates_count_effective: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateMappingWrite {
+    pub id: String,
+    pub common: TokenEventCommon,
+    pub from: String,
+    pub to: String,
+    pub power: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DataMetricTokenDelta {
+    pub power_sum: String,
+    pub member_count: i64,
+}
+
+impl Default for DataMetricTokenDelta {
+    fn default() -> Self {
+        Self {
+            power_sum: "0".to_owned(),
+            member_count: 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TokenProjectionOperation {
+    DelegateChanged {
+        id: String,
+        common: TokenEventCommon,
+        delegator: String,
+        from_delegate: String,
+        to_delegate: String,
+    },
+    DelegateVotesChanged {
+        id: String,
+        common: TokenEventCommon,
+        delegate: String,
+        previous_votes: String,
+        new_votes: String,
+    },
+    Transfer {
+        id: String,
+        common: TokenEventCommon,
+        from: String,
+        to: String,
+        value: String,
+        standard: GovernanceTokenStandard,
+    },
+}
+
+pub trait TokenProjectionRepository {
+    type Error;
+
+    fn apply(&mut self, batch: &TokenProjectionBatch) -> Result<(), Self::Error>;
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct InMemoryTokenProjectionRepository {
+    delegate_changed: BTreeMap<String, DelegateChangedWrite>,
+    delegate_votes_changed: BTreeMap<String, DelegateVotesChangedWrite>,
+    token_transfers: BTreeMap<String, TokenTransferWrite>,
+    delegate_rollings: BTreeMap<String, DelegateRollingWrite>,
+    delegates: BTreeMap<String, DelegateWrite>,
+    contributors: BTreeMap<String, ContributorWrite>,
+    delegate_mappings: BTreeMap<String, DelegateMappingWrite>,
+    data_metric: DataMetricTokenDelta,
+    applied_operations: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TokenRepositoryWriteError {}
+
+impl InMemoryTokenProjectionRepository {
+    pub fn delegate_changed(&self) -> &BTreeMap<String, DelegateChangedWrite> {
+        &self.delegate_changed
+    }
+
+    pub fn delegates(&self) -> &BTreeMap<String, DelegateWrite> {
+        &self.delegates
+    }
+
+    pub fn contributors(&self) -> &BTreeMap<String, ContributorWrite> {
+        &self.contributors
+    }
+
+    pub fn delegate_mappings(&self) -> &BTreeMap<String, DelegateMappingWrite> {
+        &self.delegate_mappings
+    }
+
+    pub fn data_metric(&self) -> &DataMetricTokenDelta {
+        &self.data_metric
+    }
+}
+
+impl TokenProjectionRepository for InMemoryTokenProjectionRepository {
+    type Error = TokenRepositoryWriteError;
+
+    fn apply(&mut self, batch: &TokenProjectionBatch) -> Result<(), Self::Error> {
+        extend_map(&mut self.delegate_changed, &batch.delegate_changed, |row| {
+            row.id.clone()
+        });
+        extend_map(
+            &mut self.delegate_votes_changed,
+            &batch.delegate_votes_changed,
+            |row| row.id.clone(),
+        );
+        extend_map(&mut self.token_transfers, &batch.token_transfers, |row| {
+            row.id.clone()
+        });
+        extend_map(
+            &mut self.delegate_rollings,
+            &batch.delegate_rollings,
+            |row| row.id.clone(),
+        );
+
+        for operation in &batch.operations {
+            if !self.applied_operations.insert(operation.id().to_owned()) {
+                continue;
+            }
+            self.apply_operation(operation);
+        }
+
+        Ok(())
+    }
+}
+
+impl InMemoryTokenProjectionRepository {
+    fn apply_operation(&mut self, operation: &TokenProjectionOperation) {
+        match operation {
+            TokenProjectionOperation::DelegateChanged {
+                common,
+                delegator,
+                from_delegate,
+                to_delegate,
+                ..
+            } => self.apply_delegate_changed(common, delegator, from_delegate, to_delegate),
+            TokenProjectionOperation::DelegateVotesChanged {
+                common,
+                delegate,
+                previous_votes,
+                new_votes,
+                ..
+            } => self.apply_delegate_votes_changed(common, delegate, previous_votes, new_votes),
+            TokenProjectionOperation::Transfer {
+                common,
+                from,
+                to,
+                value,
+                standard,
+                ..
+            } => self.apply_transfer(common, from, to, transfer_units(value, *standard)),
+        }
+    }
+
+    fn apply_delegate_changed(
+        &mut self,
+        common: &TokenEventCommon,
+        delegator: &str,
+        from_delegate: &str,
+        to_delegate: &str,
+    ) {
+        if !is_zero_address(to_delegate) {
+            self.ensure_contributor(to_delegate, common);
+        }
+        let previous_mapping = self.delegate_mappings.get(delegator).cloned();
+        let is_noop = previous_mapping
+            .as_ref()
+            .is_some_and(|mapping| mapping.to == to_delegate && from_delegate == to_delegate);
+        if is_noop {
+            return;
+        }
+
+        if let Some(previous) = previous_mapping {
+            self.upsert_delegate_snapshot(common, delegator, &previous.to, false, &previous.power);
+            self.apply_delegate_count_delta(
+                common,
+                &previous.to,
+                -1,
+                if is_nonzero_decimal(&previous.power) {
+                    -1
+                } else {
+                    0
+                },
+            );
+            self.delegate_mappings.remove(delegator);
+        }
+
+        if is_zero_address(to_delegate) {
+            return;
+        }
+
+        self.apply_delegate_count_delta(common, to_delegate, 1, 0);
+        let mapping = DelegateMappingWrite {
+            id: delegator.to_owned(),
+            common: common.clone(),
+            from: delegator.to_owned(),
+            to: to_delegate.to_owned(),
+            power: "0".to_owned(),
+        };
+        self.delegate_mappings
+            .insert(mapping.id.clone(), mapping.clone());
+
+        if !(from_delegate == zero_address() && delegator == to_delegate) {
+            self.upsert_delegate_snapshot(common, delegator, to_delegate, true, &mapping.power);
+        }
+    }
+
+    fn apply_delegate_votes_changed(
+        &mut self,
+        common: &TokenEventCommon,
+        delegate: &str,
+        previous_votes: &str,
+        new_votes: &str,
+    ) {
+        let delta = subtract_decimal_signed(new_votes, previous_votes);
+        let Some((rolling_id, side)) =
+            self.find_rolling_match(delegate, &delta, &common.transaction_hash, common.log_index)
+        else {
+            return;
+        };
+        let Some(rolling) = self.delegate_rollings.get_mut(&rolling_id) else {
+            return;
+        };
+        match side {
+            RollingSide::From => {
+                rolling.from_previous_votes = Some(previous_votes.to_owned());
+                rolling.from_new_votes = Some(new_votes.to_owned());
+            }
+            RollingSide::To => {
+                rolling.to_previous_votes = Some(previous_votes.to_owned());
+                rolling.to_new_votes = Some(new_votes.to_owned());
+            }
+        }
+        let (from_delegate, to_delegate) = match side {
+            RollingSide::From if rolling.delegator == rolling.to_delegate => {
+                (rolling.delegator.clone(), rolling.from_delegate.clone())
+            }
+            RollingSide::From => (rolling.from_delegate.clone(), rolling.delegator.clone()),
+            RollingSide::To => (rolling.delegator.clone(), rolling.to_delegate.clone()),
+        };
+        self.apply_delegate_delta(common, &from_delegate, &to_delegate, &delta);
+    }
+
+    fn apply_transfer(&mut self, common: &TokenEventCommon, from: &str, to: &str, value: String) {
+        if let Some(mapping) = self.delegate_mappings.get(from).cloned() {
+            self.apply_delegate_delta(common, &mapping.from, &mapping.to, &format!("-{value}"));
+        }
+        if let Some(mapping) = self.delegate_mappings.get(to).cloned() {
+            self.apply_delegate_delta(common, &mapping.from, &mapping.to, &value);
+        }
+    }
+
+    fn apply_delegate_delta(
+        &mut self,
+        common: &TokenEventCommon,
+        from_delegate: &str,
+        to_delegate: &str,
+        delta: &str,
+    ) {
+        if is_zero_address(to_delegate) {
+            return;
+        }
+
+        let mapping_power = self
+            .delegate_mappings
+            .get(from_delegate)
+            .filter(|mapping| mapping.to == to_delegate)
+            .map(|mapping| mapping.power.clone());
+        let previous_mapping_power = mapping_power.unwrap_or_else(|| "0".to_owned());
+        let next_mapping_power = apply_signed_decimal(&previous_mapping_power, delta);
+        if let Some(mapping) = self.delegate_mappings.get_mut(from_delegate)
+            && mapping.to == to_delegate
+        {
+            mapping.power = next_mapping_power.clone();
+            mapping.common = common.clone();
+        }
+
+        let previous_effective = is_nonzero_decimal(&previous_mapping_power);
+        let next_effective = is_nonzero_decimal(&next_mapping_power);
+        if previous_effective != next_effective {
+            self.apply_delegate_count_delta(
+                common,
+                to_delegate,
+                0,
+                if next_effective { 1 } else { -1 },
+            );
+        }
+        self.upsert_delegate_snapshot(
+            common,
+            from_delegate,
+            to_delegate,
+            true,
+            &next_mapping_power,
+        );
+    }
+
+    fn upsert_delegate_snapshot(
+        &mut self,
+        common: &TokenEventCommon,
+        from_delegate: &str,
+        to_delegate: &str,
+        is_current: bool,
+        power: &str,
+    ) {
+        if is_zero_address(to_delegate) {
+            return;
+        }
+        let id = delegate_ref(from_delegate, to_delegate);
+        let row = DelegateWrite {
+            id: id.clone(),
+            common: common.clone(),
+            from_delegate: from_delegate.to_owned(),
+            to_delegate: to_delegate.to_owned(),
+            is_current,
+            power: power.to_owned(),
+        };
+        self.delegates.insert(id, row);
+    }
+
+    fn apply_delegate_count_delta(
+        &mut self,
+        common: &TokenEventCommon,
+        delegate: &str,
+        all_delta: i64,
+        effective_delta: i64,
+    ) {
+        if is_zero_address(delegate) {
+            return;
+        }
+        let contributor = self.ensure_contributor(delegate, common);
+        contributor.delegates_count_all = (contributor.delegates_count_all + all_delta).max(0);
+        contributor.delegates_count_effective =
+            (contributor.delegates_count_effective + effective_delta).max(0);
+    }
+
+    fn ensure_contributor(
+        &mut self,
+        account: &str,
+        common: &TokenEventCommon,
+    ) -> &mut ContributorWrite {
+        self.contributors
+            .entry(account.to_owned())
+            .or_insert_with(|| {
+                self.data_metric.member_count += 1;
+                ContributorWrite {
+                    id: account.to_owned(),
+                    common: common.clone(),
+                    last_vote_block_number: None,
+                    last_vote_timestamp: None,
+                    power: "0".to_owned(),
+                    balance: None,
+                    delegates_count_all: 0,
+                    delegates_count_effective: 0,
+                }
+            })
+    }
+
+    fn find_rolling_match(
+        &self,
+        delegate: &str,
+        delta: &str,
+        transaction_hash: &str,
+        before_log_index: u64,
+    ) -> Option<(String, RollingSide)> {
+        let mut rollings = self
+            .delegate_rollings
+            .values()
+            .filter(|rolling| rolling.common.transaction_hash == transaction_hash)
+            .filter(|rolling| rolling.common.log_index < before_log_index)
+            .filter(|rolling| rolling.from_delegate != rolling.to_delegate)
+            .cloned()
+            .collect::<Vec<_>>();
+        rollings.sort_by_key(|rolling| std::cmp::Reverse(rolling.common.log_index));
+
+        let from = rollings
+            .iter()
+            .find(|rolling| rolling.from_delegate == delegate && rolling.from_new_votes.is_none());
+        let to = rollings
+            .iter()
+            .find(|rolling| rolling.to_delegate == delegate && rolling.to_new_votes.is_none());
+
+        if is_negative_decimal(delta) {
+            from.map(|rolling| (rolling.id.clone(), RollingSide::From))
+                .or_else(|| to.map(|rolling| (rolling.id.clone(), RollingSide::To)))
+        } else {
+            to.map(|rolling| (rolling.id.clone(), RollingSide::To))
+                .or_else(|| from.map(|rolling| (rolling.id.clone(), RollingSide::From)))
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RollingSide {
+    From,
+    To,
+}
+
+impl TokenProjectionOperation {
+    fn id(&self) -> &str {
+        match self {
+            Self::DelegateChanged { id, .. }
+            | Self::DelegateVotesChanged { id, .. }
+            | Self::Transfer { id, .. } => id,
+        }
+    }
+}
+
+pub fn project_token_events(
+    context: &TokenProjectionContext,
+    events: Vec<TokenProjectionEvent>,
+) -> Result<TokenProjectionBatch, TokenProjectionError> {
+    let governor_address = normalize_identifier(&context.governor_address);
+    let token_address = normalize_identifier(&context.token_address);
+    let chain_id = validate_chain_ids(&events)?;
+    let mut deduped: BTreeMap<String, TokenProjectionEvent> = BTreeMap::new();
+
+    for event in events {
+        if let DecodedTokenEvent::Transfer(transfer) = &event.event
+            && transfer.standard != context.token_standard
+        {
+            return Err(TokenProjectionError::MismatchedTokenStandard {
+                expected: context.token_standard,
+                actual: transfer.standard,
+                log_id: event.log.id,
+            });
+        }
+
+        if let Some(stored) = deduped.get(&event.log.id) {
+            if stored != &event {
+                return Err(TokenProjectionError::ConflictingDuplicateLog {
+                    log_id: event.log.id,
+                });
+            }
+            continue;
+        }
+        deduped.insert(event.log.id.clone(), event);
+    }
+
+    let mut ordered = deduped.into_values().collect::<Vec<_>>();
+    ordered.sort_by_key(|event| {
+        (
+            event.log.block_number,
+            event.log.transaction_index,
+            event.log.log_index,
+            event.log.id.clone(),
+        )
+    });
+
+    let mut event_order = Vec::new();
+    let mut delegate_changed = Vec::new();
+    let mut delegate_votes_changed = Vec::new();
+    let mut token_transfers = Vec::new();
+    let mut delegate_rollings = Vec::new();
+    let mut operations = Vec::new();
+    let mut reconcile_events = Vec::new();
+
+    for input in ordered {
+        event_order.push(input.log.id.clone());
+        reconcile_events.push(PowerReconcileEvent {
+            block_number: input.log.block_number,
+            block_timestamp_ms: input.log.block_timestamp_ms,
+            transaction_hash: normalize_identifier(&input.log.transaction_hash),
+            transaction_index: input.log.transaction_index,
+            log_index: input.log.log_index,
+            event: DecodedDaoEvent::Token(input.event.clone()),
+        });
+
+        let common = common(context, &governor_address, &token_address, &input.log);
+        match &input.event {
+            DecodedTokenEvent::DelegateChanged(event) => {
+                let row = delegate_changed_write(&input.log.id, common.clone(), event);
+                let rolling = delegate_rolling_write(&row);
+                operations.push(TokenProjectionOperation::DelegateChanged {
+                    id: input.log.id.clone(),
+                    common,
+                    delegator: row.delegator.clone(),
+                    from_delegate: row.from_delegate.clone(),
+                    to_delegate: row.to_delegate.clone(),
+                });
+                delegate_rollings.push(rolling);
+                delegate_changed.push(row);
+            }
+            DecodedTokenEvent::DelegateVotesChanged(event) => {
+                let row = delegate_votes_changed_write(&input.log.id, common.clone(), event);
+                operations.push(TokenProjectionOperation::DelegateVotesChanged {
+                    id: input.log.id.clone(),
+                    common,
+                    delegate: row.delegate.clone(),
+                    previous_votes: row.previous_votes.clone(),
+                    new_votes: row.new_votes.clone(),
+                });
+                delegate_votes_changed.push(row);
+            }
+            DecodedTokenEvent::Transfer(event) => {
+                let row = token_transfer_write(&input.log.id, common.clone(), event);
+                operations.push(TokenProjectionOperation::Transfer {
+                    id: input.log.id.clone(),
+                    common,
+                    from: row.from.clone(),
+                    to: row.to.clone(),
+                    value: row.value.clone(),
+                    standard: event.standard,
+                });
+                token_transfers.push(row);
+            }
+        }
+    }
+
+    let reconcile_context = PowerReconcileContext {
+        dao_code: context.dao_code.clone(),
+        chain_id,
+        contracts: context.contracts.clone(),
+        from_block: context.from_block,
+        to_block: context.to_block,
+        target_height: context.target_height,
+        read_plan_config: context.read_plan_config,
+        current_power_method: context.current_power_method,
+    };
+    let reconcile_plan = plan_power_reconcile(&reconcile_context, &reconcile_events);
+
+    Ok(TokenProjectionBatch {
+        event_order,
+        delegate_changed,
+        delegate_votes_changed,
+        token_transfers,
+        delegate_rollings,
+        operations,
+        reconcile_plan,
+    })
+}
+
+fn common(
+    context: &TokenProjectionContext,
+    governor_address: &str,
+    token_address: &str,
+    log: &NormalizedEvmLog,
+) -> TokenEventCommon {
+    TokenEventCommon {
+        chain_id: log.chain_id,
+        dao_code: context.dao_code.clone(),
+        governor_address: governor_address.to_owned(),
+        token_address: token_address.to_owned(),
+        contract_address: normalize_identifier(&log.address),
+        log_index: log.log_index,
+        transaction_index: log.transaction_index,
+        block_number: log.block_number.to_string(),
+        block_timestamp: log
+            .block_timestamp_ms
+            .map(|timestamp| (timestamp / 1_000).to_string()),
+        transaction_hash: normalize_identifier(&log.transaction_hash),
+    }
+}
+
+fn delegate_changed_write(
+    log_id: &str,
+    common: TokenEventCommon,
+    event: &DelegateChangedEvent,
+) -> DelegateChangedWrite {
+    DelegateChangedWrite {
+        id: log_id.to_owned(),
+        common,
+        delegator: normalize_identifier(&event.delegator),
+        from_delegate: normalize_identifier(&event.from_delegate),
+        to_delegate: normalize_identifier(&event.to_delegate),
+    }
+}
+
+fn delegate_votes_changed_write(
+    log_id: &str,
+    common: TokenEventCommon,
+    event: &DelegateVotesChangedEvent,
+) -> DelegateVotesChangedWrite {
+    DelegateVotesChangedWrite {
+        id: log_id.to_owned(),
+        common,
+        delegate: normalize_identifier(&event.delegate),
+        previous_votes: normalize_decimal(&event.previous_votes),
+        new_votes: normalize_decimal(&event.new_votes),
+    }
+}
+
+fn token_transfer_write(
+    log_id: &str,
+    common: TokenEventCommon,
+    event: &TokenTransferEvent,
+) -> TokenTransferWrite {
+    TokenTransferWrite {
+        id: log_id.to_owned(),
+        common,
+        from: normalize_identifier(&event.from),
+        to: normalize_identifier(&event.to),
+        value: normalize_decimal(&event.value),
+        standard: token_standard_label(event.standard).to_owned(),
+    }
+}
+
+fn delegate_rolling_write(row: &DelegateChangedWrite) -> DelegateRollingWrite {
+    DelegateRollingWrite {
+        id: row.id.clone(),
+        common: row.common.clone(),
+        delegator: row.delegator.clone(),
+        from_delegate: row.from_delegate.clone(),
+        to_delegate: row.to_delegate.clone(),
+        from_previous_votes: None,
+        from_new_votes: None,
+        to_previous_votes: None,
+        to_new_votes: None,
+    }
+}
+
+fn validate_chain_ids(events: &[TokenProjectionEvent]) -> Result<i32, TokenProjectionError> {
+    let Some(first) = events.first() else {
+        return Ok(0);
+    };
+    for event in events.iter().skip(1) {
+        if event.log.chain_id != first.log.chain_id {
+            return Err(TokenProjectionError::MixedChainIds {
+                expected: first.log.chain_id,
+                actual: event.log.chain_id,
+                log_id: event.log.id.clone(),
+            });
+        }
+    }
+    Ok(first.log.chain_id)
+}
+
+fn token_standard_label(standard: GovernanceTokenStandard) -> &'static str {
+    match standard {
+        GovernanceTokenStandard::Erc20 => "erc20",
+        GovernanceTokenStandard::Erc721 => "erc721",
+    }
+}
+
+fn transfer_units(value: &str, standard: GovernanceTokenStandard) -> String {
+    match standard {
+        GovernanceTokenStandard::Erc20 => normalize_decimal(value),
+        GovernanceTokenStandard::Erc721 => "1".to_owned(),
+    }
+}
+
+fn delegate_ref(from_delegate: &str, to_delegate: &str) -> String {
+    format!("{from_delegate}_{to_delegate}")
+}
+
+fn zero_address() -> &'static str {
+    "0x0000000000000000000000000000000000000000"
+}
+
+fn is_zero_address(account: &str) -> bool {
+    normalize_identifier(account) == zero_address()
+}
+
+fn normalize_identifier(value: &str) -> String {
+    value.to_ascii_lowercase()
+}
+
+fn extend_map<T: Clone>(target: &mut BTreeMap<String, T>, rows: &[T], key: impl Fn(&T) -> String) {
+    for row in rows {
+        target.insert(key(row), row.clone());
+    }
+}
+
+fn normalize_decimal(value: &str) -> String {
+    let trimmed = value.trim_start_matches('0');
+    if trimmed.is_empty() {
+        "0".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+fn is_nonzero_decimal(value: &str) -> bool {
+    normalize_decimal(value) != "0"
+}
+
+fn is_negative_decimal(value: &str) -> bool {
+    value.starts_with('-') && is_nonzero_decimal(value.trim_start_matches('-'))
+}
+
+fn apply_signed_decimal(current: &str, delta: &str) -> String {
+    if let Some(delta) = delta.strip_prefix('-') {
+        subtract_decimal_strings(current, delta)
+    } else {
+        add_decimal_strings(current, delta)
+    }
+}
+
+fn subtract_decimal_signed(left: &str, right: &str) -> String {
+    match compare_decimal_strings(left, right) {
+        Ordering::Less => format!("-{}", subtract_decimal_strings(right, left)),
+        Ordering::Equal => "0".to_owned(),
+        Ordering::Greater => subtract_decimal_strings(left, right),
+    }
+}
+
+fn add_decimal_strings(left: &str, right: &str) -> String {
+    let mut carry = 0u8;
+    let mut output = Vec::new();
+    let mut left = left.as_bytes().iter().rev();
+    let mut right = right.as_bytes().iter().rev();
+
+    loop {
+        let left_digit = left.next().map(|digit| digit - b'0');
+        let right_digit = right.next().map(|digit| digit - b'0');
+        if left_digit.is_none() && right_digit.is_none() && carry == 0 {
+            break;
+        }
+        let sum = left_digit.unwrap_or_default() + right_digit.unwrap_or_default() + carry;
+        output.push(b'0' + (sum % 10));
+        carry = sum / 10;
+    }
+
+    output.reverse();
+    normalize_decimal(&String::from_utf8(output).expect("decimal digits"))
+}
+
+fn subtract_decimal_strings(left: &str, right: &str) -> String {
+    if compare_decimal_strings(left, right) == Ordering::Less {
+        return "0".to_owned();
+    }
+
+    let mut borrow = 0i16;
+    let mut output = Vec::new();
+    let mut left = left.as_bytes().iter().rev();
+    let mut right = right.as_bytes().iter().rev();
+
+    while let Some(left_digit) = left.next().map(|digit| (digit - b'0') as i16) {
+        let right_digit = right
+            .next()
+            .map(|digit| (digit - b'0') as i16)
+            .unwrap_or_default();
+        let mut diff = left_digit - borrow - right_digit;
+        if diff < 0 {
+            diff += 10;
+            borrow = 1;
+        } else {
+            borrow = 0;
+        }
+        output.push(b'0' + diff as u8);
+    }
+
+    output.reverse();
+    normalize_decimal(&String::from_utf8(output).expect("decimal digits"))
+}
+
+fn compare_decimal_strings(left: &str, right: &str) -> Ordering {
+    let left = normalize_decimal(left.trim_start_matches('-'));
+    let right = normalize_decimal(right.trim_start_matches('-'));
+    left.len()
+        .cmp(&right.len())
+        .then_with(|| left.as_str().cmp(right.as_str()))
+}

--- a/apps/indexer/tests/token_projection.rs
+++ b/apps/indexer/tests/token_projection.rs
@@ -1,0 +1,435 @@
+use degov_datalens_indexer::{
+    BatchReadPlanConfig, ChainContracts, ChainReadMethod, DecodedTokenEvent, DelegateChangedEvent,
+    DelegateVotesChangedEvent, GovernanceTokenStandard, InMemoryTokenProjectionRepository,
+    NormalizedEvmLog, PowerActivityReason, ReadRequirement, TokenProjectionContext,
+    TokenProjectionError, TokenProjectionEvent, TokenProjectionRepository, TokenTransferEvent,
+    project_token_events,
+};
+use serde_json::json;
+
+#[test]
+fn test_project_token_events_preserves_history_mappings_relations_and_reconcile_plan() {
+    let batch = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(12, 0, 1),
+                event: transfer(
+                    account("BBBB"),
+                    account("DDDD"),
+                    "25",
+                    GovernanceTokenStandard::Erc20,
+                ),
+            },
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_changed(account("BBBB"), zero(), account("CCCC")),
+            },
+            TokenProjectionEvent {
+                log: log(11, 0, 1),
+                event: delegate_votes_changed(account("CCCC"), "0", "100"),
+            },
+            TokenProjectionEvent {
+                log: log(13, 0, 1),
+                event: transfer(
+                    account("DDDD"),
+                    account("BBBB"),
+                    "40",
+                    GovernanceTokenStandard::Erc20,
+                ),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(
+        batch.event_order,
+        vec![
+            "evm:1:10:0xtx10:0:1".to_owned(),
+            "evm:1:11:0xtx11:0:1".to_owned(),
+            "evm:1:12:0xtx12:0:1".to_owned(),
+            "evm:1:13:0xtx13:0:1".to_owned(),
+        ]
+    );
+    assert_eq!(batch.delegate_changed.len(), 1);
+    assert_eq!(batch.delegate_votes_changed.len(), 1);
+    assert_eq!(batch.token_transfers.len(), 2);
+    assert_eq!(batch.delegate_rollings.len(), 1);
+    assert_eq!(batch.delegate_changed[0].delegator, account("bbbb"));
+    assert_eq!(batch.delegate_votes_changed[0].delegate, account("cccc"));
+    assert_eq!(batch.token_transfers[0].from, account("bbbb"));
+    assert_eq!(batch.token_transfers[0].to, account("dddd"));
+
+    let mut repository = InMemoryTokenProjectionRepository::default();
+    repository.apply(&batch).expect("write succeeds");
+    repository.apply(&batch).expect("replay write succeeds");
+
+    let mapping = repository
+        .delegate_mappings()
+        .get(&account("bbbb"))
+        .expect("current mapping");
+    assert_eq!(mapping.to, account("cccc"));
+    assert_eq!(mapping.power, "40");
+
+    let relation = repository
+        .delegates()
+        .get(&format!("{}_{}", account("bbbb"), account("cccc")))
+        .expect("current delegate relation");
+    assert!(relation.is_current);
+    assert_eq!(relation.power, "40");
+
+    let delegate = repository
+        .contributors()
+        .get(&account("cccc"))
+        .expect("delegate contributor");
+    assert_eq!(delegate.delegates_count_all, 1);
+    assert_eq!(delegate.delegates_count_effective, 1);
+    assert_eq!(delegate.power, "0");
+    assert_eq!(repository.data_metric().member_count, 1);
+    assert_eq!(repository.data_metric().power_sum, "0");
+
+    assert_eq!(batch.reconcile_plan.metrics.candidate_count, 7);
+    assert_eq!(batch.reconcile_plan.metrics.deduped_count, 4);
+    assert_eq!(batch.reconcile_plan.chain_read_plan.reads.len(), 3);
+    let accounts = batch
+        .reconcile_plan
+        .candidates
+        .iter()
+        .map(|candidate| candidate.account.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        accounts,
+        vec![account("bbbb"), account("cccc"), account("dddd")]
+    );
+    let bbbb = batch
+        .reconcile_plan
+        .candidates
+        .iter()
+        .find(|candidate| candidate.account == account("bbbb"))
+        .expect("bbbb reconcile candidate");
+    assert_eq!(
+        bbbb.reasons,
+        [
+            PowerActivityReason::DelegateChanged,
+            PowerActivityReason::Transfer,
+        ]
+        .into()
+    );
+    for read in &batch.reconcile_plan.chain_read_plan.reads {
+        assert_eq!(read.requirement, ReadRequirement::Required);
+        assert_eq!(read.key.method, ChainReadMethod::GetVotes);
+    }
+}
+
+#[test]
+fn test_project_token_events_records_noop_delegate_change_without_mutating_current_mapping() {
+    let mut repository = InMemoryTokenProjectionRepository::default();
+    let first = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![TokenProjectionEvent {
+            log: log(10, 0, 1),
+            event: delegate_changed(account("BBBB"), zero(), account("CCCC")),
+        }],
+    )
+    .expect("projection succeeds");
+    repository.apply(&first).expect("first write succeeds");
+
+    let noop = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![TokenProjectionEvent {
+            log: log(11, 0, 1),
+            event: delegate_changed(account("BBBB"), account("CCCC"), account("CCCC")),
+        }],
+    )
+    .expect("projection succeeds");
+    repository.apply(&noop).expect("noop write succeeds");
+
+    assert_eq!(repository.delegate_changed().len(), 2);
+    assert_eq!(repository.delegate_mappings().len(), 1);
+    assert_eq!(
+        repository
+            .contributors()
+            .get(&account("cccc"))
+            .expect("delegate contributor")
+            .delegates_count_all,
+        1
+    );
+}
+
+#[test]
+fn test_project_token_events_undelegation_removes_mapping_without_zero_contributor() {
+    let mut repository = InMemoryTokenProjectionRepository::default();
+    let first = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![TokenProjectionEvent {
+            log: log(10, 0, 1),
+            event: delegate_changed(account("BBBB"), zero(), account("CCCC")),
+        }],
+    )
+    .expect("projection succeeds");
+    let undelegate = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![TokenProjectionEvent {
+            log: log(11, 0, 1),
+            event: delegate_changed(account("BBBB"), account("CCCC"), zero()),
+        }],
+    )
+    .expect("projection succeeds");
+
+    repository.apply(&first).expect("first write succeeds");
+    repository
+        .apply(&undelegate)
+        .expect("undelegate write succeeds");
+
+    assert!(repository.delegate_mappings().is_empty());
+    assert!(!repository.contributors().contains_key(&zero()));
+    assert_eq!(
+        repository
+            .contributors()
+            .get(&account("cccc"))
+            .expect("previous delegate contributor")
+            .delegates_count_all,
+        0
+    );
+}
+
+#[test]
+fn test_project_token_events_applies_same_transaction_delegate_vote_delta_to_relation() {
+    let batch = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_changed(account("BBBB"), zero(), account("CCCC")),
+            },
+            TokenProjectionEvent {
+                log: log(10, 0, 2),
+                event: delegate_votes_changed(account("CCCC"), "0", "100"),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+    let mut repository = InMemoryTokenProjectionRepository::default();
+
+    repository.apply(&batch).expect("write succeeds");
+
+    let mapping = repository
+        .delegate_mappings()
+        .get(&account("bbbb"))
+        .expect("current mapping");
+    assert_eq!(mapping.power, "100");
+    let relation = repository
+        .delegates()
+        .get(&format!("{}_{}", account("bbbb"), account("cccc")))
+        .expect("current delegate relation");
+    assert_eq!(relation.power, "100");
+    assert_eq!(
+        repository
+            .contributors()
+            .get(&account("cccc"))
+            .expect("delegate contributor")
+            .delegates_count_effective,
+        1
+    );
+    assert_eq!(repository.data_metric().power_sum, "0");
+}
+
+#[test]
+fn test_project_token_events_uses_erc721_unit_delta_for_relation_power() {
+    let batch = project_token_events(
+        &context(GovernanceTokenStandard::Erc721),
+        vec![
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_changed(account("BBBB"), zero(), account("CCCC")),
+            },
+            TokenProjectionEvent {
+                log: log(11, 0, 1),
+                event: transfer(
+                    account("DDDD"),
+                    account("BBBB"),
+                    "999",
+                    GovernanceTokenStandard::Erc721,
+                ),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+    let mut repository = InMemoryTokenProjectionRepository::default();
+
+    repository.apply(&batch).expect("write succeeds");
+
+    let mapping = repository
+        .delegate_mappings()
+        .get(&account("bbbb"))
+        .expect("current mapping");
+    assert_eq!(mapping.power, "1");
+    assert_eq!(batch.token_transfers[0].standard, "erc721");
+}
+
+#[test]
+fn test_project_token_events_rejects_registry_standard_mismatch() {
+    let err = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![TokenProjectionEvent {
+            log: log(10, 0, 1),
+            event: transfer(
+                account("BBBB"),
+                account("CCCC"),
+                "1",
+                GovernanceTokenStandard::Erc721,
+            ),
+        }],
+    )
+    .expect_err("standard mismatch is rejected");
+
+    assert_eq!(
+        err,
+        TokenProjectionError::MismatchedTokenStandard {
+            expected: GovernanceTokenStandard::Erc20,
+            actual: GovernanceTokenStandard::Erc721,
+            log_id: "evm:1:10:0xtx10:0:1".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_project_token_events_rejects_conflicting_duplicate_log() {
+    let err = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_votes_changed(account("BBBB"), "0", "1"),
+            },
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_votes_changed(account("BBBB"), "0", "2"),
+            },
+        ],
+    )
+    .expect_err("conflicting duplicate log is rejected");
+
+    assert_eq!(
+        err,
+        TokenProjectionError::ConflictingDuplicateLog {
+            log_id: "evm:1:10:0xtx10:0:1".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_project_token_events_rejects_mixed_chain_input() {
+    let mut second = log(11, 0, 1);
+    second.chain_id = 2;
+
+    let err = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_votes_changed(account("BBBB"), "0", "1"),
+            },
+            TokenProjectionEvent {
+                log: second,
+                event: delegate_votes_changed(account("CCCC"), "0", "1"),
+            },
+        ],
+    )
+    .expect_err("mixed chain input is rejected");
+
+    assert_eq!(
+        err,
+        TokenProjectionError::MixedChainIds {
+            expected: 1,
+            actual: 2,
+            log_id: "evm:1:11:0xtx11:0:1".to_owned(),
+        }
+    );
+}
+
+fn context(token_standard: GovernanceTokenStandard) -> TokenProjectionContext {
+    TokenProjectionContext {
+        dao_code: "unit-dao".to_owned(),
+        governor_address: account("aaaa"),
+        token_address: account("1111"),
+        contracts: ChainContracts {
+            governor: account("aaaa"),
+            governor_token: account("1111"),
+            timelock: account("2222"),
+        },
+        token_standard,
+        from_block: 10,
+        to_block: 20,
+        target_height: Some(20),
+        read_plan_config: BatchReadPlanConfig {
+            max_concurrency: 4,
+            multicall_batch_size: 10,
+        },
+        current_power_method: ChainReadMethod::GetVotes,
+    }
+}
+
+fn log(block_number: u64, transaction_index: u64, log_index: u64) -> NormalizedEvmLog {
+    NormalizedEvmLog {
+        id: format!("evm:1:{block_number}:0xtx{block_number}:{transaction_index}:{log_index}"),
+        chain_id: 1,
+        block_number,
+        block_hash: format!("0xblock{block_number}"),
+        block_timestamp_ms: Some((1_700_000_000 + block_number) * 1_000),
+        transaction_hash: format!("0xtx{block_number}"),
+        transaction_index,
+        log_index,
+        address: account("1111"),
+        topics: vec![],
+        data: "0x".to_owned(),
+        removed: false,
+        raw_payload: json!({ "blockNumber": block_number }),
+    }
+}
+
+fn transfer(
+    from: String,
+    to: String,
+    value: &str,
+    standard: GovernanceTokenStandard,
+) -> DecodedTokenEvent {
+    DecodedTokenEvent::Transfer(TokenTransferEvent {
+        from,
+        to,
+        value: value.to_owned(),
+        standard,
+    })
+}
+
+fn delegate_changed(
+    delegator: String,
+    from_delegate: String,
+    to_delegate: String,
+) -> DecodedTokenEvent {
+    DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+        delegator,
+        from_delegate,
+        to_delegate,
+    })
+}
+
+fn delegate_votes_changed(
+    delegate: String,
+    previous_votes: &str,
+    new_votes: &str,
+) -> DecodedTokenEvent {
+    DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+        delegate,
+        previous_votes: previous_votes.to_owned(),
+        new_votes: new_votes.to_owned(),
+    })
+}
+
+fn account(suffix: &str) -> String {
+    format!("0x{:0>40}", suffix.to_ascii_lowercase())
+}
+
+fn zero() -> String {
+    "0x0000000000000000000000000000000000000000".to_owned()
+}

--- a/apps/indexer/tests/token_projection.rs
+++ b/apps/indexer/tests/token_projection.rs
@@ -194,6 +194,188 @@ fn test_project_token_events_undelegation_removes_mapping_without_zero_contribut
 }
 
 #[test]
+fn test_project_token_events_redelegation_closes_old_relation_and_opens_new_relation() {
+    let mut repository = InMemoryTokenProjectionRepository::default();
+    let initial = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_changed(account("AAAA"), zero(), account("BBBB")),
+            },
+            TokenProjectionEvent {
+                log: log(10, 0, 2),
+                event: delegate_votes_changed(account("BBBB"), "0", "100"),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+    let redelegate = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(11, 0, 1),
+                event: delegate_changed(account("AAAA"), account("BBBB"), account("CCCC")),
+            },
+            TokenProjectionEvent {
+                log: log(11, 0, 2),
+                event: delegate_votes_changed(account("BBBB"), "100", "0"),
+            },
+            TokenProjectionEvent {
+                log: log(11, 0, 3),
+                event: delegate_votes_changed(account("CCCC"), "0", "100"),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    repository.apply(&initial).expect("initial write succeeds");
+    repository
+        .apply(&redelegate)
+        .expect("redelegate write succeeds");
+
+    let mapping = repository
+        .delegate_mappings()
+        .get(&account("aaaa"))
+        .expect("current mapping");
+    assert_eq!(mapping.to, account("cccc"));
+    assert_eq!(mapping.power, "100");
+    assert!(!repository.delegates().contains_key(&format!(
+        "{}_{}",
+        account("bbbb"),
+        account("aaaa")
+    )));
+    if let Some(old_relation) =
+        repository
+            .delegates()
+            .get(&format!("{}_{}", account("aaaa"), account("bbbb")))
+    {
+        assert!(!old_relation.is_current);
+    }
+    let new_relation = repository
+        .delegates()
+        .get(&format!("{}_{}", account("aaaa"), account("cccc")))
+        .expect("new current relation");
+    assert!(new_relation.is_current);
+    assert_eq!(new_relation.power, "100");
+    assert_eq!(
+        repository
+            .contributors()
+            .get(&account("bbbb"))
+            .expect("old delegate contributor")
+            .delegates_count_effective,
+        0
+    );
+    assert_eq!(
+        repository
+            .contributors()
+            .get(&account("cccc"))
+            .expect("new delegate contributor")
+            .delegates_count_effective,
+        1
+    );
+}
+
+#[test]
+fn test_project_token_events_undelegation_old_side_delta_removes_relation_without_reverse() {
+    let mut repository = InMemoryTokenProjectionRepository::default();
+    let initial = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_changed(account("AAAA"), zero(), account("BBBB")),
+            },
+            TokenProjectionEvent {
+                log: log(10, 0, 2),
+                event: delegate_votes_changed(account("BBBB"), "0", "100"),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+    let undelegate = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(11, 0, 1),
+                event: delegate_changed(account("AAAA"), account("BBBB"), zero()),
+            },
+            TokenProjectionEvent {
+                log: log(11, 0, 2),
+                event: delegate_votes_changed(account("BBBB"), "100", "0"),
+            },
+        ],
+    )
+    .expect("projection succeeds");
+
+    repository.apply(&initial).expect("initial write succeeds");
+    repository
+        .apply(&undelegate)
+        .expect("undelegate write succeeds");
+
+    assert!(repository.delegate_mappings().is_empty());
+    assert!(!repository.delegates().contains_key(&format!(
+        "{}_{}",
+        account("bbbb"),
+        account("aaaa")
+    )));
+    if let Some(old_relation) =
+        repository
+            .delegates()
+            .get(&format!("{}_{}", account("aaaa"), account("bbbb")))
+    {
+        assert!(!old_relation.is_current);
+    }
+    assert_eq!(
+        repository
+            .contributors()
+            .get(&account("bbbb"))
+            .expect("old delegate contributor")
+            .delegates_count_effective,
+        0
+    );
+}
+
+#[test]
+fn test_project_token_events_delegate_change_without_voting_units_does_not_emit_delegate_edge() {
+    let batch = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![TokenProjectionEvent {
+            log: log(10, 0, 1),
+            event: delegate_changed(account("AAAA"), zero(), account("BBBB")),
+        }],
+    )
+    .expect("projection succeeds");
+    let mut repository = InMemoryTokenProjectionRepository::default();
+
+    repository.apply(&batch).expect("write succeeds");
+
+    let mapping = repository
+        .delegate_mappings()
+        .get(&account("aaaa"))
+        .expect("mapping is preserved");
+    assert_eq!(mapping.to, account("bbbb"));
+    assert_eq!(mapping.power, "0");
+    assert!(repository.delegates().is_empty());
+    assert_eq!(
+        repository
+            .contributors()
+            .get(&account("bbbb"))
+            .expect("delegate contributor")
+            .delegates_count_all,
+        1
+    );
+    assert_eq!(
+        repository
+            .contributors()
+            .get(&account("bbbb"))
+            .expect("delegate contributor")
+            .delegates_count_effective,
+        0
+    );
+}
+
+#[test]
 fn test_project_token_events_applies_same_transaction_delegate_vote_delta_to_relation() {
     let batch = project_token_events(
         &context(GovernanceTokenStandard::Erc20),


### PR DESCRIPTION
## Summary
- Add Datalens-native token projection batch/repository models for token transfers and delegation histories
- Maintain delegate mappings, delegate relation snapshots, contributor counts, member metrics, and deterministic replay state
- Emit compact `PowerReconcilePlan` candidates for affected token/delegation accounts instead of inline power reads

## Verification
- cargo test --locked -p degov-datalens-indexer --test token_projection
- cargo clippy --locked -p degov-datalens-indexer --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check