### PR TITLE
HBX-268: Migrate Datalens diagnostic scripts

### DIFF
--- a/apps/indexer/justfile
+++ b/apps/indexer/justfile
@@ -14,6 +14,10 @@ test:
     node ./scripts/check-rust-conventions.mjs
     node ./scripts/check-postgres-schema.mjs
     node ./scripts/runtime-packaging.test.mjs
+    node ./scripts/indexer-diagnostics.test.mjs
+    node ./scripts/indexer-accuracy-audit.test.mjs
+    node ./scripts/indexer-accuracy-diagnose.test.mjs
+    node ./scripts/indexer-reconcile-diagnose.test.mjs
     cargo test --locked
     node ./scripts/check-rust-conventions.test.mjs
     node ./scripts/compatibility-preflight.test.mjs
@@ -23,7 +27,10 @@ test-unit:
     cargo test --locked
 
 test-accuracy:
-    @just test
+    node ./scripts/indexer-diagnostics.test.mjs
+    node ./scripts/indexer-accuracy-audit.test.mjs
+    node ./scripts/indexer-accuracy-diagnose.test.mjs
+    node ./scripts/indexer-reconcile-diagnose.test.mjs
 
 test-integration:
     @just test

--- a/apps/indexer/scripts/indexer-accuracy-audit.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-audit.mjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  classifyDatalensQueryError,
+  classifyProjectionMismatch,
+  compactAmount,
+  graphqlRequest,
+  loadTargets,
+  parsePositiveInt,
+  readCurrentVotes,
+  readDatalensStatus,
+  readTokenBalance,
+} from "./indexer-diagnostics.mjs";
+
+const TOP_CONTRIBUTORS_QUERY = `
+  query TopContributors($limit: Int!, $offset: Int!) {
+    contributors(limit: $limit, offset: $offset, orderBy: [power_DESC]) {
+      id
+      power
+      balance
+      delegatesCountAll
+      lastVoteTimestamp
+    }
+  }
+`;
+
+const NEGATIVE_ROWS_QUERY = `
+  query NegativeRows($limit: Int!, $offset: Int!) {
+    contributors(limit: $limit, offset: $offset, orderBy: [power_ASC], where: { power_lt: 0 }) {
+      id
+      power
+    }
+    delegates(limit: $limit, offset: $offset, orderBy: [power_ASC], where: { power_lt: 0 }) {
+      id
+      fromDelegate
+      toDelegate
+      power
+    }
+  }
+`;
+
+export function parseArgs(argv) {
+  const options = {
+    concurrency: 10,
+    databaseUrl: process.env.DEGOV_INDEXER_DATABASE_URL ?? process.env.DATABASE_URL ?? "",
+    failOnAnomalies: false,
+    jsonFile: "",
+    limit: 100,
+    markdownFile: "",
+    negativeLimit: 100,
+    targetsFile: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--fail-on-anomalies") {
+      options.failOnAnomalies = true;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      continue;
+    }
+    const [flag, inlineValue] = token.split("=", 2);
+    const value = inlineValue ?? argv[index + 1];
+    const expectsValue = inlineValue === undefined;
+
+    switch (flag) {
+      case "--concurrency":
+        options.concurrency = parsePositiveInt(value, "--concurrency");
+        break;
+      case "--database-url":
+        options.databaseUrl = value;
+        break;
+      case "--json-file":
+        options.jsonFile = value;
+        break;
+      case "--limit":
+        options.limit = parsePositiveInt(value, "--limit");
+        break;
+      case "--markdown-file":
+        options.markdownFile = value;
+        break;
+      case "--negative-limit":
+        options.negativeLimit = parsePositiveInt(value, "--negative-limit");
+        break;
+      case "--targets-file":
+        options.targetsFile = path.resolve(process.cwd(), value);
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+    if (expectsValue) {
+      index += 1;
+    }
+  }
+  return options;
+}
+
+export async function fetchTopContributors(target, limit) {
+  const data = await graphqlRequest(target.indexerEndpoint, TOP_CONTRIBUTORS_QUERY, {
+    limit,
+    offset: 0,
+  });
+  return data.contributors ?? [];
+}
+
+export async function fetchNegativeRows(target, limit) {
+  const data = await graphqlRequest(target.indexerEndpoint, NEGATIVE_ROWS_QUERY, {
+    limit,
+    offset: 0,
+  });
+  return {
+    contributors: data.contributors ?? [],
+    delegates: data.delegates ?? [],
+  };
+}
+
+async function runWithConcurrency(items, concurrency, worker) {
+  const pending = new Set();
+  const results = [];
+  for (const item of items) {
+    const task = Promise.resolve().then(() => worker(item));
+    pending.add(task);
+    results.push(task);
+    task.finally(() => pending.delete(task));
+    if (pending.size >= concurrency) {
+      await Promise.race(pending);
+    }
+  }
+  return Promise.allSettled(results);
+}
+
+export async function auditTarget(target, options, services = {}) {
+  const result = {
+    code: target.code,
+    name: target.name ?? target.code,
+    checkedAccounts: 0,
+    matches: 0,
+    mismatches: [],
+    negativeContributors: [],
+    negativeDelegates: [],
+    queryErrors: [],
+    voteReadErrors: [],
+  };
+  const fetchContributors = services.fetchTopContributors ?? fetchTopContributors;
+  const fetchNegatives = services.fetchNegativeRows ?? fetchNegativeRows;
+  const readVotes = services.readCurrentVotes ?? readCurrentVotes;
+  const readBalance = services.readTokenBalance ?? readTokenBalance;
+
+  const [contributorsResult, negativesResult] = await Promise.allSettled([
+    fetchContributors(target, target.limit ?? options.limit),
+    fetchNegatives(target, target.negativeLimit ?? options.negativeLimit),
+  ]);
+
+  if (contributorsResult.status === "rejected") {
+    result.queryErrors.push({
+      scope: "contributors",
+      classification: classifyDatalensQueryError(contributorsResult.reason),
+      message: contributorsResult.reason?.message ?? String(contributorsResult.reason),
+    });
+    return finalizeTargetResult(result);
+  }
+
+  if (negativesResult.status === "fulfilled") {
+    result.negativeContributors = negativesResult.value.contributors.map((entry) => ({
+      address: entry.id,
+      power: entry.power,
+      hint: "negative-contributor-power",
+    }));
+    result.negativeDelegates = negativesResult.value.delegates.map((entry) => ({
+      id: entry.id,
+      fromDelegate: entry.fromDelegate,
+      toDelegate: entry.toDelegate,
+      power: entry.power,
+      hint: "negative-delegate-power",
+    }));
+  } else {
+    result.queryErrors.push({
+      scope: "negative-rows",
+      classification: classifyDatalensQueryError(negativesResult.reason),
+      message: negativesResult.reason?.message ?? String(negativesResult.reason),
+    });
+  }
+
+  const contributors = contributorsResult.value;
+  result.checkedAccounts = contributors.length;
+  await runWithConcurrency(
+    contributors,
+    options.concurrency,
+    async (entry) => {
+      try {
+        const [chainVotes, tokenBalance] = await Promise.all([
+          readVotes(target, entry.id),
+          readBalance(target, entry.id).catch(() => null),
+        ]);
+        const mismatch = classifyProjectionMismatch({
+          indexed: entry.power,
+          chain: chainVotes.value,
+          source: "onchain-power",
+        });
+        if (!mismatch) {
+          result.matches += 1;
+          return;
+        }
+        result.mismatches.push({
+          address: entry.id,
+          contributorPower: entry.power,
+          contributorBalance: entry.balance,
+          chainPower: chainVotes.value,
+          chainBalance: tokenBalance,
+          detailSource: chainVotes.source,
+          delta: (BigInt(entry.power) - BigInt(chainVotes.value)).toString(),
+          hint: mismatch,
+        });
+      } catch (error) {
+        result.voteReadErrors.push({
+          address: entry.id,
+          classification: classifyDatalensQueryError(error),
+          message: error?.message ?? String(error),
+        });
+      }
+    },
+  );
+
+  return finalizeTargetResult(result);
+}
+
+export function finalizeTargetResult(result) {
+  return {
+    ...result,
+    anomalyCount:
+      result.mismatches.length +
+      result.negativeContributors.length +
+      result.negativeDelegates.length +
+      result.queryErrors.length +
+      result.voteReadErrors.length,
+  };
+}
+
+export function summarizeAudit(targets, status) {
+  const targetSummary = targets.reduce(
+    (summary, target) => ({
+      checkedAccounts: summary.checkedAccounts + target.checkedAccounts,
+      matches: summary.matches + target.matches,
+      mismatches: summary.mismatches + target.mismatches.length,
+      negativeContributors:
+        summary.negativeContributors + target.negativeContributors.length,
+      negativeDelegates: summary.negativeDelegates + target.negativeDelegates.length,
+      queryErrors: summary.queryErrors + target.queryErrors.length,
+      voteReadErrors: summary.voteReadErrors + target.voteReadErrors.length,
+      totalAnomalies: summary.totalAnomalies + target.anomalyCount,
+    }),
+    {
+      checkedAccounts: 0,
+      matches: 0,
+      mismatches: 0,
+      negativeContributors: 0,
+      negativeDelegates: 0,
+      queryErrors: 0,
+      voteReadErrors: 0,
+      totalAnomalies: 0,
+    },
+  );
+  return {
+    ...targetSummary,
+    checkpointStalls: status?.checkpointStalls?.length ?? 0,
+    onchainRefreshBacklog: Object.values(
+      status?.onchainRefreshBacklog ?? {},
+    ).reduce((sum, count) => sum + count, 0),
+  };
+}
+
+export function buildMarkdownReport(report, targets) {
+  const lines = [
+    "## Datalens Indexer Accuracy Audit",
+    "",
+    `Generated at: ${report.generatedAt}`,
+    "",
+    "### Summary",
+    "",
+    `- Checked accounts: ${report.summary.checkedAccounts}`,
+    `- Matches: ${report.summary.matches}`,
+    `- Vote mismatches: ${report.summary.mismatches}`,
+    `- Vote read errors: ${report.summary.voteReadErrors}`,
+    `- Negative contributor rows: ${report.summary.negativeContributors}`,
+    `- Negative delegate rows: ${report.summary.negativeDelegates}`,
+    `- Query errors: ${report.summary.queryErrors}`,
+    `- Checkpoint stalls: ${report.status.checkpointStalls.length}`,
+    `- Onchain refresh backlog: ${report.summary.onchainRefreshBacklog}`,
+    `- Total anomalies: ${report.summary.totalAnomalies}`,
+    "",
+  ];
+  for (const target of report.targets) {
+    const config = targets.find((entry) => entry.code === target.code) ?? {};
+    const decimals = config.tokenDecimals ?? 18;
+    lines.push(`### ${target.name} (\`${target.code}\`)`, "");
+    lines.push(`- Endpoint: ${config.indexerEndpoint ?? "unknown"}`);
+    lines.push(`- Checked: ${target.checkedAccounts}`);
+    lines.push(`- Matches: ${target.matches}`);
+    lines.push(`- Anomalies: ${target.anomalyCount}`);
+    for (const mismatch of target.mismatches) {
+      lines.push(
+        `- ${mismatch.address}: DeGov ${compactAmount(
+          mismatch.contributorPower,
+          decimals,
+        )}, chain ${compactAmount(mismatch.chainPower, decimals)}, source ${mismatch.detailSource}, hint \`${mismatch.hint}\``,
+      );
+    }
+    for (const error of [...target.queryErrors, ...target.voteReadErrors]) {
+      lines.push(`- ${error.classification}: ${error.message}`);
+    }
+    lines.push("");
+  }
+  if (report.status.checkpointStalls.length > 0) {
+    lines.push("### Checkpoint Stalls", "");
+    for (const checkpoint of report.status.checkpointStalls) {
+      lines.push(
+        `- ${checkpoint.daoCode}/${checkpoint.streamId}: processed=${checkpoint.processedHeight}, target=${checkpoint.targetHeight}, lag=${checkpoint.lagBlocks}, updated=${checkpoint.updatedAt}`,
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function runAudit(targets, options, services = {}) {
+  const targetResults = [];
+  for (const target of targets) {
+    targetResults.push(await auditTarget(target, options, services));
+  }
+  const status = services.status ?? (await readDatalensStatus(options.databaseUrl));
+  return {
+    generatedAt: new Date().toISOString(),
+    targets: targetResults,
+    status,
+    summary: summarizeAudit(targetResults, status),
+  };
+}
+
+async function writeFileIfNeeded(filePath, content) {
+  if (!filePath) {
+    return;
+  }
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content, "utf8");
+}
+
+export function usage() {
+  return [
+    "Usage: node apps/indexer/scripts/indexer-accuracy-audit.mjs [options]",
+    "",
+    "Options:",
+    "  --targets-file <path>      JSON target list for ENS, Lisk, or migrated DAOs",
+    "  --database-url <url>       Optional read-only Postgres URL for Datalens status tables",
+    "  --limit <n>                Contributors per DAO to compare",
+    "  --negative-limit <n>       Negative projection rows to inspect",
+    "  --concurrency <n>          Concurrent RPC reads",
+    "  --json-file <path>         Write JSON report",
+    "  --markdown-file <path>     Write markdown report",
+    "  --fail-on-anomalies        Exit non-zero when anomalies are found",
+  ].join("\n");
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  const targets = await loadTargets(options.targetsFile || undefined);
+  const report = await runAudit(targets, options);
+  const markdown = buildMarkdownReport(report, targets);
+  await writeFileIfNeeded(options.jsonFile, JSON.stringify(report, null, 2));
+  await writeFileIfNeeded(options.markdownFile, markdown);
+  console.log(
+    `Datalens accuracy audit checked ${report.summary.checkedAccounts} accounts across ${report.targets.length} DAOs; anomalies=${report.summary.totalAnomalies}; checkpointStalls=${report.status.checkpointStalls.length}; onchainRefreshBacklog=${report.summary.onchainRefreshBacklog}`,
+  );
+  if (options.failOnAnomalies && report.summary.totalAnomalies > 0) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/apps/indexer/scripts/indexer-accuracy-audit.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-audit.mjs
@@ -7,12 +7,14 @@ import {
   classifyDatalensQueryError,
   classifyProjectionMismatch,
   compactAmount,
+  findTargetComparisonBlock,
   graphqlRequest,
   loadTargets,
   parsePositiveInt,
   readCurrentVotes,
   readDatalensStatus,
   readTokenBalance,
+  requireOptionValue,
 } from "./indexer-diagnostics.mjs";
 
 const TOP_CONTRIBUTORS_QUERY = `
@@ -23,6 +25,7 @@ const TOP_CONTRIBUTORS_QUERY = `
       balance
       delegatesCountAll
       lastVoteTimestamp
+      blockNumber
     }
   }
 `;
@@ -88,7 +91,10 @@ export function parseArgs(argv) {
         options.negativeLimit = parsePositiveInt(value, "--negative-limit");
         break;
       case "--targets-file":
-        options.targetsFile = path.resolve(process.cwd(), value);
+        options.targetsFile = path.resolve(
+          process.cwd(),
+          requireOptionValue(flag, value),
+        );
         break;
       default:
         throw new Error(`Unknown option: ${flag}`);
@@ -327,11 +333,18 @@ export function buildMarkdownReport(report, targets) {
 }
 
 export async function runAudit(targets, options, services = {}) {
+  const status = services.status ?? (await readDatalensStatus(options.databaseUrl));
   const targetResults = [];
   for (const target of targets) {
-    targetResults.push(await auditTarget(target, options, services));
+    const comparisonBlockHeight = findTargetComparisonBlock(target, status);
+    targetResults.push(
+      await auditTarget(
+        comparisonBlockHeight ? { ...target, comparisonBlockHeight } : target,
+        options,
+        services,
+      ),
+    );
   }
-  const status = services.status ?? (await readDatalensStatus(options.databaseUrl));
   return {
     generatedAt: new Date().toISOString(),
     targets: targetResults,

--- a/apps/indexer/scripts/indexer-accuracy-audit.test.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-audit.test.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import {
+  auditTarget,
+  buildMarkdownReport,
+  parseArgs,
+  runAudit,
+} from "./indexer-accuracy-audit.mjs";
+
+const target = {
+  code: "ens-dao",
+  name: "ENS",
+  indexerEndpoint: "https://indexer.example/graphql",
+  rpcUrl: "https://rpc.example",
+  governorToken: "0x0000000000000000000000000000000000000001",
+  governor: "0x0000000000000000000000000000000000000002",
+};
+
+assert.match(
+  parseArgs([
+    "--limit",
+    "50",
+    "--negative-limit=25",
+    "--concurrency",
+    "2",
+    "--database-url",
+    "postgres://reader@example/db",
+    "--fail-on-anomalies",
+  ]).databaseUrl,
+  /^postgres:\/\/reader/,
+);
+
+const targetResult = await auditTarget(
+  target,
+  { limit: 3, negativeLimit: 2, concurrency: 2 },
+  {
+    fetchTopContributors: async () => [
+      { id: "0x1", power: "100", balance: "50" },
+      { id: "0x2", power: "200", balance: "20" },
+    ],
+    fetchNegativeRows: async () => ({
+      contributors: [{ id: "0xdead", power: "-1" }],
+      delegates: [
+        {
+          id: "0xaaa_0xbbb",
+          fromDelegate: "0xaaa",
+          toDelegate: "0xbbb",
+          power: "-2",
+        },
+      ],
+    }),
+    readCurrentVotes: async (_target, address) => ({
+      source: "token.getVotes",
+      value: address === "0x1" ? "100" : "120",
+    }),
+    readTokenBalance: async () => "50",
+  },
+);
+
+assert.equal(targetResult.checkedAccounts, 2);
+assert.equal(targetResult.matches, 1);
+assert.equal(targetResult.mismatches[0].hint, "onchain-power-indexed-higher");
+assert.equal(targetResult.negativeContributors.length, 1);
+assert.equal(targetResult.negativeDelegates.length, 1);
+assert.equal(targetResult.anomalyCount, 3);
+
+const report = await runAudit([target], { limit: 1, negativeLimit: 1, concurrency: 1 }, {
+  fetchTopContributors: async () => [{ id: "0x1", power: "10", balance: "10" }],
+  fetchNegativeRows: async () => ({ contributors: [], delegates: [] }),
+  readCurrentVotes: async () => ({ source: "token.getVotes", value: "10" }),
+  readTokenBalance: async () => "10",
+  status: {
+    checkpointStalls: [{ daoCode: "ens-dao", streamId: "governance-events" }],
+    onchainRefreshBacklog: { pending: 2 },
+  },
+});
+
+assert.equal(report.summary.checkedAccounts, 1);
+assert.equal(report.summary.checkpointStalls, 1);
+assert.equal(report.summary.onchainRefreshBacklog, 2);
+assert.match(buildMarkdownReport(report, [target]), /Datalens Indexer Accuracy Audit/);
+
+console.log("Indexer accuracy audit tests passed");

--- a/apps/indexer/scripts/indexer-accuracy-audit.test.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-audit.test.mjs
@@ -18,6 +18,15 @@ const target = {
   governor: "0x0000000000000000000000000000000000000002",
 };
 
+assert.throws(
+  () => parseArgs(["--targets-file"]),
+  /--targets-file requires a value/,
+);
+assert.throws(
+  () => parseArgs(["--targets-file", "--json-file", "report.json"]),
+  /--targets-file requires a value/,
+);
+
 assert.match(
   parseArgs([
     "--limit",
@@ -65,6 +74,24 @@ assert.equal(targetResult.mismatches[0].hint, "onchain-power-indexed-higher");
 assert.equal(targetResult.negativeContributors.length, 1);
 assert.equal(targetResult.negativeDelegates.length, 1);
 assert.equal(targetResult.anomalyCount, 3);
+
+const caughtUpTargetResult = await auditTarget(
+  { ...target, comparisonBlockHeight: "100" },
+  { limit: 1, negativeLimit: 1, concurrency: 1 },
+  {
+    fetchTopContributors: async () => [
+      { id: "0x1", power: "10", balance: "10", blockNumber: "100" },
+    ],
+    fetchNegativeRows: async () => ({ contributors: [], delegates: [] }),
+    readCurrentVotes: async (_target) => ({
+      source: "token.getVotes",
+      value: "10",
+    }),
+    readTokenBalance: async () => "10",
+  },
+);
+
+assert.equal(caughtUpTargetResult.matches, 1);
 
 const report = await runAudit([target], { limit: 1, negativeLimit: 1, concurrency: 1 }, {
   fetchTopContributors: async () => [{ id: "0x1", power: "10", balance: "10" }],

--- a/apps/indexer/scripts/indexer-accuracy-diagnose.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-diagnose.mjs
@@ -6,12 +6,14 @@ import {
   classifyDatalensQueryError,
   classifyProjectionMismatch,
   compactAmount,
+  findTargetComparisonBlock,
   graphqlRequest,
   loadTargets,
   parsePositiveInt,
   readCurrentVotes,
   readDatalensStatus,
   readTokenBalance,
+  requireOptionValue,
 } from "./indexer-diagnostics.mjs";
 
 const OVERVIEW_QUERY = `
@@ -76,7 +78,7 @@ export function parseArgs(argv) {
     const expectsValue = inlineValue === undefined;
     switch (flag) {
       case "--address":
-        options.address = value.toLowerCase();
+        options.address = requireOptionValue(flag, value).toLowerCase();
         break;
       case "--code":
       case "--dao":
@@ -108,7 +110,10 @@ export function parseArgs(argv) {
         options.rpcUrl = value;
         break;
       case "--targets-file":
-        options.targetsFile = path.resolve(process.cwd(), value);
+        options.targetsFile = path.resolve(
+          process.cwd(),
+          requireOptionValue(flag, value),
+        );
         break;
       default:
         throw new Error(`Unknown option: ${flag}`);
@@ -177,13 +182,17 @@ export async function diagnoseAddress(options, services = {}) {
     };
   }
   const contributor = overview.contributors?.[0] ?? null;
+  const comparisonBlockHeight = findTargetComparisonBlock(target, status);
+  const readTarget = comparisonBlockHeight
+    ? { ...target, comparisonBlockHeight }
+    : target;
   let chainVotes = null;
   let tokenBalance = null;
   let chainReadError = null;
   try {
     [chainVotes, tokenBalance] = await Promise.all([
-      readVotes(target, options.address),
-      readBalance(target, options.address).catch(() => null),
+      readVotes(readTarget, options.address),
+      readBalance(readTarget, options.address).catch(() => null),
     ]);
   } catch (error) {
     chainReadError = {

--- a/apps/indexer/scripts/indexer-accuracy-diagnose.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-diagnose.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+
+import {
+  classifyDatalensQueryError,
+  classifyProjectionMismatch,
+  compactAmount,
+  graphqlRequest,
+  loadTargets,
+  parsePositiveInt,
+  readCurrentVotes,
+  readDatalensStatus,
+  readTokenBalance,
+} from "./indexer-diagnostics.mjs";
+
+const OVERVIEW_QUERY = `
+  query DiagnoseOverview($address: String!, $mappingLimit: Int!, $negativeLimit: Int!) {
+    contributors(where: { id_eq: $address }) {
+      id
+      power
+      balance
+      delegatesCountAll
+      lastVoteTimestamp
+      lastVoteBlockNumber
+      blockNumber
+      transactionHash
+    }
+    delegateMappings(limit: $mappingLimit, orderBy: [power_DESC, blockNumber_DESC], where: { to_eq: $address }) {
+      id
+      from
+      to
+      power
+      blockNumber
+      transactionHash
+    }
+    delegates(limit: $negativeLimit, orderBy: [power_ASC, blockNumber_DESC], where: { OR: [{ toDelegate_eq: $address, power_lt: 0 }, { fromDelegate_eq: $address, power_lt: 0 }] }) {
+      id
+      fromDelegate
+      toDelegate
+      power
+      isCurrent
+      blockNumber
+      transactionHash
+    }
+  }
+`;
+
+export function parseArgs(argv) {
+  const options = {
+    address: "",
+    code: "",
+    concurrency: 10,
+    databaseUrl: process.env.DEGOV_INDEXER_DATABASE_URL ?? process.env.DATABASE_URL ?? "",
+    endpoint: "",
+    governor: "",
+    governorToken: "",
+    json: false,
+    mappingLimit: 250,
+    negativeLimit: 100,
+    rpcUrl: "",
+    targetsFile: "",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      continue;
+    }
+    const [flag, inlineValue] = token.split("=", 2);
+    const value = inlineValue ?? argv[index + 1];
+    const expectsValue = inlineValue === undefined;
+    switch (flag) {
+      case "--address":
+        options.address = value.toLowerCase();
+        break;
+      case "--code":
+      case "--dao":
+        options.code = value;
+        break;
+      case "--concurrency":
+        options.concurrency = parsePositiveInt(value, "--concurrency");
+        break;
+      case "--database-url":
+        options.databaseUrl = value;
+        break;
+      case "--endpoint":
+        options.endpoint = value;
+        break;
+      case "--governor":
+        options.governor = value;
+        break;
+      case "--governor-token":
+      case "--token":
+        options.governorToken = value;
+        break;
+      case "--mapping-limit":
+        options.mappingLimit = parsePositiveInt(value, "--mapping-limit");
+        break;
+      case "--negative-limit":
+        options.negativeLimit = parsePositiveInt(value, "--negative-limit");
+        break;
+      case "--rpc-url":
+        options.rpcUrl = value;
+        break;
+      case "--targets-file":
+        options.targetsFile = path.resolve(process.cwd(), value);
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+    if (expectsValue) {
+      index += 1;
+    }
+  }
+  if (!options.help && !options.address) {
+    throw new Error("--address is required");
+  }
+  return options;
+}
+
+export async function resolveTarget(options) {
+  const targets = await loadTargets(options.targetsFile || undefined).catch(() => []);
+  const matchedTarget = targets.find((target) => {
+    return (
+      (options.code && target.code === options.code) ||
+      (options.endpoint && target.indexerEndpoint === options.endpoint)
+    );
+  });
+  const target = {
+    ...(matchedTarget ?? {}),
+    ...(options.code ? { code: options.code } : {}),
+    ...(options.endpoint ? { indexerEndpoint: options.endpoint } : {}),
+    ...(options.governor ? { governor: options.governor } : {}),
+    ...(options.governorToken ? { governorToken: options.governorToken } : {}),
+    ...(options.rpcUrl ? { rpcUrl: options.rpcUrl } : {}),
+  };
+  for (const [field, hint] of [
+    ["indexerEndpoint", "--code or --endpoint"],
+    ["rpcUrl", "--code or --rpc-url"],
+    ["governorToken", "--code or --governor-token"],
+  ]) {
+    if (!target[field]) {
+      throw new Error(`Unable to resolve ${field}. Pass ${hint}.`);
+    }
+  }
+  return target;
+}
+
+export async function diagnoseAddress(options, services = {}) {
+  const target = services.target ?? (await resolveTarget(options));
+  const query = services.graphqlRequest ?? graphqlRequest;
+  const readVotes = services.readCurrentVotes ?? readCurrentVotes;
+  const readBalance = services.readTokenBalance ?? readTokenBalance;
+  const status =
+    services.status ?? (await readDatalensStatus(options.databaseUrl));
+  let overview;
+  try {
+    overview = await query(target.indexerEndpoint, OVERVIEW_QUERY, {
+      address: options.address,
+      mappingLimit: options.mappingLimit,
+      negativeLimit: options.negativeLimit,
+    });
+  } catch (error) {
+    return {
+      target,
+      address: options.address,
+      queryError: {
+        classification: classifyDatalensQueryError(error),
+        message: error.message ?? String(error),
+      },
+      status,
+    };
+  }
+  const contributor = overview.contributors?.[0] ?? null;
+  let chainVotes = null;
+  let tokenBalance = null;
+  let chainReadError = null;
+  try {
+    [chainVotes, tokenBalance] = await Promise.all([
+      readVotes(target, options.address),
+      readBalance(target, options.address).catch(() => null),
+    ]);
+  } catch (error) {
+    chainReadError = {
+      classification: classifyDatalensQueryError(error),
+      message: error.message ?? String(error),
+    };
+  }
+
+  return {
+    target: {
+      code: target.code ?? "custom",
+      name: target.name ?? target.code ?? "custom",
+      indexerEndpoint: target.indexerEndpoint,
+      rpcUrl: target.rpcUrl,
+      governor: target.governor ?? null,
+      governorToken: target.governorToken,
+      tokenDecimals: target.tokenDecimals ?? 18,
+    },
+    address: options.address,
+    contributor,
+    chainVotes,
+    tokenBalance,
+    chainReadError,
+    contributorDelta:
+      contributor && chainVotes
+        ? (BigInt(contributor.power) - BigInt(chainVotes.value)).toString()
+        : null,
+    projectionClassification:
+      contributor && chainVotes
+        ? classifyProjectionMismatch({
+            indexed: contributor.power,
+            chain: chainVotes.value,
+            source: "onchain-power",
+          })
+        : null,
+    incomingMappings: overview.delegateMappings ?? [],
+    negativeDelegates: overview.delegates ?? [],
+    status,
+  };
+}
+
+export function printHumanReport(report) {
+  if (report.queryError) {
+    console.log(`Query error: ${report.queryError.classification}`);
+    console.log(report.queryError.message);
+    return;
+  }
+  const decimals = report.target.tokenDecimals ?? 18;
+  console.log(`DAO: ${report.target.code}`);
+  console.log(`Address: ${report.address}`);
+  console.log(`Endpoint: ${report.target.indexerEndpoint}`);
+  console.log(
+    `DeGov power: ${
+      report.contributor ? compactAmount(report.contributor.power, decimals) : "missing"
+    }`,
+  );
+  console.log(
+    `Chain power: ${
+      report.chainVotes
+        ? `${compactAmount(report.chainVotes.value, decimals)} (${report.chainVotes.source})`
+        : "unavailable"
+    }`,
+  );
+  console.log(`Projection: ${report.projectionClassification ?? "match-or-missing"}`);
+  console.log(`Incoming mappings: ${report.incomingMappings.length}`);
+  console.log(`Negative delegates touching address: ${report.negativeDelegates.length}`);
+  console.log(`Checkpoint stalls: ${report.status.checkpointStalls.length}`);
+  console.log(
+    `Onchain refresh backlog: ${JSON.stringify(report.status.onchainRefreshBacklog)}`,
+  );
+  if (report.chainReadError) {
+    console.log(`Chain read error: ${report.chainReadError.classification}`);
+    console.log(report.chainReadError.message);
+  }
+}
+
+export function usage() {
+  return [
+    "Usage: node apps/indexer/scripts/indexer-accuracy-diagnose.mjs --address <address> [options]",
+    "",
+    "Options:",
+    "  --code <dao>              DAO code from targets JSON",
+    "  --endpoint <url>          DeGov GraphQL endpoint",
+    "  --rpc-url <url>           Chain RPC URL",
+    "  --governor-token <addr>   Votes token contract",
+    "  --governor <addr>         Optional governor fallback",
+    "  --database-url <url>      Optional read-only Postgres URL for Datalens status",
+    "  --json                    Print JSON report",
+  ].join("\n");
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  const report = await diagnoseAddress(options);
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  printHumanReport(report);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs
@@ -7,6 +7,12 @@ import {
   parseArgs,
 } from "./indexer-accuracy-diagnose.mjs";
 
+assert.throws(() => parseArgs(["--address"]), /--address requires a value/);
+assert.throws(
+  () => parseArgs(["--targets-file", "--json"]),
+  /--targets-file requires a value/,
+);
+
 const options = parseArgs([
   "--address",
   "0x983110309620d911731ac0932219af06091b6744",
@@ -64,6 +70,48 @@ assert.equal(report.projectionClassification, "onchain-power-indexed-higher");
 assert.equal(report.incomingMappings.length, 1);
 assert.equal(report.negativeDelegates.length, 1);
 assert.deepEqual(report.status.onchainRefreshBacklog, { pending: 1 });
+
+const historicalReadReport = await diagnoseAddress(
+  {
+    ...options,
+    databaseUrl: "",
+  },
+  {
+    target: {
+      code: "ens-dao",
+      name: "ENS",
+      indexerEndpoint: "https://indexer.example/graphql",
+      rpcUrl: "https://rpc.example",
+      governorToken: "0x0000000000000000000000000000000000000001",
+    },
+    graphqlRequest: async () => ({
+      contributors: [
+        { id: options.address, power: "100", balance: "10", blockNumber: "100" },
+      ],
+      delegateMappings: [],
+      delegates: [],
+    }),
+    readCurrentVotes: async (target) => ({
+      source: "token.getVotes",
+      value: target.comparisonBlockHeight === "100" ? "100" : "80",
+    }),
+    readTokenBalance: async () => "10",
+    status: {
+      checkpoints: [
+        {
+          daoCode: "ens-dao",
+          streamId: "governance-events",
+          processedHeight: "100",
+          targetHeight: "150",
+        },
+      ],
+      checkpointStalls: [],
+      onchainRefreshBacklog: {},
+    },
+  },
+);
+
+assert.equal(historicalReadReport.projectionClassification, null);
 
 const queryErrorReport = await diagnoseAddress(
   {

--- a/apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import {
+  diagnoseAddress,
+  parseArgs,
+} from "./indexer-accuracy-diagnose.mjs";
+
+const options = parseArgs([
+  "--address",
+  "0x983110309620d911731ac0932219af06091b6744",
+  "--code",
+  "ens-dao",
+  "--mapping-limit",
+  "25",
+  "--json",
+]);
+
+assert.equal(options.address, "0x983110309620d911731ac0932219af06091b6744");
+assert.equal(options.code, "ens-dao");
+assert.equal(options.mappingLimit, 25);
+assert.equal(options.json, true);
+
+const report = await diagnoseAddress(
+  {
+    ...options,
+    databaseUrl: "",
+    negativeLimit: 5,
+  },
+  {
+    target: {
+      code: "ens-dao",
+      name: "ENS",
+      indexerEndpoint: "https://indexer.example/graphql",
+      rpcUrl: "https://rpc.example",
+      governorToken: "0x0000000000000000000000000000000000000001",
+    },
+    graphqlRequest: async () => ({
+      contributors: [{ id: options.address, power: "100", balance: "10" }],
+      delegateMappings: [
+        { id: "0x1_0x2", from: "0x1", to: options.address, power: "100" },
+      ],
+      delegates: [
+        {
+          id: "0x1_0x2",
+          fromDelegate: "0x1",
+          toDelegate: options.address,
+          power: "-1",
+        },
+      ],
+    }),
+    readCurrentVotes: async () => ({ source: "token.getVotes", value: "80" }),
+    readTokenBalance: async () => "10",
+    status: {
+      checkpointStalls: [],
+      onchainRefreshBacklog: { pending: 1 },
+    },
+  },
+);
+
+assert.equal(report.contributorDelta, "20");
+assert.equal(report.projectionClassification, "onchain-power-indexed-higher");
+assert.equal(report.incomingMappings.length, 1);
+assert.equal(report.negativeDelegates.length, 1);
+assert.deepEqual(report.status.onchainRefreshBacklog, { pending: 1 });
+
+const queryErrorReport = await diagnoseAddress(
+  {
+    ...options,
+    databaseUrl: "",
+  },
+  {
+    target: {
+      indexerEndpoint: "https://indexer.example/graphql",
+      rpcUrl: "https://rpc.example",
+      governorToken: "0x0000000000000000000000000000000000000001",
+    },
+    graphqlRequest: async () => {
+      throw new Error("Datalens native query failed");
+    },
+    status: {
+      checkpointStalls: [],
+      onchainRefreshBacklog: {},
+    },
+  },
+);
+
+assert.equal(queryErrorReport.queryError.classification, "datalens-query-error");
+
+console.log("Indexer accuracy diagnose tests passed");

--- a/apps/indexer/scripts/indexer-accuracy-targets.json
+++ b/apps/indexer/scripts/indexer-accuracy-targets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "code": "ens-dao",
+    "name": "ENS",
+    "indexerEndpoint": "https://indexer.degov.ai/ens-dao/graphql",
+    "rpcUrl": "https://ethereum-rpc.publicnode.com",
+    "governor": "0x323A76393544d5ecca80cd6ef2A560C6a395b7E3",
+    "governorToken": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+    "tokenDecimals": 18
+  },
+  {
+    "code": "lisk-dao",
+    "name": "Lisk",
+    "indexerEndpoint": "https://indexer.degov.ai/lisk-dao/graphql",
+    "rpcUrl": "https://rpc.api.lisk.com",
+    "governor": "0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568",
+    "governorToken": "0x2eE6Eca46d2406454708a1C80356a6E63b57D404",
+    "tokenDecimals": 18
+  }
+]

--- a/apps/indexer/scripts/indexer-diagnostics.mjs
+++ b/apps/indexer/scripts/indexer-diagnostics.mjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const DEFAULT_TARGETS_FILE = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "indexer-accuracy-targets.json",
+);
+
+export function parsePositiveInt(value, fieldName) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${fieldName} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function normalizeAddress(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+export function classifyDatalensQueryError(error) {
+  const message = String(error?.message ?? error ?? "");
+  const lower = message.toLowerCase();
+
+  if (
+    lower.includes("decode") ||
+    lower.includes("invalid data") ||
+    lower.includes("abi") ||
+    lower.includes("overflow") ||
+    lower.includes("cannot parse")
+  ) {
+    return "decode-error";
+  }
+  if (
+    lower.includes("field") ||
+    lower.includes("column") ||
+    lower.includes("relation") ||
+    lower.includes("does not exist") ||
+    lower.includes("unknown argument")
+  ) {
+    return "projection-mismatch";
+  }
+  if (
+    lower.includes("datalens") ||
+    lower.includes("native/graphql") ||
+    lower.includes("native query") ||
+    lower.includes("query failed")
+  ) {
+    return "datalens-query-error";
+  }
+  if (
+    lower.includes("timeout") ||
+    lower.includes("econnreset") ||
+    lower.includes("429") ||
+    lower.includes("rate limit")
+  ) {
+    return "transport-error";
+  }
+
+  return "unknown-query-error";
+}
+
+export function classifyProjectionMismatch({ indexed, chain, source = "chain" }) {
+  if (indexed === null || indexed === undefined) {
+    return `${source}-missing-indexed-row`;
+  }
+  if (chain === null || chain === undefined) {
+    return `${source}-missing-reference-row`;
+  }
+
+  const indexedValue = BigInt(indexed);
+  const chainValue = BigInt(chain);
+  if (indexedValue === chainValue) {
+    return null;
+  }
+  return indexedValue > chainValue
+    ? `${source}-indexed-higher`
+    : `${source}-indexed-lower`;
+}
+
+export function summarizeCheckpointRows(rows, options = {}) {
+  const nowMs = options.nowMs ?? Date.now();
+  const stallMinutes = options.stallMinutes ?? 15;
+  return rows.map((row) => {
+    const processedHeight = row.processed_height ?? row.processedHeight ?? null;
+    const targetHeight = row.target_height ?? row.targetHeight ?? null;
+    const nextBlock = row.next_block ?? row.nextBlock ?? null;
+    const updatedAt = row.updated_at ?? row.updatedAt ?? null;
+    const updatedMs = updatedAt ? Date.parse(updatedAt) : Number.NaN;
+    const ageMinutes = Number.isFinite(updatedMs)
+      ? Math.max(0, Math.floor((nowMs - updatedMs) / 60000))
+      : null;
+    const lagBlocks =
+      targetHeight === null || processedHeight === null
+        ? null
+        : (BigInt(targetHeight) - BigInt(processedHeight)).toString();
+    const stalled =
+      ageMinutes !== null &&
+      ageMinutes >= stallMinutes &&
+      (lagBlocks === null || BigInt(lagBlocks) > 0n);
+
+    return {
+      daoCode: row.dao_code ?? row.daoCode ?? null,
+      chainId: row.chain_id ?? row.chainId ?? null,
+      streamId: row.stream_id ?? row.streamId ?? null,
+      dataSourceVersion:
+        row.data_source_version ?? row.dataSourceVersion ?? null,
+      nextBlock: nextBlock === null ? null : String(nextBlock),
+      processedHeight:
+        processedHeight === null ? null : String(processedHeight),
+      targetHeight: targetHeight === null ? null : String(targetHeight),
+      lagBlocks,
+      updatedAt,
+      ageMinutes,
+      stalled,
+      lastError: row.last_error ?? row.lastError ?? null,
+      lockOwner: row.lock_owner ?? row.lockOwner ?? null,
+      lockedAt: row.locked_at ?? row.lockedAt ?? null,
+      classification: row.last_error
+        ? classifyDatalensQueryError(row.last_error)
+        : stalled
+          ? "checkpoint-stall"
+          : "checkpoint-ok",
+    };
+  });
+}
+
+export function summarizeStatusTables({
+  checkpoints = [],
+  reconcileTasks = [],
+  refreshTasks = [],
+  legacyStatus = null,
+} = {}) {
+  const checkpointRows = summarizeCheckpointRows(checkpoints);
+  const countByStatus = (rows) =>
+    rows.reduce((counts, row) => {
+      const status = String(row.status ?? "unknown");
+      counts[status] = (counts[status] ?? 0) + 1;
+      return counts;
+    }, {});
+  const classifyTaskErrors = (rows) =>
+    rows
+      .filter((row) => row.error)
+      .map((row) => ({
+        id: row.id,
+        status: row.status,
+        attempts: row.attempts,
+        classification: classifyDatalensQueryError(row.error),
+        error: row.error,
+      }));
+
+  return {
+    checkpoints: checkpointRows,
+    checkpointStalls: checkpointRows.filter((row) => row.stalled),
+    checkpointErrors: checkpointRows.filter((row) => row.lastError),
+    reconcileBacklog: countByStatus(reconcileTasks),
+    reconcileErrors: classifyTaskErrors(reconcileTasks),
+    onchainRefreshBacklog: countByStatus(refreshTasks),
+    onchainRefreshErrors: classifyTaskErrors(refreshTasks),
+    legacySquidStatus: legacyStatus,
+  };
+}
+
+export async function graphqlRequest(endpoint, query, variables = {}) {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GraphQL request failed with HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const payload = await response.json();
+  if (payload.errors?.length) {
+    throw new Error(
+      payload.errors
+        .map((error) => error.message || JSON.stringify(error))
+        .join("; "),
+    );
+  }
+
+  return payload.data;
+}
+
+export async function rpcCall(rpcUrl, method, params) {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`RPC ${method} failed with HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message || JSON.stringify(payload.error));
+  }
+  return payload.result;
+}
+
+export function encodeAddressArgument(address) {
+  return normalizeAddress(address).replace(/^0x/, "").padStart(64, "0");
+}
+
+export async function readUint256(rpcUrl, contract, selector, args = []) {
+  const data = `${selector}${args.join("")}`;
+  const result = await rpcCall(rpcUrl, "eth_call", [
+    { to: contract, data },
+    "latest",
+  ]);
+  if (!result || result === "0x") {
+    throw new Error("decode error: eth_call returned no data");
+  }
+  return BigInt(result).toString();
+}
+
+export async function readCurrentVotes(target, address) {
+  const account = encodeAddressArgument(address);
+  try {
+    return {
+      source: "token.getVotes",
+      value: await readUint256(
+        target.rpcUrl,
+        target.governorToken,
+        "0x9ab24eb0",
+        [account],
+      ),
+    };
+  } catch (tokenError) {
+    if (!target.governor) {
+      throw tokenError;
+    }
+    const blockNumber = BigInt(await rpcCall(target.rpcUrl, "eth_blockNumber", []));
+    const timepoint = (blockNumber > 1n ? blockNumber - 1n : blockNumber)
+      .toString(16)
+      .padStart(64, "0");
+    return {
+      source: "governor.getVotes",
+      value: await readUint256(
+        target.rpcUrl,
+        target.governor,
+        "0xeb9019d4",
+        [account, timepoint],
+      ),
+    };
+  }
+}
+
+export async function readTokenBalance(target, address) {
+  return readUint256(target.rpcUrl, target.governorToken, "0x70a08231", [
+    encodeAddressArgument(address),
+  ]);
+}
+
+export function compactAmount(rawValue, decimals = 18) {
+  const value = BigInt(rawValue);
+  const divisor = 10n ** BigInt(decimals);
+  const whole = value / divisor;
+  const fraction = value >= 0n ? value % divisor : (-value) % divisor;
+  if (whole !== 0n) {
+    return whole.toString();
+  }
+  if (fraction === 0n) {
+    return "0";
+  }
+  return value < 0n ? "-0" : "0";
+}
+
+export async function loadTargets(targetsFile = DEFAULT_TARGETS_FILE) {
+  const raw = await readFile(targetsFile, "utf8");
+  const targets = JSON.parse(raw);
+  if (!Array.isArray(targets) || targets.length === 0) {
+    throw new Error("Targets file must contain a non-empty JSON array");
+  }
+  return targets.map((target) => ({
+    tokenDecimals: 18,
+    ...target,
+    indexerEndpoint: target.indexerEndpoint ?? target.indexer,
+  }));
+}
+
+export async function queryPostgres(databaseUrl, sql) {
+  if (!databaseUrl) {
+    return [];
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("psql", [
+      databaseUrl,
+      "--no-align",
+      "--tuples-only",
+      "--csv",
+      "--command",
+      sql,
+    ]);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status) => {
+      if (status !== 0) {
+        reject(new Error(stderr.trim() || `psql exited with ${status}`));
+        return;
+      }
+      resolve(parseCsvRows(stdout));
+    });
+  });
+}
+
+function parseCsvRows(raw) {
+  const lines = raw.trim().split("\n").filter(Boolean);
+  return lines.map((line) => {
+    const [payload] = parseCsvLine(line);
+    return payload ? JSON.parse(payload) : {};
+  });
+}
+
+function parseCsvLine(line) {
+  const values = [];
+  let current = "";
+  let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '"' && line[index + 1] === '"') {
+      current += '"';
+      index += 1;
+    } else if (char === '"') {
+      quoted = !quoted;
+    } else if (char === "," && !quoted) {
+      values.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  values.push(current);
+  return values;
+}
+
+export async function readDatalensStatus(databaseUrl) {
+  if (!databaseUrl) {
+    return summarizeStatusTables();
+  }
+
+  const [checkpoints, reconcileTasks, refreshTasks, legacyStatus] =
+    await Promise.all([
+      queryPostgres(
+        databaseUrl,
+        "SELECT row_to_json(t) FROM (SELECT dao_code, chain_id, stream_id, data_source_version, next_block::TEXT, processed_height::TEXT, target_height::TEXT, updated_at::TEXT, last_error, lock_owner, locked_at::TEXT FROM degov_indexer_checkpoint ORDER BY chain_id, dao_code, stream_id) t",
+      ),
+      queryPostgres(
+        databaseUrl,
+        "SELECT row_to_json(t) FROM (SELECT id, status, attempts, next_run_at::TEXT, locked_at::TEXT, processed_at::TEXT, error FROM degov_indexer_reconcile_task ORDER BY next_run_at LIMIT 100) t",
+      ).catch((error) => [
+        {
+          id: "degov_indexer_reconcile_task",
+          status: "query-error",
+          attempts: 0,
+          error: error.message,
+        },
+      ]),
+      queryPostgres(
+        databaseUrl,
+        "SELECT row_to_json(t) FROM (SELECT id, status, attempts, next_run_at::TEXT, locked_at::TEXT, processed_at::TEXT, error FROM onchain_refresh_task ORDER BY next_run_at LIMIT 100) t",
+      ).catch((error) => [
+        {
+          id: "onchain_refresh_task",
+          status: "query-error",
+          attempts: 0,
+          error: error.message,
+        },
+      ]),
+      queryPostgres(
+        databaseUrl,
+        "SELECT row_to_json(t) FROM (SELECT height::TEXT, hash FROM squid_processor.status LIMIT 1) t",
+      ).catch(() => []),
+    ]);
+
+  return summarizeStatusTables({
+    checkpoints,
+    reconcileTasks,
+    refreshTasks,
+    legacyStatus: legacyStatus[0] ?? null,
+  });
+}

--- a/apps/indexer/scripts/indexer-diagnostics.mjs
+++ b/apps/indexer/scripts/indexer-diagnostics.mjs
@@ -3,9 +3,10 @@
 import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const DEFAULT_TARGETS_FILE = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "indexer-accuracy-targets.json",
 );
 
@@ -19,6 +20,13 @@ export function parsePositiveInt(value, fieldName) {
 
 export function normalizeAddress(value) {
   return String(value ?? "").trim().toLowerCase();
+}
+
+export function requireOptionValue(flag, value) {
+  if (value === undefined || String(value).startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
 }
 
 export function classifyDatalensQueryError(error) {
@@ -102,6 +110,7 @@ export function summarizeCheckpointRows(rows, options = {}) {
       ageMinutes >= stallMinutes &&
       (lagBlocks === null || BigInt(lagBlocks) > 0n);
 
+    const lastError = row.last_error ?? row.lastError ?? null;
     return {
       daoCode: row.dao_code ?? row.daoCode ?? null,
       chainId: row.chain_id ?? row.chainId ?? null,
@@ -116,11 +125,11 @@ export function summarizeCheckpointRows(rows, options = {}) {
       updatedAt,
       ageMinutes,
       stalled,
-      lastError: row.last_error ?? row.lastError ?? null,
+      lastError,
       lockOwner: row.lock_owner ?? row.lockOwner ?? null,
       lockedAt: row.locked_at ?? row.lockedAt ?? null,
-      classification: row.last_error
-        ? classifyDatalensQueryError(row.last_error)
+      classification: lastError
+        ? classifyDatalensQueryError(lastError)
         : stalled
           ? "checkpoint-stall"
           : "checkpoint-ok",
@@ -215,11 +224,44 @@ export function encodeAddressArgument(address) {
   return normalizeAddress(address).replace(/^0x/, "").padStart(64, "0");
 }
 
-export async function readUint256(rpcUrl, contract, selector, args = []) {
+export function formatBlockTag(blockHeight) {
+  if (blockHeight === null || blockHeight === undefined || blockHeight === "") {
+    return "latest";
+  }
+  if (typeof blockHeight === "string" && blockHeight.startsWith("0x")) {
+    return blockHeight;
+  }
+  return `0x${BigInt(blockHeight).toString(16)}`;
+}
+
+export function findTargetComparisonBlock(target, status) {
+  const checkpoints = status?.checkpoints ?? [];
+  const matching = checkpoints.filter((checkpoint) => {
+    return (
+      checkpoint.daoCode === target.code ||
+      checkpoint.dao_code === target.code ||
+      (target.chainId !== undefined &&
+        target.chainId !== null &&
+        (checkpoint.chainId === target.chainId ||
+          checkpoint.chain_id === target.chainId))
+    );
+  });
+  const heights = matching
+    .map((checkpoint) => checkpoint.processedHeight ?? checkpoint.processed_height)
+    .filter((height) => height !== null && height !== undefined);
+  if (heights.length === 0) {
+    return null;
+  }
+  return heights.reduce((lowest, height) =>
+    BigInt(height) < BigInt(lowest) ? String(height) : String(lowest),
+  );
+}
+
+export async function readUint256(rpcUrl, contract, selector, args = [], blockTag = "latest") {
   const data = `${selector}${args.join("")}`;
   const result = await rpcCall(rpcUrl, "eth_call", [
     { to: contract, data },
-    "latest",
+    blockTag,
   ]);
   if (!result || result === "0x") {
     throw new Error("decode error: eth_call returned no data");
@@ -229,6 +271,7 @@ export async function readUint256(rpcUrl, contract, selector, args = []) {
 
 export async function readCurrentVotes(target, address) {
   const account = encodeAddressArgument(address);
+  const blockTag = formatBlockTag(target.comparisonBlockHeight ?? target.blockTag);
   try {
     return {
       source: "token.getVotes",
@@ -237,13 +280,32 @@ export async function readCurrentVotes(target, address) {
         target.governorToken,
         "0x9ab24eb0",
         [account],
+        blockTag,
       ),
     };
   } catch (tokenError) {
+    try {
+      return {
+        source: "token.getCurrentVotes",
+        value: await readUint256(
+          target.rpcUrl,
+          target.governorToken,
+          "0xb58131b0",
+          [account],
+          blockTag,
+        ),
+      };
+    } catch {
+      // Continue to the governor fallback below when available.
+    }
     if (!target.governor) {
       throw tokenError;
     }
-    const blockNumber = BigInt(await rpcCall(target.rpcUrl, "eth_blockNumber", []));
+    const blockNumber =
+      target.comparisonBlockHeight === null ||
+      target.comparisonBlockHeight === undefined
+        ? BigInt(await rpcCall(target.rpcUrl, "eth_blockNumber", []))
+        : BigInt(target.comparisonBlockHeight);
     const timepoint = (blockNumber > 1n ? blockNumber - 1n : blockNumber)
       .toString(16)
       .padStart(64, "0");
@@ -254,15 +316,17 @@ export async function readCurrentVotes(target, address) {
         target.governor,
         "0xeb9019d4",
         [account, timepoint],
+        blockTag,
       ),
     };
   }
 }
 
 export async function readTokenBalance(target, address) {
+  const blockTag = formatBlockTag(target.comparisonBlockHeight ?? target.blockTag);
   return readUint256(target.rpcUrl, target.governorToken, "0x70a08231", [
     encodeAddressArgument(address),
-  ]);
+  ], blockTag);
 }
 
 export function compactAmount(rawValue, decimals = 18) {

--- a/apps/indexer/scripts/indexer-diagnostics.test.mjs
+++ b/apps/indexer/scripts/indexer-diagnostics.test.mjs
@@ -5,6 +5,8 @@ import assert from "node:assert/strict";
 import {
   classifyDatalensQueryError,
   classifyProjectionMismatch,
+  findTargetComparisonBlock,
+  readCurrentVotes,
   summarizeCheckpointRows,
   summarizeStatusTables,
 } from "./indexer-diagnostics.mjs";
@@ -87,6 +89,17 @@ assert.equal(checkpointRows[0].lagBlocks, "50");
 assert.equal(checkpointRows[0].classification, "checkpoint-stall");
 assert.equal(checkpointRows[1].classification, "projection-mismatch");
 
+const camelCaseErrorRow = summarizeCheckpointRows([
+  {
+    daoCode: "op-dao",
+    streamId: "governance-events",
+    processedHeight: "1",
+    targetHeight: "1",
+    lastError: "field balance does not exist",
+  },
+]);
+assert.equal(camelCaseErrorRow[0].classification, "projection-mismatch");
+
 const status = summarizeStatusTables({
   checkpoints: [
     {
@@ -114,5 +127,54 @@ assert.deepEqual(status.reconcileBacklog, { pending: 1, failed: 1 });
 assert.deepEqual(status.onchainRefreshBacklog, { pending: 2 });
 assert.equal(status.reconcileErrors[0].classification, "datalens-query-error");
 assert.deepEqual(status.legacySquidStatus, { height: "99", hash: null });
+
+const comparisonBlock = findTargetComparisonBlock(
+  { code: "ens-dao" },
+  {
+    checkpoints: [
+      {
+        daoCode: "ens-dao",
+        streamId: "governance-events",
+        processedHeight: "100",
+        targetHeight: "150",
+      },
+    ],
+  },
+);
+assert.equal(comparisonBlock, "100");
+
+const originalFetch = globalThis.fetch;
+const calls = [];
+globalThis.fetch = async (_url, init) => {
+  const body = JSON.parse(init.body);
+  calls.push(body.params);
+  if (calls.length === 1) {
+    return {
+      ok: true,
+      json: async () => ({ result: "0x" }),
+    };
+  }
+  return {
+    ok: true,
+    json: async () => ({ result: "0x2a" }),
+  };
+};
+try {
+  const voteResult = await readCurrentVotes(
+    {
+      rpcUrl: "https://rpc.example",
+      governorToken: "0x0000000000000000000000000000000000000001",
+      comparisonBlockHeight: "100",
+    },
+    "0x0000000000000000000000000000000000000002",
+  );
+  assert.equal(voteResult.source, "token.getCurrentVotes");
+  assert.equal(voteResult.value, "42");
+  assert.equal(calls[0][1], "0x64");
+  assert.match(calls[1][0].data, /^0xb58131b0/);
+  assert.equal(calls[1][1], "0x64");
+} finally {
+  globalThis.fetch = originalFetch;
+}
 
 console.log("Indexer diagnostics tests passed");

--- a/apps/indexer/scripts/indexer-diagnostics.test.mjs
+++ b/apps/indexer/scripts/indexer-diagnostics.test.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import {
+  classifyDatalensQueryError,
+  classifyProjectionMismatch,
+  summarizeCheckpointRows,
+  summarizeStatusTables,
+} from "./indexer-diagnostics.mjs";
+
+assert.equal(
+  classifyDatalensQueryError(new Error("Datalens native query failed")),
+  "datalens-query-error",
+);
+assert.equal(
+  classifyDatalensQueryError(new Error("cannot parse uint256 ABI payload")),
+  "decode-error",
+);
+assert.equal(
+  classifyDatalensQueryError(new Error('column "power" does not exist')),
+  "projection-mismatch",
+);
+assert.equal(
+  classifyDatalensQueryError(new Error("RPC timeout")),
+  "transport-error",
+);
+
+assert.equal(
+  classifyProjectionMismatch({
+    indexed: "10",
+    chain: "8",
+    source: "onchain-power",
+  }),
+  "onchain-power-indexed-higher",
+);
+assert.equal(
+  classifyProjectionMismatch({
+    indexed: "8",
+    chain: "10",
+    source: "onchain-power",
+  }),
+  "onchain-power-indexed-lower",
+);
+assert.equal(
+  classifyProjectionMismatch({
+    indexed: "10",
+    chain: "10",
+    source: "onchain-power",
+  }),
+  null,
+);
+
+const checkpointRows = summarizeCheckpointRows(
+  [
+    {
+      dao_code: "ens-dao",
+      chain_id: 1,
+      stream_id: "governance-events",
+      data_source_version: "datalens-v1",
+      next_block: "101",
+      processed_height: "100",
+      target_height: "150",
+      updated_at: "2026-06-02T07:00:00.000Z",
+      last_error: null,
+    },
+    {
+      dao_code: "lisk-dao",
+      chain_id: 1135,
+      stream_id: "governance-events",
+      data_source_version: "datalens-v1",
+      next_block: "200",
+      processed_height: "199",
+      target_height: "200",
+      updated_at: "2026-06-02T07:59:00.000Z",
+      last_error: "column proposal_id does not exist",
+    },
+  ],
+  {
+    nowMs: Date.parse("2026-06-02T08:00:00.000Z"),
+    stallMinutes: 15,
+  },
+);
+
+assert.equal(checkpointRows[0].stalled, true);
+assert.equal(checkpointRows[0].lagBlocks, "50");
+assert.equal(checkpointRows[0].classification, "checkpoint-stall");
+assert.equal(checkpointRows[1].classification, "projection-mismatch");
+
+const status = summarizeStatusTables({
+  checkpoints: [
+    {
+      dao_code: "ens-dao",
+      chain_id: 1,
+      stream_id: "governance-events",
+      data_source_version: "datalens-v1",
+      processed_height: "100",
+      target_height: "101",
+      updated_at: "2026-06-02T07:00:00.000Z",
+    },
+  ],
+  reconcileTasks: [
+    { id: "r1", status: "pending", attempts: 0 },
+    { id: "r2", status: "failed", attempts: 3, error: "Datalens query failed" },
+  ],
+  refreshTasks: [
+    { id: "p1", status: "pending", attempts: 0 },
+    { id: "p2", status: "pending", attempts: 1 },
+  ],
+  legacyStatus: { height: "99", hash: null },
+});
+
+assert.deepEqual(status.reconcileBacklog, { pending: 1, failed: 1 });
+assert.deepEqual(status.onchainRefreshBacklog, { pending: 2 });
+assert.equal(status.reconcileErrors[0].classification, "datalens-query-error");
+assert.deepEqual(status.legacySquidStatus, { height: "99", hash: null });
+
+console.log("Indexer diagnostics tests passed");

--- a/apps/indexer/scripts/indexer-reconcile-diagnose.mjs
+++ b/apps/indexer/scripts/indexer-reconcile-diagnose.mjs
@@ -2,7 +2,7 @@
 
 import {
   readDatalensStatus,
-  summarizeStatusTables,
+  requireOptionValue,
 } from "./indexer-diagnostics.mjs";
 
 export function parseArgs(argv) {
@@ -24,7 +24,7 @@ export function parseArgs(argv) {
     const value = inlineValue ?? argv[index + 1];
     switch (flag) {
       case "--database-url":
-        options.databaseUrl = value;
+        options.databaseUrl = requireOptionValue(flag, value);
         if (inlineValue === undefined) {
           index += 1;
         }
@@ -54,9 +54,10 @@ export function buildHumanSummary(status) {
 
 export function usage() {
   return [
-    "Usage: node apps/indexer/scripts/indexer-reconcile-diagnose.mjs --database-url <postgres-url> [--json]",
+    "Usage: node apps/indexer/scripts/indexer-reconcile-diagnose.mjs [--database-url <postgres-url>] [--json]",
     "",
     "Reads Datalens-owned checkpoint, reconcile, and onchain refresh status tables.",
+    "--database-url falls back to DEGOV_INDEXER_DATABASE_URL, then DATABASE_URL.",
     "The script only runs SELECT statements. squid_processor.status is reported as a legacy bridge when present.",
   ].join("\n");
 }

--- a/apps/indexer/scripts/indexer-reconcile-diagnose.mjs
+++ b/apps/indexer/scripts/indexer-reconcile-diagnose.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import {
+  readDatalensStatus,
+  summarizeStatusTables,
+} from "./indexer-diagnostics.mjs";
+
+export function parseArgs(argv) {
+  const options = {
+    databaseUrl: process.env.DEGOV_INDEXER_DATABASE_URL ?? process.env.DATABASE_URL ?? "",
+    json: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      continue;
+    }
+    const [flag, inlineValue] = token.split("=", 2);
+    const value = inlineValue ?? argv[index + 1];
+    switch (flag) {
+      case "--database-url":
+        options.databaseUrl = value;
+        if (inlineValue === undefined) {
+          index += 1;
+        }
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+  return options;
+}
+
+export function buildHumanSummary(status) {
+  return [
+    "Datalens reconcile diagnostics",
+    `checkpoint rows: ${status.checkpoints.length}`,
+    `checkpoint stalls: ${status.checkpointStalls.length}`,
+    `checkpoint errors: ${status.checkpointErrors.length}`,
+    `reconcile backlog: ${JSON.stringify(status.reconcileBacklog)}`,
+    `reconcile errors: ${status.reconcileErrors.length}`,
+    `onchain refresh backlog: ${JSON.stringify(status.onchainRefreshBacklog)}`,
+    `onchain refresh errors: ${status.onchainRefreshErrors.length}`,
+    `legacy squid_processor.status: ${
+      status.legacySquidStatus ? JSON.stringify(status.legacySquidStatus) : "not present"
+    }`,
+  ].join("\n");
+}
+
+export function usage() {
+  return [
+    "Usage: node apps/indexer/scripts/indexer-reconcile-diagnose.mjs --database-url <postgres-url> [--json]",
+    "",
+    "Reads Datalens-owned checkpoint, reconcile, and onchain refresh status tables.",
+    "The script only runs SELECT statements. squid_processor.status is reported as a legacy bridge when present.",
+  ].join("\n");
+}
+
+export async function diagnoseReconcile(options, services = {}) {
+  if (!options.databaseUrl && !services.status) {
+    throw new Error("--database-url or DEGOV_INDEXER_DATABASE_URL is required");
+  }
+  return services.status ?? readDatalensStatus(options.databaseUrl);
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  const status = await diagnoseReconcile(options);
+  if (options.json) {
+    console.log(JSON.stringify(status, null, 2));
+    return;
+  }
+  console.log(buildHumanSummary(status));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs
+++ b/apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import {
+  buildHumanSummary,
+  diagnoseReconcile,
+  parseArgs,
+} from "./indexer-reconcile-diagnose.mjs";
+
+assert.equal(
+  parseArgs(["--database-url", "postgres://reader@example/db", "--json"]).json,
+  true,
+);
+
+await assert.rejects(
+  () => diagnoseReconcile({ databaseUrl: "" }),
+  /--database-url/,
+);
+
+const status = {
+  ...summarizeFixture(),
+  legacySquidStatus: { height: "100", hash: null },
+};
+
+assert.equal(await diagnoseReconcile({ databaseUrl: "" }, { status }), status);
+assert.match(buildHumanSummary(status), /checkpoint stalls: 1/);
+assert.match(buildHumanSummary(status), /legacy squid_processor.status/);
+
+function summarizeFixture() {
+  return {
+    checkpoints: [{ daoCode: "ens-dao" }],
+    checkpointStalls: [{ daoCode: "ens-dao" }],
+    checkpointErrors: [],
+    reconcileBacklog: { pending: 1 },
+    reconcileErrors: [],
+    onchainRefreshBacklog: { pending: 2 },
+    onchainRefreshErrors: [],
+  };
+}
+
+console.log("Indexer reconcile diagnose tests passed");

--- a/package.json
+++ b/package.json
@@ -4,12 +4,17 @@
   "private": true,
   "packageManager": "pnpm@10.32.1",
   "scripts": {
+    "audit:accuracy": "node apps/indexer/scripts/indexer-accuracy-audit.mjs",
+    "audit:diagnose": "node apps/indexer/scripts/indexer-accuracy-diagnose.mjs",
+    "audit:diagnose-address": "pnpm run audit:diagnose",
+    "audit:reconcile": "node apps/indexer/scripts/indexer-reconcile-diagnose.mjs",
     "indexer": "cargo run -p degov-datalens-indexer --locked -- run",
     "indexer:build": "cargo build -p degov-datalens-indexer --locked",
     "indexer:graphql": "cargo run -p degov-datalens-indexer --locked -- graphql",
     "indexer:migrate": "cargo run -p degov-datalens-indexer --locked -- migrate",
     "indexer:smoke-datalens": "cargo run -p degov-datalens-indexer --locked -- smoke-datalens",
-    "indexer:worker": "cargo run -p degov-datalens-indexer --locked -- worker"
+    "indexer:worker": "cargo run -p degov-datalens-indexer --locked -- worker",
+    "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs"
   },
   "pnpm": {
     "packageExtensions": {


### PR DESCRIPTION
## Summary
- Adds Datalens-native accuracy audit, address diagnose, and reconcile/status diagnostics.
- Reads Datalens-native checkpoint/reconcile tables and reports legacy SQD status only as a bridge when present.
- Adds package scripts and focused tests for the diagnostic tooling.

## Verification
- pnpm run test:indexer-scripts
- node ./scripts/check-rust-conventions.mjs && node ./scripts/check-postgres-schema.mjs
- cargo test --locked --lib
- audit/diagnose/reconcile --help commands
- live read-only audit dry run against ENS + Lisk
- live ENS diagnose dry run
- git diff --check