### PR TITLE
Serve GraphiQL on a dedicated indexer path

### DIFF
--- a/apps/indexer/src/graphql/mod.rs
+++ b/apps/indexer/src/graphql/mod.rs
@@ -1,6 +1,7 @@
 use async_graphql::{
     ComplexObject, Context, EmptyMutation, EmptySubscription, Enum, InputObject, Object,
-    Result as GraphqlResult, Schema, SimpleObject, http::GraphiQLSource,
+    Result as GraphqlResult, Schema, SimpleObject,
+    http::{GraphiQLSource, graphiql_plugin_explorer},
 };
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
@@ -59,6 +60,7 @@ async fn graphql_graphiql(endpoint: String) -> impl IntoResponse {
         GraphiQLSource::build()
             .endpoint(&endpoint)
             .title("DeGov Indexer GraphiQL")
+            .plugins(&[graphiql_plugin_explorer()])
             .finish(),
     )
 }

--- a/apps/indexer/src/graphql/mod.rs
+++ b/apps/indexer/src/graphql/mod.rs
@@ -1,13 +1,12 @@
 use async_graphql::{
     ComplexObject, Context, EmptyMutation, EmptySubscription, Enum, InputObject, Object,
-    Result as GraphqlResult, Schema, SimpleObject,
-    http::{GraphQLPlaygroundConfig, playground_source},
+    Result as GraphqlResult, Schema, SimpleObject, http::GraphiQLSource,
 };
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
     Router,
     response::{Html, IntoResponse},
-    routing::get,
+    routing::{get, post},
 };
 use sqlx::{FromRow, PgPool, Postgres, QueryBuilder};
 
@@ -35,7 +34,15 @@ where
 {
     let mut router = Router::new();
     for path in paths {
-        router = router.route(path.as_ref(), get(graphql_playground).post(graphql_handler));
+        let graphql_path = path.as_ref().to_owned();
+        let graphiql_path = graphiql_path_for_graphql_path(&graphql_path);
+        router = router.route(&graphql_path, post(graphql_handler)).route(
+            &graphiql_path,
+            get({
+                let endpoint = graphql_path.clone();
+                move || graphql_graphiql(endpoint.clone())
+            }),
+        );
     }
     router.with_state(schema)
 }
@@ -47,8 +54,25 @@ async fn graphql_handler(
     schema.execute(request.into_inner()).await.into()
 }
 
-async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(GraphQLPlaygroundConfig::new("/graphql")))
+async fn graphql_graphiql(endpoint: String) -> impl IntoResponse {
+    Html(
+        GraphiQLSource::build()
+            .endpoint(&endpoint)
+            .title("DeGov Indexer GraphiQL")
+            .finish(),
+    )
+}
+
+fn graphiql_path_for_graphql_path(path: &str) -> String {
+    path.strip_suffix("/graphql")
+        .map(|prefix| {
+            if prefix.is_empty() {
+                "/graphiql".to_owned()
+            } else {
+                format!("{prefix}/graphiql")
+            }
+        })
+        .unwrap_or_else(|| format!("{path}/graphiql"))
 }
 
 #[derive(Default)]

--- a/apps/indexer/src/graphql/mod.rs
+++ b/apps/indexer/src/graphql/mod.rs
@@ -1,7 +1,7 @@
 use async_graphql::{
     ComplexObject, Context, EmptyMutation, EmptySubscription, Enum, InputObject, Object,
     Result as GraphqlResult, Schema, SimpleObject,
-    http::{GraphiQLSource, graphiql_plugin_explorer},
+    http::{GraphiQLPlugin, GraphiQLSource},
 };
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
@@ -59,10 +59,28 @@ async fn graphql_graphiql(endpoint: String) -> impl IntoResponse {
     Html(
         GraphiQLSource::build()
             .endpoint(&endpoint)
+            .version("3.9.0")
             .title("DeGov Indexer GraphiQL")
-            .plugins(&[graphiql_plugin_explorer()])
+            .plugins(&[graphiql_explorer_plugin()])
             .finish(),
     )
+}
+
+fn graphiql_explorer_plugin<'a>() -> GraphiQLPlugin<'a> {
+    GraphiQLPlugin {
+        name: "GraphiQLPluginExplorer",
+        constructor: "GraphiQLPluginExplorer.explorerPlugin",
+        head_assets: Some(
+            r#"<link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer@3.0.0/dist/style.css" />"#,
+        ),
+        body_assets: Some(
+            r#"<script
+      src="https://unpkg.com/@graphiql/plugin-explorer@3.0.0/dist/index.umd.js"
+      crossorigin
+    ></script>"#,
+        ),
+        ..Default::default()
+    }
 }
 
 fn graphiql_path_for_graphql_path(path: &str) -> String {

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -450,6 +450,32 @@ async fn test_graphql_http_endpoint_serves_post_requests() -> Result<(), Box<dyn
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_http_endpoint_serves_graphiql_on_dedicated_path() -> Result<(), Box<dyn Error>>
+{
+    let database = TestDatabase::connect().await?;
+    let schema = graphql::build_schema(database.pool.clone());
+    let app = graphql::build_router(schema);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let graphiql_endpoint = format!("http://{}/graphiql", listener.local_addr()?);
+    let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let response = timeout(
+        Duration::from_secs(5),
+        Client::new().get(graphiql_endpoint).send(),
+    )
+    .await??;
+    assert!(response.status().is_success());
+    let body = response.text().await?;
+    assert!(body.contains("GraphiQL"));
+    assert!(body.contains("/graphql"));
+
+    server.abort();
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_schema_serves_indexer_accuracy_audit_queries() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     let schema = graphql::build_schema(database.pool.clone());
@@ -528,6 +554,32 @@ async fn test_graphql_http_endpoint_serves_configured_dao_path() -> Result<(), B
     .await?;
 
     assert_eq!(response["data"]["squidStatus"]["height"], 900);
+
+    server.abort();
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_http_endpoint_serves_configured_dao_graphiql_path()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let schema = graphql::build_schema(database.pool.clone());
+    let app = graphql::build_router_with_paths(schema, ["/degov-demo-dao/graphql".to_owned()]);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let graphiql_endpoint = format!("http://{}/degov-demo-dao/graphiql", listener.local_addr()?);
+    let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let response = timeout(
+        Duration::from_secs(5),
+        Client::new().get(graphiql_endpoint).send(),
+    )
+    .await??;
+    assert!(response.status().is_success());
+    let body = response.text().await?;
+    assert!(body.contains("GraphiQL"));
+    assert!(body.contains("/degov-demo-dao/graphql"));
 
     server.abort();
     database.cleanup().await?;

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -456,8 +456,16 @@ async fn test_graphql_http_endpoint_serves_graphiql_on_dedicated_path() -> Resul
     let schema = graphql::build_schema(database.pool.clone());
     let app = graphql::build_router(schema);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let graphql_endpoint = format!("http://{}/graphql", listener.local_addr()?);
     let graphiql_endpoint = format!("http://{}/graphiql", listener.local_addr()?);
     let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let response = timeout(
+        Duration::from_secs(5),
+        Client::new().get(graphql_endpoint).send(),
+    )
+    .await??;
+    assert_eq!(response.status().as_u16(), 405);
 
     let response = timeout(
         Duration::from_secs(5),
@@ -571,8 +579,16 @@ async fn test_graphql_http_endpoint_serves_configured_dao_graphiql_path()
     let schema = graphql::build_schema(database.pool.clone());
     let app = graphql::build_router_with_paths(schema, ["/degov-demo-dao/graphql".to_owned()]);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let graphql_endpoint = format!("http://{}/degov-demo-dao/graphql", listener.local_addr()?);
     let graphiql_endpoint = format!("http://{}/degov-demo-dao/graphiql", listener.local_addr()?);
     let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let response = timeout(
+        Duration::from_secs(5),
+        Client::new().get(graphql_endpoint).send(),
+    )
+    .await??;
+    assert_eq!(response.status().as_u16(), 405);
 
     let response = timeout(
         Duration::from_secs(5),

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -468,6 +468,8 @@ async fn test_graphql_http_endpoint_serves_graphiql_on_dedicated_path() -> Resul
     let body = response.text().await?;
     assert!(body.contains("GraphiQL"));
     assert!(body.contains("/graphql"));
+    assert!(body.contains("@graphiql/plugin-explorer"));
+    assert!(body.contains("GraphiQLPluginExplorer.explorerPlugin"));
 
     server.abort();
     database.cleanup().await?;
@@ -580,6 +582,8 @@ async fn test_graphql_http_endpoint_serves_configured_dao_graphiql_path()
     let body = response.text().await?;
     assert!(body.contains("GraphiQL"));
     assert!(body.contains("/degov-demo-dao/graphql"));
+    assert!(body.contains("@graphiql/plugin-explorer"));
+    assert!(body.contains("GraphiQLPluginExplorer.explorerPlugin"));
 
     server.abort();
     database.cleanup().await?;

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -468,7 +468,8 @@ async fn test_graphql_http_endpoint_serves_graphiql_on_dedicated_path() -> Resul
     let body = response.text().await?;
     assert!(body.contains("GraphiQL"));
     assert!(body.contains("/graphql"));
-    assert!(body.contains("@graphiql/plugin-explorer"));
+    assert!(body.contains("graphiql@3.9.0"));
+    assert!(body.contains("@graphiql/plugin-explorer@3.0.0"));
     assert!(body.contains("GraphiQLPluginExplorer.explorerPlugin"));
 
     server.abort();
@@ -582,7 +583,8 @@ async fn test_graphql_http_endpoint_serves_configured_dao_graphiql_path()
     let body = response.text().await?;
     assert!(body.contains("GraphiQL"));
     assert!(body.contains("/degov-demo-dao/graphql"));
-    assert!(body.contains("@graphiql/plugin-explorer"));
+    assert!(body.contains("graphiql@3.9.0"));
+    assert!(body.contains("@graphiql/plugin-explorer@3.0.0"));
     assert!(body.contains("GraphiQLPluginExplorer.explorerPlugin"));
 
     server.abort();


### PR DESCRIPTION
## Summary

- replace the GraphQL Playground response with GraphiQL
- keep the GraphQL API as POST-only on `/graphql`
- expose the interactive UI on a dedicated `/graphiql` route
- enable the GraphiQL Explorer plugin so fields can be selected from the left panel and inserted into the editor
- pin GraphiQL and Explorer CDN assets to versions that provide compatible UMD bundles
- derive DAO-scoped UI paths from configured API paths, e.g. `/lisk-dao/graphql` -> `/lisk-dao/graphiql`

## Why

The old behavior served the playground from the same `/graphql` path as the API, which made local and remote interaction awkward. This matches the Datalens-style split where API traffic and browser UI traffic use separate paths.

The Explorer plugin also needs pinned CDN assets. The unversioned async-graphql helper resolves to the latest `@graphiql/plugin-explorer`, which no longer exposes the expected UMD bundle and leaves the browser stuck at `Loading...` with `GraphiQLPluginExplorer is not defined`.

## Validation

- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55444/indexer cargo test -p degov-datalens-indexer --test graphql_service --locked`
- `cargo fmt --all --check`
- `cargo build -p degov-datalens-indexer --locked`
- rebuilt and restarted the local docker compose `indexer-graphql` service
- verified `POST http://eu2.ncp.kahub.in:8005/graphql` returns GraphQL data
- verified `GET http://eu2.ncp.kahub.in:8005/graphiql` renders GraphiQL instead of staying on `Loading...`
- verified browser console has zero errors in a fresh Playwright session
- verified the Explorer panel opens and lists schema fields such as `contributors`, `proposals`, and `squidStatus`
- verified `GET http://127.0.0.1:8005/graphql` returns `405 Method Not Allowed`
