### PR TITLE
HBX-257: Update Datalens runtime packaging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,9 @@
 DEGOV_DB_PORT=5432
 DEGOV_DB_PASSWORD=password
 DEGOV_DB_NAME=postgres
-DEGOV_INDEXER_DB_NAME=indexer
 DEGOV_INDEXER_DATABASE_URL=postgresql://postgres:password@localhost:5432/indexer
 DEGOV_INDEXER_PORT=4350
-DEGOV_INDEXER_GRAPHQL_ENDPOINT=https://indexer.next.degov.ai/degov-demo-dao/graphql
+DEGOV_INDEXER_GRAPHQL_ENDPOINT=
 
 # Datalens-native indexer.
 # Keep DATALENS_ENDPOINT as the service base URL; the Rust SDK derives /native/graphql.

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 # Database and local service ports.
 DEGOV_DB_PORT=5432
 DEGOV_DB_PASSWORD=password
+DEGOV_DB_NAME=postgres
+DEGOV_INDEXER_DB_NAME=indexer
+DEGOV_INDEXER_DATABASE_URL=postgresql://postgres:password@localhost:5432/indexer
 DEGOV_INDEXER_PORT=4350
+DEGOV_INDEXER_GRAPHQL_ENDPOINT=https://indexer.next.degov.ai/degov-demo-dao/graphql
 
 # Datalens-native indexer.
 # Keep DATALENS_ENDPOINT as the service base URL; the Rust SDK derives /native/graphql.
@@ -17,6 +21,10 @@ DATALENS_DATASET_FAMILY=evm
 DATALENS_DATASET_NAME=logs
 DATALENS_QUERY_BLOCK_RANGE_LIMIT=1000
 DATALENS_QUERY_ROW_LIMIT=1000
+DATALENS_GOVERNOR_ADDRESS=
+DATALENS_GOVERNOR_TOKEN_ADDRESS=
+DATALENS_GOVERNOR_TOKEN_STANDARD=ERC20
+DATALENS_TIMELOCK_ADDRESS=
 
 # Onchain refresh worker.
 # Keep enabled when using onchain voting power refresh locally.
@@ -46,7 +54,7 @@ DEGOV_ONCHAIN_REFRESH_POLL_INTERVAL_MS=10000
 # Delay before newly created event refresh tasks become claimable.
 DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS=120000
 
-# Advisory-lock TTL for serializing worker writes with processor writes.
+# Advisory-lock TTL for serializing worker writes with indexer writes.
 DEGOV_ONCHAIN_REFRESH_LOCK_TTL_MS=300000
 
 # Web app.

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -18,9 +18,10 @@ serde_json = "1.0.150"
 sha3 = "0.10.9"
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio-rustls", "postgres"] }
 thiserror = "2.0.17"
+tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["ansi", "env-filter", "fmt"] }
 
 [dev-dependencies]
 temp-env = "0.3.6"
-tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.52.3", features = ["sync"] }

--- a/apps/indexer/justfile
+++ b/apps/indexer/justfile
@@ -13,6 +13,7 @@ build:
 test:
     node ./scripts/check-rust-conventions.mjs
     node ./scripts/check-postgres-schema.mjs
+    node ./scripts/runtime-packaging.test.mjs
     cargo test --locked
     node ./scripts/check-rust-conventions.test.mjs
     node ./scripts/compatibility-preflight.test.mjs

--- a/apps/indexer/scripts/runtime-packaging.test.mjs
+++ b/apps/indexer/scripts/runtime-packaging.test.mjs
@@ -42,6 +42,16 @@ assert.match(
 );
 assert.doesNotMatch(
   composeYaml,
+  /DEGOV_INDEXER_DB_NAME/,
+  "compose must not expose an indexer DB override unless init creates the same DB",
+);
+assert.match(
+  composeYaml,
+  /DEGOV_INDEXER_DATABASE_URL: postgresql:\/\/postgres:\$\{DEGOV_DB_PASSWORD:-postgres\}@postgres\/indexer/,
+  "compose must point the indexer at the DB created by postgres init",
+);
+assert.doesNotMatch(
+  composeYaml,
   /\b(npx\s+sqd|sqd\s+serve|squid-processor|processor:start)\b/i,
   "compose must not start removed SQD processor commands",
 );
@@ -49,5 +59,15 @@ assert.doesNotMatch(
 assert.match(envExample, /DATALENS_ENDPOINT=/);
 assert.match(envExample, /DEGOV_INDEXER_DATABASE_URL=/);
 assert.match(envExample, /DEGOV_INDEXER_GRAPHQL_ENDPOINT=/);
+assert.doesNotMatch(
+  envExample,
+  /^DEGOV_INDEXER_DB_NAME=/m,
+  ".env.example must not advertise an indexer DB override not honored by postgres init",
+);
+assert.doesNotMatch(
+  envExample,
+  /^DEGOV_INDEXER_GRAPHQL_ENDPOINT=https?:\/\/indexer\.next\.degov\.ai/m,
+  ".env.example must not default local runtime packaging to the remote hosted indexer",
+);
 
 console.log("Runtime packaging check passed");

--- a/apps/indexer/scripts/runtime-packaging.test.mjs
+++ b/apps/indexer/scripts/runtime-packaging.test.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..", "..", "..");
+
+const [packageJson, composeYaml, envExample] = await Promise.all([
+  readFile(path.join(repositoryRoot, "package.json"), "utf8"),
+  readFile(path.join(repositoryRoot, "docker-compose.yml"), "utf8"),
+  readFile(path.join(repositoryRoot, ".env.example"), "utf8"),
+]);
+
+const packageConfig = JSON.parse(packageJson);
+
+for (const scriptName of [
+  "indexer",
+  "indexer:migrate",
+  "indexer:worker",
+  "indexer:graphql",
+]) {
+  assert.equal(
+    typeof packageConfig.scripts?.[scriptName],
+    "string",
+    `package.json must define ${scriptName}`,
+  );
+}
+
+assert.match(packageConfig.scripts.indexer, /degov-datalens-indexer .*run/);
+assert.match(packageConfig.scripts["indexer:worker"], /degov-datalens-indexer .*worker/);
+assert.match(packageConfig.scripts["indexer:graphql"], /degov-datalens-indexer .*graphql/);
+assert.match(packageConfig.scripts["indexer:migrate"], /degov-datalens-indexer .*migrate/);
+
+assert.match(composeYaml, /^\s+indexer:/m, "compose must define an indexer service");
+assert.match(composeYaml, /^\s+onchain-worker:/m, "compose must define an onchain worker service");
+assert.match(composeYaml, /DATALENS_ENDPOINT/, "compose must pass Datalens environment");
+assert.match(
+  composeYaml,
+  /DEGOV_INDEXER_DATABASE_URL/,
+  "compose must pass the indexer database URL",
+);
+assert.doesNotMatch(
+  composeYaml,
+  /\b(npx\s+sqd|sqd\s+serve|squid-processor|processor:start)\b/i,
+  "compose must not start removed SQD processor commands",
+);
+
+assert.match(envExample, /DATALENS_ENDPOINT=/);
+assert.match(envExample, /DEGOV_INDEXER_DATABASE_URL=/);
+assert.match(envExample, /DEGOV_INDEXER_GRAPHQL_ENDPOINT=/);
+
+console.log("Runtime packaging check passed");

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -1,6 +1,11 @@
+use std::env;
+
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use degov_datalens_indexer::{DatalensConfig, DatalensNativeClient, verify_datalens_service};
+use sqlx::{Executor, postgres::PgPoolOptions};
+
+const POSTGRES_SCHEMA_SQL: &str = include_str!("../schema/postgres.sql");
 
 #[derive(Debug, Parser)]
 #[command(name = "degov-datalens-indexer")]
@@ -11,14 +16,23 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    Run,
+    Worker,
+    Migrate,
+    Graphql,
     SmokeDatalens,
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     init_logging()?;
     let cli = Cli::parse();
 
     match cli.command {
+        Command::Run => run_indexer().await,
+        Command::Worker => run_worker(),
+        Command::Migrate => migrate().await,
+        Command::Graphql => graphql(),
         Command::SmokeDatalens => smoke_datalens(),
     }
 }
@@ -33,14 +47,94 @@ fn init_logging() -> anyhow::Result<()> {
 
 fn smoke_datalens() -> anyhow::Result<()> {
     let config = DatalensConfig::from_env().context("load Datalens configuration")?;
+    verify_datalens(&config)
+}
+
+async fn run_indexer() -> anyhow::Result<()> {
+    let config = DatalensConfig::from_env().context("load Datalens configuration")?;
+    let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
+    let contracts = config
+        .dao_contracts
+        .as_ref()
+        .context("Datalens indexer run requires DATALENS_GOVERNOR_* contract envs")?;
+
+    verify_datalens(&config)?;
+    log::info!(
+        "Datalens indexer runtime boundary is ready dao_chain={} dataset={} governor={} token={} timelock={} database_url_configured={}",
+        config.chain.configured_name,
+        config.dataset.key(),
+        contracts.governor,
+        contracts.governor_token,
+        contracts.timelock,
+        !database_url.is_empty()
+    );
+    log::info!("Datalens server is an external dependency; DeGov runs as an application consumer");
+
+    Ok(())
+}
+
+fn run_worker() -> anyhow::Result<()> {
+    let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
+    let enabled =
+        env::var("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED").unwrap_or_else(|_| "true".to_owned());
+
+    log::info!(
+        "onchain refresh worker packaging is ready enabled={} database_url_configured={}",
+        enabled,
+        !database_url.is_empty()
+    );
+
+    Ok(())
+}
+
+async fn migrate() -> anyhow::Result<()> {
+    let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await
+        .context("connect to DeGov indexer Postgres")?;
+
+    pool.execute(POSTGRES_SCHEMA_SQL)
+        .await
+        .context("apply Datalens-native DeGov indexer schema")?;
+
+    log::info!("Datalens-native DeGov indexer schema applied");
+
+    Ok(())
+}
+
+fn graphql() -> anyhow::Result<()> {
+    let endpoint = required_env("DEGOV_INDEXER_GRAPHQL_ENDPOINT")?;
+
+    log::info!(
+        "GraphQL/API packaging is configured endpoint={}; Datalens server remains external",
+        endpoint
+    );
+
+    Ok(())
+}
+
+fn verify_datalens(config: &DatalensConfig) -> anyhow::Result<()> {
     log::info!(
         "checking Datalens readiness for application {} at {}",
         config.application,
         config.endpoint
     );
-    let client = DatalensNativeClient::from_config(&config).context("create Datalens client")?;
+    let client = DatalensNativeClient::from_config(config).context("create Datalens client")?;
     verify_datalens_service(&client).context("verify Datalens service")?;
     log::info!("Datalens native GraphQL readiness confirmed");
 
     Ok(())
+}
+
+fn required_env(name: &'static str) -> anyhow::Result<String> {
+    let value = env::var(name).with_context(|| format!("{name} is required"))?;
+    let value = value.trim().to_owned();
+
+    if value.is_empty() {
+        anyhow::bail!("{name} must not be empty");
+    }
+
+    Ok(value)
 }

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, future};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Command::Run => run_indexer().await,
-        Command::Worker => run_worker(),
+        Command::Worker => run_worker().await,
         Command::Migrate => migrate().await,
         Command::Graphql => graphql(),
         Command::SmokeDatalens => smoke_datalens(),
@@ -70,20 +70,35 @@ async fn run_indexer() -> anyhow::Result<()> {
     );
     log::info!("Datalens server is an external dependency; DeGov runs as an application consumer");
 
-    Ok(())
+    wait_for_service_shutdown("Datalens indexer runtime").await
 }
 
-fn run_worker() -> anyhow::Result<()> {
+async fn run_worker() -> anyhow::Result<()> {
     let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
-    let enabled =
-        env::var("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED").unwrap_or_else(|_| "true".to_owned());
+    let enabled = env::var("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED")
+        .map(|value| onchain_refresh_worker_enabled(&value))
+        .unwrap_or(Ok(true))?;
+
+    if !enabled {
+        log::info!(
+            "onchain refresh worker is disabled by DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED; keeping service alive"
+        );
+        return wait_for_service_shutdown("disabled onchain refresh worker").await;
+    }
 
     log::info!(
         "onchain refresh worker packaging is ready enabled={} database_url_configured={}",
         enabled,
         !database_url.is_empty()
     );
+    log::info!("onchain refresh worker runtime will process refresh tasks in a follow-up package");
 
+    wait_for_service_shutdown("onchain refresh worker").await
+}
+
+async fn wait_for_service_shutdown(service_name: &str) -> anyhow::Result<()> {
+    log::info!("{service_name} service is running; stop the process to shut it down");
+    future::pending::<()>().await;
     Ok(())
 }
 
@@ -95,9 +110,11 @@ async fn migrate() -> anyhow::Result<()> {
         .await
         .context("connect to DeGov indexer Postgres")?;
 
-    pool.execute(POSTGRES_SCHEMA_SQL)
-        .await
-        .context("apply Datalens-native DeGov indexer schema")?;
+    for statement in postgres_schema_statements(POSTGRES_SCHEMA_SQL) {
+        pool.execute(statement).await.with_context(|| {
+            format!("apply Datalens-native DeGov indexer schema statement: {statement}")
+        })?;
+    }
 
     log::info!("Datalens-native DeGov indexer schema applied");
 
@@ -137,4 +154,167 @@ fn required_env(name: &'static str) -> anyhow::Result<String> {
     }
 
     Ok(value)
+}
+
+fn onchain_refresh_worker_enabled(value: &str) -> anyhow::Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" => Ok(true),
+        "false" | "0" | "no" => Ok(false),
+        _ => anyhow::bail!(
+            "DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED must be one of true, false, 1, 0, yes, or no"
+        ),
+    }
+}
+
+fn postgres_schema_statements(sql: &str) -> Vec<&str> {
+    let mut statements = Vec::new();
+    let mut statement_start = 0;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+    let mut dollar_quote_tag: Option<&str> = None;
+    let mut chars = sql.char_indices().peekable();
+
+    while let Some((index, character)) = chars.next() {
+        let rest = &sql[index..];
+
+        if let Some(tag) = dollar_quote_tag {
+            if rest.starts_with(tag) {
+                dollar_quote_tag = None;
+                for _ in 1..tag.chars().count() {
+                    chars.next();
+                }
+            }
+            continue;
+        }
+
+        if in_line_comment {
+            if character == '\n' {
+                in_line_comment = false;
+            }
+            continue;
+        }
+
+        if in_block_comment {
+            if rest.starts_with("*/") {
+                in_block_comment = false;
+                chars.next();
+            }
+            continue;
+        }
+
+        if in_single_quote {
+            if character == '\'' {
+                if matches!(chars.peek(), Some((_, '\''))) {
+                    chars.next();
+                } else {
+                    in_single_quote = false;
+                }
+            }
+            continue;
+        }
+
+        if in_double_quote {
+            if character == '"' {
+                in_double_quote = false;
+            }
+            continue;
+        }
+
+        if rest.starts_with("--") {
+            in_line_comment = true;
+            chars.next();
+            continue;
+        }
+
+        if rest.starts_with("/*") {
+            in_block_comment = true;
+            chars.next();
+            continue;
+        }
+
+        if character == '\'' {
+            in_single_quote = true;
+            continue;
+        }
+
+        if character == '"' {
+            in_double_quote = true;
+            continue;
+        }
+
+        if character == '$' {
+            if let Some(tag_end) = rest[1..].find('$') {
+                let tag = &rest[..=tag_end + 1];
+
+                if tag[1..tag.len() - 1]
+                    .chars()
+                    .all(|tag_char| tag_char == '_' || tag_char.is_ascii_alphanumeric())
+                {
+                    dollar_quote_tag = Some(tag);
+                    for _ in 1..tag.chars().count() {
+                        chars.next();
+                    }
+                }
+            }
+            continue;
+        }
+
+        if character == ';' {
+            let statement = sql[statement_start..index].trim();
+
+            if !statement.is_empty() {
+                statements.push(statement);
+            }
+
+            statement_start = index + character.len_utf8();
+        }
+    }
+
+    let statement = sql[statement_start..].trim();
+
+    if !statement.is_empty() {
+        statements.push(statement);
+    }
+
+    statements
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_postgres_schema_statements_splits_schema_into_individual_statements() {
+        let statements = postgres_schema_statements(
+            "CREATE TABLE one (id INTEGER);\n\n-- comment with ;\nCREATE INDEX one_id_idx ON one (id);\n",
+        );
+
+        assert_eq!(
+            statements,
+            vec![
+                "CREATE TABLE one (id INTEGER)",
+                "-- comment with ;\nCREATE INDEX one_id_idx ON one (id)"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_onchain_refresh_worker_enabled_accepts_disabled_values() {
+        assert!(!onchain_refresh_worker_enabled("false").expect("false parses"));
+        assert!(!onchain_refresh_worker_enabled("0").expect("0 parses"));
+        assert!(!onchain_refresh_worker_enabled("no").expect("no parses"));
+    }
+
+    #[test]
+    fn test_onchain_refresh_worker_enabled_rejects_ambiguous_values() {
+        let error = onchain_refresh_worker_enabled("disabled").expect_err("disabled is invalid");
+
+        assert!(
+            error
+                .to_string()
+                .contains("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED")
+        );
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       dockerfile: docker/indexer.Dockerfile
     command: migrate
     environment:
-      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/${DEGOV_INDEXER_DB_NAME:-indexer}
+      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/indexer
 
   indexer:
     image: degov-indexer
@@ -35,7 +35,7 @@ services:
       dockerfile: docker/indexer.Dockerfile
     command: run
     environment:
-      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/${DEGOV_INDEXER_DB_NAME:-indexer}
+      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/indexer
       DATALENS_ENDPOINT: ${DATALENS_ENDPOINT:-}
       DATALENS_APPLICATION: ${DATALENS_APPLICATION:-}
       DATALENS_TOKEN: ${DATALENS_TOKEN:-}
@@ -64,7 +64,7 @@ services:
       dockerfile: docker/indexer.Dockerfile
     command: worker
     environment:
-      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/${DEGOV_INDEXER_DB_NAME:-indexer}
+      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/indexer
       DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED: ${DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED:-true}
       DEGOV_ONCHAIN_REFRESH_BATCH_SIZE: ${DEGOV_ONCHAIN_REFRESH_BATCH_SIZE:-100}
       DEGOV_ONCHAIN_REFRESH_RECONCILE_SEED_BATCH_SIZE: ${DEGOV_ONCHAIN_REFRESH_RECONCILE_SEED_BATCH_SIZE:-100}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,78 @@ services:
     image: postgres:17-alpine
     shm_size: 1gb
     environment:
-      POSTGRES_DB: postgres
+      POSTGRES_DB: ${DEGOV_DB_NAME:-postgres}
       POSTGRES_PASSWORD: ${DEGOV_DB_PASSWORD:-postgres}
     volumes:
       - ./.data/postgres:/var/lib/postgresql/data
       - ./init-scripts/postgres:/docker-entrypoint-initdb.d
     ports:
       - "${DEGOV_DB_PORT:-5432}:5432"
+
+  indexer-migrate:
+    image: degov-indexer
+    profiles:
+      - indexer
+    depends_on:
+      - postgres
+    build:
+      context: .
+      dockerfile: docker/indexer.Dockerfile
+    command: migrate
+    environment:
+      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/${DEGOV_INDEXER_DB_NAME:-indexer}
+
+  indexer:
+    image: degov-indexer
+    profiles:
+      - indexer
+    depends_on:
+      - postgres
+    build:
+      context: .
+      dockerfile: docker/indexer.Dockerfile
+    command: run
+    environment:
+      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/${DEGOV_INDEXER_DB_NAME:-indexer}
+      DATALENS_ENDPOINT: ${DATALENS_ENDPOINT:-}
+      DATALENS_APPLICATION: ${DATALENS_APPLICATION:-}
+      DATALENS_TOKEN: ${DATALENS_TOKEN:-}
+      DATALENS_TIMEOUT_SECONDS: ${DATALENS_TIMEOUT_SECONDS:-60}
+      DATALENS_FINALITY: ${DATALENS_FINALITY:-durable_only}
+      DATALENS_CHAIN_FAMILY: ${DATALENS_CHAIN_FAMILY:-evm}
+      DATALENS_CHAIN_NAME: ${DATALENS_CHAIN_NAME:-ethereum}
+      DATALENS_CHAIN_ID: ${DATALENS_CHAIN_ID:-1}
+      DATALENS_DATASET_FAMILY: ${DATALENS_DATASET_FAMILY:-evm}
+      DATALENS_DATASET_NAME: ${DATALENS_DATASET_NAME:-logs}
+      DATALENS_QUERY_BLOCK_RANGE_LIMIT: ${DATALENS_QUERY_BLOCK_RANGE_LIMIT:-1000}
+      DATALENS_QUERY_ROW_LIMIT: ${DATALENS_QUERY_ROW_LIMIT:-1000}
+      DATALENS_GOVERNOR_ADDRESS: ${DATALENS_GOVERNOR_ADDRESS:-}
+      DATALENS_GOVERNOR_TOKEN_ADDRESS: ${DATALENS_GOVERNOR_TOKEN_ADDRESS:-}
+      DATALENS_GOVERNOR_TOKEN_STANDARD: ${DATALENS_GOVERNOR_TOKEN_STANDARD:-}
+      DATALENS_TIMELOCK_ADDRESS: ${DATALENS_TIMELOCK_ADDRESS:-}
+
+  onchain-worker:
+    image: degov-indexer
+    profiles:
+      - indexer
+    depends_on:
+      - postgres
+    build:
+      context: .
+      dockerfile: docker/indexer.Dockerfile
+    command: worker
+    environment:
+      DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/${DEGOV_INDEXER_DB_NAME:-indexer}
+      DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED: ${DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED:-true}
+      DEGOV_ONCHAIN_REFRESH_BATCH_SIZE: ${DEGOV_ONCHAIN_REFRESH_BATCH_SIZE:-100}
+      DEGOV_ONCHAIN_REFRESH_RECONCILE_SEED_BATCH_SIZE: ${DEGOV_ONCHAIN_REFRESH_RECONCILE_SEED_BATCH_SIZE:-100}
+      DEGOV_ONCHAIN_REFRESH_MULTICALL_CHUNK_SIZE: ${DEGOV_ONCHAIN_REFRESH_MULTICALL_CHUNK_SIZE:-100}
+      DEGOV_ONCHAIN_REFRESH_CONCURRENCY: ${DEGOV_ONCHAIN_REFRESH_CONCURRENCY:-1}
+      DEGOV_ONCHAIN_REFRESH_MAX_BATCHES_PER_POLL: ${DEGOV_ONCHAIN_REFRESH_MAX_BATCHES_PER_POLL:-1}
+      DEGOV_ONCHAIN_REFRESH_MAX_SYNC_LAG_BLOCKS: ${DEGOV_ONCHAIN_REFRESH_MAX_SYNC_LAG_BLOCKS:-1000}
+      DEGOV_ONCHAIN_REFRESH_POLL_INTERVAL_MS: ${DEGOV_ONCHAIN_REFRESH_POLL_INTERVAL_MS:-10000}
+      DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS: ${DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS:-120000}
+      DEGOV_ONCHAIN_REFRESH_LOCK_TTL_MS: ${DEGOV_ONCHAIN_REFRESH_LOCK_TTL_MS:-300000}
 
   web:
     image: degov-web
@@ -21,6 +86,7 @@ services:
     ports:
       - "${DEGOV_WEB_PORT:-3000}:3000"
     environment:
-      JWT_SECRET_KEY: ${DEGOV_WEB_JWT_SECRET}
+      JWT_SECRET_KEY: ${DEGOV_WEB_JWT_SECRET:-}
       DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/degov
+      DEGOV_INDEXER_GRAPHQL_ENDPOINT: ${DEGOV_INDEXER_GRAPHQL_ENDPOINT:-}
       # DEGOV_CONFIG_PATH: degov.yml

--- a/docker/indexer.Dockerfile
+++ b/docker/indexer.Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1.95-bookworm AS builder
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY apps/indexer/Cargo.toml apps/indexer/Cargo.toml
+COPY apps/indexer/src apps/indexer/src
+COPY apps/indexer/schema apps/indexer/schema
+
+RUN cargo build -p degov-datalens-indexer --locked --release
+
+FROM debian:bookworm-slim AS runner
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/degov-datalens-indexer /usr/local/bin/degov-datalens-indexer
+
+USER nobody:nogroup
+
+ENTRYPOINT [ "degov-datalens-indexer" ]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "2.0.0",
   "private": true,
   "packageManager": "pnpm@10.32.1",
+  "scripts": {
+    "indexer": "cargo run -p degov-datalens-indexer --locked -- run",
+    "indexer:build": "cargo build -p degov-datalens-indexer --locked",
+    "indexer:graphql": "cargo run -p degov-datalens-indexer --locked -- graphql",
+    "indexer:migrate": "cargo run -p degov-datalens-indexer --locked -- migrate",
+    "indexer:smoke-datalens": "cargo run -p degov-datalens-indexer --locked -- smoke-datalens",
+    "indexer:worker": "cargo run -p degov-datalens-indexer --locked -- worker"
+  },
   "pnpm": {
     "packageExtensions": {
       "@hookform/resolvers@4.1.3": {


### PR DESCRIPTION
## Summary
- Adds Datalens-native indexer package scripts and Rust CLI subcommands for run/migrate/worker/graphql/smoke flows.
- Updates docker-compose, env examples, and the indexer Dockerfile for the Datalens consumer runtime.
- Adds a packaging smoke test to guard against removed SQD command references.

## Verification
- node apps/indexer/scripts/runtime-packaging.test.mjs
- cargo fmt --all --check
- cargo check -p degov-datalens-indexer --locked
- cargo clippy -p degov-datalens-indexer --all-targets --locked -- -D warnings
- docker compose --profile indexer config
- DEGOV_INDEXER_GRAPHQL_ENDPOINT=http://localhost:4350/graphql pnpm indexer:graphql
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://datalens:datalens@127.0.0.1:5432/datalens_test just test
- git diff --check