### PR TITLE
fix(indexer): propagate onchain refresh power source

### DIFF
--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -164,7 +164,8 @@ async fn run_worker() -> anyhow::Result<()> {
         runtime.read_plan_config(),
         runtime.current_power_method,
     );
-    let worker = OnchainRefreshWorker::new(pool, runtime.worker_config(), reader);
+    let worker = OnchainRefreshWorker::new(pool, runtime.worker_config(), reader)
+        .with_current_power_method(runtime.current_power_method);
 
     loop {
         let mut poll_claimed = 0;

--- a/apps/indexer/src/onchain_refresh.rs
+++ b/apps/indexer/src/onchain_refresh.rs
@@ -103,6 +103,7 @@ pub struct OnchainRefreshWorker<R> {
     pool: PgPool,
     config: OnchainRefreshWorkerConfig,
     reader: R,
+    current_power_method: ChainReadMethod,
 }
 
 impl<R> OnchainRefreshWorker<R>
@@ -114,7 +115,13 @@ where
             pool,
             config,
             reader,
+            current_power_method: ChainReadMethod::GetVotes,
         }
+    }
+
+    pub fn with_current_power_method(mut self, current_power_method: ChainReadMethod) -> Self {
+        self.current_power_method = current_power_method;
+        self
     }
 
     pub async fn run_once(&self) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
@@ -263,7 +270,14 @@ where
 
         let previous = read_contributor_refresh_values(&mut transaction, &task.account).await?;
         upsert_contributor_refresh(&mut transaction, task, value).await?;
-        insert_refresh_checkpoints(&mut transaction, task, value, previous).await?;
+        insert_refresh_checkpoints(
+            &mut transaction,
+            task,
+            value,
+            previous,
+            self.current_power_method,
+        )
+        .await?;
         refresh_data_metric(&mut transaction, task).await?;
         complete_task(&mut transaction, &task.id, now_ms).await?;
 
@@ -674,6 +688,7 @@ async fn insert_refresh_checkpoints(
     task: &OnchainRefreshTask,
     value: &OnchainRefreshReadValue,
     previous: ContributorRefreshValues,
+    current_power_method: ChainReadMethod,
 ) -> Result<(), sqlx::Error> {
     if task.refresh_balance {
         let previous_balance = previous.balance.as_deref().unwrap_or("0");
@@ -720,8 +735,8 @@ async fn insert_refresh_checkpoints(
              VALUES (
                 $1, $2, $3, $4, $5, $5, $6, 'blocknumber', $7::NUMERIC(78, 0),
                 $8::NUMERIC(78, 0), $9::NUMERIC(78, 0),
-                ($9::NUMERIC(78, 0) - $8::NUMERIC(78, 0)), 'getVotes', 'onchain-refresh',
-                $7::NUMERIC(78, 0), $10::NUMERIC(78, 0), 'onchain-refresh'
+                ($9::NUMERIC(78, 0) - $8::NUMERIC(78, 0)), $10, 'onchain-refresh',
+                $7::NUMERIC(78, 0), $11::NUMERIC(78, 0), 'onchain-refresh'
              )
              ON CONFLICT (id) DO NOTHING",
         )
@@ -737,6 +752,7 @@ async fn insert_refresh_checkpoints(
         .bind(&task.last_seen_block_number)
         .bind(previous_power)
         .bind(new_power)
+        .bind(current_power_checkpoint_source(current_power_method))
         .bind(&task.last_seen_block_timestamp)
         .execute(&mut **transaction)
         .await?;
@@ -846,6 +862,13 @@ fn onchain_refresh_checkpoint_scope(task: &OnchainRefreshTask) -> String {
         task.account,
         task.last_seen_block_number,
     )
+}
+
+fn current_power_checkpoint_source(method: ChainReadMethod) -> &'static str {
+    match method {
+        ChainReadMethod::CurrentVotes => "getCurrentVotes",
+        _ => "getVotes",
+    }
 }
 
 fn parse_u64(value: &str) -> Result<u64, OnchainRefreshReaderError> {

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use degov_datalens_indexer::{
-    OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError, OnchainRefreshTask,
-    OnchainRefreshWorker, OnchainRefreshWorkerConfig,
+    ChainReadMethod, OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError,
+    OnchainRefreshTask, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
 };
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
@@ -164,6 +164,52 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     assert_power_checkpoint(&database.pool, ACCOUNT_TWO, "0", "5", "5").await?;
     assert_balance_checkpoint(&database.pool, ACCOUNT_ONE, "4", "17", "13").await?;
     assert_table_count(&database.pool, "token_balance_checkpoint", 1).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_uses_current_votes_checkpoint_source()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        false,
+        true,
+    )
+    .await?;
+
+    let reader = MockOnchainRefreshReader::new([(
+        "task-one",
+        OnchainRefreshReadValue {
+            task_id: "task-one".to_owned(),
+            balance: None,
+            power: Some("11".to_owned()),
+        },
+    )]);
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            max_attempts: 3,
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    )
+    .with_current_power_method(ChainReadMethod::CurrentVotes);
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.completed, 1);
+    assert_power_checkpoint_source(&database.pool, ACCOUNT_ONE, "getCurrentVotes").await?;
 
     database.cleanup().await?;
 
@@ -573,6 +619,25 @@ async fn assert_power_checkpoint(
     assert_eq!(row.get::<String, _>("block_number"), "12");
     assert_eq!(row.get::<String, _>("block_timestamp"), "12000");
     assert_eq!(row.get::<String, _>("transaction_hash"), "onchain-refresh");
+
+    Ok(())
+}
+
+async fn assert_power_checkpoint_source(
+    pool: &PgPool,
+    account: &str,
+    source: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT source
+         FROM vote_power_checkpoint
+         WHERE account = $1",
+    )
+    .bind(account)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("source"), source);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Propagates the configured onchain refresh power read method into checkpoint/source metadata.
- Keeps the default getVotes behavior unchanged.
- Adds tests for default getVotes and configured getCurrentVotes source values.

## Tests
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://datalens:datalens@localhost:5432/datalens_test cargo test --locked -p degov-datalens-indexer
- cargo build --locked -p degov-datalens-indexer
- rustfmt --edition 2024 --check apps/indexer/src/main.rs apps/indexer/src/onchain_refresh.rs apps/indexer/tests/onchain_refresh_worker.rs

Parent: HBX-283
Issue: HBX-295