### PR TITLE
HBX-262: Prepare Datalens staging deployment path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - indexer
           - web
     steps:
       - uses: actions/checkout@v5

--- a/apps/indexer/scripts/indexer-accuracy-audit.mjs
+++ b/apps/indexer/scripts/indexer-accuracy-audit.mjs
@@ -325,7 +325,7 @@ export function buildMarkdownReport(report, targets) {
     lines.push("### Checkpoint Stalls", "");
     for (const checkpoint of report.status.checkpointStalls) {
       lines.push(
-        `- ${checkpoint.daoCode}/${checkpoint.streamId}: processed=${checkpoint.processedHeight}, target=${checkpoint.targetHeight}, lag=${checkpoint.lagBlocks}, updated=${checkpoint.updatedAt}`,
+        `- ${checkpoint.daoCode}/${checkpoint.streamId}: processed=${checkpoint.processedHeight}, target=${checkpoint.targetHeight}, sync=${checkpoint.syncPercent ?? "unknown"}%, lag=${checkpoint.lagBlocks}, updated=${checkpoint.updatedAt}`,
       );
     }
   }

--- a/apps/indexer/scripts/indexer-diagnostics.mjs
+++ b/apps/indexer/scripts/indexer-diagnostics.mjs
@@ -105,6 +105,7 @@ export function summarizeCheckpointRows(rows, options = {}) {
       targetHeight === null || processedHeight === null
         ? null
         : (BigInt(targetHeight) - BigInt(processedHeight)).toString();
+    const syncPercent = calculateSyncPercent(processedHeight, targetHeight);
     const stalled =
       ageMinutes !== null &&
       ageMinutes >= stallMinutes &&
@@ -122,6 +123,7 @@ export function summarizeCheckpointRows(rows, options = {}) {
         processedHeight === null ? null : String(processedHeight),
       targetHeight: targetHeight === null ? null : String(targetHeight),
       lagBlocks,
+      syncPercent,
       updatedAt,
       ageMinutes,
       stalled,
@@ -135,6 +137,29 @@ export function summarizeCheckpointRows(rows, options = {}) {
           : "checkpoint-ok",
     };
   });
+}
+
+export function calculateSyncPercent(processedHeight, targetHeight) {
+  if (
+    processedHeight === null ||
+    processedHeight === undefined ||
+    targetHeight === null ||
+    targetHeight === undefined
+  ) {
+    return null;
+  }
+
+  const processed = BigInt(processedHeight);
+  const target = BigInt(targetHeight);
+  if (target <= 0n) {
+    return processed >= target ? 100 : null;
+  }
+  if (processed >= target) {
+    return 100;
+  }
+
+  const roundedBasisPoints = (processed * 10_000n + target / 2n) / target;
+  return Number(roundedBasisPoints) / 100;
 }
 
 export function summarizeStatusTables({

--- a/apps/indexer/scripts/indexer-diagnostics.test.mjs
+++ b/apps/indexer/scripts/indexer-diagnostics.test.mjs
@@ -86,6 +86,7 @@ const checkpointRows = summarizeCheckpointRows(
 
 assert.equal(checkpointRows[0].stalled, true);
 assert.equal(checkpointRows[0].lagBlocks, "50");
+assert.equal(checkpointRows[0].syncPercent, 66.67);
 assert.equal(checkpointRows[0].classification, "checkpoint-stall");
 assert.equal(checkpointRows[1].classification, "projection-mismatch");
 

--- a/apps/indexer/scripts/indexer-reconcile-diagnose.mjs
+++ b/apps/indexer/scripts/indexer-reconcile-diagnose.mjs
@@ -37,9 +37,19 @@ export function parseArgs(argv) {
 }
 
 export function buildHumanSummary(status) {
+  const syncRows = status.checkpoints
+    .filter(
+      (checkpoint) =>
+        checkpoint.syncPercent !== null && checkpoint.syncPercent !== undefined,
+    )
+    .map(
+      (checkpoint) =>
+        `${checkpoint.daoCode}/${checkpoint.streamId}=${checkpoint.syncPercent}%`,
+    );
   return [
     "Datalens reconcile diagnostics",
     `checkpoint rows: ${status.checkpoints.length}`,
+    `checkpoint sync: ${syncRows.length ? syncRows.join(", ") : "unknown"}`,
     `checkpoint stalls: ${status.checkpointStalls.length}`,
     `checkpoint errors: ${status.checkpointErrors.length}`,
     `reconcile backlog: ${JSON.stringify(status.reconcileBacklog)}`,

--- a/apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs
+++ b/apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs
@@ -29,7 +29,7 @@ assert.match(buildHumanSummary(status), /legacy squid_processor.status/);
 
 function summarizeFixture() {
   return {
-    checkpoints: [{ daoCode: "ens-dao" }],
+    checkpoints: [{ daoCode: "ens-dao", streamId: "governance-events", syncPercent: 80 }],
     checkpointStalls: [{ daoCode: "ens-dao" }],
     checkpointErrors: [],
     reconcileBacklog: { pending: 1 },

--- a/apps/indexer/scripts/staging-deployment-contract.test.mjs
+++ b/apps/indexer/scripts/staging-deployment-contract.test.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..", "..", "..");
+
+const [contractJson, releaseYaml] = await Promise.all([
+  readFile(
+    path.join(repositoryRoot, "deploy/staging/datalens-indexer-daos.json"),
+    "utf8",
+  ),
+  readFile(path.join(repositoryRoot, ".github/workflows/release.yml"), "utf8"),
+]);
+
+const contract = JSON.parse(contractJson);
+
+assert.equal(contract.environment, "staging");
+assert.equal(contract.image.repository, "ghcr.io/ringecosystem/degov/indexer");
+assert.equal(contract.image.tagTemplate, "sha-<git-sha>");
+assert.deepEqual(contract.entrypoints, {
+  migrate: ["migrate"],
+  indexer: ["run"],
+  graphql: ["graphql"],
+  onchainRefreshWorker: ["worker"],
+});
+assert.equal(contract.onchainRefreshWorker.enabled, false);
+assert.match(
+  contract.onchainRefreshWorker.enableWhen,
+  /checkpoint\/status integration/i,
+);
+assert.equal(contract.datalens.endpointEnv, "DATALENS_ENDPOINT");
+assert.equal(contract.datalens.tokenEnv, "DATALENS_TOKEN");
+assert.equal(contract.datalens.applicationEnv, "DATALENS_APPLICATION");
+assert.equal(contract.datalens.application, "degov-staging");
+assert.equal(contract.datalens.dataset.family, "evm");
+assert.equal(contract.datalens.dataset.name, "logs");
+
+assert.ok(contract.daos.length >= 1, "staging contract must include selected DAOs");
+
+const daoCodes = new Set();
+const databaseNames = new Set();
+for (const dao of contract.daos) {
+  assert.ok(dao.code, "DAO code is required");
+  assert.ok(!daoCodes.has(dao.code), `duplicate DAO code ${dao.code}`);
+  daoCodes.add(dao.code);
+
+  assert.match(
+    dao.databaseName,
+    /^degov_datalens_migration_[a-z0-9_]+$/,
+    `${dao.code} must use a fresh Datalens migration DB name`,
+  );
+  assert.ok(
+    !databaseNames.has(dao.databaseName),
+    `duplicate database name ${dao.databaseName}`,
+  );
+  databaseNames.add(dao.databaseName);
+
+  assert.equal(dao.env.DATALENS_APPLICATION, contract.datalens.application);
+  assert.equal(dao.env.DATALENS_DATASET_FAMILY, contract.datalens.dataset.family);
+  assert.equal(dao.env.DATALENS_DATASET_NAME, contract.datalens.dataset.name);
+  assert.equal(dao.env.DATALENS_CHAIN_FAMILY, "evm");
+  assert.ok(dao.env.DATALENS_CHAIN_NAME);
+  assert.ok(Number.isInteger(dao.env.DATALENS_CHAIN_ID));
+  assert.match(dao.env.DATALENS_GOVERNOR_ADDRESS, /^0x[0-9a-fA-F]{40}$/);
+  assert.match(dao.env.DATALENS_GOVERNOR_TOKEN_ADDRESS, /^0x[0-9a-fA-F]{40}$/);
+  assert.match(dao.env.DATALENS_GOVERNOR_TOKEN_STANDARD, /^ERC(20|721)$/);
+  if (dao.env.DATALENS_TIMELOCK_ADDRESS) {
+    assert.match(dao.env.DATALENS_TIMELOCK_ADDRESS, /^0x[0-9a-fA-F]{40}$/);
+  }
+}
+
+assert.match(
+  releaseYaml,
+  /-\s+indexer\b/,
+  "release workflow must publish the Datalens-native indexer image",
+);
+
+console.log("Staging deployment contract check passed");

--- a/deploy/staging/datalens-indexer-daos.json
+++ b/deploy/staging/datalens-indexer-daos.json
@@ -1,0 +1,67 @@
+{
+  "environment": "staging",
+  "image": {
+    "repository": "ghcr.io/ringecosystem/degov/indexer",
+    "tagTemplate": "sha-<git-sha>"
+  },
+  "entrypoints": {
+    "migrate": ["migrate"],
+    "indexer": ["run"],
+    "graphql": ["graphql"],
+    "onchainRefreshWorker": ["worker"]
+  },
+  "datalens": {
+    "endpointEnv": "DATALENS_ENDPOINT",
+    "tokenEnv": "DATALENS_TOKEN",
+    "applicationEnv": "DATALENS_APPLICATION",
+    "application": "degov-staging",
+    "dataset": {
+      "family": "evm",
+      "name": "logs"
+    }
+  },
+  "database": {
+    "urlEnv": "DEGOV_INDEXER_DATABASE_URL",
+    "freshDatabasePrefix": "degov_datalens_migration_"
+  },
+  "onchainRefreshWorker": {
+    "enabled": false,
+    "enableWhen": "Enable only after checkpoint/status integration can prove refresh tasks are created, processed, retried, and surfaced in diagnostics."
+  },
+  "daos": [
+    {
+      "code": "degov-demo-dao",
+      "databaseName": "degov_datalens_migration_degov_demo_dao",
+      "registryConfigPath": "degov.yml",
+      "graphqlPath": "/degov-demo-dao/graphql",
+      "startBlock": 5873342,
+      "env": {
+        "DATALENS_APPLICATION": "degov-staging",
+        "DATALENS_FINALITY": "durable_only",
+        "DATALENS_CHAIN_FAMILY": "evm",
+        "DATALENS_CHAIN_NAME": "darwinia",
+        "DATALENS_CHAIN_ID": 46,
+        "DATALENS_DATASET_FAMILY": "evm",
+        "DATALENS_DATASET_NAME": "logs",
+        "DATALENS_QUERY_BLOCK_RANGE_LIMIT": 1000,
+        "DATALENS_QUERY_ROW_LIMIT": 1000,
+        "DATALENS_GOVERNOR_ADDRESS": "0xC9EA55E644F496D6CaAEDcBAD91dE7481Dcd7517",
+        "DATALENS_GOVERNOR_TOKEN_ADDRESS": "0xbC9f58566810F7e853e1eef1b9957ac82F9971df",
+        "DATALENS_GOVERNOR_TOKEN_STANDARD": "ERC20",
+        "DATALENS_TIMELOCK_ADDRESS": "0x6AB15C6ada9515A8E21321e241013dB457C8576c"
+      }
+    }
+  ],
+  "sharedSecretKeys": [
+    "DATALENS_ENDPOINT",
+    "DATALENS_TOKEN",
+    "DEGOV_INDEXER_DATABASE_URL"
+  ],
+  "requiredRuntimeChecks": [
+    "pod-readiness",
+    "db-checkpoint-progress",
+    "graphql-availability",
+    "worker-task-status",
+    "page-sync-percentage"
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ or API/data-model reference material unless a newer document says otherwise.
 - [Developer guide](./guides/20260325__indexer_developer_guide.md)
 - [Accuracy diagnosis guide](./guides/20260331__indexer_accuracy_diagnosis.md)
 - [Datalens DAO migration runbook](./runbook/datalens-dao-migration.md)
+- [Datalens staging deployment runbook](./runbook/datalens-staging-deployment.md)
 - [Accuracy research summary](./research/20260401__indexer_accuracy_research.md)
 - [Architecture overview](./architecture/20260325__indexer_architecture.md)
 - [Datalens indexer architecture contract](./spec/datalens-indexer-architecture-contract.md)

--- a/docs/runbook/datalens-staging-deployment.md
+++ b/docs/runbook/datalens-staging-deployment.md
@@ -1,0 +1,136 @@
+# Datalens Staging Deployment Runbook
+
+> Purpose: define the staging deployment path for selected DAOs running the
+> Datalens-native DeGov indexer.
+>
+> Read this when: preparing or reviewing GitOps changes for the HBX-244 manual
+> migration wave.
+>
+> This does not define production rollout policy; use
+> `docs/runbook/datalens-dao-migration.md` before promotion.
+
+## Deployment contract
+
+Use `deploy/staging/datalens-indexer-daos.json` as the source-controlled
+staging contract. It pins the Datalens-native image repository,
+`degov-datalens-indexer` entrypoints, selected DAO env, fresh migration DB
+names, and worker state.
+
+The release workflow publishes the indexer image as:
+
+```text
+ghcr.io/ringecosystem/degov/indexer:sha-<git-sha>
+```
+
+Deploy one workload set per selected DAO. Keep staging namespace, database
+name, image tag, and GraphQL route separate from production. Do not share a
+production DB, production GraphQL route, or production web config with a
+Datalens migration validation pod.
+
+## Required environment
+
+Each DAO indexer deployment must receive:
+
+- `DEGOV_INDEXER_DATABASE_URL`: points to a fresh DB whose name starts with
+  `degov_datalens_migration_`.
+- `DATALENS_ENDPOINT`: Datalens service base URL, not `/native/graphql`.
+- `DATALENS_TOKEN`: application bearer token from GitOps-managed secrets.
+- `DATALENS_APPLICATION`: `degov-staging` for staging validation.
+- `DATALENS_CHAIN_FAMILY`, `DATALENS_CHAIN_NAME`, and `DATALENS_CHAIN_ID`.
+- `DATALENS_DATASET_FAMILY` and `DATALENS_DATASET_NAME`.
+- `DATALENS_GOVERNOR_ADDRESS`, `DATALENS_GOVERNOR_TOKEN_ADDRESS`,
+  `DATALENS_GOVERNOR_TOKEN_STANDARD`, and `DATALENS_TIMELOCK_ADDRESS`.
+
+Run `migrate` against the fresh DB before starting `run`. Start `graphql` only
+after the DB schema exists and the staging web route points at the staging
+GraphQL endpoint.
+
+## Datalens dependency gate
+
+Confirm these Datalens server dependencies before rollout:
+
+- endpoint responds to the native GraphQL readiness smoke check;
+- chain config includes the selected chain id/name and EVM log dataset;
+- S3/cache backing the queried dataset is healthy for the selected range;
+- application auth accepts the `degov-staging` token;
+- query limits are compatible with the chunk size configured in the DAO env.
+
+Use the runtime smoke check with a token loaded from secret management:
+
+```bash
+pnpm run indexer:smoke-datalens
+```
+
+## Worker state
+
+Keep `DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED=false` in staging GitOps until
+checkpoint/status integration proves refresh tasks are created, processed,
+retried, and surfaced in diagnostics. The staging contract records this as
+`onchainRefreshWorker.enabled=false`.
+
+When the worker is enabled later, deploy it as a separate workload using the
+`worker` entrypoint and monitor `onchainRefreshBacklog` plus
+`onchainRefreshErrors`.
+
+## Rollout checks
+
+Use the repo scripts for database and GraphQL checks. Kubernetes commands must
+target the staging cluster and namespace; in Helixbox workspaces use
+`kubectl --kubeconfig=avault/.kube/<cluster>.config`.
+
+```bash
+kubectl --kubeconfig=avault/.kube/<cluster>.config \
+  -n <staging-namespace> rollout status deploy/<dao>-degov-datalens-indexer
+
+kubectl --kubeconfig=avault/.kube/<cluster>.config \
+  -n <staging-namespace> logs deploy/<dao>-degov-datalens-indexer --since=10m
+```
+
+Look for DAO, chain, dataset, chunk range, processed height, task backlog, and
+projection error fields in logs. Any projection error should include enough
+context to identify the DAO, stream, block range, and failing projection.
+
+Check DB checkpoint progress and sync percentage:
+
+```bash
+pnpm run audit:reconcile -- \
+  --database-url "$DEGOV_INDEXER_DATABASE_URL" \
+  --json
+```
+
+The JSON output includes `processedHeight`, `targetHeight`, `lagBlocks`,
+`syncPercent`, `reconcileBacklog`, `reconcileErrors`,
+`onchainRefreshBacklog`, and `onchainRefreshErrors`.
+
+Check GraphQL availability:
+
+```bash
+curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
+  -H 'content-type: application/json' \
+  --data '{"query":"query { dataMetrics(limit: 1) { proposalsCount } }"}'
+```
+
+For DAOs with Tally coverage, run the Tally/onchain comparison after indexing
+reaches the intended target height:
+
+```bash
+pnpm run audit:tally-onchain -- \
+  --targets-file apps/indexer/scripts/indexer-accuracy-targets.json \
+  --database-url "$DEGOV_INDEXER_DATABASE_URL" \
+  --json-file reports/tally-onchain-e2e.json \
+  --markdown-file reports/tally-onchain-e2e.md
+```
+
+## Rollback
+
+Rollback does not require an in-place DB migration because staging uses fresh
+Datalens migration databases.
+
+1. Revert the staging GitOps image tag to the previous known-good image.
+2. Restore the previous env/config secret set for the selected DAO.
+3. Repoint the staging web GraphQL endpoint to the previous staging endpoint.
+4. Keep or set `DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED=false`.
+5. Leave the failed `degov_datalens_migration_*` DB intact for inspection, or
+   delete it only after the validation notes have been captured.
+6. Re-run pod readiness and GraphQL availability checks against the restored
+   deployment.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "indexer:smoke-datalens": "cargo run -p degov-datalens-indexer --locked -- smoke-datalens",
     "indexer:worker": "cargo run -p degov-datalens-indexer --locked -- worker",
     "test:indexer": "cargo test -p degov-datalens-indexer --locked",
-    "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs && node apps/indexer/scripts/v4-parity-audit.test.mjs && node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs"
+    "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/runtime-packaging.test.mjs && node apps/indexer/scripts/staging-deployment-contract.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs && node apps/indexer/scripts/v4-parity-audit.test.mjs && node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs"
   },
   "pnpm": {
     "packageExtensions": {


### PR DESCRIPTION
## Summary

- Publish the Datalens-native `indexer` image from the release workflow alongside `web`.
- Add a source-controlled staging deployment contract for selected DAO validation, fresh migration DB naming, Datalens env/secrets, entrypoints, and worker-disabled state.
- Add staging rollout/rollback runbook notes and expose checkpoint `syncPercent` through diagnostics and audit output.

## Notes

- This keeps the HBX-262 work in `ringecosystem/degov`; this repo has the image/runtime contract but no live Argo/Flux manifest tree to edit.
- `deploy/staging/datalens-indexer-daos.json` is intentionally staging-only and starts with the checked-in demo DAO contract set. Additional DAOs can be added when their full registry contract set is selected for validation.
- Keep `DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED=false` until checkpoint/status integration is ready for worker task verification.

## Rollout verification

Use `docs/runbook/datalens-staging-deployment.md` for the full sequence. The required checks cover:

- pod readiness with staging `kubectl rollout status`;
- DB checkpoint progress and `syncPercent` via `pnpm run audit:reconcile -- --database-url ... --json`;
- GraphQL availability with the staging GraphQL endpoint;
- worker task status through `onchainRefreshBacklog` and `onchainRefreshErrors`;
- Tally/onchain comparison for DAOs that have Tally targets after indexing reaches the intended height.

## Rollback

Rollback is documented in `docs/runbook/datalens-staging-deployment.md`: revert the staging image tag/env to the previous known-good config, repoint staging web GraphQL to the previous endpoint, keep the worker disabled, and leave the fresh `degov_datalens_migration_*` DB available for inspection unless validation notes have been captured.

## Verification

- `pnpm run test:indexer-scripts`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://datalens:datalens@localhost:55432/datalens_test pnpm run test:indexer`
