### PR TITLE
feat(indexer): add contract set sync planner

### DIFF
--- a/apps/indexer/src/config.rs
+++ b/apps/indexer/src/config.rs
@@ -143,6 +143,15 @@ impl DatalensContractSetConfig {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensRuntimeContractSet {
+    pub dao_code: String,
+    pub contract: DatalensContractSetConfig,
+    pub config: DatalensConfig,
+    pub contract_set_id: String,
+    pub addresses: DaoContractAddresses,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct DatasetKeyConfig {
     pub family: String,
@@ -309,6 +318,48 @@ impl DatalensConfig {
         config
     }
 
+    pub fn configured_contract_sets(
+        &self,
+        dao_filter: Option<&str>,
+    ) -> Result<Vec<DatalensRuntimeContractSet>, ConfigError> {
+        let total_contract_sets = self
+            .chains
+            .iter()
+            .map(|chain| chain.contracts.len())
+            .sum::<usize>();
+        let mut configured = Vec::new();
+
+        for contract in self.chains.iter().flat_map(|chain| chain.contracts.iter()) {
+            let dao_code = match (contract.dao_code.as_deref(), dao_filter) {
+                (Some(dao_code), Some(filter)) if dao_code != filter => continue,
+                (Some(dao_code), _) => dao_code.to_owned(),
+                (None, Some(filter)) if total_contract_sets == 1 => filter.to_owned(),
+                (None, Some(_)) => continue,
+                (None, None) => {
+                    return Err(ConfigError::InvalidField {
+                        field: "DATALENS_CHAINS_JSON".to_owned(),
+                        reason: "contract set daoCode is required for all contract set mode"
+                            .to_owned(),
+                    });
+                }
+            };
+
+            configured.push(self.runtime_contract_set(&dao_code, contract));
+        }
+
+        if configured.is_empty() {
+            let reason = dao_filter
+                .map(|dao_code| format!("no contract set configured for {dao_code}"))
+                .unwrap_or_else(|| "no contract sets configured".to_owned());
+            return Err(ConfigError::InvalidField {
+                field: "DEGOV_INDEXER_DAO_CODE".to_owned(),
+                reason,
+            });
+        }
+
+        Ok(configured)
+    }
+
     pub fn contract_set_scope_id(
         &self,
         dao_code: &str,
@@ -334,6 +385,24 @@ impl DatalensConfig {
         .map(|(key, value)| format!("{key}={value}"))
         .collect::<Vec<_>>()
         .join("|")
+    }
+
+    fn runtime_contract_set(
+        &self,
+        dao_code: &str,
+        contract: &DatalensContractSetConfig,
+    ) -> DatalensRuntimeContractSet {
+        let contract_set_id = self.contract_set_scope_id(dao_code, contract);
+        let addresses = contract.addresses();
+        let config = self.for_contract_set(contract);
+
+        DatalensRuntimeContractSet {
+            dao_code: dao_code.to_owned(),
+            contract: contract.clone(),
+            config,
+            contract_set_id,
+            addresses,
+        }
     }
 }
 
@@ -921,6 +990,180 @@ mod tests {
                 let selected = config.select_contract_set("lisk-dao").expect("select lisk");
                 assert_eq!(selected.chain_id, 1135);
                 assert_eq!(selected.start_block, 568752);
+            },
+        );
+    }
+
+    #[test]
+    fn test_configured_contract_sets_returns_stable_config_order() {
+        with_datalens_env(
+            &[
+                ("DATALENS_ENDPOINT", Some("https://datalens.ringdao.com")),
+                ("DATALENS_APPLICATION", Some("degov-live")),
+                ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+                (
+                    "DATALENS_CHAINS_JSON",
+                    Some(
+                        r#"[
+                            {
+                                "chainId": 1135,
+                                "networkName": "lisk",
+                                "contracts": [
+                                    {
+                                        "daoCode": "lisk-dao",
+                                        "chainId": 1135,
+                                        "networkName": "lisk",
+                                        "governor": "0x1111111111111111111111111111111111111111",
+                                        "governorToken": "0x2222222222222222222222222222222222222222",
+                                        "tokenStandard": "ERC20",
+                                        "timelock": "0x3333333333333333333333333333333333333333",
+                                        "startBlock": 568752
+                                    },
+                                    {
+                                        "daoCode": "demo-dao",
+                                        "chainId": 1135,
+                                        "networkName": "lisk",
+                                        "governor": "0x4444444444444444444444444444444444444444",
+                                        "governorToken": "0x5555555555555555555555555555555555555555",
+                                        "tokenStandard": "ERC721",
+                                        "timelock": "0x6666666666666666666666666666666666666666",
+                                        "startBlock": 700000
+                                    }
+                                ]
+                            },
+                            {
+                                "chainId": 1,
+                                "networkName": "ethereum",
+                                "contracts": [
+                                    {
+                                        "daoCode": "ens-dao",
+                                        "chainId": 1,
+                                        "networkName": "ethereum",
+                                        "governor": "0x7777777777777777777777777777777777777777",
+                                        "governorToken": "0x8888888888888888888888888888888888888888",
+                                        "tokenStandard": "ERC20",
+                                        "timelock": "0x9999999999999999999999999999999999999999",
+                                        "startBlock": 100
+                                    }
+                                ]
+                            }
+                        ]"#,
+                    ),
+                ),
+            ],
+            || {
+                let config = DatalensConfig::from_env().expect("load config");
+                let configured = config
+                    .configured_contract_sets(None)
+                    .expect("configured contract sets");
+
+                assert_eq!(configured.len(), 3);
+                assert_eq!(configured[0].dao_code, "lisk-dao");
+                assert_eq!(configured[1].dao_code, "demo-dao");
+                assert_eq!(configured[2].dao_code, "ens-dao");
+                assert_eq!(configured[0].config.chain.configured_name, "lisk");
+                assert_eq!(configured[2].config.chain.network_id, Some(1));
+            },
+        );
+    }
+
+    #[test]
+    fn test_configured_contract_sets_filters_by_dao_code() {
+        with_datalens_env(
+            &[
+                ("DATALENS_ENDPOINT", Some("https://datalens.ringdao.com")),
+                ("DATALENS_APPLICATION", Some("degov-live")),
+                ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+                (
+                    "DATALENS_CHAINS_JSON",
+                    Some(
+                        r#"[
+                            {
+                                "chainId": 1135,
+                                "networkName": "lisk",
+                                "contracts": [
+                                    {
+                                        "daoCode": "shared-dao",
+                                        "chainId": 1135,
+                                        "networkName": "lisk",
+                                        "governor": "0x1111111111111111111111111111111111111111",
+                                        "governorToken": "0x2222222222222222222222222222222222222222",
+                                        "tokenStandard": "ERC20",
+                                        "timelock": "0x3333333333333333333333333333333333333333",
+                                        "startBlock": 568752
+                                    }
+                                ]
+                            },
+                            {
+                                "chainId": 1,
+                                "networkName": "ethereum",
+                                "contracts": [
+                                    {
+                                        "daoCode": "other-dao",
+                                        "chainId": 1,
+                                        "networkName": "ethereum",
+                                        "governor": "0x4444444444444444444444444444444444444444",
+                                        "governorToken": "0x5555555555555555555555555555555555555555",
+                                        "tokenStandard": "ERC20",
+                                        "timelock": "0x6666666666666666666666666666666666666666",
+                                        "startBlock": 100
+                                    }
+                                ]
+                            }
+                        ]"#,
+                    ),
+                ),
+            ],
+            || {
+                let config = DatalensConfig::from_env().expect("load config");
+                let configured = config
+                    .configured_contract_sets(Some("shared-dao"))
+                    .expect("configured contract sets");
+
+                assert_eq!(configured.len(), 1);
+                assert_eq!(configured[0].dao_code, "shared-dao");
+                assert_eq!(configured[0].contract.chain_id, 1135);
+            },
+        );
+    }
+
+    #[test]
+    fn test_configured_contract_sets_preserves_legacy_single_contract_env_behavior() {
+        with_datalens_env(
+            &[
+                ("DATALENS_ENDPOINT", Some("https://datalens.ringdao.com/")),
+                ("DATALENS_APPLICATION", Some("degov-live")),
+                ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+                ("DATALENS_CHAIN_NAME", Some("ethereum")),
+                ("DATALENS_CHAIN_ID", Some("1")),
+                ("DEGOV_INDEXER_DAO_CODE", Some("legacy-dao")),
+                ("DEGOV_INDEXER_START_BLOCK", Some("568752")),
+                (
+                    "DATALENS_GOVERNOR_ADDRESS",
+                    Some("0x1111111111111111111111111111111111111111"),
+                ),
+                (
+                    "DATALENS_GOVERNOR_TOKEN_ADDRESS",
+                    Some("0x2222222222222222222222222222222222222222"),
+                ),
+                ("DATALENS_GOVERNOR_TOKEN_STANDARD", Some("ERC20")),
+                (
+                    "DATALENS_TIMELOCK_ADDRESS",
+                    Some("0x3333333333333333333333333333333333333333"),
+                ),
+            ],
+            || {
+                let config = DatalensConfig::from_env().expect("load config");
+                let selected = config
+                    .select_contract_set("legacy-dao")
+                    .expect("select legacy contract set");
+                let configured = config
+                    .configured_contract_sets(Some("legacy-dao"))
+                    .expect("configured contract sets");
+
+                assert_eq!(configured.len(), 1);
+                assert_eq!(configured[0].dao_code, "legacy-dao");
+                assert_eq!(configured[0].contract, selected);
             },
         );
     }

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -30,7 +30,8 @@ pub use checkpoint::{
 };
 pub use config::{
     ChainFamily, ChainIdentityConfig, DatalensChainConfig, DatalensConfig,
-    DatalensContractSetConfig, DatalensFinality, DatasetKeyConfig, QueryLimitConfig, SecretString,
+    DatalensContractSetConfig, DatalensFinality, DatalensRuntimeContractSet, DatasetKeyConfig,
+    QueryLimitConfig, SecretString,
 };
 pub use dao_event::{
     CallExecutedEvent, CallSaltEvent, CallScheduledEvent, DaoEventDecodeError, DecodedDaoEvent,

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -87,7 +87,11 @@ async fn run_indexer() -> anyhow::Result<()> {
         for contract_set in contract_sets {
             let contract_runtime = match runtime.for_configured_contract_set(&contract_set) {
                 Ok(contract_runtime) => contract_runtime,
-                Err(error) if runtime.target_height < contract_set.contract.start_block => {
+                Err(error)
+                    if runtime.should_skip_contract_set_start_after_target(
+                        contract_set.contract.start_block,
+                    ) =>
+                {
                     log::warn!(
                         "skipping Datalens indexer contract set because configured startBlock is above target dao_code={} chain_id={} contract_set_id={} start_block={} target_height={} error={}",
                         contract_set.dao_code,
@@ -442,6 +446,11 @@ impl IndexerRuntimeConfig {
         Ok(runtime
             .with_start_block(contract_set.contract.start_block)?
             .with_contract_set_scope(contract_set.contract_set_id.clone()))
+    }
+
+    fn should_skip_contract_set_start_after_target(&self, start_block: i64) -> bool {
+        matches!(self.contract_set_mode, IndexerContractSetMode::All)
+            && self.target_height < start_block
     }
 }
 
@@ -1030,5 +1039,71 @@ mod tests {
             options.checkpoint_identity.contract_set_id,
             selected[0].contract_set_id
         );
+    }
+
+    #[test]
+    fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
+        let config = DatalensConfig {
+            endpoint: "https://datalens.ringdao.com".to_owned(),
+            application: "degov-live".to_owned(),
+            bearer_token: degov_datalens_indexer::SecretString::new("unit-test-redacted-value"),
+            timeout: Duration::from_secs(60),
+            finality: degov_datalens_indexer::DatalensFinality::DurableOnly,
+            chain: degov_datalens_indexer::ChainIdentityConfig {
+                family: degov_datalens_indexer::ChainFamily::Evm,
+                configured_name: "ethereum".to_owned(),
+                network_id: Some(1),
+            },
+            dataset: degov_datalens_indexer::DatasetKeyConfig {
+                family: "evm".to_owned(),
+                name: "logs".to_owned(),
+            },
+            query_limits: degov_datalens_indexer::QueryLimitConfig {
+                block_range_limit: 1_000,
+            },
+            dao_contracts: None,
+            chains: vec![degov_datalens_indexer::DatalensChainConfig {
+                family: degov_datalens_indexer::ChainFamily::Evm,
+                configured_name: "lisk".to_owned(),
+                network_id: 1135,
+                contracts: vec![degov_datalens_indexer::DatalensContractSetConfig {
+                    dao_code: Some("lisk-dao".to_owned()),
+                    chain_id: 1135,
+                    network_name: "lisk".to_owned(),
+                    governor: "0x1111111111111111111111111111111111111111".to_owned(),
+                    governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+                    governor_token_standard: degov_datalens_indexer::GovernanceTokenStandard::Erc20,
+                    timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+                    start_block: 568752,
+                }],
+            }],
+        };
+        let runtime = IndexerRuntimeConfig {
+            dao_filter: Some("lisk-dao".to_owned()),
+            contract_set_mode: IndexerContractSetMode::Single,
+            target_height: 568751,
+            checkpoint_stream_id: "datalens-native".to_owned(),
+            data_source_version: "datalens-v1".to_owned(),
+            query_max_attempts: 3,
+            progress_refresh_lag_blocks: 100,
+            poll_interval: Duration::from_secs(10),
+            run_once: true,
+            max_chunks_per_run: None,
+            database_max_connections: 1,
+        };
+        let selected = config
+            .configured_contract_sets(Some("lisk-dao"))
+            .expect("configured contract sets");
+        let error = runtime
+            .for_configured_contract_set(&selected[0])
+            .expect_err("single mode target below startBlock is invalid");
+        let all_mode_runtime = IndexerRuntimeConfig {
+            contract_set_mode: IndexerContractSetMode::All,
+            ..runtime.clone()
+        };
+
+        assert!(!runtime.should_skip_contract_set_start_after_target(568752));
+        assert!(all_mode_runtime.should_skip_contract_set_start_after_target(568752));
+        assert!(error.to_string().contains("DEGOV_INDEXER_TARGET_HEIGHT"));
     }
 }

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -4,10 +4,11 @@ use anyhow::Context;
 use clap::{Parser, Subcommand};
 use degov_datalens_indexer::{
     BatchReadPlanConfig, ChainContracts, ChainReadMethod, DaoEventDecoder, DatalensConfig,
-    DatalensNativeClient, EvmRpcChainTool, IndexerCheckpointIdentity, IndexerRunner,
-    IndexerRunnerContexts, IndexerRunnerOptions, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
-    PostgresIndexerRunnerStore, ProposalProjectionContext, TimelockProjectionContext,
-    TokenProjectionContext, VoteProjectionContext, verify_datalens_service,
+    DatalensNativeClient, DatalensRuntimeContractSet, EvmRpcChainTool, IndexerCheckpointIdentity,
+    IndexerRunner, IndexerRunnerContexts, IndexerRunnerOptions, OnchainRefreshWorker,
+    OnchainRefreshWorkerConfig, PostgresIndexerRunnerStore, ProposalProjectionContext,
+    TimelockProjectionContext, TokenProjectionContext, VoteProjectionContext,
+    verify_datalens_service,
 };
 use sqlx::{Executor, postgres::PgPoolOptions};
 use tokio::task;
@@ -62,25 +63,13 @@ async fn run_indexer() -> anyhow::Result<()> {
     let config = DatalensConfig::from_env().context("load Datalens configuration")?;
     let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
     let runtime = IndexerRuntimeConfig::from_env()?;
-    let contract_set = config
-        .select_contract_set(&runtime.dao_code)
-        .context("select Datalens indexer contract set")?;
-    let contract_set_id = config.contract_set_scope_id(&runtime.dao_code, &contract_set);
-    let runtime = runtime.with_start_block(contract_set.start_block)?;
-    let runtime = runtime.with_contract_set_scope(contract_set_id);
-    let config = config.for_contract_set(&contract_set);
-    let contracts = contract_set.addresses();
 
     verify_datalens(&config).await?;
     log::info!(
-        "Datalens indexer runtime boundary is ready dao_code={} dao_chain={} dataset={} governor={} token={} timelock={} start_block={} target_height={} database_url_configured={}",
-        runtime.dao_code,
-        config.chain.configured_name,
+        "Datalens indexer runtime boundary is ready contract_set_mode={} dao_filter={:?} dataset={} target_height={} database_url_configured={}",
+        runtime.contract_set_mode.as_str(),
+        runtime.dao_filter,
         config.dataset.key(),
-        contracts.governor,
-        contracts.governor_token,
-        contracts.timelock,
-        runtime.start_block,
         runtime.target_height,
         !database_url.is_empty()
     );
@@ -91,42 +80,47 @@ async fn run_indexer() -> anyhow::Result<()> {
         .await
         .context("connect to DeGov indexer Postgres")?;
     loop {
-        let runtime_pass = runtime.clone();
-        let config_pass = config.clone();
-        let contracts_pass = contracts.clone();
-        let pool_pass = pool.clone();
-        let report = task::spawn_blocking(move || -> anyhow::Result<_> {
-            let client = DatalensNativeClient::from_config(&config_pass)
-                .context("create Datalens client")?;
-            let store = PostgresIndexerRunnerStore::new(pool_pass);
-            let mut runner = IndexerRunner::new(
-                runtime_pass.options(&config_pass, &contracts_pass)?,
-                runtime_pass.contexts(&contracts_pass),
-                client,
-                store,
-                DaoEventDecoder,
+        let contract_sets = runtime
+            .configured_contract_sets(&config)
+            .context("select Datalens indexer contract sets")?;
+
+        for contract_set in contract_sets {
+            let contract_runtime = match runtime.for_configured_contract_set(&contract_set) {
+                Ok(contract_runtime) => contract_runtime,
+                Err(error) if runtime.target_height < contract_set.contract.start_block => {
+                    log::warn!(
+                        "skipping Datalens indexer contract set because configured startBlock is above target dao_code={} chain_id={} contract_set_id={} start_block={} target_height={} error={}",
+                        contract_set.dao_code,
+                        contract_set.contract.chain_id,
+                        contract_set.contract_set_id,
+                        contract_set.contract.start_block,
+                        runtime.target_height,
+                        error
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            let report = run_contract_set_pass(
+                contract_runtime.clone(),
+                contract_set.config.clone(),
+                contract_set.addresses.clone(),
+                pool.clone(),
+            )
+            .await?;
+
+            log::info!(
+                "Datalens indexer run pass completed dao_code={} chain_id={} contract_set_id={} chunks_processed={} processed_height={:?} target_height={} synced_percentage={} onchain_refresh_allowed={}",
+                contract_runtime.dao_code,
+                contract_set.contract.chain_id,
+                contract_runtime.checkpoint_contract_set_id,
+                report.chunks_processed,
+                report.last_progress.processed_height,
+                report.last_progress.target_height,
+                report.last_progress.synced_percentage,
+                report.last_progress.onchain_refresh_allowed
             );
-            if let Some(chunks) = runtime_pass.max_chunks_per_run {
-                runner.request_shutdown_after_chunks(chunks);
-            }
-
-            runner
-                .run_to_target(runtime_pass.target_height)
-                .context("run Datalens indexer to target height")
-        })
-        .await
-        .context("join Datalens indexer runner task")?;
-        let report = report?;
-
-        log::info!(
-            "Datalens indexer run pass completed dao_code={} chunks_processed={} processed_height={:?} target_height={} synced_percentage={} onchain_refresh_allowed={}",
-            runtime.dao_code,
-            report.chunks_processed,
-            report.last_progress.processed_height,
-            report.last_progress.target_height,
-            report.last_progress.synced_percentage,
-            report.last_progress.onchain_refresh_allowed
-        );
+        }
 
         if runtime.run_once {
             return Ok(());
@@ -134,6 +128,48 @@ async fn run_indexer() -> anyhow::Result<()> {
 
         sleep(runtime.poll_interval).await;
     }
+}
+
+async fn run_contract_set_pass(
+    runtime: IndexerContractSetRuntimeConfig,
+    config: DatalensConfig,
+    contracts: degov_datalens_indexer::DaoContractAddresses,
+    pool: sqlx::PgPool,
+) -> anyhow::Result<degov_datalens_indexer::IndexerRunnerReport> {
+    log::info!(
+        "Datalens indexer contract set pass is ready dao_code={} dao_chain={} chain_id={:?} contract_set_id={} governor={} token={} timelock={} start_block={} target_height={}",
+        runtime.dao_code,
+        config.chain.configured_name,
+        config.chain.network_id,
+        runtime.checkpoint_contract_set_id,
+        contracts.governor,
+        contracts.governor_token,
+        contracts.timelock,
+        runtime.start_block,
+        runtime.target_height
+    );
+
+    task::spawn_blocking(move || -> anyhow::Result<_> {
+        let client =
+            DatalensNativeClient::from_config(&config).context("create Datalens client")?;
+        let store = PostgresIndexerRunnerStore::new(pool);
+        let mut runner = IndexerRunner::new(
+            runtime.options(&config, &contracts)?,
+            runtime.contexts(&contracts),
+            client,
+            store,
+            DaoEventDecoder,
+        );
+        if let Some(chunks) = runtime.max_chunks_per_run {
+            runner.request_shutdown_after_chunks(chunks);
+        }
+
+        runner
+            .run_to_target(runtime.target_height)
+            .context("run Datalens indexer to target height")
+    })
+    .await
+    .context("join Datalens indexer runner task")?
 }
 
 async fn run_worker() -> anyhow::Result<()> {
@@ -262,6 +298,47 @@ fn verify_datalens_blocking(config: &DatalensConfig) -> anyhow::Result<()> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct IndexerRuntimeConfig {
+    dao_filter: Option<String>,
+    contract_set_mode: IndexerContractSetMode,
+    target_height: i64,
+    poll_interval: Duration,
+    run_once: bool,
+    max_chunks_per_run: Option<u64>,
+    database_max_connections: u32,
+    checkpoint_stream_id: String,
+    data_source_version: String,
+    query_max_attempts: u32,
+    progress_refresh_lag_blocks: i64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IndexerContractSetMode {
+    Single,
+    All,
+}
+
+impl IndexerContractSetMode {
+    fn from_env() -> anyhow::Result<Self> {
+        match optional_env("DEGOV_INDEXER_CONTRACT_SET_MODE")?
+            .as_deref()
+            .unwrap_or("single")
+        {
+            "single" => Ok(Self::Single),
+            "all" => Ok(Self::All),
+            _ => anyhow::bail!("DEGOV_INDEXER_CONTRACT_SET_MODE must be single or all"),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Single => "single",
+            Self::All => "all",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct IndexerContractSetRuntimeConfig {
     dao_code: String,
     start_block: i64,
     target_height: i64,
@@ -270,15 +347,16 @@ struct IndexerRuntimeConfig {
     data_source_version: String,
     query_max_attempts: u32,
     progress_refresh_lag_blocks: i64,
-    poll_interval: Duration,
-    run_once: bool,
     max_chunks_per_run: Option<u64>,
-    database_max_connections: u32,
 }
 
 impl IndexerRuntimeConfig {
     fn from_env() -> anyhow::Result<Self> {
-        let dao_code = required_env("DEGOV_INDEXER_DAO_CODE")?;
+        let contract_set_mode = IndexerContractSetMode::from_env()?;
+        let dao_filter = match contract_set_mode {
+            IndexerContractSetMode::Single => Some(required_env("DEGOV_INDEXER_DAO_CODE")?),
+            IndexerContractSetMode::All => optional_env("DEGOV_INDEXER_DAO_CODE")?,
+        };
         let target_height = required_env_i64("DEGOV_INDEXER_TARGET_HEIGHT")?;
 
         let query_max_attempts = optional_env_u32("DEGOV_INDEXER_QUERY_MAX_ATTEMPTS")?.unwrap_or(3);
@@ -298,10 +376,9 @@ impl IndexerRuntimeConfig {
         let run_once = optional_env_bool("DEGOV_INDEXER_RUN_ONCE")?.unwrap_or(false);
 
         Ok(Self {
-            dao_code,
-            start_block: 0,
+            dao_filter,
+            contract_set_mode,
             target_height,
-            checkpoint_contract_set_id: String::new(),
             checkpoint_stream_id: optional_env("DEGOV_INDEXER_STREAM_ID")?
                 .unwrap_or_else(|| "datalens-native".to_owned()),
             data_source_version: optional_env("DEGOV_INDEXER_DATA_SOURCE_VERSION")?
@@ -318,6 +395,57 @@ impl IndexerRuntimeConfig {
         })
     }
 
+    fn configured_contract_sets(
+        &self,
+        config: &DatalensConfig,
+    ) -> anyhow::Result<Vec<DatalensRuntimeContractSet>> {
+        match self.contract_set_mode {
+            IndexerContractSetMode::Single => {
+                let dao_code = self
+                    .dao_filter
+                    .as_deref()
+                    .context("DEGOV_INDEXER_DAO_CODE is required")?;
+                let selected = config
+                    .select_contract_set(dao_code)
+                    .context("select Datalens indexer contract set")?;
+                let configured = config
+                    .configured_contract_sets(Some(dao_code))
+                    .context("select configured Datalens indexer contract set")?;
+                configured
+                    .into_iter()
+                    .find(|contract_set| contract_set.contract == selected)
+                    .map(|contract_set| vec![contract_set])
+                    .context("selected Datalens indexer contract set was not configured")
+            }
+            IndexerContractSetMode::All => config
+                .configured_contract_sets(self.dao_filter.as_deref())
+                .context("select configured Datalens indexer contract sets"),
+        }
+    }
+
+    fn for_configured_contract_set(
+        &self,
+        contract_set: &DatalensRuntimeContractSet,
+    ) -> anyhow::Result<IndexerContractSetRuntimeConfig> {
+        let runtime = IndexerContractSetRuntimeConfig {
+            dao_code: contract_set.dao_code.clone(),
+            start_block: 0,
+            target_height: self.target_height,
+            checkpoint_contract_set_id: String::new(),
+            checkpoint_stream_id: self.checkpoint_stream_id.clone(),
+            data_source_version: self.data_source_version.clone(),
+            query_max_attempts: self.query_max_attempts,
+            progress_refresh_lag_blocks: self.progress_refresh_lag_blocks,
+            max_chunks_per_run: self.max_chunks_per_run,
+        };
+
+        Ok(runtime
+            .with_start_block(contract_set.contract.start_block)?
+            .with_contract_set_scope(contract_set.contract_set_id.clone()))
+    }
+}
+
+impl IndexerContractSetRuntimeConfig {
     fn with_start_block(mut self, start_block: i64) -> anyhow::Result<Self> {
         if self.target_height < start_block {
             anyhow::bail!(
@@ -831,6 +959,76 @@ mod tests {
 
                 assert!(error.to_string().contains("DEGOV_INDEXER_TARGET_HEIGHT"));
             },
+        );
+    }
+
+    #[test]
+    fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
+        let config = DatalensConfig {
+            endpoint: "https://datalens.ringdao.com".to_owned(),
+            application: "degov-live".to_owned(),
+            bearer_token: degov_datalens_indexer::SecretString::new("unit-test-redacted-value"),
+            timeout: Duration::from_secs(60),
+            finality: degov_datalens_indexer::DatalensFinality::DurableOnly,
+            chain: degov_datalens_indexer::ChainIdentityConfig {
+                family: degov_datalens_indexer::ChainFamily::Evm,
+                configured_name: "ethereum".to_owned(),
+                network_id: Some(1),
+            },
+            dataset: degov_datalens_indexer::DatasetKeyConfig {
+                family: "evm".to_owned(),
+                name: "logs".to_owned(),
+            },
+            query_limits: degov_datalens_indexer::QueryLimitConfig {
+                block_range_limit: 1_000,
+            },
+            dao_contracts: None,
+            chains: vec![degov_datalens_indexer::DatalensChainConfig {
+                family: degov_datalens_indexer::ChainFamily::Evm,
+                configured_name: "lisk".to_owned(),
+                network_id: 1135,
+                contracts: vec![degov_datalens_indexer::DatalensContractSetConfig {
+                    dao_code: Some("lisk-dao".to_owned()),
+                    chain_id: 1135,
+                    network_name: "lisk".to_owned(),
+                    governor: "0x1111111111111111111111111111111111111111".to_owned(),
+                    governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+                    governor_token_standard: degov_datalens_indexer::GovernanceTokenStandard::Erc20,
+                    timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+                    start_block: 568752,
+                }],
+            }],
+        };
+        let runtime = IndexerRuntimeConfig {
+            dao_filter: Some("lisk-dao".to_owned()),
+            contract_set_mode: IndexerContractSetMode::Single,
+            target_height: 568800,
+            checkpoint_stream_id: "datalens-native".to_owned(),
+            data_source_version: "datalens-v1".to_owned(),
+            query_max_attempts: 3,
+            progress_refresh_lag_blocks: 100,
+            poll_interval: Duration::from_secs(10),
+            run_once: true,
+            max_chunks_per_run: None,
+            database_max_connections: 1,
+        };
+        let selected = config
+            .configured_contract_sets(Some("lisk-dao"))
+            .expect("configured contract sets");
+
+        let planned = runtime
+            .for_configured_contract_set(&selected[0])
+            .expect("planned contract set runtime");
+        let options = planned
+            .options(&selected[0].config, &selected[0].addresses)
+            .expect("runner options");
+
+        assert_eq!(planned.dao_code, "lisk-dao");
+        assert_eq!(planned.start_block, 568752);
+        assert_eq!(options.checkpoint_identity.chain_id, 1135);
+        assert_eq!(
+            options.checkpoint_identity.contract_set_id,
+            selected[0].contract_set_id
         );
     }
 }

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -195,6 +195,20 @@ where
             .store
             .read_or_create_checkpoint(&self.options.checkpoint_identity, self.options.start_block)
             .map_err(to_checkpoint_error)?;
+        let checkpoint_choice = if checkpoint.next_block > self.options.start_block {
+            "resume"
+        } else {
+            "start"
+        };
+        info!(
+            "Datalens indexer checkpoint selected dao_code={} chain_id={} contract_set_id={} start_block={} next_block={} checkpoint_choice={}",
+            self.options.checkpoint_identity.dao_code,
+            self.options.checkpoint_identity.chain_id,
+            self.options.checkpoint_identity.contract_set_id,
+            self.options.start_block,
+            checkpoint.next_block,
+            checkpoint_choice
+        );
 
         loop {
             if self
@@ -421,20 +435,20 @@ fn page_rows(rows: serde_json::Value) -> Result<Vec<serde_json::Value>, IndexerR
         serde_json::Value::Array(rows) => Ok(rows),
         serde_json::Value::Object(mut object) => {
             let Some(rows) = object.remove("rows") else {
-                return Err(invalid_rows_payload_error(serde_json::Value::Object(object)));
+                return Err(invalid_rows_payload_error(serde_json::Value::Object(
+                    object,
+                )));
             };
 
             match rows {
                 serde_json::Value::Array(rows) => Ok(rows),
-                serde_json::Value::Object(mut rows_object) => {
-                    match rows_object.remove("rows") {
-                        Some(serde_json::Value::Array(rows)) => Ok(rows),
-                        Some(other) => Err(invalid_rows_payload_error(other)),
-                        None => Err(invalid_rows_payload_error(serde_json::Value::Object(
-                            rows_object,
-                        ))),
-                    }
-                }
+                serde_json::Value::Object(mut rows_object) => match rows_object.remove("rows") {
+                    Some(serde_json::Value::Array(rows)) => Ok(rows),
+                    Some(other) => Err(invalid_rows_payload_error(other)),
+                    None => Err(invalid_rows_payload_error(serde_json::Value::Object(
+                        rows_object,
+                    ))),
+                },
                 other => Err(invalid_rows_payload_error(other)),
             }
         }

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -130,6 +130,25 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    insert_checkpoint(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
+    let datalens = FakeDatalensServer::start(vec![], vec![], vec![]);
+
+    run_indexer_all_contract_sets_command(&database.database_url, &datalens.endpoint).await?;
+
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
+    assert_checkpoint_scope(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
+    assert_checkpoint_scope(&database.pool, SECOND_CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
+    assert_checkpoint_row_count(&database.pool, 2).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
 async fn run_indexer_command(
     database_url: &str,
     datalens_endpoint: &str,
@@ -181,6 +200,91 @@ async fn run_indexer_command(
     if !status.success() {
         return Err(format!(
             "indexer run failed with status {status}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn run_indexer_all_contract_sets_command(
+    database_url: &str,
+    datalens_endpoint: &str,
+) -> Result<(), Box<dyn Error>> {
+    let chains_json = json!([
+        {
+            "chainId": 1,
+            "networkName": "ethereum",
+            "contracts": [
+                {
+                    "daoCode": "demo-dao",
+                    "chainId": 1,
+                    "networkName": "ethereum",
+                    "governor": GOVERNOR,
+                    "governorToken": TOKEN,
+                    "tokenStandard": "ERC20",
+                    "timelock": TIMELOCK,
+                    "startBlock": 1
+                },
+                {
+                    "daoCode": "demo-dao",
+                    "chainId": 1,
+                    "networkName": "ethereum",
+                    "governor": SECOND_GOVERNOR,
+                    "governorToken": SECOND_TOKEN,
+                    "tokenStandard": "ERC20",
+                    "timelock": SECOND_TIMELOCK,
+                    "startBlock": 1
+                }
+            ]
+        }
+    ])
+    .to_string();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_degov-datalens-indexer"))
+        .arg("run")
+        .env("DEGOV_INDEXER_DATABASE_URL", database_url)
+        .env("DEGOV_INDEXER_CONTRACT_SET_MODE", "all")
+        .env("DEGOV_INDEXER_TARGET_HEIGHT", "2")
+        .env("DEGOV_INDEXER_RUN_ONCE", "true")
+        .env("DATALENS_ENDPOINT", datalens_endpoint)
+        .env("DATALENS_APPLICATION", "degov-test")
+        .env("DATALENS_TOKEN", "unit-test-redacted-value")
+        .env("DATALENS_FINALITY", "durable_only")
+        .env("DATALENS_CHAIN_FAMILY", "evm")
+        .env("DATALENS_CHAIN_NAME", "ethereum")
+        .env("DATALENS_CHAIN_ID", "1")
+        .env("DATALENS_DATASET_FAMILY", "evm")
+        .env("DATALENS_DATASET_NAME", "logs")
+        .env("DATALENS_QUERY_BLOCK_RANGE_LIMIT", "10")
+        .env("DATALENS_CHAINS_JSON", chains_json)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let status = timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(status) = child.try_wait()? {
+                return Ok::<_, std::io::Error>(status);
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    let status = match status {
+        Ok(status) => status?,
+        Err(_) => {
+            let _ = child.kill();
+            return Err("indexer all-mode run command timed out".into());
+        }
+    };
+    let output = child.wait_with_output()?;
+
+    if !status.success() {
+        return Err(format!(
+            "indexer all-mode run failed with status {status}\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         )
@@ -336,6 +440,73 @@ async fn assert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
     assert_eq!(row.get::<i64, _>(0), 3);
     assert_eq!(row.get::<i64, _>(1), 2);
     assert_eq!(row.get::<i64, _>(2), 2);
+
+    Ok(())
+}
+
+async fn insert_checkpoint(
+    pool: &PgPool,
+    contract_set_id: &str,
+    next_block: i64,
+    processed_height: Option<i64>,
+    target_height: Option<i64>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO degov_indexer_checkpoint (
+            dao_code,
+            chain_id,
+            contract_set_id,
+            stream_id,
+            data_source_version,
+            next_block,
+            processed_height,
+            target_height
+        ) VALUES ('demo-dao', 1, $1, 'datalens-native', 'datalens-v1', $2, $3, $4)",
+    )
+    .bind(contract_set_id)
+    .bind(next_block)
+    .bind(processed_height)
+    .bind(target_height)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn assert_checkpoint_scope(
+    pool: &PgPool,
+    contract_set_id: &str,
+    next_block: i64,
+    processed_height: Option<i64>,
+    target_height: Option<i64>,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT next_block::BIGINT, processed_height::BIGINT, target_height::BIGINT
+         FROM degov_indexer_checkpoint
+         WHERE dao_code = 'demo-dao'
+           AND chain_id = 1
+           AND contract_set_id = $1
+           AND stream_id = 'datalens-native'
+           AND data_source_version = 'datalens-v1'",
+    )
+    .bind(contract_set_id)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<i64, _>(0), next_block);
+    assert_eq!(row.get::<Option<i64>, _>(1), processed_height);
+    assert_eq!(row.get::<Option<i64>, _>(2), target_height);
+
+    Ok(())
+}
+
+async fn assert_checkpoint_row_count(pool: &PgPool, expected: i64) -> Result<(), sqlx::Error> {
+    let count: i64 = sqlx::query("SELECT count(*)::BIGINT FROM degov_indexer_checkpoint")
+        .fetch_one(pool)
+        .await?
+        .get(0);
+
+    assert_eq!(count, expected);
 
     Ok(())
 }
@@ -624,6 +795,10 @@ const GOVERNOR: &str = "0x1111111111111111111111111111111111111111";
 const TOKEN: &str = "0x2222222222222222222222222222222222222222";
 const TIMELOCK: &str = "0x3333333333333333333333333333333333333333";
 const CONTRACT_SET_ID: &str = "dao=demo-dao|chain=1|datalens_chain=ethereum|dataset=evm.logs|governor=0x1111111111111111111111111111111111111111|token=0x2222222222222222222222222222222222222222|token_standard=erc20|timelock=0x3333333333333333333333333333333333333333";
+const SECOND_GOVERNOR: &str = "0x4444444444444444444444444444444444444444";
+const SECOND_TOKEN: &str = "0x5555555555555555555555555555555555555555";
+const SECOND_TIMELOCK: &str = "0x6666666666666666666666666666666666666666";
+const SECOND_CONTRACT_SET_ID: &str = "dao=demo-dao|chain=1|datalens_chain=ethereum|dataset=evm.logs|governor=0x4444444444444444444444444444444444444444|token=0x5555555555555555555555555555555555555555|token_standard=erc20|timelock=0x6666666666666666666666666666666666666666";
 const PROPOSER: &str = "0x0000000000000000000000000000000000000a01";
 const TARGET: &str = "0x0000000000000000000000000000000000000a02";
 const VOTER: &str = "0x0000000000000000000000000000000000000b01";


### PR DESCRIPTION
## Summary
- add configured contract-set iteration with explicit all-mode selection
- run the existing single-set IndexerRunner once per selected contract set
- keep scoped checkpoint resume/start behavior independent per contract set

## Tests
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://datalens:datalens@localhost:5432/datalens_test cargo test -p degov-datalens-indexer

Stacked on #771.

Closes HBX-288.