### PR TITLE
HBX-267: Preserve proposal metadata behavior

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod evm_log;
 pub mod planner;
 pub mod power_reconcile;
+pub mod proposal_metadata;
 pub mod proposal_projection;
 pub mod timelock_projection;
 pub mod token_projection;
@@ -49,6 +50,7 @@ pub use power_reconcile::{
     PowerReconcileEvent, PowerReconcileMetrics, PowerReconcilePlan, PowerRefreshReadSource,
     PowerRefreshStatus, PowerRefreshStatusRecord, plan_power_reconcile,
 };
+pub use proposal_metadata::{ProposalTextMetadata, derive_proposal_metadata};
 pub use proposal_projection::{
     InMemoryProposalProjectionRepository, ProposalActionWrite, ProposalCreatedWrite,
     ProposalDeadlineExtensionWrite, ProposalEventCommon, ProposalExtendedWrite, ProposalIdWrite,

--- a/apps/indexer/src/proposal_metadata.rs
+++ b/apps/indexer/src/proposal_metadata.rs
@@ -1,0 +1,136 @@
+use sha3::{Digest, Keccak256};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalTextMetadata {
+    pub description: String,
+    pub title: String,
+    pub description_body: String,
+    pub description_hash: String,
+    pub discussion: Option<String>,
+    pub signature_content: Vec<String>,
+}
+
+pub fn derive_proposal_metadata(description: &str) -> ProposalTextMetadata {
+    let (title, description_body) = extract_title_and_body(description);
+    let (description_body, discussion, signature_content) =
+        extract_description_tags(&description_body);
+
+    ProposalTextMetadata {
+        description: description.to_owned(),
+        title,
+        description_body,
+        description_hash: description_hash(description),
+        discussion,
+        signature_content,
+    }
+}
+
+fn extract_title_and_body(description: &str) -> (String, String) {
+    if let Some(rest) = description.strip_prefix('#') {
+        let Some(rest) = strip_heading_space(rest) else {
+            return fallback_title_and_body(description);
+        };
+        let mut parts = rest.splitn(2, '\n');
+        let raw_title = parts.next().unwrap_or_default();
+        let title = normalize_heading_title(raw_title);
+        let body = parts.next().unwrap_or_default().trim().to_owned();
+        return (title, body);
+    }
+
+    fallback_title_and_body(description)
+}
+
+fn strip_heading_space(value: &str) -> Option<&str> {
+    let trimmed = value.trim_start_matches(char::is_whitespace);
+    if trimmed.len() == value.len() {
+        return None;
+    }
+    Some(trimmed)
+}
+
+fn normalize_heading_title(value: &str) -> String {
+    let clean_title = strip_html_tags(value).trim().to_owned();
+    if clean_title
+        .chars()
+        .all(|character| character.is_ascii_digit() || character.is_whitespace())
+    {
+        return clean_title
+            .split_whitespace()
+            .next()
+            .unwrap_or(clean_title.as_str())
+            .to_owned();
+    }
+
+    clean_title
+}
+
+fn fallback_title_and_body(description: &str) -> (String, String) {
+    let trimmed = description.trim();
+    let mut lines = trimmed.lines();
+    let fallback_title = strip_html_tags(lines.next().unwrap_or_default())
+        .trim()
+        .to_owned();
+    let title = if fallback_title.len() > 50 {
+        format!("{}...", fallback_title.chars().take(50).collect::<String>())
+    } else {
+        fallback_title
+    };
+    let body = lines.collect::<Vec<_>>().join("\n").trim().to_owned();
+
+    (title, body)
+}
+
+fn extract_description_tags(description: &str) -> (String, Option<String>, Vec<String>) {
+    let mut description = description.to_owned();
+    let mut discussion = None;
+    let mut signature_raw = None;
+
+    if let Some((remaining, value)) = extract_single_tag(&description, "discussion") {
+        description = remaining;
+        discussion = Some(value);
+    }
+    if let Some((remaining, value)) = extract_single_tag(&description, "signature") {
+        description = remaining;
+        signature_raw = Some(value);
+    }
+    let signature_content = signature_raw
+        .and_then(|value| serde_json::from_str::<Vec<String>>(&value).ok())
+        .unwrap_or_default();
+
+    (description.trim().to_owned(), discussion, signature_content)
+}
+
+fn extract_single_tag(description: &str, tag: &str) -> Option<(String, String)> {
+    let open_tag = format!("<{tag}>");
+    let close_tag = format!("</{tag}>");
+    let start = description.find(&open_tag)?;
+    let content_start = start + open_tag.len();
+    let content_end = description[content_start..].find(&close_tag)? + content_start;
+    let content = description[content_start..content_end].trim().to_owned();
+    let mut remaining = String::with_capacity(description.len());
+    remaining.push_str(&description[..start]);
+    remaining.push_str(&description[content_end + close_tag.len()..]);
+
+    Some((remaining.trim().to_owned(), content))
+}
+
+fn strip_html_tags(value: &str) -> String {
+    let mut stripped = String::with_capacity(value.len());
+    let mut in_tag = false;
+
+    for character in value.chars() {
+        match character {
+            '<' => in_tag = true,
+            '>' if in_tag => in_tag = false,
+            _ if !in_tag => stripped.push(character),
+            _ => {}
+        }
+    }
+
+    stripped
+}
+
+fn description_hash(description: &str) -> String {
+    let hash = Keccak256::digest(description.as_bytes());
+    format!("0x{}", hex::encode(hash))
+}

--- a/apps/indexer/src/proposal_metadata.rs
+++ b/apps/indexer/src/proposal_metadata.rs
@@ -26,10 +26,8 @@ pub fn derive_proposal_metadata(description: &str) -> ProposalTextMetadata {
 }
 
 fn extract_title_and_body(description: &str) -> (String, String) {
-    if let Some(rest) = description.strip_prefix('#') {
-        let Some(rest) = strip_heading_space(rest) else {
-            return fallback_title_and_body(description);
-        };
+    let trimmed = description.trim();
+    if let Some(rest) = trimmed.strip_prefix("# ") {
         let mut parts = rest.splitn(2, '\n');
         let raw_title = parts.next().unwrap_or_default();
         let title = normalize_heading_title(raw_title);
@@ -37,15 +35,7 @@ fn extract_title_and_body(description: &str) -> (String, String) {
         return (title, body);
     }
 
-    fallback_title_and_body(description)
-}
-
-fn strip_heading_space(value: &str) -> Option<&str> {
-    let trimmed = value.trim_start_matches(char::is_whitespace);
-    if trimmed.len() == value.len() {
-        return None;
-    }
-    Some(trimmed)
+    fallback_title_and_body(trimmed)
 }
 
 fn normalize_heading_title(value: &str) -> String {
@@ -65,9 +55,8 @@ fn normalize_heading_title(value: &str) -> String {
 }
 
 fn fallback_title_and_body(description: &str) -> (String, String) {
-    let trimmed = description.trim();
-    let mut lines = trimmed.lines();
-    let fallback_title = strip_html_tags(lines.next().unwrap_or_default())
+    let mut lines = description.lines();
+    let fallback_title = strip_html_tags(lines.next().unwrap_or_default().trim_start_matches('#'))
         .trim()
         .to_owned();
     let title = if fallback_title.len() > 50 {

--- a/apps/indexer/src/proposal_projection.rs
+++ b/apps/indexer/src/proposal_projection.rs
@@ -1,11 +1,9 @@
 use std::collections::BTreeMap;
 
-use sha3::{Digest, Keccak256};
-
 use crate::{
     BatchReadPlanConfig, ChainContracts, ChainReadExecutionReport, ChainReadMethod, ChainReadPlan,
     ChainReadPlanBuilder, ChainReadReason, ChainReadValue, DecodedGovernorEvent, NormalizedEvmLog,
-    ProposalCreatedEvent, ProposalExtendedEvent, ProposalQueuedEvent,
+    ProposalCreatedEvent, ProposalExtendedEvent, ProposalQueuedEvent, derive_proposal_metadata,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -711,7 +709,7 @@ fn proposal_id_write(log_id: &str, common: ProposalEventCommon) -> ProposalIdWri
 }
 
 fn proposal_write(common: ProposalEventCommon, event: &ProposalCreatedEvent) -> ProposalWrite {
-    let (title, description_body) = split_description(&event.description);
+    let metadata = derive_proposal_metadata(&event.description);
 
     ProposalWrite {
         id: proposal_ref(
@@ -737,10 +735,10 @@ fn proposal_write(common: ProposalEventCommon, event: &ProposalCreatedEvent) -> 
         calldatas: event.calldatas.clone(),
         vote_start: event.vote_start.clone(),
         vote_end: event.vote_end.clone(),
-        description: event.description.clone(),
-        title,
-        description_body,
-        description_hash: description_hash(&event.description),
+        description: metadata.description,
+        title: metadata.title,
+        description_body: metadata.description_body,
+        description_hash: metadata.description_hash,
         proposal_snapshot: Some(event.vote_start.clone()),
         proposal_deadline: Some(event.vote_end.clone()),
         block_number: common.block_number.clone(),
@@ -863,6 +861,8 @@ fn deadline_extension_write(
 }
 
 fn lifecycle_stub(common: &ProposalEventCommon, state: &str) -> ProposalWrite {
+    let metadata = derive_proposal_metadata("");
+
     ProposalWrite {
         id: proposal_ref(
             &common.governor_address,
@@ -883,10 +883,10 @@ fn lifecycle_stub(common: &ProposalEventCommon, state: &str) -> ProposalWrite {
         calldatas: Vec::new(),
         vote_start: "0".to_owned(),
         vote_end: "0".to_owned(),
-        description: String::new(),
-        title: String::new(),
-        description_body: String::new(),
-        description_hash: description_hash(""),
+        description: metadata.description,
+        title: metadata.title,
+        description_body: metadata.description_body,
+        description_hash: metadata.description_hash,
         proposal_snapshot: None,
         proposal_deadline: None,
         block_number: common.block_number.clone(),
@@ -1075,30 +1075,6 @@ fn proposal_ref(governor_address: &str, proposal_id: &str, chain_id: i32) -> Str
         "proposal:{chain_id}:{}:{proposal_id}",
         normalize_identifier(governor_address)
     )
-}
-
-fn split_description(description: &str) -> (String, String) {
-    let trimmed = description.trim();
-    if let Some(rest) = trimmed.strip_prefix("# ") {
-        let mut parts = rest.splitn(2, '\n');
-        let title = parts.next().unwrap_or_default().trim().to_owned();
-        let body = parts.next().unwrap_or_default().trim().to_owned();
-        return (title, body);
-    }
-
-    let mut lines = trimmed.lines();
-    let title = lines
-        .next()
-        .unwrap_or_default()
-        .trim_start_matches('#')
-        .trim();
-    let body = lines.collect::<Vec<_>>().join("\n").trim().to_owned();
-    (title.to_owned(), body)
-}
-
-fn description_hash(description: &str) -> String {
-    let hash = Keccak256::digest(description.as_bytes());
-    format!("0x{}", hex::encode(hash))
 }
 
 fn normalize_identifier(value: &str) -> String {

--- a/apps/indexer/tests/proposal_metadata.rs
+++ b/apps/indexer/tests/proposal_metadata.rs
@@ -35,6 +35,20 @@ fn test_derive_proposal_metadata_applies_stable_title_fallback_rules() {
 }
 
 #[test]
+fn test_derive_proposal_metadata_preserves_legacy_hash_fallback_titles() {
+    let compact_heading = derive_proposal_metadata("#Title\nBody");
+    let nested_heading = derive_proposal_metadata("## Title\nBody");
+    let indented_heading = derive_proposal_metadata("  # Title\nBody");
+
+    assert_eq!(compact_heading.title, "Title");
+    assert_eq!(compact_heading.description_body, "Body");
+    assert_eq!(nested_heading.title, "Title");
+    assert_eq!(nested_heading.description_body, "Body");
+    assert_eq!(indented_heading.title, "Title");
+    assert_eq!(indented_heading.description_body, "Body");
+}
+
+#[test]
 fn test_derive_proposal_metadata_extracts_deterministic_description_tags() {
     let metadata = derive_proposal_metadata(
         "# Title\n\nMain text\n\n<discussion>https://forum.example/proposal</discussion>\n\n<signature>[\"transfer(address,uint256)\",\"\"]</signature>",

--- a/apps/indexer/tests/proposal_metadata.rs
+++ b/apps/indexer/tests/proposal_metadata.rs
@@ -1,0 +1,70 @@
+use degov_datalens_indexer::derive_proposal_metadata;
+
+#[test]
+fn test_derive_proposal_metadata_preserves_raw_description_and_hashes_utf8_bytes() {
+    let description = "# Proposal title\n\nProposal body";
+
+    let metadata = derive_proposal_metadata(description);
+
+    assert_eq!(metadata.description, description);
+    assert_eq!(metadata.title, "Proposal title");
+    assert_eq!(metadata.description_body, "Proposal body");
+    assert_eq!(
+        metadata.description_hash,
+        "0x3bec3dfa58e028fdf10e56bebf69d18a3170b2897a2381164179670dd2fa0193"
+    );
+}
+
+#[test]
+fn test_derive_proposal_metadata_applies_stable_title_fallback_rules() {
+    let html_heading = derive_proposal_metadata("# <span>Upgrade treasury</span>\nBody");
+    let numeric_heading = derive_proposal_metadata("# 1 1\nBody");
+    let fallback = derive_proposal_metadata(
+        "<b>Plain proposal title that is definitely longer than fifty characters</b>\nBody",
+    );
+
+    assert_eq!(html_heading.title, "Upgrade treasury");
+    assert_eq!(html_heading.description_body, "Body");
+    assert_eq!(numeric_heading.title, "1");
+    assert_eq!(numeric_heading.description_body, "Body");
+    assert_eq!(
+        fallback.title,
+        "Plain proposal title that is definitely longer tha..."
+    );
+    assert_eq!(fallback.description_body, "Body");
+}
+
+#[test]
+fn test_derive_proposal_metadata_extracts_deterministic_description_tags() {
+    let metadata = derive_proposal_metadata(
+        "# Title\n\nMain text\n\n<discussion>https://forum.example/proposal</discussion>\n\n<signature>[\"transfer(address,uint256)\",\"\"]</signature>",
+    );
+
+    assert_eq!(metadata.title, "Title");
+    assert_eq!(metadata.description_body, "Main text");
+    assert_eq!(
+        metadata.discussion.as_deref(),
+        Some("https://forum.example/proposal")
+    );
+    assert_eq!(
+        metadata.signature_content,
+        vec!["transfer(address,uint256)".to_owned(), String::new()]
+    );
+}
+
+#[test]
+fn test_derive_proposal_metadata_is_deterministic_without_provider_configuration() {
+    temp_env::with_vars(
+        [
+            ("OPENROUTER_API_KEY", None::<&str>),
+            ("TEXTPLUS_API_KEY", None::<&str>),
+            ("OPENAI_API_KEY", None::<&str>),
+        ],
+        || {
+            let first = derive_proposal_metadata("# Title\n\nBody");
+            let second = derive_proposal_metadata("# Title\n\nBody");
+
+            assert_eq!(first, second);
+        },
+    );
+}


### PR DESCRIPTION
## Summary
- Adds deterministic proposal metadata derivation for Datalens-native proposal projection.
- Preserves proposal title, description, description hash, and metadata behavior without requiring AI/provider credentials for core indexing.
- Integrates metadata fields into proposal projection output and exports the helper API.

## Verification
- cargo test --locked -p degov-datalens-indexer --test proposal_metadata
- cargo test --locked -p degov-datalens-indexer --test proposal_projection
- cargo clippy --locked -p degov-datalens-indexer --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check