### PR TITLE
fix(indexer): persist token projection parity tables

### DIFF
--- a/apps/indexer/src/onchain_refresh.rs
+++ b/apps/indexer/src/onchain_refresh.rs
@@ -692,8 +692,8 @@ async fn insert_refresh_checkpoints(
              ON CONFLICT (id) DO NOTHING",
         )
         .bind(format!(
-            "onchain-refresh-balance-{}-{}",
-            task.account, task.last_seen_block_number
+            "onchain-refresh-balance-{}",
+            onchain_refresh_checkpoint_scope(task)
         ))
         .bind(task.chain_id)
         .bind(&task.dao_code)
@@ -726,8 +726,8 @@ async fn insert_refresh_checkpoints(
              ON CONFLICT (id) DO NOTHING",
         )
         .bind(format!(
-            "onchain-refresh-power-{}-{}",
-            task.account, task.last_seen_block_number
+            "onchain-refresh-power-{}",
+            onchain_refresh_checkpoint_scope(task)
         ))
         .bind(task.chain_id)
         .bind(&task.dao_code)
@@ -833,6 +833,18 @@ fn data_metric_id(chain_id: i32, governor_address: &str, dao_code: Option<&str>)
     format!(
         "{chain_id}:{governor_address}:{}",
         dao_code.unwrap_or_default()
+    )
+}
+
+fn onchain_refresh_checkpoint_scope(task: &OnchainRefreshTask) -> String {
+    format!(
+        "{}:{}:{}:{}:{}:{}",
+        task.chain_id,
+        task.dao_code.as_deref().unwrap_or_default(),
+        task.governor_address,
+        task.token_address,
+        task.account,
+        task.last_seen_block_number,
     )
 }
 

--- a/apps/indexer/src/onchain_refresh.rs
+++ b/apps/indexer/src/onchain_refresh.rs
@@ -261,7 +261,9 @@ where
 
         let mut transaction = self.pool.begin().await?;
 
+        let previous = read_contributor_refresh_values(&mut transaction, &task.account).await?;
         upsert_contributor_refresh(&mut transaction, task, value).await?;
+        insert_refresh_checkpoints(&mut transaction, task, value, previous).await?;
         refresh_data_metric(&mut transaction, task).await?;
         complete_task(&mut transaction, &task.id, now_ms).await?;
 
@@ -636,6 +638,109 @@ async fn upsert_contributor_refresh(
     .bind(value.balance.as_deref())
     .execute(&mut **transaction)
     .await?;
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct ContributorRefreshValues {
+    power: Option<String>,
+    balance: Option<String>,
+}
+
+async fn read_contributor_refresh_values(
+    transaction: &mut Transaction<'_, Postgres>,
+    account: &str,
+) -> Result<ContributorRefreshValues, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT power::TEXT AS power, balance::TEXT AS balance
+         FROM contributor
+         WHERE id = $1",
+    )
+    .bind(account)
+    .fetch_optional(&mut **transaction)
+    .await?;
+
+    Ok(row
+        .map(|row| ContributorRefreshValues {
+            power: row.get("power"),
+            balance: row.get("balance"),
+        })
+        .unwrap_or_default())
+}
+
+async fn insert_refresh_checkpoints(
+    transaction: &mut Transaction<'_, Postgres>,
+    task: &OnchainRefreshTask,
+    value: &OnchainRefreshReadValue,
+    previous: ContributorRefreshValues,
+) -> Result<(), sqlx::Error> {
+    if task.refresh_balance {
+        let previous_balance = previous.balance.as_deref().unwrap_or("0");
+        let new_balance = value.balance.as_deref().unwrap_or("0");
+        sqlx::query(
+            "INSERT INTO token_balance_checkpoint (
+                id, chain_id, dao_code, governor_address, token_address, contract_address,
+                account, previous_balance, new_balance, delta, source, cause, block_number,
+                block_timestamp, transaction_hash
+             )
+             VALUES (
+                $1, $2, $3, $4, $5, $5, $6, $7::NUMERIC(78, 0), $8::NUMERIC(78, 0),
+                ($8::NUMERIC(78, 0) - $7::NUMERIC(78, 0)), 'balanceOf', 'onchain-refresh',
+                $9::NUMERIC(78, 0), $10::NUMERIC(78, 0), 'onchain-refresh'
+             )
+             ON CONFLICT (id) DO NOTHING",
+        )
+        .bind(format!(
+            "onchain-refresh-balance-{}-{}",
+            task.account, task.last_seen_block_number
+        ))
+        .bind(task.chain_id)
+        .bind(&task.dao_code)
+        .bind(&task.governor_address)
+        .bind(&task.token_address)
+        .bind(&task.account)
+        .bind(previous_balance)
+        .bind(new_balance)
+        .bind(&task.last_seen_block_number)
+        .bind(&task.last_seen_block_timestamp)
+        .execute(&mut **transaction)
+        .await?;
+    }
+
+    if task.refresh_power {
+        let previous_power = previous.power.as_deref().unwrap_or("0");
+        let new_power = value.power.as_deref().unwrap_or("0");
+        sqlx::query(
+            "INSERT INTO vote_power_checkpoint (
+                id, chain_id, dao_code, governor_address, token_address, contract_address,
+                account, clock_mode, timepoint, previous_power, new_power, delta, source, cause,
+                block_number, block_timestamp, transaction_hash
+             )
+             VALUES (
+                $1, $2, $3, $4, $5, $5, $6, 'blocknumber', $7::NUMERIC(78, 0),
+                $8::NUMERIC(78, 0), $9::NUMERIC(78, 0),
+                ($9::NUMERIC(78, 0) - $8::NUMERIC(78, 0)), 'getVotes', 'onchain-refresh',
+                $7::NUMERIC(78, 0), $10::NUMERIC(78, 0), 'onchain-refresh'
+             )
+             ON CONFLICT (id) DO NOTHING",
+        )
+        .bind(format!(
+            "onchain-refresh-power-{}-{}",
+            task.account, task.last_seen_block_number
+        ))
+        .bind(task.chain_id)
+        .bind(&task.dao_code)
+        .bind(&task.governor_address)
+        .bind(&task.token_address)
+        .bind(&task.account)
+        .bind(&task.last_seen_block_number)
+        .bind(previous_power)
+        .bind(new_power)
+        .bind(&task.last_seen_block_timestamp)
+        .execute(&mut **transaction)
+        .await?;
+    }
 
     Ok(())
 }

--- a/apps/indexer/src/postgres_store.rs
+++ b/apps/indexer/src/postgres_store.rs
@@ -1,17 +1,18 @@
 use std::{fmt, future::Future};
 
-use sqlx::{PgPool, Postgres, Transaction};
+use sqlx::{PgPool, Postgres, Row, Transaction};
 
 use crate::{
     CheckpointRepository, ContributorVoteSignalWrite, DelegateChangedWrite, DelegateRollingWrite,
-    DelegateVotesChangedWrite, IndexerCheckpoint, IndexerCheckpointIdentity,
-    IndexerProjectionBatch, IndexerRunnerStore, IndexerRunnerTransaction, PowerReconcileCandidate,
-    ProposalActionWrite, ProposalCreatedWrite, ProposalDeadlineExtensionWrite,
-    ProposalExtendedWrite, ProposalIdWrite, ProposalProjectionBatch, ProposalQueuedWrite,
-    ProposalStateEpochWrite, ProposalVoteTotalWrite, ProposalWrite, TimelockCallWrite,
-    TimelockMinDelayChangeWrite, TimelockOperationHintWrite, TimelockOperationWrite,
-    TimelockProjectionBatch, TimelockRoleEventWrite, TokenProjectionBatch, TokenTransferWrite,
-    VoteCastGroupWrite, VoteCastWithParamsWrite, VoteCastWrite, VoteProjectionBatch,
+    DelegateVotesChangedWrite, GovernanceTokenStandard, IndexerCheckpoint,
+    IndexerCheckpointIdentity, IndexerProjectionBatch, IndexerRunnerStore,
+    IndexerRunnerTransaction, PowerReconcileCandidate, ProposalActionWrite, ProposalCreatedWrite,
+    ProposalDeadlineExtensionWrite, ProposalExtendedWrite, ProposalIdWrite,
+    ProposalProjectionBatch, ProposalQueuedWrite, ProposalStateEpochWrite, ProposalVoteTotalWrite,
+    ProposalWrite, TimelockCallWrite, TimelockMinDelayChangeWrite, TimelockOperationHintWrite,
+    TimelockOperationWrite, TimelockProjectionBatch, TimelockRoleEventWrite, TokenEventCommon,
+    TokenProjectionBatch, TokenProjectionOperation, TokenTransferWrite, VoteCastGroupWrite,
+    VoteCastWithParamsWrite, VoteCastWrite, VoteProjectionBatch,
 };
 
 #[derive(Clone)]
@@ -226,17 +227,36 @@ async fn write_token_batch(
     transaction: &mut Transaction<'_, Postgres>,
     batch: &TokenProjectionBatch,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let mut inserted_operation_ids = Vec::new();
+
     for row in &batch.delegate_changed {
-        insert_delegate_changed(transaction, row).await?;
+        if insert_delegate_changed(transaction, row).await? {
+            inserted_operation_ids.push(row.id.as_str());
+        }
     }
     for row in &batch.delegate_votes_changed {
-        insert_delegate_votes_changed(transaction, row).await?;
+        if insert_delegate_votes_changed(transaction, row).await? {
+            inserted_operation_ids.push(row.id.as_str());
+        }
     }
     for row in &batch.token_transfers {
-        insert_token_transfer(transaction, row).await?;
+        if insert_token_transfer(transaction, row).await? {
+            inserted_operation_ids.push(row.id.as_str());
+        }
     }
     for row in &batch.delegate_rollings {
         upsert_delegate_rolling(transaction, row).await?;
+    }
+    for row in &batch.delegate_votes_changed {
+        insert_vote_power_checkpoint(transaction, row).await?;
+    }
+    for operation in &batch.operations {
+        if inserted_operation_ids
+            .iter()
+            .any(|inserted_id| *inserted_id == token_operation_id(operation))
+        {
+            apply_token_operation(transaction, operation).await?;
+        }
     }
     for candidate in &batch.reconcile_plan.candidates {
         upsert_onchain_refresh_task(transaction, candidate).await?;
@@ -924,8 +944,8 @@ async fn refresh_vote_data_metric(
 async fn insert_delegate_changed(
     transaction: &mut Transaction<'_, Postgres>,
     row: &DelegateChangedWrite,
-) -> Result<(), PostgresIndexerRunnerStoreError> {
-    sqlx::query(
+) -> Result<bool, PostgresIndexerRunnerStoreError> {
+    let result = sqlx::query(
         "INSERT INTO delegate_changed (
             id, chain_id, dao_code, governor_address, token_address, contract_address,
             log_index, transaction_index, delegator, from_delegate, to_delegate, block_number,
@@ -963,14 +983,14 @@ async fn insert_delegate_changed(
     .execute(&mut **transaction)
     .await?;
 
-    Ok(())
+    Ok(result.rows_affected() > 0)
 }
 
 async fn insert_delegate_votes_changed(
     transaction: &mut Transaction<'_, Postgres>,
     row: &DelegateVotesChangedWrite,
-) -> Result<(), PostgresIndexerRunnerStoreError> {
-    sqlx::query(
+) -> Result<bool, PostgresIndexerRunnerStoreError> {
+    let result = sqlx::query(
         "INSERT INTO delegate_votes_changed (
             id, chain_id, dao_code, governor_address, token_address, contract_address,
             log_index, transaction_index, delegate, previous_votes, new_votes, block_number,
@@ -1008,14 +1028,14 @@ async fn insert_delegate_votes_changed(
     .execute(&mut **transaction)
     .await?;
 
-    Ok(())
+    Ok(result.rows_affected() > 0)
 }
 
 async fn insert_token_transfer(
     transaction: &mut Transaction<'_, Postgres>,
     row: &TokenTransferWrite,
-) -> Result<(), PostgresIndexerRunnerStoreError> {
-    sqlx::query(
+) -> Result<bool, PostgresIndexerRunnerStoreError> {
+    let result = sqlx::query(
         "INSERT INTO token_transfer (
             id, chain_id, dao_code, governor_address, token_address, contract_address,
             log_index, transaction_index, \"from\", \"to\", value, standard, block_number,
@@ -1054,7 +1074,7 @@ async fn insert_token_transfer(
     .execute(&mut **transaction)
     .await?;
 
-    Ok(())
+    Ok(result.rows_affected() > 0)
 }
 
 async fn upsert_delegate_rolling(
@@ -1103,6 +1123,594 @@ async fn upsert_delegate_rolling(
     .bind(row.from_new_votes.as_deref())
     .bind(row.to_previous_votes.as_deref())
     .bind(row.to_new_votes.as_deref())
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(())
+}
+
+async fn insert_vote_power_checkpoint(
+    transaction: &mut Transaction<'_, Postgres>,
+    row: &DelegateVotesChangedWrite,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let delta = signed_decimal_delta(transaction, &row.new_votes, &row.previous_votes).await?;
+    let rollings = transaction_rollings(transaction, &row.common.transaction_hash).await?;
+    let transfers_count: i64 =
+        sqlx::query("SELECT count(*)::BIGINT FROM token_transfer WHERE transaction_hash = $1")
+            .bind(&row.common.transaction_hash)
+            .fetch_one(&mut **transaction)
+            .await?
+            .get(0);
+    let rolling_match =
+        find_rolling_match_from_rows(&rollings, &row.delegate, &delta, row.common.log_index);
+    let cause = vote_power_checkpoint_cause(!rollings.is_empty(), transfers_count > 0);
+
+    sqlx::query(
+        "INSERT INTO vote_power_checkpoint (
+            id, chain_id, dao_code, governor_address, token_address, contract_address,
+            log_index, transaction_index, account, clock_mode, timepoint, previous_power,
+            new_power, delta, source, cause, delegator, from_delegate, to_delegate, block_number,
+            block_timestamp, transaction_hash
+         )
+         VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, 'blocknumber', $10::NUMERIC(78, 0),
+            $11::NUMERIC(78, 0), $12::NUMERIC(78, 0), $13::NUMERIC(78, 0), 'event',
+            $14, $15, $16, $17, $18::NUMERIC(78, 0), $19::NUMERIC(78, 0), $20
+         )
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(&row.id)
+    .bind(row.common.chain_id)
+    .bind(&row.common.dao_code)
+    .bind(&row.common.governor_address)
+    .bind(&row.common.token_address)
+    .bind(&row.common.contract_address)
+    .bind(u64_to_i32(
+        row.common.log_index,
+        "vote_power_checkpoint.log_index",
+    )?)
+    .bind(u64_to_i32(
+        row.common.transaction_index,
+        "vote_power_checkpoint.transaction_index",
+    )?)
+    .bind(&row.delegate)
+    .bind(&row.common.block_number)
+    .bind(&row.previous_votes)
+    .bind(&row.new_votes)
+    .bind(&delta)
+    .bind(cause)
+    .bind(rolling_match.as_ref().map(|item| item.delegator.as_str()))
+    .bind(
+        rolling_match
+            .as_ref()
+            .map(|item| item.from_delegate.as_str()),
+    )
+    .bind(rolling_match.as_ref().map(|item| item.to_delegate.as_str()))
+    .bind(&row.common.block_number)
+    .bind(required_numeric(
+        &row.common.block_timestamp,
+        "vote_power_checkpoint.block_timestamp",
+    )?)
+    .bind(&row.common.transaction_hash)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(())
+}
+
+async fn apply_token_operation(
+    transaction: &mut Transaction<'_, Postgres>,
+    operation: &TokenProjectionOperation,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    match operation {
+        TokenProjectionOperation::DelegateChanged {
+            common,
+            delegator,
+            from_delegate,
+            to_delegate,
+            ..
+        } => {
+            apply_delegate_changed_operation(
+                transaction,
+                common,
+                delegator,
+                from_delegate,
+                to_delegate,
+            )
+            .await
+        }
+        TokenProjectionOperation::DelegateVotesChanged {
+            common,
+            delegate,
+            previous_votes,
+            new_votes,
+            ..
+        } => {
+            apply_delegate_votes_changed_operation(
+                transaction,
+                common,
+                delegate,
+                previous_votes,
+                new_votes,
+            )
+            .await
+        }
+        TokenProjectionOperation::Transfer {
+            common,
+            from,
+            to,
+            value,
+            standard,
+            ..
+        } => apply_transfer_operation(transaction, common, from, to, value, *standard).await,
+    }
+}
+
+async fn apply_delegate_changed_operation(
+    transaction: &mut Transaction<'_, Postgres>,
+    common: &TokenEventCommon,
+    delegator: &str,
+    from_delegate: &str,
+    to_delegate: &str,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    if !is_zero_address(to_delegate) {
+        ensure_contributor(transaction, to_delegate, common).await?;
+    }
+    let previous_mapping = read_delegate_mapping(transaction, delegator).await?;
+    let is_noop = previous_mapping
+        .as_ref()
+        .is_some_and(|mapping| mapping.to == to_delegate && from_delegate == to_delegate);
+    if is_noop {
+        return Ok(());
+    }
+
+    if let Some(previous) = previous_mapping {
+        upsert_delegate_snapshot(
+            transaction,
+            common,
+            delegator,
+            &previous.to,
+            false,
+            &previous.power,
+        )
+        .await?;
+        apply_delegate_count_delta(
+            transaction,
+            common,
+            &previous.to,
+            -1,
+            if is_nonzero_decimal(&previous.power) {
+                -1
+            } else {
+                0
+            },
+        )
+        .await?;
+        sqlx::query("DELETE FROM delegate_mapping WHERE id = $1")
+            .bind(delegator)
+            .execute(&mut **transaction)
+            .await?;
+    }
+
+    if is_zero_address(to_delegate) {
+        return Ok(());
+    }
+
+    apply_delegate_count_delta(transaction, common, to_delegate, 1, 0).await?;
+    upsert_delegate_mapping(transaction, common, delegator, to_delegate, "0").await?;
+
+    Ok(())
+}
+
+async fn apply_delegate_votes_changed_operation(
+    transaction: &mut Transaction<'_, Postgres>,
+    common: &TokenEventCommon,
+    delegate: &str,
+    previous_votes: &str,
+    new_votes: &str,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let delta = signed_decimal_delta(transaction, new_votes, previous_votes).await?;
+    let rollings = transaction_rollings(transaction, &common.transaction_hash).await?;
+    let Some(rolling_match) =
+        find_rolling_match_from_rows(&rollings, delegate, &delta, common.log_index)
+    else {
+        return Ok(());
+    };
+
+    match rolling_match.side {
+        RollingSide::From => {
+            sqlx::query(
+                "UPDATE delegate_rolling
+                 SET from_previous_votes = $2::NUMERIC(78, 0),
+                     from_new_votes = $3::NUMERIC(78, 0)
+                 WHERE id = $1",
+            )
+            .bind(&rolling_match.id)
+            .bind(previous_votes)
+            .bind(new_votes)
+            .execute(&mut **transaction)
+            .await?;
+            apply_delegate_delta(
+                transaction,
+                common,
+                &rolling_match.delegator,
+                &rolling_match.from_delegate,
+                &delta,
+            )
+            .await
+        }
+        RollingSide::To => {
+            sqlx::query(
+                "UPDATE delegate_rolling
+                 SET to_previous_votes = $2::NUMERIC(78, 0),
+                     to_new_votes = $3::NUMERIC(78, 0)
+                 WHERE id = $1",
+            )
+            .bind(&rolling_match.id)
+            .bind(previous_votes)
+            .bind(new_votes)
+            .execute(&mut **transaction)
+            .await?;
+            apply_delegate_delta(
+                transaction,
+                common,
+                &rolling_match.delegator,
+                &rolling_match.to_delegate,
+                &delta,
+            )
+            .await
+        }
+    }
+}
+
+async fn apply_transfer_operation(
+    transaction: &mut Transaction<'_, Postgres>,
+    common: &TokenEventCommon,
+    from: &str,
+    to: &str,
+    value: &str,
+    standard: GovernanceTokenStandard,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let value = transfer_units(value, standard);
+    if let Some(mapping) = read_delegate_mapping(transaction, from).await? {
+        apply_delegate_delta(
+            transaction,
+            common,
+            &mapping.from,
+            &mapping.to,
+            &format!("-{value}"),
+        )
+        .await?;
+    }
+    if let Some(mapping) = read_delegate_mapping(transaction, to).await? {
+        apply_delegate_delta(transaction, common, &mapping.from, &mapping.to, &value).await?;
+    }
+
+    Ok(())
+}
+
+async fn apply_delegate_delta(
+    transaction: &mut Transaction<'_, Postgres>,
+    common: &TokenEventCommon,
+    from_delegate: &str,
+    to_delegate: &str,
+    delta: &str,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    if is_zero_address(to_delegate) {
+        return Ok(());
+    }
+
+    let previous_mapping_power = read_delegate_mapping(transaction, from_delegate)
+        .await?
+        .filter(|mapping| mapping.to == to_delegate)
+        .map(|mapping| mapping.power)
+        .unwrap_or_else(|| "0".to_owned());
+    let next_mapping_power =
+        add_signed_decimal(transaction, &previous_mapping_power, delta).await?;
+
+    sqlx::query(
+        r#"UPDATE delegate_mapping
+           SET chain_id = $2, dao_code = $3, governor_address = $4, token_address = $5,
+               contract_address = $6, log_index = $7, transaction_index = $8,
+               power = $9::NUMERIC(78, 0), block_number = $10::NUMERIC(78, 0),
+               block_timestamp = $11::NUMERIC(78, 0), transaction_hash = $12
+           WHERE id = $1 AND "to" = $13"#,
+    )
+    .bind(from_delegate)
+    .bind(common.chain_id)
+    .bind(&common.dao_code)
+    .bind(&common.governor_address)
+    .bind(&common.token_address)
+    .bind(&common.contract_address)
+    .bind(u64_to_i32(common.log_index, "delegate_mapping.log_index")?)
+    .bind(u64_to_i32(
+        common.transaction_index,
+        "delegate_mapping.transaction_index",
+    )?)
+    .bind(&next_mapping_power)
+    .bind(&common.block_number)
+    .bind(required_numeric(
+        &common.block_timestamp,
+        "delegate_mapping.block_timestamp",
+    )?)
+    .bind(&common.transaction_hash)
+    .bind(to_delegate)
+    .execute(&mut **transaction)
+    .await?;
+
+    let previous_effective = is_nonzero_decimal(&previous_mapping_power);
+    let next_effective = is_nonzero_decimal(&next_mapping_power);
+    if previous_effective != next_effective {
+        apply_delegate_count_delta(
+            transaction,
+            common,
+            to_delegate,
+            0,
+            if next_effective { 1 } else { -1 },
+        )
+        .await?;
+    }
+    upsert_delegate_snapshot(
+        transaction,
+        common,
+        from_delegate,
+        to_delegate,
+        true,
+        &next_mapping_power,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn upsert_delegate_snapshot(
+    transaction: &mut Transaction<'_, Postgres>,
+    common: &TokenEventCommon,
+    from_delegate: &str,
+    to_delegate: &str,
+    is_current: bool,
+    power: &str,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    if is_zero_address(to_delegate) {
+        return Ok(());
+    }
+    let id = delegate_ref(from_delegate, to_delegate);
+    if is_current && !is_nonzero_decimal(power) {
+        sqlx::query("DELETE FROM delegate WHERE id = $1")
+            .bind(&id)
+            .execute(&mut **transaction)
+            .await?;
+        return Ok(());
+    }
+
+    sqlx::query(
+        "INSERT INTO delegate (
+            id, chain_id, dao_code, governor_address, token_address, contract_address,
+            log_index, transaction_index, from_delegate, to_delegate, block_number,
+            block_timestamp, transaction_hash, is_current, power
+         )
+         VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::NUMERIC(78, 0),
+            $12::NUMERIC(78, 0), $13, $14, $15::NUMERIC(78, 0)
+         )
+         ON CONFLICT (id) DO UPDATE
+         SET chain_id = EXCLUDED.chain_id,
+             dao_code = EXCLUDED.dao_code,
+             governor_address = EXCLUDED.governor_address,
+             token_address = EXCLUDED.token_address,
+             contract_address = EXCLUDED.contract_address,
+             log_index = EXCLUDED.log_index,
+             transaction_index = EXCLUDED.transaction_index,
+             block_number = EXCLUDED.block_number,
+             block_timestamp = EXCLUDED.block_timestamp,
+             transaction_hash = EXCLUDED.transaction_hash,
+             is_current = EXCLUDED.is_current,
+             power = EXCLUDED.power",
+    )
+    .bind(id)
+    .bind(common.chain_id)
+    .bind(&common.dao_code)
+    .bind(&common.governor_address)
+    .bind(&common.token_address)
+    .bind(&common.contract_address)
+    .bind(u64_to_i32(common.log_index, "delegate.log_index")?)
+    .bind(u64_to_i32(
+        common.transaction_index,
+        "delegate.transaction_index",
+    )?)
+    .bind(from_delegate)
+    .bind(to_delegate)
+    .bind(&common.block_number)
+    .bind(required_numeric(
+        &common.block_timestamp,
+        "delegate.block_timestamp",
+    )?)
+    .bind(&common.transaction_hash)
+    .bind(is_current)
+    .bind(power)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(())
+}
+
+async fn upsert_delegate_mapping(
+    transaction: &mut Transaction<'_, Postgres>,
+    common: &TokenEventCommon,
+    from: &str,
+    to: &str,
+    power: &str,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    sqlx::query(
+        r#"INSERT INTO delegate_mapping (
+            id, chain_id, dao_code, governor_address, token_address, contract_address,
+            log_index, transaction_index, "from", "to", power, block_number, block_timestamp,
+            transaction_hash
+         )
+         VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::NUMERIC(78, 0),
+            $12::NUMERIC(78, 0), $13::NUMERIC(78, 0), $14
+         )
+         ON CONFLICT (id) DO UPDATE
+         SET chain_id = EXCLUDED.chain_id,
+             dao_code = EXCLUDED.dao_code,
+             governor_address = EXCLUDED.governor_address,
+             token_address = EXCLUDED.token_address,
+             contract_address = EXCLUDED.contract_address,
+             log_index = EXCLUDED.log_index,
+             transaction_index = EXCLUDED.transaction_index,
+             "from" = EXCLUDED."from",
+             "to" = EXCLUDED."to",
+             power = EXCLUDED.power,
+             block_number = EXCLUDED.block_number,
+             block_timestamp = EXCLUDED.block_timestamp,
+             transaction_hash = EXCLUDED.transaction_hash"#,
+    )
+    .bind(from)
+    .bind(common.chain_id)
+    .bind(&common.dao_code)
+    .bind(&common.governor_address)
+    .bind(&common.token_address)
+    .bind(&common.contract_address)
+    .bind(u64_to_i32(common.log_index, "delegate_mapping.log_index")?)
+    .bind(u64_to_i32(
+        common.transaction_index,
+        "delegate_mapping.transaction_index",
+    )?)
+    .bind(from)
+    .bind(to)
+    .bind(power)
+    .bind(&common.block_number)
+    .bind(required_numeric(
+        &common.block_timestamp,
+        "delegate_mapping.block_timestamp",
+    )?)
+    .bind(&common.transaction_hash)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(())
+}
+
+async fn apply_delegate_count_delta(
+    transaction: &mut Transaction<'_, Postgres>,
+    common: &TokenEventCommon,
+    delegate: &str,
+    all_delta: i64,
+    effective_delta: i64,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    if is_zero_address(delegate) {
+        return Ok(());
+    }
+    ensure_contributor(transaction, delegate, common).await?;
+
+    sqlx::query(
+        "UPDATE contributor
+         SET chain_id = $2, dao_code = $3, governor_address = $4, token_address = $5,
+             contract_address = $6, log_index = $7, transaction_index = $8,
+             block_number = $9::NUMERIC(78, 0), block_timestamp = $10::NUMERIC(78, 0),
+             transaction_hash = $11,
+             delegates_count_all = GREATEST(delegates_count_all + $12, 0),
+             delegates_count_effective = GREATEST(delegates_count_effective + $13, 0)
+         WHERE id = $1",
+    )
+    .bind(delegate)
+    .bind(common.chain_id)
+    .bind(&common.dao_code)
+    .bind(&common.governor_address)
+    .bind(&common.token_address)
+    .bind(&common.contract_address)
+    .bind(u64_to_i32(common.log_index, "contributor.log_index")?)
+    .bind(u64_to_i32(
+        common.transaction_index,
+        "contributor.transaction_index",
+    )?)
+    .bind(&common.block_number)
+    .bind(required_numeric(
+        &common.block_timestamp,
+        "contributor.block_timestamp",
+    )?)
+    .bind(&common.transaction_hash)
+    .bind(i64_to_i32(
+        all_delta,
+        "contributor.delegates_count_all_delta",
+    )?)
+    .bind(i64_to_i32(
+        effective_delta,
+        "contributor.delegates_count_effective_delta",
+    )?)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(())
+}
+
+async fn ensure_contributor(
+    transaction: &mut Transaction<'_, Postgres>,
+    account: &str,
+    common: &TokenEventCommon,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let result = sqlx::query(
+        "INSERT INTO contributor (
+            id, chain_id, dao_code, governor_address, token_address, contract_address,
+            log_index, transaction_index, block_number, block_timestamp, transaction_hash,
+            power, balance, delegates_count_all, delegates_count_effective
+         )
+         VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9::NUMERIC(78, 0), $10::NUMERIC(78, 0),
+            $11, 0::NUMERIC(78, 0), NULL, 0, 0
+         )
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(account)
+    .bind(common.chain_id)
+    .bind(&common.dao_code)
+    .bind(&common.governor_address)
+    .bind(&common.token_address)
+    .bind(&common.contract_address)
+    .bind(u64_to_i32(common.log_index, "contributor.log_index")?)
+    .bind(u64_to_i32(
+        common.transaction_index,
+        "contributor.transaction_index",
+    )?)
+    .bind(&common.block_number)
+    .bind(required_numeric(
+        &common.block_timestamp,
+        "contributor.block_timestamp",
+    )?)
+    .bind(&common.transaction_hash)
+    .execute(&mut **transaction)
+    .await?;
+
+    if result.rows_affected() > 0 {
+        increment_member_count(transaction, common).await?;
+    }
+
+    Ok(())
+}
+
+async fn increment_member_count(
+    transaction: &mut Transaction<'_, Postgres>,
+    common: &TokenEventCommon,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    sqlx::query(
+        "INSERT INTO data_metric (
+            id, chain_id, dao_code, governor_address, token_address, member_count
+         )
+         VALUES ($1, $2, $3, $4, $5, 1)
+         ON CONFLICT ON CONSTRAINT data_metric_lookup_unique DO UPDATE
+         SET token_address = COALESCE(data_metric.token_address, EXCLUDED.token_address),
+             member_count = COALESCE(data_metric.member_count, 0) + 1",
+    )
+    .bind(data_metric_id(
+        common.chain_id,
+        &common.governor_address,
+        &common.dao_code,
+    ))
+    .bind(common.chain_id)
+    .bind(&common.dao_code)
+    .bind(&common.governor_address)
+    .bind(&common.token_address)
     .execute(&mut **transaction)
     .await?;
 
@@ -1505,7 +2113,206 @@ fn required_numeric<'a>(
         .ok_or_else(|| PostgresIndexerRunnerStoreError::new(format!("{field} is required")))
 }
 
+#[derive(Clone, Debug)]
+struct DelegateMappingSnapshot {
+    from: String,
+    to: String,
+    power: String,
+}
+
+#[derive(Clone, Debug)]
+struct DelegateRollingSnapshot {
+    id: String,
+    log_index: i32,
+    delegator: String,
+    from_delegate: String,
+    to_delegate: String,
+    from_new_votes: Option<String>,
+    to_new_votes: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RollingSide {
+    From,
+    To,
+}
+
+#[derive(Clone, Debug)]
+struct DelegateRollingMatch {
+    id: String,
+    delegator: String,
+    from_delegate: String,
+    to_delegate: String,
+    side: RollingSide,
+}
+
+async fn read_delegate_mapping(
+    transaction: &mut Transaction<'_, Postgres>,
+    from: &str,
+) -> Result<Option<DelegateMappingSnapshot>, PostgresIndexerRunnerStoreError> {
+    let row = sqlx::query(
+        r#"SELECT "from", "to", power::TEXT AS power
+           FROM delegate_mapping
+           WHERE id = $1"#,
+    )
+    .bind(from)
+    .fetch_optional(&mut **transaction)
+    .await?;
+
+    Ok(row.map(|row| DelegateMappingSnapshot {
+        from: row.get("from"),
+        to: row.get("to"),
+        power: row.get("power"),
+    }))
+}
+
+async fn transaction_rollings(
+    transaction: &mut Transaction<'_, Postgres>,
+    transaction_hash: &str,
+) -> Result<Vec<DelegateRollingSnapshot>, PostgresIndexerRunnerStoreError> {
+    let rows = sqlx::query(
+        "SELECT id, log_index, delegator, from_delegate, to_delegate,
+                from_new_votes::TEXT AS from_new_votes,
+                to_new_votes::TEXT AS to_new_votes
+         FROM delegate_rolling
+         WHERE transaction_hash = $1
+           AND from_delegate <> to_delegate
+         ORDER BY log_index DESC",
+    )
+    .bind(transaction_hash)
+    .fetch_all(&mut **transaction)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| DelegateRollingSnapshot {
+            id: row.get("id"),
+            log_index: row.get("log_index"),
+            delegator: row.get("delegator"),
+            from_delegate: row.get("from_delegate"),
+            to_delegate: row.get("to_delegate"),
+            from_new_votes: row.get("from_new_votes"),
+            to_new_votes: row.get("to_new_votes"),
+        })
+        .collect())
+}
+
+fn find_rolling_match_from_rows(
+    rollings: &[DelegateRollingSnapshot],
+    delegate: &str,
+    delta: &str,
+    before_log_index: u64,
+) -> Option<DelegateRollingMatch> {
+    let before_log_index = u64_to_i32(before_log_index, "delegate_rolling.match_log_index").ok()?;
+    let from = rollings
+        .iter()
+        .filter(|rolling| rolling.log_index < before_log_index)
+        .filter(|rolling| rolling.from_new_votes.is_none())
+        .find(|rolling| rolling.from_delegate == delegate)
+        .map(|rolling| rolling_match(rolling, RollingSide::From));
+    let to = rollings
+        .iter()
+        .filter(|rolling| rolling.log_index < before_log_index)
+        .filter(|rolling| rolling.to_new_votes.is_none())
+        .find(|rolling| rolling.to_delegate == delegate)
+        .map(|rolling| rolling_match(rolling, RollingSide::To));
+
+    if is_negative_decimal(delta) {
+        from.or(to)
+    } else {
+        to.or(from)
+    }
+}
+
+fn rolling_match(rolling: &DelegateRollingSnapshot, side: RollingSide) -> DelegateRollingMatch {
+    DelegateRollingMatch {
+        id: rolling.id.clone(),
+        delegator: rolling.delegator.clone(),
+        from_delegate: rolling.from_delegate.clone(),
+        to_delegate: rolling.to_delegate.clone(),
+        side,
+    }
+}
+
+async fn signed_decimal_delta(
+    transaction: &mut Transaction<'_, Postgres>,
+    next: &str,
+    previous: &str,
+) -> Result<String, PostgresIndexerRunnerStoreError> {
+    let row = sqlx::query("SELECT ($1::NUMERIC(78, 0) - $2::NUMERIC(78, 0))::TEXT AS delta")
+        .bind(next)
+        .bind(previous)
+        .fetch_one(&mut **transaction)
+        .await?;
+
+    Ok(row.get("delta"))
+}
+
+async fn add_signed_decimal(
+    transaction: &mut Transaction<'_, Postgres>,
+    value: &str,
+    delta: &str,
+) -> Result<String, PostgresIndexerRunnerStoreError> {
+    let row = sqlx::query("SELECT ($1::NUMERIC(78, 0) + $2::NUMERIC(78, 0))::TEXT AS value")
+        .bind(value)
+        .bind(delta)
+        .fetch_one(&mut **transaction)
+        .await?;
+
+    Ok(row.get("value"))
+}
+
+fn is_negative_decimal(value: &str) -> bool {
+    value.trim_start().starts_with('-')
+}
+
+fn is_nonzero_decimal(value: &str) -> bool {
+    !value
+        .trim()
+        .trim_start_matches('-')
+        .trim_start_matches('0')
+        .is_empty()
+}
+
+fn vote_power_checkpoint_cause(has_delegate_change: bool, has_transfer: bool) -> &'static str {
+    match (has_delegate_change, has_transfer) {
+        (true, true) => "delegate-change+transfer",
+        (true, false) => "delegate-change",
+        (false, true) => "transfer",
+        (false, false) => "delegate-votes-changed",
+    }
+}
+
+fn token_operation_id(operation: &TokenProjectionOperation) -> &str {
+    match operation {
+        TokenProjectionOperation::DelegateChanged { id, .. }
+        | TokenProjectionOperation::DelegateVotesChanged { id, .. }
+        | TokenProjectionOperation::Transfer { id, .. } => id,
+    }
+}
+
+fn transfer_units(value: &str, standard: GovernanceTokenStandard) -> String {
+    match standard {
+        GovernanceTokenStandard::Erc20 => value.to_owned(),
+        GovernanceTokenStandard::Erc721 => "1".to_owned(),
+    }
+}
+
+fn delegate_ref(from_delegate: &str, to_delegate: &str) -> String {
+    format!("{from_delegate}_{to_delegate}")
+}
+
+fn is_zero_address(value: &str) -> bool {
+    value.eq_ignore_ascii_case("0x0000000000000000000000000000000000000000")
+}
+
 fn u64_to_i32(value: u64, field: &str) -> Result<i32, PostgresIndexerRunnerStoreError> {
+    i32::try_from(value).map_err(|_| {
+        PostgresIndexerRunnerStoreError::new(format!("{field} value {value} exceeds INTEGER"))
+    })
+}
+
+fn i64_to_i32(value: i64, field: &str) -> Result<i32, PostgresIndexerRunnerStoreError> {
     i32::try_from(value).map_err(|_| {
         PostgresIndexerRunnerStoreError::new(format!("{field} value {value} exceeds INTEGER"))
     })

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -242,6 +242,80 @@ async fn test_onchain_refresh_worker_marks_claimed_tasks_failed_when_reader_fail
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_checkpoint_ids_include_scope() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task_with_scope(
+        &database.pool,
+        "task-one",
+        46,
+        "demo-dao",
+        GOVERNOR,
+        TOKEN,
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        true,
+        true,
+    )
+    .await?;
+    seed_task_with_scope(
+        &database.pool,
+        "task-two",
+        46,
+        "other-dao",
+        GOVERNOR_TWO,
+        TOKEN_TWO,
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        true,
+        true,
+    )
+    .await?;
+
+    let reader = MockOnchainRefreshReader::new([
+        (
+            "task-one",
+            OnchainRefreshReadValue {
+                task_id: "task-one".to_owned(),
+                balance: Some("17".to_owned()),
+                power: Some("11".to_owned()),
+            },
+        ),
+        (
+            "task-two",
+            OnchainRefreshReadValue {
+                task_id: "task-two".to_owned(),
+                balance: Some("23".to_owned()),
+                power: Some("19".to_owned()),
+            },
+        ),
+    ]);
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            max_attempts: 3,
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.completed, 2);
+    assert_scoped_checkpoint_count(&database.pool, "vote_power_checkpoint", ACCOUNT_ONE, 2).await?;
+    assert_scoped_checkpoint_count(&database.pool, "token_balance_checkpoint", ACCOUNT_ONE, 2)
+        .await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
 #[derive(Clone, Debug)]
 struct MockOnchainRefreshReader {
     values: BTreeMap<String, OnchainRefreshReadValue>,
@@ -343,6 +417,35 @@ async fn seed_task(
     refresh_balance: bool,
     refresh_power: bool,
 ) -> Result<(), sqlx::Error> {
+    seed_task_with_scope(
+        pool,
+        task_id,
+        46,
+        "demo-dao",
+        GOVERNOR,
+        TOKEN,
+        account,
+        status,
+        attempts,
+        refresh_balance,
+        refresh_power,
+    )
+    .await
+}
+
+async fn seed_task_with_scope(
+    pool: &PgPool,
+    task_id: &str,
+    chain_id: i32,
+    dao_code: &str,
+    governor: &str,
+    token: &str,
+    account: &str,
+    status: &str,
+    attempts: i32,
+    refresh_balance: bool,
+    refresh_power: bool,
+) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO onchain_refresh_task (
             id, chain_id, dao_code, governor_address, token_address, account,
@@ -351,15 +454,17 @@ async fn seed_task(
             status, attempts, next_run_at, pending_after_lock, created_at, updated_at
          )
          VALUES (
-            $1, 46, 'demo-dao', $2, $3, $4, $5, $6, 'token-activity',
+            $1, $2, $3, $4, $5, $6, $7, $8, 'token-activity',
             10::NUMERIC(78, 0), 12::NUMERIC(78, 0), 12000::NUMERIC(78, 0),
-            '0xtask', $7, $8, 0::NUMERIC(78, 0), false, 10000::NUMERIC(78, 0),
+            '0xtask', $9, $10, 0::NUMERIC(78, 0), false, 10000::NUMERIC(78, 0),
             10000::NUMERIC(78, 0)
          )",
     )
     .bind(task_id)
-    .bind(GOVERNOR)
-    .bind(TOKEN)
+    .bind(chain_id)
+    .bind(dao_code)
+    .bind(governor)
+    .bind(token)
     .bind(account)
     .bind(refresh_balance)
     .bind(refresh_power)
@@ -514,6 +619,25 @@ async fn assert_table_count(pool: &PgPool, table: &str, expected: i64) -> Result
     Ok(())
 }
 
+async fn assert_scoped_checkpoint_count(
+    pool: &PgPool,
+    table: &str,
+    account: &str,
+    expected: i64,
+) -> Result<(), sqlx::Error> {
+    let count: i64 = sqlx::query(&format!(
+        "SELECT count(*)::BIGINT FROM {table} WHERE account = $1"
+    ))
+    .bind(account)
+    .fetch_one(pool)
+    .await?
+    .get(0);
+
+    assert_eq!(count, expected);
+
+    Ok(())
+}
+
 fn unique_schema_name() -> String {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -530,6 +654,8 @@ fn unique_schema_name() -> String {
 }
 
 const GOVERNOR: &str = "0x1111111111111111111111111111111111111111";
+const GOVERNOR_TWO: &str = "0x3333333333333333333333333333333333333333";
 const TOKEN: &str = "0x2222222222222222222222222222222222222222";
+const TOKEN_TWO: &str = "0x4444444444444444444444444444444444444444";
 const ACCOUNT_ONE: &str = "0x0000000000000000000000000000000000000001";
 const ACCOUNT_TWO: &str = "0x0000000000000000000000000000000000000002";

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -160,6 +160,10 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     assert_completed_task(&database.pool, "task-one", 1).await?;
     assert_completed_task(&database.pool, "task-two", 2).await?;
     assert_data_metric(&database.pool, "16", 2, 7).await?;
+    assert_power_checkpoint(&database.pool, ACCOUNT_ONE, "3", "11", "8").await?;
+    assert_power_checkpoint(&database.pool, ACCOUNT_TWO, "0", "5", "5").await?;
+    assert_balance_checkpoint(&database.pool, ACCOUNT_ONE, "4", "17", "13").await?;
+    assert_table_count(&database.pool, "token_balance_checkpoint", 1).await?;
 
     database.cleanup().await?;
 
@@ -434,6 +438,78 @@ async fn assert_data_metric(
     assert_eq!(row.get::<String, _>("power_sum"), power_sum);
     assert_eq!(row.get::<i32, _>("member_count"), member_count);
     assert_eq!(row.get::<i32, _>("votes_count"), votes_count);
+
+    Ok(())
+}
+
+async fn assert_power_checkpoint(
+    pool: &PgPool,
+    account: &str,
+    previous_power: &str,
+    new_power: &str,
+    delta: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT previous_power::TEXT AS previous_power, new_power::TEXT AS new_power,
+                delta::TEXT AS delta, source, cause, block_number::TEXT AS block_number,
+                block_timestamp::TEXT AS block_timestamp, transaction_hash
+         FROM vote_power_checkpoint
+         WHERE account = $1",
+    )
+    .bind(account)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("previous_power"), previous_power);
+    assert_eq!(row.get::<String, _>("new_power"), new_power);
+    assert_eq!(row.get::<String, _>("delta"), delta);
+    assert_eq!(row.get::<String, _>("source"), "getVotes");
+    assert_eq!(row.get::<String, _>("cause"), "onchain-refresh");
+    assert_eq!(row.get::<String, _>("block_number"), "12");
+    assert_eq!(row.get::<String, _>("block_timestamp"), "12000");
+    assert_eq!(row.get::<String, _>("transaction_hash"), "onchain-refresh");
+
+    Ok(())
+}
+
+async fn assert_balance_checkpoint(
+    pool: &PgPool,
+    account: &str,
+    previous_balance: &str,
+    new_balance: &str,
+    delta: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT previous_balance::TEXT AS previous_balance,
+                new_balance::TEXT AS new_balance, delta::TEXT AS delta, source, cause,
+                block_number::TEXT AS block_number, block_timestamp::TEXT AS block_timestamp,
+                transaction_hash
+         FROM token_balance_checkpoint
+         WHERE account = $1",
+    )
+    .bind(account)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("previous_balance"), previous_balance);
+    assert_eq!(row.get::<String, _>("new_balance"), new_balance);
+    assert_eq!(row.get::<String, _>("delta"), delta);
+    assert_eq!(row.get::<String, _>("source"), "balanceOf");
+    assert_eq!(row.get::<String, _>("cause"), "onchain-refresh");
+    assert_eq!(row.get::<String, _>("block_number"), "12");
+    assert_eq!(row.get::<String, _>("block_timestamp"), "12000");
+    assert_eq!(row.get::<String, _>("transaction_hash"), "onchain-refresh");
+
+    Ok(())
+}
+
+async fn assert_table_count(pool: &PgPool, table: &str, expected: i64) -> Result<(), sqlx::Error> {
+    let count: i64 = sqlx::query(&format!("SELECT count(*)::BIGINT FROM {table}"))
+        .fetch_one(pool)
+        .await?
+        .get(0);
+
+    assert_eq!(count, expected);
 
     Ok(())
 }

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -120,6 +120,8 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
     assert_table_count(&database.pool, "vote_cast", 1).await?;
     assert_table_count(&database.pool, "delegate_changed", 1).await?;
     assert_table_count(&database.pool, "token_transfer", 1).await?;
+    assert_table_count(&database.pool, "vote_power_checkpoint", 1).await?;
+    assert_token_projection_state(&database.pool).await?;
     assert_table_count(&database.pool, "timelock_operation", 1).await?;
     assert_checkpoint(&database.pool).await?;
 
@@ -332,6 +334,85 @@ async fn assert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
     assert_eq!(row.get::<i64, _>(0), 3);
     assert_eq!(row.get::<i64, _>(1), 2);
     assert_eq!(row.get::<i64, _>(2), 2);
+
+    Ok(())
+}
+
+async fn assert_token_projection_state(pool: &PgPool) -> Result<(), sqlx::Error> {
+    let mapping = sqlx::query(
+        r#"SELECT "from", "to", power::TEXT AS power
+           FROM delegate_mapping
+           WHERE id = $1"#,
+    )
+    .bind(DELEGATOR)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(mapping.get::<String, _>("from"), DELEGATOR);
+    assert_eq!(mapping.get::<String, _>("to"), DELEGATE);
+    assert_eq!(mapping.get::<String, _>("power"), "75");
+
+    let delegate = sqlx::query(
+        "SELECT from_delegate, to_delegate, power::TEXT AS power, is_current
+         FROM delegate
+         WHERE id = $1",
+    )
+    .bind(format!("{DELEGATOR}_{DELEGATE}"))
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(delegate.get::<String, _>("from_delegate"), DELEGATOR);
+    assert_eq!(delegate.get::<String, _>("to_delegate"), DELEGATE);
+    assert_eq!(delegate.get::<String, _>("power"), "75");
+    assert!(delegate.get::<bool, _>("is_current"));
+
+    let contributor = sqlx::query(
+        "SELECT power::TEXT AS power, balance::TEXT AS balance,
+                delegates_count_all, delegates_count_effective
+         FROM contributor
+         WHERE id = $1",
+    )
+    .bind(DELEGATE)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(contributor.get::<String, _>("power"), "0");
+    assert_eq!(contributor.get::<Option<String>, _>("balance"), None);
+    assert_eq!(contributor.get::<i32, _>("delegates_count_all"), 1);
+    assert_eq!(contributor.get::<i32, _>("delegates_count_effective"), 1);
+
+    let checkpoint = sqlx::query(
+        "SELECT account, clock_mode, timepoint::TEXT AS timepoint,
+                previous_power::TEXT AS previous_power, new_power::TEXT AS new_power,
+                delta::TEXT AS delta, source, cause, delegator, from_delegate, to_delegate
+         FROM vote_power_checkpoint",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(checkpoint.get::<String, _>("account"), DELEGATE);
+    assert_eq!(checkpoint.get::<String, _>("clock_mode"), "blocknumber");
+    assert_eq!(checkpoint.get::<String, _>("timepoint"), "2");
+    assert_eq!(checkpoint.get::<String, _>("previous_power"), "0");
+    assert_eq!(checkpoint.get::<String, _>("new_power"), "100");
+    assert_eq!(checkpoint.get::<String, _>("delta"), "100");
+    assert_eq!(checkpoint.get::<String, _>("source"), "event");
+    assert_eq!(
+        checkpoint.get::<String, _>("cause"),
+        "delegate-change+transfer"
+    );
+    assert_eq!(
+        checkpoint.get::<Option<String>, _>("delegator"),
+        Some(DELEGATOR.to_owned())
+    );
+    assert_eq!(
+        checkpoint.get::<Option<String>, _>("from_delegate"),
+        Some(ZERO_ADDRESS.to_owned())
+    );
+    assert_eq!(
+        checkpoint.get::<Option<String>, _>("to_delegate"),
+        Some(DELEGATE.to_owned())
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## What changed
- Persist token projection snapshot state in the Postgres runner store: delegate mappings, delegate rows, contributor delegate counts, and vote-power checkpoints.
- Write onchain refresh power/balance checkpoints from RPC-read values while preserving contributor power/balance as ChainTool/RPC sourced.
- Add Postgres regression assertions for token projection parity rows and refresh checkpoints.

## Verification
- pnpm run test:indexer-scripts
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:55437/indexer pnpm run test:indexer
- pnpm run indexer:build
- git diff --check