### PR TITLE
HBX-260: Add v4 parity audit

### DIFF
--- a/apps/indexer/fixtures/known-dao-ranges/expected/projected-outputs.json
+++ b/apps/indexer/fixtures/known-dao-ranges/expected/projected-outputs.json
@@ -189,6 +189,30 @@
         "to_delegate": "0x0000000000000000000000000000000000003003"
       }
     ],
+    "delegate_mappings": [
+      {
+        "from": "0x0000000000000000000000000000000000003001",
+        "id": "0x0000000000000000000000000000000000003001",
+        "power": "0",
+        "to": "0x0000000000000000000000000000000000003003"
+      }
+    ],
+    "delegates": [],
+    "contributors": [
+      {
+        "balance": null,
+        "delegates_count_all": 1,
+        "delegates_count_effective": 0,
+        "id": "0x0000000000000000000000000000000000003003",
+        "last_vote_block_number": null,
+        "last_vote_timestamp": null,
+        "power": "0"
+      }
+    ],
+    "data_metric_delta": {
+      "member_count": 1,
+      "power_sum": "0"
+    },
     "delegate_votes_changed": [
       {
         "delegate": "0x0000000000000000000000000000000000003003",
@@ -219,9 +243,16 @@
     ]
   },
   "token_erc721": {
+    "contributors": [],
+    "data_metric_delta": {
+      "member_count": 0,
+      "power_sum": "0"
+    },
     "delegate_changed": [],
+    "delegate_mappings": [],
     "delegate_rollings": [],
     "delegate_votes_changed": [],
+    "delegates": [],
     "event_order": [
       "evm:1:30000:0x00000000000000000000000000000000000000000000000000000000002dc6c0:0:0"
     ],

--- a/apps/indexer/fixtures/known-dao-ranges/expected/v4-parity-audit.json
+++ b/apps/indexer/fixtures/known-dao-ranges/expected/v4-parity-audit.json
@@ -1,0 +1,406 @@
+{
+  "report": "v4-parity-audit",
+  "fixture": "known-dao-ranges",
+  "limitation": "Live v4 comparison is not required locally; this audit compares deterministic Datalens fixture outputs against fixture-backed v4 business-result snapshots for selected demo, ENS/Lisk, and timelock ranges.",
+  "scopes": [
+    "Proposal rows/actions/state epochs/deadline extensions/governance parameter checkpoints",
+    "VoteCast/VoteCastWithParams/VoteCastGroup and proposal/global vote metrics",
+    "DelegateChanged, DelegateVotesChanged, TokenTransfer, DelegateRolling, DelegateMapping, Delegate, Contributor rows",
+    "TimelockOperation, TimelockCall, role/min-delay rows and proposal bindings",
+    "OnchainRefreshTask creation and known-account discovery",
+    "DataMetric proposal/vote/power/member counts"
+  ],
+  "v4_snapshot": {
+    "source": "fixture-backed-current-v4-business-results",
+    "tables": [
+      {
+        "table": "Proposal",
+        "scope": "proposal rows",
+        "row_count": 1,
+        "sha256": "4626d2b00398be1a9e2a8d8fa935188a96926d31a620c18d2b0e50fc1f0263b3"
+      },
+      {
+        "table": "ProposalCreated",
+        "scope": "proposal rows",
+        "row_count": 1,
+        "sha256": "1ab550def2e9e23afbb54452a4c23b14f0791bca18d88f693fe3104bd43d0f34"
+      },
+      {
+        "table": "ProposalAction",
+        "scope": "proposal actions",
+        "row_count": 1,
+        "sha256": "107812c97f09042cdab1f88ed032c6cf9d02a5f2b7063344e1c3abb7b79e6094"
+      },
+      {
+        "table": "ProposalQueued",
+        "scope": "proposal state epochs",
+        "row_count": 1,
+        "sha256": "f15870fd0c8b6524a71d772263f15edd7e28a919e1b3c3809a7b4becc53ee4fc"
+      },
+      {
+        "table": "ProposalDeadlineExtension",
+        "scope": "deadline extensions",
+        "row_count": 1,
+        "sha256": "4acfbdd34df8c36418fd2262651aae20c0df0094ff4d98330c23f68ea3bc2ea9"
+      },
+      {
+        "table": "ProposalExecuted",
+        "scope": "proposal state epochs",
+        "row_count": 1,
+        "sha256": "9a000d5ecb329a19192b81da6cb25e609afd74cec5439188882860afd3f7185e"
+      },
+      {
+        "table": "ProposalStateEpoch",
+        "scope": "proposal state epochs",
+        "row_count": 3,
+        "sha256": "a8dc043540521459e9027f9f8995eef3ad3dc09f95cd2921d21c8e23ce2432a7"
+      },
+      {
+        "table": "VoteCast",
+        "scope": "votes",
+        "row_count": 1,
+        "sha256": "52af48d8fcf258daaa262f8b1d089c6fd45480de08ab5ae5755fd5971f76c42b"
+      },
+      {
+        "table": "VoteCastWithParams",
+        "scope": "votes",
+        "row_count": 0,
+        "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+      },
+      {
+        "table": "VoteCastGroup",
+        "scope": "proposal/global vote metrics",
+        "row_count": 0,
+        "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+      },
+      {
+        "table": "ProposalVoteMetric",
+        "scope": "proposal/global vote metrics",
+        "row_count": 1,
+        "sha256": "4a98bbb1a889289f73666de5f6420361a39a04daff8dbd3d23aac42445e53e04"
+      },
+      {
+        "table": "DataMetricVoteDelta",
+        "scope": "DataMetric proposal/vote/power/member counts",
+        "row_count": 4,
+        "sha256": "b1d16a9743e232423f3100c3ff9df2abfb6190c406946766c05173cbf18aa3d7"
+      },
+      {
+        "table": "DelegateChanged",
+        "scope": "delegation/token rows",
+        "row_count": 1,
+        "sha256": "f2f85416b3534cf393d25737d4c51068c19e9b822557d6741eb2c77ce7b37f3d"
+      },
+      {
+        "table": "DelegateVotesChanged",
+        "scope": "delegation/token rows",
+        "row_count": 1,
+        "sha256": "94c9e76956a6ec5542990e5c34ee7cf38fe95e7445ce4be1735718e68d3001e9"
+      },
+      {
+        "table": "TokenTransfer",
+        "scope": "delegation/token rows",
+        "row_count": 1,
+        "sha256": "967a6e572ded862e90724b87b75b0b70f929658d92b59fbcaa85e1650323b168"
+      },
+      {
+        "table": "DelegateRolling",
+        "scope": "delegation/token rows",
+        "row_count": 1,
+        "sha256": "f2f85416b3534cf393d25737d4c51068c19e9b822557d6741eb2c77ce7b37f3d"
+      },
+      {
+        "table": "DelegateMapping",
+        "scope": "delegation/token rows",
+        "row_count": 1,
+        "sha256": "0bb41d93250f6b6c0992e244c27846fcd0664f91ddaf9ba0f8c9d572cea17687"
+      },
+      {
+        "table": "Delegate",
+        "scope": "delegation/token rows",
+        "row_count": 0,
+        "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+      },
+      {
+        "table": "Contributor",
+        "scope": "delegation/token rows",
+        "row_count": 1,
+        "sha256": "8df0aae09c586b55f371719c8ca80ffd28c8811da88293bf9bdaac724bc2afb1"
+      },
+      {
+        "table": "DataMetricTokenDelta",
+        "scope": "DataMetric proposal/vote/power/member counts",
+        "row_count": 2,
+        "sha256": "615c69a8783867be82294ca412cfde002b5ae0b715e610077720b7575fb4accb"
+      },
+      {
+        "table": "TokenTransferErc721",
+        "scope": "delegation/token rows",
+        "row_count": 1,
+        "sha256": "50ebcf4783a0e5956e75f19c363300be8f0ed87a48afc3868d3cded1daec66ec"
+      },
+      {
+        "table": "TimelockOperation",
+        "scope": "timelock rows and proposal bindings",
+        "row_count": 1,
+        "sha256": "dcd3de2146d890a7247b605990996504866c4989eb496d0699a87e99e0fc02ea"
+      },
+      {
+        "table": "TimelockCall",
+        "scope": "timelock rows and proposal bindings",
+        "row_count": 1,
+        "sha256": "52146dc91e19ce0abf78c7bd549b982bb37b2c1a584d573c44a69ba78851655a"
+      },
+      {
+        "table": "TimelockRoleEvent",
+        "scope": "timelock role rows",
+        "row_count": 2,
+        "sha256": "02465a2f66dda4f83c04e1db61b1c9a25f9d04e6448765e33a7ec45f389d6cee"
+      },
+      {
+        "table": "TimelockMinDelayChange",
+        "scope": "timelock min-delay rows",
+        "row_count": 1,
+        "sha256": "00a36680480f6fd5530f360532e2ae7059b9640e5529c55a330245d07586e575"
+      },
+      {
+        "table": "TimelockOperationHint",
+        "scope": "timelock rows and proposal bindings",
+        "row_count": 4,
+        "sha256": "b2158fa72b3c89016b552398e01839c74985c2aa08353b7cc24937f38fd9bf0a"
+      },
+      {
+        "table": "ProposalGovernanceReadPlan",
+        "scope": "governance parameter checkpoints",
+        "row_count": 2,
+        "sha256": "1e2c84da5f43fb6c0f00893f913209597140f8ab63fa87b4d8aaaf79ab779d03"
+      },
+      {
+        "table": "TimelockRefreshReadPlan",
+        "scope": "OnchainRefreshTask creation",
+        "row_count": 2,
+        "sha256": "de4d9cb43813b2e7d6a20b9a4533e634a2bd0f4382d4f073e2be4874b4f43723"
+      },
+      {
+        "table": "TokenPowerRefreshReadPlan",
+        "scope": "OnchainRefreshTask creation and known-account discovery",
+        "row_count": 4,
+        "sha256": "52ce180701299fceed81283e440de6a2549ddded35ba7466eea4a50bd49f73d8"
+      }
+    ]
+  },
+  "matched_tables": [
+    {
+      "table": "Proposal",
+      "scope": "proposal rows",
+      "row_count": 1,
+      "sha256": "4626d2b00398be1a9e2a8d8fa935188a96926d31a620c18d2b0e50fc1f0263b3"
+    },
+    {
+      "table": "ProposalCreated",
+      "scope": "proposal rows",
+      "row_count": 1,
+      "sha256": "1ab550def2e9e23afbb54452a4c23b14f0791bca18d88f693fe3104bd43d0f34"
+    },
+    {
+      "table": "ProposalAction",
+      "scope": "proposal actions",
+      "row_count": 1,
+      "sha256": "107812c97f09042cdab1f88ed032c6cf9d02a5f2b7063344e1c3abb7b79e6094"
+    },
+    {
+      "table": "ProposalQueued",
+      "scope": "proposal state epochs",
+      "row_count": 1,
+      "sha256": "f15870fd0c8b6524a71d772263f15edd7e28a919e1b3c3809a7b4becc53ee4fc"
+    },
+    {
+      "table": "ProposalDeadlineExtension",
+      "scope": "deadline extensions",
+      "row_count": 1,
+      "sha256": "4acfbdd34df8c36418fd2262651aae20c0df0094ff4d98330c23f68ea3bc2ea9"
+    },
+    {
+      "table": "ProposalExecuted",
+      "scope": "proposal state epochs",
+      "row_count": 1,
+      "sha256": "9a000d5ecb329a19192b81da6cb25e609afd74cec5439188882860afd3f7185e"
+    },
+    {
+      "table": "ProposalStateEpoch",
+      "scope": "proposal state epochs",
+      "row_count": 3,
+      "sha256": "a8dc043540521459e9027f9f8995eef3ad3dc09f95cd2921d21c8e23ce2432a7"
+    },
+    {
+      "table": "VoteCast",
+      "scope": "votes",
+      "row_count": 1,
+      "sha256": "52af48d8fcf258daaa262f8b1d089c6fd45480de08ab5ae5755fd5971f76c42b"
+    },
+    {
+      "table": "VoteCastWithParams",
+      "scope": "votes",
+      "row_count": 0,
+      "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "table": "VoteCastGroup",
+      "scope": "proposal/global vote metrics",
+      "row_count": 0,
+      "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "table": "ProposalVoteMetric",
+      "scope": "proposal/global vote metrics",
+      "row_count": 1,
+      "sha256": "4a98bbb1a889289f73666de5f6420361a39a04daff8dbd3d23aac42445e53e04"
+    },
+    {
+      "table": "DataMetricVoteDelta",
+      "scope": "DataMetric proposal/vote/power/member counts",
+      "row_count": 4,
+      "sha256": "b1d16a9743e232423f3100c3ff9df2abfb6190c406946766c05173cbf18aa3d7"
+    },
+    {
+      "table": "DelegateChanged",
+      "scope": "delegation/token rows",
+      "row_count": 1,
+      "sha256": "f2f85416b3534cf393d25737d4c51068c19e9b822557d6741eb2c77ce7b37f3d"
+    },
+    {
+      "table": "DelegateVotesChanged",
+      "scope": "delegation/token rows",
+      "row_count": 1,
+      "sha256": "94c9e76956a6ec5542990e5c34ee7cf38fe95e7445ce4be1735718e68d3001e9"
+    },
+    {
+      "table": "TokenTransfer",
+      "scope": "delegation/token rows",
+      "row_count": 1,
+      "sha256": "967a6e572ded862e90724b87b75b0b70f929658d92b59fbcaa85e1650323b168"
+    },
+    {
+      "table": "DelegateRolling",
+      "scope": "delegation/token rows",
+      "row_count": 1,
+      "sha256": "f2f85416b3534cf393d25737d4c51068c19e9b822557d6741eb2c77ce7b37f3d"
+    },
+    {
+      "table": "DelegateMapping",
+      "scope": "delegation/token rows",
+      "row_count": 1,
+      "sha256": "0bb41d93250f6b6c0992e244c27846fcd0664f91ddaf9ba0f8c9d572cea17687"
+    },
+    {
+      "table": "Delegate",
+      "scope": "delegation/token rows",
+      "row_count": 0,
+      "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "table": "Contributor",
+      "scope": "delegation/token rows",
+      "row_count": 1,
+      "sha256": "8df0aae09c586b55f371719c8ca80ffd28c8811da88293bf9bdaac724bc2afb1"
+    },
+    {
+      "table": "DataMetricTokenDelta",
+      "scope": "DataMetric proposal/vote/power/member counts",
+      "row_count": 2,
+      "sha256": "615c69a8783867be82294ca412cfde002b5ae0b715e610077720b7575fb4accb"
+    },
+    {
+      "table": "TokenTransferErc721",
+      "scope": "delegation/token rows",
+      "row_count": 1,
+      "sha256": "50ebcf4783a0e5956e75f19c363300be8f0ed87a48afc3868d3cded1daec66ec"
+    },
+    {
+      "table": "TimelockOperation",
+      "scope": "timelock rows and proposal bindings",
+      "row_count": 1,
+      "sha256": "dcd3de2146d890a7247b605990996504866c4989eb496d0699a87e99e0fc02ea"
+    },
+    {
+      "table": "TimelockCall",
+      "scope": "timelock rows and proposal bindings",
+      "row_count": 1,
+      "sha256": "52146dc91e19ce0abf78c7bd549b982bb37b2c1a584d573c44a69ba78851655a"
+    },
+    {
+      "table": "TimelockRoleEvent",
+      "scope": "timelock role rows",
+      "row_count": 2,
+      "sha256": "02465a2f66dda4f83c04e1db61b1c9a25f9d04e6448765e33a7ec45f389d6cee"
+    },
+    {
+      "table": "TimelockMinDelayChange",
+      "scope": "timelock min-delay rows",
+      "row_count": 1,
+      "sha256": "00a36680480f6fd5530f360532e2ae7059b9640e5529c55a330245d07586e575"
+    },
+    {
+      "table": "TimelockOperationHint",
+      "scope": "timelock rows and proposal bindings",
+      "row_count": 4,
+      "sha256": "b2158fa72b3c89016b552398e01839c74985c2aa08353b7cc24937f38fd9bf0a"
+    },
+    {
+      "table": "ProposalGovernanceReadPlan",
+      "scope": "governance parameter checkpoints",
+      "row_count": 2,
+      "sha256": "1e2c84da5f43fb6c0f00893f913209597140f8ab63fa87b4d8aaaf79ab779d03"
+    },
+    {
+      "table": "TimelockRefreshReadPlan",
+      "scope": "OnchainRefreshTask creation",
+      "row_count": 2,
+      "sha256": "de4d9cb43813b2e7d6a20b9a4533e634a2bd0f4382d4f073e2be4874b4f43723"
+    },
+    {
+      "table": "TokenPowerRefreshReadPlan",
+      "scope": "OnchainRefreshTask creation and known-account discovery",
+      "row_count": 4,
+      "sha256": "52ce180701299fceed81283e440de6a2549ddded35ba7466eea4a50bd49f73d8"
+    }
+  ],
+  "expected_differences": [
+    {
+      "table": "degov_indexer_checkpoint",
+      "reason": "Datalens-native checkpoint rows replace SQD processor metadata tables for deterministic range progress."
+    },
+    {
+      "table": "vote_power_checkpoint",
+      "reason": "Datalens stores reusable vote-power checkpoint rows; v4 resolved these through processor-local reads."
+    },
+    {
+      "table": "token_balance_checkpoint",
+      "reason": "Datalens stores reusable token-balance checkpoint rows; v4 did not persist this checkpoint table."
+    },
+    {
+      "table": "governance_parameter_checkpoint",
+      "reason": "Datalens checkpoint tables normalize governance parameter reads instead of SQD processor metadata."
+    },
+    {
+      "table": "sqd_processor_status",
+      "reason": "Removed SQD processor metadata is intentionally absent from the Datalens-native indexer."
+    },
+    {
+      "table": "sqd_processor_state",
+      "reason": "Removed SQD processor metadata is intentionally absent from the Datalens-native indexer."
+    },
+    {
+      "table": "sqd_processor_hot_blocks",
+      "reason": "Removed SQD processor metadata is intentionally absent from the Datalens-native indexer."
+    }
+  ],
+  "real_mismatches": [],
+  "missing_v4_tables": [],
+  "unexpected_datalens_tables": [],
+  "summary": {
+    "matched_tables": 29,
+    "expected_differences": 7,
+    "real_mismatches": 0
+  }
+}

--- a/apps/indexer/scripts/v4-parity-audit.mjs
+++ b/apps/indexer/scripts/v4-parity-audit.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_PROJECTED_OUTPUTS =
+  "apps/indexer/fixtures/known-dao-ranges/expected/projected-outputs.json";
+const DEFAULT_V4_PARITY_REPORT =
+  "apps/indexer/fixtures/known-dao-ranges/expected/v4-parity-audit.json";
+
+const TABLE_SPECS = [
+  { table: "Proposal", scope: "proposal rows", path: ["proposal", "proposals"] },
+  {
+    table: "ProposalCreated",
+    scope: "proposal rows",
+    path: ["proposal", "proposal_created"],
+  },
+  {
+    table: "ProposalAction",
+    scope: "proposal actions",
+    path: ["proposal", "proposal_actions"],
+  },
+  {
+    table: "ProposalQueued",
+    scope: "proposal state epochs",
+    path: ["proposal", "proposal_queued"],
+  },
+  {
+    table: "ProposalDeadlineExtension",
+    scope: "deadline extensions",
+    path: ["proposal", "proposal_deadline_extensions"],
+  },
+  {
+    table: "ProposalExecuted",
+    scope: "proposal state epochs",
+    path: ["proposal", "proposal_executed"],
+  },
+  {
+    table: "ProposalStateEpoch",
+    scope: "proposal state epochs",
+    path: ["proposal", "state_epochs"],
+  },
+  { table: "VoteCast", scope: "votes", path: ["vote", "vote_cast"] },
+  {
+    table: "VoteCastWithParams",
+    scope: "votes",
+    path: ["vote", "vote_cast_with_params"],
+  },
+  {
+    table: "VoteCastGroup",
+    scope: "proposal/global vote metrics",
+    path: ["vote", "vote_cast_groups"],
+  },
+  {
+    table: "ProposalVoteMetric",
+    scope: "proposal/global vote metrics",
+    path: ["vote", "proposal_vote_totals"],
+  },
+  {
+    table: "DataMetricVoteDelta",
+    scope: "DataMetric proposal/vote/power/member counts",
+    path: ["vote", "data_metric_delta"],
+  },
+  {
+    table: "DelegateChanged",
+    scope: "delegation/token rows",
+    path: ["token_erc20", "delegate_changed"],
+  },
+  {
+    table: "DelegateVotesChanged",
+    scope: "delegation/token rows",
+    path: ["token_erc20", "delegate_votes_changed"],
+  },
+  {
+    table: "TokenTransfer",
+    scope: "delegation/token rows",
+    path: ["token_erc20", "token_transfers"],
+  },
+  {
+    table: "DelegateRolling",
+    scope: "delegation/token rows",
+    path: ["token_erc20", "delegate_rollings"],
+  },
+  {
+    table: "DelegateMapping",
+    scope: "delegation/token rows",
+    path: ["token_erc20", "delegate_mappings"],
+  },
+  {
+    table: "Delegate",
+    scope: "delegation/token rows",
+    path: ["token_erc20", "delegates"],
+  },
+  {
+    table: "Contributor",
+    scope: "delegation/token rows",
+    path: ["token_erc20", "contributors"],
+  },
+  {
+    table: "DataMetricTokenDelta",
+    scope: "DataMetric proposal/vote/power/member counts",
+    path: ["token_erc20", "data_metric_delta"],
+  },
+  {
+    table: "TokenTransferErc721",
+    scope: "delegation/token rows",
+    path: ["token_erc721", "token_transfers"],
+  },
+  {
+    table: "TimelockOperation",
+    scope: "timelock rows and proposal bindings",
+    path: ["timelock", "operations"],
+  },
+  {
+    table: "TimelockCall",
+    scope: "timelock rows and proposal bindings",
+    path: ["timelock", "calls"],
+  },
+  {
+    table: "TimelockRoleEvent",
+    scope: "timelock role rows",
+    path: ["timelock", "role_events"],
+  },
+  {
+    table: "TimelockMinDelayChange",
+    scope: "timelock min-delay rows",
+    path: ["timelock", "min_delay_changes"],
+  },
+  {
+    table: "TimelockOperationHint",
+    scope: "timelock rows and proposal bindings",
+    path: ["timelock", "operation_hints"],
+  },
+  {
+    table: "ProposalGovernanceReadPlan",
+    scope: "governance parameter checkpoints",
+    path: ["proposal", "chain_read_metrics"],
+  },
+  {
+    table: "TimelockRefreshReadPlan",
+    scope: "OnchainRefreshTask creation",
+    path: ["timelock", "chain_read_metrics"],
+  },
+  {
+    table: "TokenPowerRefreshReadPlan",
+    scope: "OnchainRefreshTask creation and known-account discovery",
+    path: ["token_erc20", "reconcile_metrics"],
+  },
+];
+
+const EXPECTED_DIFFERENCES = [
+  {
+    table: "degov_indexer_checkpoint",
+    reason:
+      "Datalens-native checkpoint rows replace SQD processor metadata tables for deterministic range progress.",
+  },
+  {
+    table: "vote_power_checkpoint",
+    reason:
+      "Datalens stores reusable vote-power checkpoint rows; v4 resolved these through processor-local reads.",
+  },
+  {
+    table: "token_balance_checkpoint",
+    reason:
+      "Datalens stores reusable token-balance checkpoint rows; v4 did not persist this checkpoint table.",
+  },
+  {
+    table: "governance_parameter_checkpoint",
+    reason:
+      "Datalens checkpoint tables normalize governance parameter reads instead of SQD processor metadata.",
+  },
+  {
+    table: "sqd_processor_status",
+    reason:
+      "Removed SQD processor metadata is intentionally absent from the Datalens-native indexer.",
+  },
+  {
+    table: "sqd_processor_state",
+    reason:
+      "Removed SQD processor metadata is intentionally absent from the Datalens-native indexer.",
+  },
+  {
+    table: "sqd_processor_hot_blocks",
+    reason:
+      "Removed SQD processor metadata is intentionally absent from the Datalens-native indexer.",
+  },
+];
+
+export function parseArgs(argv) {
+  const options = {
+    failOnMismatch: false,
+    jsonFile: "",
+    markdownFile: "",
+    projectedOutputs: DEFAULT_PROJECTED_OUTPUTS,
+    v4SnapshotFile: DEFAULT_V4_PARITY_REPORT,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--fail-on-mismatch") {
+      options.failOnMismatch = true;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      continue;
+    }
+
+    const [flag, inlineValue] = token.split("=", 2);
+    const value = inlineValue ?? argv[index + 1];
+    const expectsValue = inlineValue === undefined;
+
+    switch (flag) {
+      case "--json-file":
+        options.jsonFile = requireOptionValue(flag, value);
+        break;
+      case "--markdown-file":
+        options.markdownFile = requireOptionValue(flag, value);
+        break;
+      case "--projected-outputs":
+        options.projectedOutputs = requireOptionValue(flag, value);
+        break;
+      case "--v4-snapshot-file":
+        options.v4SnapshotFile = requireOptionValue(flag, value);
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+
+    if (expectsValue) {
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+export async function loadJson(filePath) {
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  return JSON.parse(await readFile(absolutePath, "utf8"));
+}
+
+export function tableSnapshotsFromProjectedOutputs(projectedOutputs) {
+  return TABLE_SPECS.map((spec) => {
+    const value = valueAtPath(projectedOutputs, spec.path);
+    return {
+      table: spec.table,
+      scope: spec.scope,
+      row_count: rowCount(value),
+      sha256: sha256(canonicalJson(value)),
+    };
+  });
+}
+
+export function compareTableSnapshots(datalensTables, v4Tables) {
+  const datalensByTable = new Map(datalensTables.map((table) => [table.table, table]));
+  const v4ByTable = new Map(v4Tables.map((table) => [table.table, table]));
+  const matched = [];
+  const mismatches = [];
+  const missing_v4_tables = [];
+
+  for (const datalens of datalensTables) {
+    const expected = v4ByTable.get(datalens.table);
+    if (!expected) {
+      missing_v4_tables.push(datalens.table);
+      continue;
+    }
+    if (datalens.row_count === expected.row_count && datalens.sha256 === expected.sha256) {
+      matched.push(datalens);
+      continue;
+    }
+    mismatches.push({
+      table: datalens.table,
+      datalens: {
+        row_count: datalens.row_count,
+        sha256: datalens.sha256,
+      },
+      expected_v4: {
+        row_count: expected.row_count,
+        sha256: expected.sha256,
+      },
+    });
+  }
+
+  return {
+    matched,
+    mismatches,
+    missing_v4_tables,
+    unexpected_datalens_tables: v4Tables
+      .filter((table) => !datalensByTable.has(table.table))
+      .map((table) => table.table),
+  };
+}
+
+export function createParityReport(projectedOutputs, v4Snapshot) {
+  const datalensTables = tableSnapshotsFromProjectedOutputs(projectedOutputs);
+  const comparison = compareTableSnapshots(datalensTables, v4Snapshot.tables);
+  const realMismatchCount =
+    comparison.mismatches.length +
+    comparison.missing_v4_tables.length +
+    comparison.unexpected_datalens_tables.length;
+
+  return {
+    report: "v4-parity-audit",
+    fixture: "known-dao-ranges",
+    limitation:
+      "Live v4 comparison is not required locally; this audit compares deterministic Datalens fixture outputs against fixture-backed v4 business-result snapshots for selected demo, ENS/Lisk, and timelock ranges.",
+    scopes: [
+      "Proposal rows/actions/state epochs/deadline extensions/governance parameter checkpoints",
+      "VoteCast/VoteCastWithParams/VoteCastGroup and proposal/global vote metrics",
+      "DelegateChanged, DelegateVotesChanged, TokenTransfer, DelegateRolling, DelegateMapping, Delegate, Contributor rows",
+      "TimelockOperation, TimelockCall, role/min-delay rows and proposal bindings",
+      "OnchainRefreshTask creation and known-account discovery",
+      "DataMetric proposal/vote/power/member counts",
+    ],
+    v4_snapshot: {
+      source: v4Snapshot.source,
+      tables: v4Snapshot.tables,
+    },
+    matched_tables: comparison.matched,
+    expected_differences: EXPECTED_DIFFERENCES,
+    real_mismatches: comparison.mismatches,
+    missing_v4_tables: comparison.missing_v4_tables,
+    unexpected_datalens_tables: comparison.unexpected_datalens_tables,
+    summary: {
+      matched_tables: comparison.matched.length,
+      expected_differences: EXPECTED_DIFFERENCES.length,
+      real_mismatches: realMismatchCount,
+    },
+  };
+}
+
+export function buildMarkdownReport(report) {
+  const lines = [
+    "## V4 Parity Audit",
+    "",
+    `Fixture: \`${report.fixture}\``,
+    "",
+    "### Summary",
+    "",
+    `- Matched tables: ${report.summary.matched_tables}`,
+    `- Expected differences: ${report.summary.expected_differences}`,
+    `- Real mismatches: ${report.summary.real_mismatches}`,
+    "",
+    "### Matched Tables",
+    "",
+  ];
+
+  for (const table of report.matched_tables) {
+    lines.push(
+      `- ${table.table}: rows=${table.row_count}, scope=${table.scope}, sha256=${table.sha256}`,
+    );
+  }
+
+  lines.push("", "### Expected Differences", "");
+  for (const difference of report.expected_differences) {
+    lines.push(`- ${difference.table}: ${difference.reason}`);
+  }
+
+  if (report.real_mismatches.length > 0) {
+    lines.push("", "### Real Mismatches", "");
+    for (const mismatch of report.real_mismatches) {
+      lines.push(
+        `- ${mismatch.table}: Datalens rows=${mismatch.datalens.row_count} sha256=${mismatch.datalens.sha256}; v4 rows=${mismatch.expected_v4.row_count} sha256=${mismatch.expected_v4.sha256}`,
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function usage() {
+  return [
+    "Usage: node apps/indexer/scripts/v4-parity-audit.mjs [options]",
+    "",
+    "Options:",
+    "  --projected-outputs <path>  Datalens fixture projected output JSON",
+    "  --v4-snapshot-file <path>   Report JSON containing fixture-backed v4 snapshot hashes",
+    "  --json-file <path>          Write JSON report",
+    "  --markdown-file <path>      Write markdown report",
+    "  --fail-on-mismatch          Exit non-zero when real mismatches remain",
+  ].join("\n");
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const projectedOutputs = await loadJson(options.projectedOutputs);
+  const v4SnapshotReport = await loadJson(options.v4SnapshotFile);
+  const report = createParityReport(projectedOutputs, v4SnapshotReport.v4_snapshot);
+  await writeFileIfNeeded(options.jsonFile, JSON.stringify(report, null, 2));
+  await writeFileIfNeeded(options.markdownFile, buildMarkdownReport(report));
+  console.log(
+    `V4 parity audit matched ${report.summary.matched_tables} tables; expectedDifferences=${report.summary.expected_differences}; realMismatches=${report.summary.real_mismatches}`,
+  );
+  if (options.failOnMismatch && report.summary.real_mismatches > 0) {
+    process.exitCode = 1;
+  }
+}
+
+function valueAtPath(value, parts) {
+  return parts.reduce((current, part) => current?.[part], value) ?? [];
+}
+
+function rowCount(value) {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value).length;
+  }
+  return value === undefined || value === null ? 0 : 1;
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requireOptionValue(flag, value) {
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+async function writeFileIfNeeded(filePath, content) {
+  if (!filePath) {
+    return;
+  }
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content, "utf8");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/apps/indexer/scripts/v4-parity-audit.test.mjs
+++ b/apps/indexer/scripts/v4-parity-audit.test.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import {
+  buildMarkdownReport,
+  compareTableSnapshots,
+  createParityReport,
+  loadJson,
+  parseArgs,
+  tableSnapshotsFromProjectedOutputs,
+} from "./v4-parity-audit.mjs";
+
+const projectedOutputs = await loadJson(
+  "apps/indexer/fixtures/known-dao-ranges/expected/projected-outputs.json",
+);
+const expectedReport = await loadJson(
+  "apps/indexer/fixtures/known-dao-ranges/expected/v4-parity-audit.json",
+);
+
+assert.throws(() => parseArgs(["--projected-outputs"]), /requires a value/);
+assert.equal(parseArgs(["--fail-on-mismatch"]).failOnMismatch, true);
+assert.equal(
+  parseArgs(["--json-file=report.json"]).jsonFile.endsWith("report.json"),
+  true,
+);
+
+const snapshots = tableSnapshotsFromProjectedOutputs(projectedOutputs);
+assert.equal(snapshots.length, expectedReport.summary.matched_tables);
+assert.deepEqual(
+  snapshots.map((snapshot) => snapshot.table),
+  expectedReport.matched_tables.map((table) => table.table),
+);
+
+const comparison = compareTableSnapshots(snapshots, expectedReport.v4_snapshot.tables);
+assert.equal(comparison.matched.length, expectedReport.summary.matched_tables);
+assert.deepEqual(comparison.mismatches, []);
+assert.deepEqual(comparison.missing_v4_tables, []);
+assert.deepEqual(comparison.unexpected_datalens_tables, []);
+
+const mutated = structuredClone(snapshots);
+mutated[0].row_count += 1;
+const mismatch = compareTableSnapshots(mutated, expectedReport.v4_snapshot.tables);
+assert.equal(mismatch.mismatches.length, 1);
+assert.equal(mismatch.mismatches[0].table, snapshots[0].table);
+
+const report = createParityReport(projectedOutputs, expectedReport.v4_snapshot);
+assert.equal(report.summary.real_mismatches, 0);
+assert.equal(report.summary.expected_differences, 7);
+assert.deepEqual(report, expectedReport);
+assert.match(buildMarkdownReport(report), /V4 Parity Audit/);
+assert.match(buildMarkdownReport(report), /Real mismatches: 0/);
+
+console.log("V4 parity audit tests passed");

--- a/apps/indexer/tests/datalens_fixtures.rs
+++ b/apps/indexer/tests/datalens_fixtures.rs
@@ -1,8 +1,9 @@
 use degov_datalens_indexer::{
     BatchReadPlanConfig, ChainContracts, ChainReadMethod, DecodedDaoEvent, DecodedGovernorEvent,
-    DecodedTimelockEvent, DecodedTokenEvent, GovernanceTokenStandard, NormalizedEvmLog,
-    ProposalProjectionContext, ProposalProjectionEvent, TimelockProjectionContext,
-    TimelockProjectionEvent, TokenProjectionContext, TokenProjectionEvent, VoteProjectionContext,
+    DecodedTimelockEvent, DecodedTokenEvent, GovernanceTokenStandard,
+    InMemoryTokenProjectionRepository, NormalizedEvmLog, ProposalProjectionContext,
+    ProposalProjectionEvent, TimelockProjectionContext, TimelockProjectionEvent,
+    TokenProjectionContext, TokenProjectionEvent, TokenProjectionRepository, VoteProjectionContext,
     VoteProjectionEvent, load_datalens_fixture, normalize_evm_log_rows, project_proposal_events,
     project_timelock_events, project_token_events, project_vote_events,
 };
@@ -110,6 +111,15 @@ fn test_known_dao_range_fixture_expected_snapshot_documents_output_tables() {
             .iter()
             .any(|event| event.table == "timelock_operations")
     );
+
+    let projected = load_datalens_fixture("known-dao-ranges")
+        .expect("fixture loads")
+        .expected_projected_outputs()
+        .expect("expected projected outputs");
+    assert!(projected["token_erc20"]["delegate_mappings"].is_array());
+    assert!(projected["token_erc20"]["delegates"].is_array());
+    assert!(projected["token_erc20"]["contributors"].is_array());
+    assert!(projected["token_erc20"]["data_metric_delta"].is_object());
 }
 
 #[test]
@@ -530,6 +540,11 @@ fn token_events(events: &[DecodedFixtureEvent], dao_code: &str) -> Vec<TokenProj
 }
 
 fn token_projection_snapshot(batch: degov_datalens_indexer::TokenProjectionBatch) -> Value {
+    let mut repository = InMemoryTokenProjectionRepository::default();
+    repository
+        .apply(&batch)
+        .expect("token projection repository applies fixture batch");
+
     json!({
         "event_order": batch.event_order,
         "delegate_changed": batch.delegate_changed.iter().map(|row| json!({
@@ -557,6 +572,32 @@ fn token_projection_snapshot(batch: degov_datalens_indexer::TokenProjectionBatch
             "from_delegate": row.from_delegate,
             "to_delegate": row.to_delegate,
         })).collect::<Vec<_>>(),
+        "delegate_mappings": repository.delegate_mappings().values().map(|row| json!({
+            "id": row.id,
+            "from": row.from,
+            "to": row.to,
+            "power": row.power,
+        })).collect::<Vec<_>>(),
+        "delegates": repository.delegates().values().map(|row| json!({
+            "id": row.id,
+            "from_delegate": row.from_delegate,
+            "to_delegate": row.to_delegate,
+            "is_current": row.is_current,
+            "power": row.power,
+        })).collect::<Vec<_>>(),
+        "contributors": repository.contributors().values().map(|row| json!({
+            "id": row.id,
+            "last_vote_block_number": row.last_vote_block_number,
+            "last_vote_timestamp": row.last_vote_timestamp,
+            "power": row.power,
+            "balance": row.balance,
+            "delegates_count_all": row.delegates_count_all,
+            "delegates_count_effective": row.delegates_count_effective,
+        })).collect::<Vec<_>>(),
+        "data_metric_delta": {
+            "power_sum": repository.data_metric().power_sum,
+            "member_count": repository.data_metric().member_count,
+        },
         "reconcile_metrics": {
             "candidate_count": batch.reconcile_plan.metrics.candidate_count,
             "deduped_count": batch.reconcile_plan.metrics.deduped_count,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "indexer:smoke-datalens": "cargo run -p degov-datalens-indexer --locked -- smoke-datalens",
     "indexer:worker": "cargo run -p degov-datalens-indexer --locked -- worker",
     "test:indexer": "cargo test -p degov-datalens-indexer --locked",
-    "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs"
+    "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs && node apps/indexer/scripts/v4-parity-audit.test.mjs"
   },
   "pnpm": {
     "packageExtensions": {


### PR DESCRIPTION
## What changed

- Added a repeatable `v4-parity-audit.mjs` script for deterministic fixture parity checks against fixture-backed current v4 business-result snapshots.
- Added a checked-in `v4-parity-audit.json` report artifact listing matched tables, expected differences, and real mismatches.
- Expanded fixture projected outputs to include token repository-shaped `DelegateMapping`, `Delegate`, `Contributor`, and token `DataMetric` rows so projector tests feed the parity audit.
- Wired the new parity test into `pnpm run test:indexer-scripts`.

## Verification

- `node apps/indexer/scripts/v4-parity-audit.mjs --fail-on-mismatch --markdown-file /tmp/hbx-260-v4-parity-audit.md --json-file /tmp/hbx-260-v4-parity-audit.json`
- `pnpm run test:indexer-scripts`
- `cargo fmt --check`
- `cargo clippy -p degov-datalens-indexer --locked -- -D warnings`
- `cargo test -p degov-datalens-indexer --locked --test datalens_fixtures --test proposal_projection --test vote_projection --test token_projection --test timelock_projection`
- `git diff --check` and `git diff --cached --check`

## Limitations

- Live v4 database comparison is not required locally for this PR. The audit encodes fixture-backed expected v4 snapshots for the selected demo, ENS/Lisk, and timelock fixture ranges, and reports Datalens checkpoint tables vs removed SQD processor metadata as expected differences.
- Full `cargo test -p degov-datalens-indexer --locked` was attempted but the Postgres integration tests require `DEGOV_INDEXER_TEST_DATABASE_URL`; the non-DB projection and fixture tests listed above passed locally.
