### PR TITLE
fix(indexer): align Datalens staging contract

### DIFF
--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -12,9 +12,9 @@ the old processor architecture.
 The package now contains the initial Rust configuration and Datalens client
 boundary for the upcoming runtime. It validates the deployed Datalens service
 base endpoint, application identity, bearer token, timeout, finality mode, chain
-identity, dataset key, and query limits at startup. The bearer token is loaded
-from environment or secret-backed configuration and is redacted by config
-formatting.
+identity, dataset key, and query block range limit at startup. The bearer token
+is loaded from environment or secret-backed configuration and is redacted by
+config formatting.
 
 ## PostgreSQL schema ownership
 

--- a/apps/indexer/scripts/staging-deployment-contract.test.mjs
+++ b/apps/indexer/scripts/staging-deployment-contract.test.mjs
@@ -6,12 +6,16 @@ import path from "node:path";
 
 const repositoryRoot = path.resolve(import.meta.dirname, "..", "..", "..");
 
-const [contractJson, releaseYaml] = await Promise.all([
+const [contractJson, releaseYaml, runbookMarkdown] = await Promise.all([
   readFile(
     path.join(repositoryRoot, "deploy/staging/datalens-indexer-daos.json"),
     "utf8",
   ),
   readFile(path.join(repositoryRoot, ".github/workflows/release.yml"), "utf8"),
+  readFile(
+    path.join(repositoryRoot, "docs/runbook/datalens-staging-deployment.md"),
+    "utf8",
+  ),
 ]);
 
 const contract = JSON.parse(contractJson);
@@ -60,6 +64,7 @@ for (const dao of contract.daos) {
   assert.equal(dao.env.DATALENS_APPLICATION, contract.datalens.application);
   assert.equal(dao.env.DATALENS_DATASET_FAMILY, contract.datalens.dataset.family);
   assert.equal(dao.env.DATALENS_DATASET_NAME, contract.datalens.dataset.name);
+  assert.equal(dao.env.DATALENS_QUERY_ROW_LIMIT, undefined);
   assert.equal(dao.env.DATALENS_CHAIN_FAMILY, "evm");
   assert.ok(dao.env.DATALENS_CHAIN_NAME);
   assert.ok(Number.isInteger(dao.env.DATALENS_CHAIN_ID));
@@ -75,6 +80,21 @@ assert.match(
   releaseYaml,
   /-\s+indexer\b/,
   "release workflow must publish the Datalens-native indexer image",
+);
+
+assert.deepEqual(contract.requiredRuntimeChecks, [
+  "pod-readiness",
+  "graphql-availability",
+]);
+assert.deepEqual(contract.futureRuntimeChecks, [
+  "db-checkpoint-progress",
+  "worker-task-status",
+  "page-sync-percentage",
+]);
+assert.doesNotMatch(
+  runbookMarkdown,
+  /pnpm run audit:tally-onchain --[\s\S]*?--database-url/,
+  "Tally/onchain audit does not accept --database-url",
 );
 
 console.log("Staging deployment contract check passed");

--- a/apps/indexer/src/config.rs
+++ b/apps/indexer/src/config.rs
@@ -17,7 +17,6 @@ pub const DEFAULT_DATALENS_CHAIN_ID: i32 = 1;
 pub const DEFAULT_DATALENS_DATASET_FAMILY: &str = "evm";
 pub const DEFAULT_DATALENS_DATASET_NAME: &str = "logs";
 pub const DEFAULT_DATALENS_QUERY_BLOCK_RANGE_LIMIT: u32 = 1_000;
-pub const DEFAULT_DATALENS_QUERY_ROW_LIMIT: u32 = 1_000;
 pub const DEGOV_DATALENS_USER_AGENT: &str = "degov-datalens-indexer";
 
 #[derive(Clone, Eq, PartialEq)]
@@ -128,7 +127,6 @@ impl DatasetKeyConfig {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct QueryLimitConfig {
     pub block_range_limit: u32,
-    pub row_limit: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -157,7 +155,6 @@ struct RawDatalensConfig {
     datalens_dataset_family: String,
     datalens_dataset_name: String,
     datalens_query_block_range_limit: u32,
-    datalens_query_row_limit: u32,
     datalens_governor_address: Option<String>,
     datalens_governor_token_address: Option<String>,
     datalens_governor_token_standard: Option<String>,
@@ -178,7 +175,6 @@ impl Default for RawDatalensConfig {
             datalens_dataset_family: DEFAULT_DATALENS_DATASET_FAMILY.to_owned(),
             datalens_dataset_name: DEFAULT_DATALENS_DATASET_NAME.to_owned(),
             datalens_query_block_range_limit: DEFAULT_DATALENS_QUERY_BLOCK_RANGE_LIMIT,
-            datalens_query_row_limit: DEFAULT_DATALENS_QUERY_ROW_LIMIT,
             datalens_governor_address: None,
             datalens_governor_token_address: None,
             datalens_governor_token_standard: None,
@@ -203,7 +199,6 @@ impl DatalensConfig {
                     "DATALENS_DATASET_FAMILY",
                     "DATALENS_DATASET_NAME",
                     "DATALENS_QUERY_BLOCK_RANGE_LIMIT",
-                    "DATALENS_QUERY_ROW_LIMIT",
                     "DATALENS_GOVERNOR_ADDRESS",
                     "DATALENS_GOVERNOR_TOKEN_ADDRESS",
                     "DATALENS_GOVERNOR_TOKEN_STANDARD",
@@ -247,11 +242,6 @@ impl TryFrom<RawDatalensConfig> for DatalensConfig {
                 field: "DATALENS_QUERY_BLOCK_RANGE_LIMIT",
             });
         }
-        if raw.datalens_query_row_limit == 0 {
-            return Err(ConfigError::InvalidLimit {
-                field: "DATALENS_QUERY_ROW_LIMIT",
-            });
-        }
 
         Ok(Self {
             endpoint,
@@ -270,7 +260,6 @@ impl TryFrom<RawDatalensConfig> for DatalensConfig {
             },
             query_limits: QueryLimitConfig {
                 block_range_limit: raw.datalens_query_block_range_limit,
-                row_limit: raw.datalens_query_row_limit,
             },
             dao_contracts: dao_contract_addresses(
                 raw.datalens_governor_address,
@@ -378,7 +367,6 @@ mod tests {
                 ("DATALENS_DATASET_FAMILY", Some("evm")),
                 ("DATALENS_DATASET_NAME", Some("logs")),
                 ("DATALENS_QUERY_BLOCK_RANGE_LIMIT", Some("500")),
-                ("DATALENS_QUERY_ROW_LIMIT", Some("250")),
                 (
                     "DATALENS_GOVERNOR_ADDRESS",
                     Some("0x1111111111111111111111111111111111111111"),
@@ -408,7 +396,6 @@ mod tests {
                 assert_eq!(config.chain.network_id, Some(1));
                 assert_eq!(config.dataset.key(), "evm.logs");
                 assert_eq!(config.query_limits.block_range_limit, 500);
-                assert_eq!(config.query_limits.row_limit, 250);
                 assert_eq!(
                     config.dao_contracts.as_ref().expect("contracts").governor,
                     "0x1111111111111111111111111111111111111111"

--- a/apps/indexer/src/planner.rs
+++ b/apps/indexer/src/planner.rs
@@ -428,10 +428,7 @@ mod tests {
                 family: "evm".to_owned(),
                 name: "logs".to_owned(),
             },
-            query_limits: QueryLimitConfig {
-                block_range_limit,
-                row_limit: 500,
-            },
+            query_limits: QueryLimitConfig { block_range_limit },
             dao_contracts: None,
         }
     }

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -277,7 +277,6 @@ fn options() -> IndexerRunnerOptions {
             },
             query_limits: QueryLimitConfig {
                 block_range_limit: 1,
-                row_limit: 100,
             },
             dao_contracts: Some(addresses()),
         },

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -392,7 +392,6 @@ fn options() -> IndexerRunnerOptions {
             },
             query_limits: QueryLimitConfig {
                 block_range_limit: 10,
-                row_limit: 100,
             },
             dao_contracts: Some(addresses()),
         },

--- a/deploy/staging/datalens-indexer-daos.json
+++ b/deploy/staging/datalens-indexer-daos.json
@@ -44,7 +44,6 @@
         "DATALENS_DATASET_FAMILY": "evm",
         "DATALENS_DATASET_NAME": "logs",
         "DATALENS_QUERY_BLOCK_RANGE_LIMIT": 1000,
-        "DATALENS_QUERY_ROW_LIMIT": 1000,
         "DATALENS_GOVERNOR_ADDRESS": "0xC9EA55E644F496D6CaAEDcBAD91dE7481Dcd7517",
         "DATALENS_GOVERNOR_TOKEN_ADDRESS": "0xbC9f58566810F7e853e1eef1b9957ac82F9971df",
         "DATALENS_GOVERNOR_TOKEN_STANDARD": "ERC20",
@@ -59,8 +58,10 @@
   ],
   "requiredRuntimeChecks": [
     "pod-readiness",
+    "graphql-availability"
+  ],
+  "futureRuntimeChecks": [
     "db-checkpoint-progress",
-    "graphql-availability",
     "worker-task-status",
     "page-sync-percentage"
   ]

--- a/docs/runbook/datalens-staging-deployment.md
+++ b/docs/runbook/datalens-staging-deployment.md
@@ -53,7 +53,8 @@ Confirm these Datalens server dependencies before rollout:
 - chain config includes the selected chain id/name and EVM log dataset;
 - S3/cache backing the queried dataset is healthy for the selected range;
 - application auth accepts the `degov-staging` token;
-- query limits are compatible with the chunk size configured in the DAO env.
+- the Datalens query block range limit is compatible with the chunk size
+  configured in the DAO env.
 
 Use the runtime smoke check with a token loaded from secret management:
 
@@ -86,9 +87,27 @@ kubectl --kubeconfig=avault/.kube/<cluster>.config \
   -n <staging-namespace> logs deploy/<dao>-degov-datalens-indexer --since=10m
 ```
 
-Look for DAO, chain, dataset, chunk range, processed height, task backlog, and
-projection error fields in logs. Any projection error should include enough
-context to identify the DAO, stream, block range, and failing projection.
+Look for pod startup, configured DAO, chain, dataset, DB migration, GraphQL
+startup, and projection error fields in logs. Any projection error should
+include enough context to identify the DAO, stream, block range, and failing
+projection.
+
+Check GraphQL availability:
+
+```bash
+curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
+  -H 'content-type: application/json' \
+  --data '{"query":"query { dataMetrics(limit: 1) { proposalsCount } }"}'
+```
+
+Do not treat missing checkpoint advancement, worker task status, or page sync
+percentage as current staging acceptance until the staging runner performs live
+Datalens chunk processing and checkpoint commits.
+
+## Future post-runner checks
+
+After live Datalens chunk processing and checkpoint commits are enabled in
+staging, reclassify these checks as required acceptance.
 
 Check DB checkpoint progress and sync percentage:
 
@@ -102,21 +121,13 @@ The JSON output includes `processedHeight`, `targetHeight`, `lagBlocks`,
 `syncPercent`, `reconcileBacklog`, `reconcileErrors`,
 `onchainRefreshBacklog`, and `onchainRefreshErrors`.
 
-Check GraphQL availability:
-
-```bash
-curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
-  -H 'content-type: application/json' \
-  --data '{"query":"query { dataMetrics(limit: 1) { proposalsCount } }"}'
-```
-
 For DAOs with Tally coverage, run the Tally/onchain comparison after indexing
-reaches the intended target height:
+reaches the intended target height. The Tally/onchain script reads DeGov
+GraphQL endpoints from the targets file and does not accept a database URL.
 
 ```bash
 pnpm run audit:tally-onchain -- \
   --targets-file apps/indexer/scripts/indexer-accuracy-targets.json \
-  --database-url "$DEGOV_INDEXER_DATABASE_URL" \
   --json-file reports/tally-onchain-e2e.json \
   --markdown-file reports/tally-onchain-e2e.md
 ```


### PR DESCRIPTION
Fixes HBX-275
Fixes HBX-276

## Summary
- split Datalens staging runtime checks into current required checks and future post-runner checks
- fix the staging runbook Tally/onchain command so it only uses supported options
- remove the unused DATALENS_QUERY_ROW_LIMIT config path while keeping the block range limit

## Verification
- pnpm run test:indexer-scripts
- pnpm run indexer:build
- cargo test -p degov-datalens-indexer --locked --lib --bins
- git diff --check

## Notes
- pnpm run test:indexer still requires DEGOV_INDEXER_TEST_DATABASE_URL for checkpoint_repository integration tests.