### PR TITLE
HBX-256: Implement Datalens indexer runner

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -8,6 +8,7 @@ pub mod evm_log;
 pub mod planner;
 pub mod power_reconcile;
 pub mod proposal_projection;
+pub mod runner;
 pub mod timelock_projection;
 pub mod token_projection;
 pub mod vote_projection;
@@ -56,6 +57,12 @@ pub use proposal_projection::{
     ProposalProjectionEvent, ProposalProjectionRepository, ProposalQueuedWrite,
     ProposalRepositoryWriteError, ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite,
     project_proposal_events,
+};
+pub use runner::{
+    DaoEventDecoder, InMemoryIndexerRunnerStore, InMemoryIndexerRunnerStoreError,
+    IndexerEventDecoder, IndexerProjectionBatch, IndexerRunner, IndexerRunnerContexts,
+    IndexerRunnerError, IndexerRunnerOptions, IndexerRunnerProgress, IndexerRunnerReport,
+    IndexerRunnerStore, IndexerRunnerTransaction,
 };
 pub use timelock_projection::{
     InMemoryTimelockProjectionRepository, TIMELOCK_POSTGRES_ADAPTER_GAP, TimelockCallWrite,

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -317,6 +317,16 @@ where
             let logs = normalize_evm_log_rows(self.options.checkpoint_identity.chain_id, rows)
                 .map_err(|error| IndexerRunnerError::Normalize(error.to_string()))?;
             for log in logs {
+                if log.removed {
+                    info!(
+                        "skipping removed Datalens EVM log before decode dao_code={} chain_id={} log_id={} block_number={}",
+                        self.options.checkpoint_identity.dao_code,
+                        self.options.checkpoint_identity.chain_id,
+                        log.id,
+                        log.block_number
+                    );
+                    continue;
+                }
                 let token_standard = (page.plan.source == DaoLogSource::GovernorToken)
                     .then_some(self.options.addresses.governor_token_standard);
                 let event = self.decoder.decode(

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -1,0 +1,680 @@
+use std::collections::VecDeque;
+use std::fmt;
+
+use log::{error, info};
+use thiserror::Error;
+
+use crate::{
+    CheckpointBlockRange, CheckpointError, DaoContractAddresses, DaoEventDecodeError, DaoLogSource,
+    DatalensConfig, DatalensError, DatalensLogPage, DatalensLogQueryReader, DecodedDaoEvent,
+    GovernanceTokenStandard, InMemoryProposalProjectionRepository,
+    InMemoryTimelockProjectionRepository, InMemoryTokenProjectionRepository,
+    InMemoryVoteProjectionRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
+    NormalizedEvmLog, ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionEvent,
+    ProposalProjectionRepository, TimelockProjectionBatch, TimelockProjectionContext,
+    TimelockProjectionEvent, TimelockProjectionRepository, TokenProjectionBatch,
+    TokenProjectionContext, TokenProjectionEvent, TokenProjectionRepository, VoteProjectionBatch,
+    VoteProjectionContext, VoteProjectionEvent, VoteProjectionRepository, decode_dao_log,
+    fetch_dao_log_pages, normalize_evm_log_rows, plan_dao_log_queries, plan_next_checkpoint_range,
+    project_proposal_events, project_timelock_events, project_token_events, project_vote_events,
+};
+
+#[derive(Clone, Debug)]
+pub struct IndexerRunnerOptions {
+    pub datalens_config: DatalensConfig,
+    pub addresses: DaoContractAddresses,
+    pub checkpoint_identity: IndexerCheckpointIdentity,
+    pub start_block: i64,
+    pub query_max_attempts: u32,
+    pub safe_height: Option<i64>,
+    pub progress_refresh_lag_blocks: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexerRunnerContexts {
+    pub vote: VoteProjectionContext,
+    pub token: TokenProjectionContext,
+    pub proposal: Option<ProposalProjectionContext>,
+    pub timelock: Option<TimelockProjectionContext>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IndexerRunnerProgress {
+    pub processed_height: Option<i64>,
+    pub target_height: i64,
+    pub synced_percentage: f64,
+    pub onchain_refresh_allowed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IndexerRunnerReport {
+    pub chunks_processed: u64,
+    pub shutdown_requested: bool,
+    pub last_progress: IndexerRunnerProgress,
+}
+
+#[derive(Debug, Error)]
+pub enum IndexerRunnerError {
+    #[error("Datalens runner checkpoint error: {0}")]
+    Checkpoint(#[from] CheckpointError),
+
+    #[error("Datalens runner query error: {0}")]
+    Datalens(#[from] DatalensError),
+
+    #[error("Datalens runner EVM log normalization error: {0}")]
+    Normalize(String),
+
+    #[error("Datalens runner DAO event decode error: {0}")]
+    Decode(#[from] DaoEventDecodeError),
+
+    #[error("Datalens runner projection error: {0}")]
+    Projection(String),
+
+    #[error("Datalens runner transaction error: {0}")]
+    Transaction(String),
+}
+
+pub trait IndexerEventDecoder: Clone {
+    fn decode(
+        &self,
+        dao_code: &str,
+        source: DaoLogSource,
+        token_standard: Option<GovernanceTokenStandard>,
+        log: &NormalizedEvmLog,
+    ) -> Result<DecodedDaoEvent, DaoEventDecodeError>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DaoEventDecoder;
+
+impl IndexerEventDecoder for DaoEventDecoder {
+    fn decode(
+        &self,
+        dao_code: &str,
+        source: DaoLogSource,
+        token_standard: Option<GovernanceTokenStandard>,
+        log: &NormalizedEvmLog,
+    ) -> Result<DecodedDaoEvent, DaoEventDecodeError> {
+        decode_dao_log(dao_code, source, token_standard, log)
+    }
+}
+
+pub trait IndexerRunnerStore {
+    type Error: fmt::Display;
+    type Transaction<'a>: IndexerRunnerTransaction<Error = Self::Error>
+    where
+        Self: 'a;
+
+    fn read_or_create_checkpoint(
+        &mut self,
+        identity: &IndexerCheckpointIdentity,
+        start_block: i64,
+    ) -> Result<IndexerCheckpoint, Self::Error>;
+
+    fn begin_transaction(&mut self) -> Result<Self::Transaction<'_>, Self::Error>;
+}
+
+pub trait IndexerRunnerTransaction {
+    type Error: fmt::Display;
+
+    fn apply_projection_batch(&mut self, batch: &IndexerProjectionBatch)
+    -> Result<(), Self::Error>;
+
+    fn advance_checkpoint(
+        &mut self,
+        identity: &IndexerCheckpointIdentity,
+        processed_height: i64,
+        target_height: Option<i64>,
+    ) -> Result<(), Self::Error>;
+
+    fn commit(self) -> Result<(), Self::Error>;
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct IndexerProjectionBatch {
+    pub proposal: Option<ProposalProjectionBatch>,
+    pub vote: Option<VoteProjectionBatch>,
+    pub token: Option<TokenProjectionBatch>,
+    pub timelock: Option<TimelockProjectionBatch>,
+}
+
+pub struct IndexerRunner<R, S, D = DaoEventDecoder> {
+    options: IndexerRunnerOptions,
+    contexts: IndexerRunnerContexts,
+    reader: R,
+    store: S,
+    decoder: D,
+    shutdown_after_chunks: Option<u64>,
+}
+
+impl<R, S, D> IndexerRunner<R, S, D>
+where
+    R: DatalensLogQueryReader,
+    S: IndexerRunnerStore,
+    D: IndexerEventDecoder,
+{
+    pub fn new(
+        options: IndexerRunnerOptions,
+        contexts: IndexerRunnerContexts,
+        reader: R,
+        store: S,
+        decoder: D,
+    ) -> Self {
+        Self {
+            options,
+            contexts,
+            reader,
+            store,
+            decoder,
+            shutdown_after_chunks: None,
+        }
+    }
+
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+
+    pub fn store_mut(&mut self) -> &mut S {
+        &mut self.store
+    }
+
+    pub fn request_shutdown_after_chunks(&mut self, chunks: u64) {
+        self.shutdown_after_chunks = Some(chunks);
+    }
+
+    pub fn run_to_target(
+        &mut self,
+        target_height: i64,
+    ) -> Result<IndexerRunnerReport, IndexerRunnerError> {
+        let effective_target = self
+            .options
+            .safe_height
+            .map_or(target_height, |safe_height| safe_height.min(target_height));
+        let mut chunks_processed = 0;
+        let mut checkpoint = self
+            .store
+            .read_or_create_checkpoint(&self.options.checkpoint_identity, self.options.start_block)
+            .map_err(to_checkpoint_error)?;
+
+        loop {
+            if self
+                .shutdown_after_chunks
+                .is_some_and(|limit| chunks_processed >= limit)
+            {
+                return Ok(IndexerRunnerReport {
+                    chunks_processed,
+                    shutdown_requested: true,
+                    last_progress: progress(
+                        checkpoint.processed_height,
+                        effective_target,
+                        self.options.progress_refresh_lag_blocks,
+                    ),
+                });
+            }
+
+            let Some(range) = plan_next_checkpoint_range(
+                &checkpoint,
+                self.options.datalens_config.query_limits.block_range_limit,
+                effective_target,
+            )?
+            else {
+                return Ok(IndexerRunnerReport {
+                    chunks_processed,
+                    shutdown_requested: false,
+                    last_progress: progress(
+                        checkpoint.processed_height,
+                        effective_target,
+                        self.options.progress_refresh_lag_blocks,
+                    ),
+                });
+            };
+
+            info!(
+                "processing Datalens indexer chunk dao_code={} chain_id={} from_block={} to_block={} target_height={}",
+                self.options.checkpoint_identity.dao_code,
+                self.options.checkpoint_identity.chain_id,
+                range.from_block,
+                range.to_block,
+                effective_target
+            );
+
+            let batch = match self.process_range(range, effective_target) {
+                Ok(batch) => batch,
+                Err(error) => {
+                    error!(
+                        "Datalens indexer chunk failed before transaction dao_code={} chain_id={} from_block={} to_block={} error={}",
+                        self.options.checkpoint_identity.dao_code,
+                        self.options.checkpoint_identity.chain_id,
+                        range.from_block,
+                        range.to_block,
+                        error
+                    );
+                    return Err(error);
+                }
+            };
+            let dao_code = self.options.checkpoint_identity.dao_code.clone();
+            let chain_id = self.options.checkpoint_identity.chain_id;
+            let mut transaction = self
+                .store
+                .begin_transaction()
+                .map_err(|error| transaction_error(&dao_code, chain_id, range, error))?;
+            transaction
+                .apply_projection_batch(&batch)
+                .map_err(|error| transaction_error(&dao_code, chain_id, range, error))?;
+            transaction
+                .advance_checkpoint(
+                    &self.options.checkpoint_identity,
+                    range.to_block,
+                    Some(effective_target),
+                )
+                .map_err(|error| transaction_error(&dao_code, chain_id, range, error))?;
+            transaction
+                .commit()
+                .map_err(|error| transaction_error(&dao_code, chain_id, range, error))?;
+
+            chunks_processed += 1;
+            info!(
+                "committed Datalens indexer chunk and advanced checkpoint dao_code={} chain_id={} processed_height={} target_height={}",
+                self.options.checkpoint_identity.dao_code,
+                self.options.checkpoint_identity.chain_id,
+                range.to_block,
+                effective_target
+            );
+            checkpoint = self
+                .store
+                .read_or_create_checkpoint(
+                    &self.options.checkpoint_identity,
+                    self.options.start_block,
+                )
+                .map_err(to_checkpoint_error)?;
+        }
+    }
+
+    fn process_range(
+        &mut self,
+        range: CheckpointBlockRange,
+        target_height: i64,
+    ) -> Result<IndexerProjectionBatch, IndexerRunnerError> {
+        let plans = plan_dao_log_queries(
+            &self.options.datalens_config,
+            &self.options.addresses,
+            range.from_block,
+            range.to_block,
+        )?;
+        let pages = fetch_dao_log_pages(&mut self.reader, &plans, self.options.query_max_attempts)?;
+        let decoded = self.decode_pages(pages)?;
+
+        self.project_events(decoded, range, target_height)
+    }
+
+    fn decode_pages(
+        &self,
+        pages: Vec<DatalensLogPage>,
+    ) -> Result<Vec<(NormalizedEvmLog, DecodedDaoEvent)>, IndexerRunnerError> {
+        let mut decoded = Vec::new();
+        for page in pages {
+            let rows = page_rows(page.rows)?;
+            let logs = normalize_evm_log_rows(self.options.checkpoint_identity.chain_id, rows)
+                .map_err(|error| IndexerRunnerError::Normalize(error.to_string()))?;
+            for log in logs {
+                let token_standard = (page.plan.source == DaoLogSource::GovernorToken)
+                    .then_some(self.options.addresses.governor_token_standard);
+                let event = self.decoder.decode(
+                    &self.options.checkpoint_identity.dao_code,
+                    page.plan.source,
+                    token_standard,
+                    &log,
+                )?;
+                decoded.push((log, event));
+            }
+        }
+        decoded.sort_by_key(|(log, _)| (log.block_number, log.transaction_index, log.log_index));
+        Ok(decoded)
+    }
+
+    fn project_events(
+        &self,
+        decoded: Vec<(NormalizedEvmLog, DecodedDaoEvent)>,
+        range: CheckpointBlockRange,
+        target_height: i64,
+    ) -> Result<IndexerProjectionBatch, IndexerRunnerError> {
+        let mut proposal_events = Vec::new();
+        let mut vote_events = Vec::new();
+        let mut token_events = Vec::new();
+        let mut timelock_events = Vec::new();
+
+        for (log, event) in decoded {
+            match event {
+                DecodedDaoEvent::Governor(event) => {
+                    if self.contexts.proposal.is_some() {
+                        proposal_events.push(ProposalProjectionEvent {
+                            log: log.clone(),
+                            event: event.clone(),
+                        });
+                    }
+                    vote_events.push(VoteProjectionEvent { log, event });
+                }
+                DecodedDaoEvent::Token(event) => {
+                    token_events.push(TokenProjectionEvent { log, event });
+                }
+                DecodedDaoEvent::Timelock(event) => {
+                    if self.contexts.timelock.is_some() {
+                        timelock_events.push(TimelockProjectionEvent { log, event });
+                    }
+                }
+                DecodedDaoEvent::UnsupportedTopic(_) => {}
+            }
+        }
+
+        let proposal = self
+            .contexts
+            .proposal
+            .as_ref()
+            .filter(|_| !proposal_events.is_empty())
+            .map(|context| project_proposal_events(context, proposal_events))
+            .transpose()
+            .map_err(|error| IndexerRunnerError::Projection(format!("{error:?}")))?;
+        let vote = (!vote_events.is_empty())
+            .then(|| project_vote_events(&self.contexts.vote, vote_events))
+            .transpose()
+            .map_err(|error| IndexerRunnerError::Projection(format!("{error:?}")))?;
+        let token_context = TokenProjectionContext {
+            from_block: u64::try_from(range.from_block).unwrap_or_default(),
+            to_block: u64::try_from(range.to_block).unwrap_or_default(),
+            target_height: u64::try_from(target_height).ok(),
+            ..self.contexts.token.clone()
+        };
+        let token = (!token_events.is_empty())
+            .then(|| project_token_events(&token_context, token_events))
+            .transpose()
+            .map_err(|error| IndexerRunnerError::Projection(format!("{error:?}")))?;
+        let timelock = self
+            .contexts
+            .timelock
+            .as_ref()
+            .filter(|_| !timelock_events.is_empty())
+            .map(|context| project_timelock_events(context, timelock_events))
+            .transpose()
+            .map_err(|error| IndexerRunnerError::Projection(format!("{error:?}")))?;
+
+        Ok(IndexerProjectionBatch {
+            proposal,
+            vote,
+            token,
+            timelock,
+        })
+    }
+}
+
+fn page_rows(rows: serde_json::Value) -> Result<Vec<serde_json::Value>, IndexerRunnerError> {
+    match rows {
+        serde_json::Value::Array(rows) => Ok(rows),
+        other => Err(IndexerRunnerError::Normalize(format!(
+            "Datalens log query returned non-array rows: {other}"
+        ))),
+    }
+}
+
+fn progress(
+    processed_height: Option<i64>,
+    target_height: i64,
+    refresh_lag_blocks: i64,
+) -> IndexerRunnerProgress {
+    let synced_percentage = if target_height <= 0 {
+        100.0
+    } else {
+        processed_height
+            .map(|height| ((height as f64 / target_height as f64) * 100.0).min(100.0))
+            .unwrap_or(0.0)
+    };
+    let onchain_refresh_allowed = processed_height
+        .map(|height| height.saturating_add(refresh_lag_blocks) >= target_height)
+        .unwrap_or(false);
+
+    IndexerRunnerProgress {
+        processed_height,
+        target_height,
+        synced_percentage,
+        onchain_refresh_allowed,
+    }
+}
+
+fn to_checkpoint_error(error: impl fmt::Display) -> IndexerRunnerError {
+    IndexerRunnerError::Transaction(error.to_string())
+}
+
+fn transaction_error(
+    dao_code: &str,
+    chain_id: i32,
+    range: CheckpointBlockRange,
+    error: impl fmt::Display,
+) -> IndexerRunnerError {
+    error!(
+        "Datalens indexer chunk transaction failed; checkpoint was not advanced dao_code={} chain_id={} from_block={} to_block={} error={}",
+        dao_code, chain_id, range.from_block, range.to_block, error
+    );
+    IndexerRunnerError::Transaction(error.to_string())
+}
+
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[error("{message}")]
+pub struct InMemoryIndexerRunnerStoreError {
+    message: String,
+}
+
+impl InMemoryIndexerRunnerStoreError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InMemoryIndexerRunnerStore {
+    checkpoint: Option<IndexerCheckpoint>,
+    proposal_repository: InMemoryProposalProjectionRepository,
+    vote_repository: InMemoryVoteProjectionRepository,
+    token_repository: InMemoryTokenProjectionRepository,
+    timelock_repository: InMemoryTimelockProjectionRepository,
+    commit_count: u64,
+    commit_failures: VecDeque<String>,
+}
+
+impl InMemoryIndexerRunnerStore {
+    pub fn new(identity: IndexerCheckpointIdentity, start_block: i64) -> Self {
+        Self {
+            checkpoint: Some(checkpoint(identity, start_block)),
+            proposal_repository: InMemoryProposalProjectionRepository::default(),
+            vote_repository: InMemoryVoteProjectionRepository::default(),
+            token_repository: InMemoryTokenProjectionRepository::default(),
+            timelock_repository: InMemoryTimelockProjectionRepository::default(),
+            commit_count: 0,
+            commit_failures: VecDeque::new(),
+        }
+    }
+
+    pub fn checkpoint(&self) -> Option<&IndexerCheckpoint> {
+        self.checkpoint.as_ref()
+    }
+
+    pub fn commit_count(&self) -> u64 {
+        self.commit_count
+    }
+
+    pub fn fail_next_commit(&mut self, message: impl Into<String>) {
+        self.commit_failures.push_back(message.into());
+    }
+
+    pub fn rewind_next_block_for_replay(&mut self, next_block: i64) {
+        if let Some(checkpoint) = &mut self.checkpoint {
+            checkpoint.next_block = next_block;
+        }
+    }
+
+    pub fn proposal_repository(&self) -> &InMemoryProposalProjectionRepository {
+        &self.proposal_repository
+    }
+
+    pub fn vote_repository(&self) -> &InMemoryVoteProjectionRepository {
+        &self.vote_repository
+    }
+
+    pub fn token_repository(&self) -> &InMemoryTokenProjectionRepository {
+        &self.token_repository
+    }
+
+    pub fn timelock_repository(&self) -> &InMemoryTimelockProjectionRepository {
+        &self.timelock_repository
+    }
+}
+
+impl IndexerRunnerStore for InMemoryIndexerRunnerStore {
+    type Error = InMemoryIndexerRunnerStoreError;
+    type Transaction<'a> = InMemoryIndexerRunnerTransaction<'a>;
+
+    fn read_or_create_checkpoint(
+        &mut self,
+        identity: &IndexerCheckpointIdentity,
+        start_block: i64,
+    ) -> Result<IndexerCheckpoint, Self::Error> {
+        if self.checkpoint.is_none() {
+            self.checkpoint = Some(checkpoint(identity.clone(), start_block));
+        }
+        self.checkpoint
+            .clone()
+            .ok_or_else(|| InMemoryIndexerRunnerStoreError::new("checkpoint is missing"))
+    }
+
+    fn begin_transaction(&mut self) -> Result<Self::Transaction<'_>, Self::Error> {
+        Ok(InMemoryIndexerRunnerTransaction {
+            store: self,
+            staged_checkpoint: None,
+            proposal_repository: None,
+            vote_repository: None,
+            token_repository: None,
+            timelock_repository: None,
+        })
+    }
+}
+
+pub struct InMemoryIndexerRunnerTransaction<'a> {
+    store: &'a mut InMemoryIndexerRunnerStore,
+    staged_checkpoint: Option<IndexerCheckpoint>,
+    proposal_repository: Option<InMemoryProposalProjectionRepository>,
+    vote_repository: Option<InMemoryVoteProjectionRepository>,
+    token_repository: Option<InMemoryTokenProjectionRepository>,
+    timelock_repository: Option<InMemoryTimelockProjectionRepository>,
+}
+
+impl IndexerRunnerTransaction for InMemoryIndexerRunnerTransaction<'_> {
+    type Error = InMemoryIndexerRunnerStoreError;
+
+    fn apply_projection_batch(
+        &mut self,
+        batch: &IndexerProjectionBatch,
+    ) -> Result<(), Self::Error> {
+        if let Some(batch) = &batch.proposal {
+            let repository = self
+                .proposal_repository
+                .get_or_insert_with(|| self.store.proposal_repository.clone());
+            repository.apply(batch).map_err(|error| {
+                InMemoryIndexerRunnerStoreError::new(format!("proposal write failed: {error:?}"))
+            })?;
+        }
+        if let Some(batch) = &batch.vote {
+            let repository = self
+                .vote_repository
+                .get_or_insert_with(|| self.store.vote_repository.clone());
+            repository.apply(batch).map_err(|error| {
+                InMemoryIndexerRunnerStoreError::new(format!("vote write failed: {error:?}"))
+            })?;
+        }
+        if let Some(batch) = &batch.token {
+            let repository = self
+                .token_repository
+                .get_or_insert_with(|| self.store.token_repository.clone());
+            repository.apply(batch).map_err(|error| {
+                InMemoryIndexerRunnerStoreError::new(format!("token write failed: {error:?}"))
+            })?;
+        }
+        if let Some(batch) = &batch.timelock {
+            let repository = self
+                .timelock_repository
+                .get_or_insert_with(|| self.store.timelock_repository.clone());
+            repository.apply(batch).map_err(|error| {
+                InMemoryIndexerRunnerStoreError::new(format!("timelock write failed: {error:?}"))
+            })?;
+        }
+
+        Ok(())
+    }
+
+    fn advance_checkpoint(
+        &mut self,
+        identity: &IndexerCheckpointIdentity,
+        processed_height: i64,
+        target_height: Option<i64>,
+    ) -> Result<(), Self::Error> {
+        let mut checkpoint = self
+            .store
+            .checkpoint
+            .clone()
+            .ok_or_else(|| InMemoryIndexerRunnerStoreError::new("checkpoint is missing"))?;
+        if checkpoint.identity != *identity {
+            return Err(InMemoryIndexerRunnerStoreError::new(
+                "checkpoint identity mismatch",
+            ));
+        }
+        checkpoint.processed_height = Some(
+            checkpoint
+                .processed_height
+                .map_or(processed_height, |current| current.max(processed_height)),
+        );
+        checkpoint.next_block = checkpoint.next_block.max(processed_height + 1);
+        checkpoint.target_height = match (checkpoint.target_height, target_height) {
+            (Some(current), Some(next)) => Some(current.max(next)),
+            (None, Some(next)) => Some(next),
+            (current, None) => current,
+        };
+        checkpoint.last_error = None;
+        self.staged_checkpoint = Some(checkpoint);
+        Ok(())
+    }
+
+    fn commit(mut self) -> Result<(), Self::Error> {
+        if let Some(message) = self.store.commit_failures.pop_front() {
+            return Err(InMemoryIndexerRunnerStoreError::new(message));
+        }
+        if let Some(repository) = self.proposal_repository.take() {
+            self.store.proposal_repository = repository;
+        }
+        if let Some(repository) = self.vote_repository.take() {
+            self.store.vote_repository = repository;
+        }
+        if let Some(repository) = self.token_repository.take() {
+            self.store.token_repository = repository;
+        }
+        if let Some(repository) = self.timelock_repository.take() {
+            self.store.timelock_repository = repository;
+        }
+        if let Some(checkpoint) = self.staged_checkpoint.take() {
+            self.store.checkpoint = Some(checkpoint);
+        }
+        self.store.commit_count += 1;
+        Ok(())
+    }
+}
+
+fn checkpoint(identity: IndexerCheckpointIdentity, start_block: i64) -> IndexerCheckpoint {
+    IndexerCheckpoint {
+        identity,
+        next_block: start_block,
+        processed_height: None,
+        target_height: None,
+        updated_at: "in-memory".to_owned(),
+        last_error: None,
+        lock_owner: None,
+        locked_at: None,
+    }
+}

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -1,0 +1,302 @@
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use datalens_sdk::native::QueryInput;
+use degov_datalens_indexer::{
+    BatchReadPlanConfig, ChainContracts, ChainFamily, ChainIdentityConfig, DaoContractAddresses,
+    DaoEventDecodeError, DaoLogSource, DatalensConfig, DatalensError, DatalensFinality,
+    DatalensLogQueryReader, DatasetKeyConfig, DecodedDaoEvent, DecodedGovernorEvent,
+    DecodedTokenEvent, GovernanceTokenStandard, InMemoryIndexerRunnerStore,
+    IndexerCheckpointIdentity, IndexerEventDecoder, IndexerRunner, IndexerRunnerContexts,
+    IndexerRunnerOptions, NormalizedEvmLog, QueryLimitConfig, SecretString, TokenProjectionContext,
+    VoteCastEvent, VoteProjectionContext,
+};
+use serde_json::{Value, json};
+
+#[test]
+fn test_runner_processes_multiple_chunks_and_advances_checkpoint_after_commits() {
+    let mut runner = runner(
+        vec![
+            vec![row(1, 0, 0)],
+            vec![],
+            vec![],
+            vec![row(2, 0, 0)],
+            vec![],
+            vec![],
+        ],
+        ScriptedDecoder,
+    );
+
+    let report = runner.run_to_target(2).expect("runner succeeds");
+
+    assert_eq!(report.chunks_processed, 2);
+    assert_eq!(report.last_progress.processed_height, Some(2));
+    assert_eq!(report.last_progress.synced_percentage, 100.0);
+    assert!(report.last_progress.onchain_refresh_allowed);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        3
+    );
+    assert_eq!(runner.store().commit_count(), 2);
+    assert_eq!(
+        runner
+            .store()
+            .vote_repository()
+            .data_metric()
+            .votes_weight_for_sum,
+        "30"
+    );
+}
+
+#[test]
+fn test_runner_keeps_checkpoint_unchanged_when_transaction_fails() {
+    let mut runner = runner(vec![vec![row(1, 0, 0)], vec![], vec![]], ScriptedDecoder);
+    runner
+        .store_mut()
+        .fail_next_commit("projection write failed");
+
+    let error = runner.run_to_target(1).expect_err("commit fails");
+
+    assert!(error.to_string().contains("projection write failed"));
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        1
+    );
+    assert_eq!(runner.store().commit_count(), 0);
+    assert_eq!(
+        runner.store().vote_repository().data_metric().votes_count,
+        0
+    );
+}
+
+#[test]
+fn test_runner_replay_over_same_range_does_not_double_count_business_totals() {
+    let mut runner = runner(
+        vec![
+            vec![row(1, 0, 0)],
+            vec![],
+            vec![],
+            vec![row(1, 0, 0)],
+            vec![],
+            vec![],
+        ],
+        ScriptedDecoder,
+    );
+
+    runner.run_to_target(1).expect("first run succeeds");
+    runner.store_mut().rewind_next_block_for_replay(1);
+    runner.run_to_target(1).expect("replay succeeds");
+
+    assert_eq!(
+        runner.store().vote_repository().data_metric().votes_count,
+        1
+    );
+    assert_eq!(
+        runner
+            .store()
+            .vote_repository()
+            .data_metric()
+            .votes_weight_for_sum,
+        "10"
+    );
+    assert_eq!(runner.store().commit_count(), 2);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        2
+    );
+}
+
+#[test]
+fn test_runner_stops_gracefully_between_chunks() {
+    let mut runner = runner(
+        vec![
+            vec![row(1, 0, 0)],
+            vec![],
+            vec![],
+            vec![row(2, 0, 0)],
+            vec![],
+            vec![],
+        ],
+        ScriptedDecoder,
+    );
+    runner.request_shutdown_after_chunks(1);
+
+    let report = runner.run_to_target(2).expect("runner stops cleanly");
+
+    assert_eq!(report.chunks_processed, 1);
+    assert!(report.shutdown_requested);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        2
+    );
+    assert_eq!(runner.store().commit_count(), 1);
+}
+
+struct ScriptedDatalensReader {
+    rows: VecDeque<Vec<Value>>,
+}
+
+impl DatalensLogQueryReader for ScriptedDatalensReader {
+    fn query_logs(&mut self, _input: QueryInput) -> Result<Value, DatalensError> {
+        Ok(Value::Array(
+            self.rows.pop_front().expect("scripted query response"),
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct ScriptedDecoder;
+
+impl IndexerEventDecoder for ScriptedDecoder {
+    fn decode(
+        &self,
+        _dao_code: &str,
+        source: DaoLogSource,
+        _token_standard: Option<GovernanceTokenStandard>,
+        log: &NormalizedEvmLog,
+    ) -> Result<DecodedDaoEvent, DaoEventDecodeError> {
+        match source {
+            DaoLogSource::Governor => Ok(DecodedDaoEvent::Governor(
+                DecodedGovernorEvent::VoteCast(VoteCastEvent {
+                    voter: format!("0x{:040}", log.block_number),
+                    proposal_id: "42".to_owned(),
+                    support: 1,
+                    weight: (log.block_number * 10).to_string(),
+                    reason: String::new(),
+                }),
+            )),
+            DaoLogSource::GovernorToken => Ok(DecodedDaoEvent::Token(
+                DecodedTokenEvent::DelegateChanged(degov_datalens_indexer::DelegateChangedEvent {
+                    delegator: "0x0000000000000000000000000000000000000001".to_owned(),
+                    from_delegate: "0x0000000000000000000000000000000000000000".to_owned(),
+                    to_delegate: "0x0000000000000000000000000000000000000002".to_owned(),
+                }),
+            )),
+            DaoLogSource::Timelock => Ok(DecodedDaoEvent::UnsupportedTopic(
+                degov_datalens_indexer::UnsupportedTopicEvent {
+                    dao_code: "demo-dao".to_owned(),
+                    source,
+                    block_number: log.block_number,
+                    transaction_hash: log.transaction_hash.clone(),
+                    address: log.address.clone(),
+                    topic0: log.topics[0].clone(),
+                },
+            )),
+        }
+    }
+}
+
+fn runner(
+    rows: Vec<Vec<Value>>,
+    decoder: ScriptedDecoder,
+) -> IndexerRunner<ScriptedDatalensReader, InMemoryIndexerRunnerStore, ScriptedDecoder> {
+    IndexerRunner::new(
+        options(),
+        contexts(),
+        ScriptedDatalensReader {
+            rows: VecDeque::from(rows),
+        },
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+        decoder,
+    )
+}
+
+fn options() -> IndexerRunnerOptions {
+    IndexerRunnerOptions {
+        datalens_config: DatalensConfig {
+            endpoint: "https://datalens.example".to_owned(),
+            application: "degov-test".to_owned(),
+            bearer_token: SecretString::new("test-token"),
+            timeout: Duration::from_secs(30),
+            finality: DatalensFinality::DurableOnly,
+            chain: ChainIdentityConfig {
+                family: ChainFamily::Evm,
+                configured_name: "ethereum".to_owned(),
+                network_id: Some(1),
+            },
+            dataset: DatasetKeyConfig {
+                family: "evm".to_owned(),
+                name: "logs".to_owned(),
+            },
+            query_limits: QueryLimitConfig {
+                block_range_limit: 1,
+                row_limit: 100,
+            },
+            dao_contracts: Some(addresses()),
+        },
+        addresses: addresses(),
+        checkpoint_identity: identity(),
+        start_block: 1,
+        query_max_attempts: 1,
+        safe_height: None,
+        progress_refresh_lag_blocks: 0,
+    }
+}
+
+fn contexts() -> IndexerRunnerContexts {
+    let contracts = ChainContracts {
+        governor: "0x1111111111111111111111111111111111111111".to_owned(),
+        governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+        timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+    };
+    let read_plan_config = BatchReadPlanConfig {
+        max_concurrency: 10,
+        multicall_batch_size: 100,
+    };
+
+    IndexerRunnerContexts {
+        vote: VoteProjectionContext {
+            dao_code: "demo-dao".to_owned(),
+            governor_address: contracts.governor.clone(),
+            contracts: contracts.clone(),
+            read_plan_config,
+        },
+        token: TokenProjectionContext {
+            dao_code: "demo-dao".to_owned(),
+            governor_address: contracts.governor.clone(),
+            token_address: contracts.governor_token.clone(),
+            contracts,
+            token_standard: GovernanceTokenStandard::Erc20,
+            from_block: 1,
+            to_block: 1,
+            target_height: None,
+            read_plan_config,
+            current_power_method: degov_datalens_indexer::ChainReadMethod::GetVotes,
+        },
+        proposal: None,
+        timelock: None,
+    }
+}
+
+fn identity() -> IndexerCheckpointIdentity {
+    IndexerCheckpointIdentity {
+        dao_code: "demo-dao".to_owned(),
+        chain_id: 1,
+        stream_id: "datalens-native".to_owned(),
+        data_source_version: "test".to_owned(),
+    }
+}
+
+fn addresses() -> DaoContractAddresses {
+    DaoContractAddresses {
+        governor: "0x1111111111111111111111111111111111111111".to_owned(),
+        governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+        governor_token_standard: GovernanceTokenStandard::Erc20,
+        timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+    }
+}
+
+fn row(block_number: u64, transaction_index: u64, log_index: u64) -> Value {
+    json!({
+        "block_number": block_number,
+        "block_hash": format!("0xblock{block_number}"),
+        "block_timestamp": 1_700_000_000 + block_number,
+        "transaction_hash": format!("0xtx{block_number}"),
+        "transaction_index": transaction_index,
+        "log_index": log_index,
+        "address": "0x1111111111111111111111111111111111111111",
+        "topics": ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+        "data": "0x",
+        "removed": false
+    })
+}

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -49,6 +49,30 @@ fn test_runner_processes_multiple_chunks_and_advances_checkpoint_after_commits()
 }
 
 #[test]
+fn test_runner_skips_removed_logs_before_decode_and_still_advances_checkpoint() {
+    let mut options = options();
+    options.datalens_config.finality = DatalensFinality::IncludePending;
+    let mut runner = runner_with_decoder(
+        vec![vec![removed_row(1, 0, 0)], vec![], vec![]],
+        RejectRemovedDecoder,
+        options,
+    );
+
+    let report = runner.run_to_target(1).expect("runner succeeds");
+
+    assert_eq!(report.chunks_processed, 1);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        2
+    );
+    assert_eq!(runner.store().commit_count(), 1);
+    assert_eq!(
+        runner.store().vote_repository().data_metric().votes_count,
+        0
+    );
+}
+
+#[test]
 fn test_runner_keeps_checkpoint_unchanged_when_transaction_fails() {
     let mut runner = runner(vec![vec![row(1, 0, 0)], vec![], vec![]], ScriptedDecoder);
     runner
@@ -186,12 +210,45 @@ impl IndexerEventDecoder for ScriptedDecoder {
     }
 }
 
+#[derive(Clone)]
+struct RejectRemovedDecoder;
+
+impl IndexerEventDecoder for RejectRemovedDecoder {
+    fn decode(
+        &self,
+        _dao_code: &str,
+        _source: DaoLogSource,
+        _token_standard: Option<GovernanceTokenStandard>,
+        log: &NormalizedEvmLog,
+    ) -> Result<DecodedDaoEvent, DaoEventDecodeError> {
+        assert!(!log.removed, "removed log reached decoder");
+        Ok(DecodedDaoEvent::UnsupportedTopic(
+            degov_datalens_indexer::UnsupportedTopicEvent {
+                dao_code: "demo-dao".to_owned(),
+                source: DaoLogSource::Governor,
+                block_number: log.block_number,
+                transaction_hash: log.transaction_hash.clone(),
+                address: log.address.clone(),
+                topic0: log.topics[0].clone(),
+            },
+        ))
+    }
+}
+
 fn runner(
     rows: Vec<Vec<Value>>,
     decoder: ScriptedDecoder,
 ) -> IndexerRunner<ScriptedDatalensReader, InMemoryIndexerRunnerStore, ScriptedDecoder> {
+    runner_with_decoder(rows, decoder, options())
+}
+
+fn runner_with_decoder<D: IndexerEventDecoder>(
+    rows: Vec<Vec<Value>>,
+    decoder: D,
+    options: IndexerRunnerOptions,
+) -> IndexerRunner<ScriptedDatalensReader, InMemoryIndexerRunnerStore, D> {
     IndexerRunner::new(
-        options(),
+        options,
         contexts(),
         ScriptedDatalensReader {
             rows: VecDeque::from(rows),
@@ -287,6 +344,19 @@ fn addresses() -> DaoContractAddresses {
 }
 
 fn row(block_number: u64, transaction_index: u64, log_index: u64) -> Value {
+    row_with_removed(block_number, transaction_index, log_index, false)
+}
+
+fn removed_row(block_number: u64, transaction_index: u64, log_index: u64) -> Value {
+    row_with_removed(block_number, transaction_index, log_index, true)
+}
+
+fn row_with_removed(
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+    removed: bool,
+) -> Value {
     json!({
         "block_number": block_number,
         "block_hash": format!("0xblock{block_number}"),
@@ -297,6 +367,6 @@ fn row(block_number: u64, transaction_index: u64, log_index: u64) -> Value {
         "address": "0x1111111111111111111111111111111111111111",
         "topics": ["0x0000000000000000000000000000000000000000000000000000000000000000"],
         "data": "0x",
-        "removed": false
+        "removed": removed
     })
 }


### PR DESCRIPTION
## Summary
- Adds the Datalens-native runner abstraction for chunked log processing.
- Connects query planning, log normalization, decoding, projection/write application, and checkpoint advancement behind explicit transactional semantics.
- Adds failure/idempotency tests for checkpoint behavior and repeat execution.

## Verification
- cargo test --locked -p degov-datalens-indexer --test indexer_runner
- cargo clippy --locked -p degov-datalens-indexer --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check