### PR TITLE
Add indexer config file loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +499,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
+dependencies = [
+ "pathdiff",
+ "serde_core",
+ "serde_json",
+ "toml",
+ "winnow",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +698,7 @@ dependencies = [
  "async-graphql-axum",
  "axum",
  "clap",
+ "config",
  "datalens-sdk",
  "ethabi",
  "figment",
@@ -919,6 +940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,7 +1109,16 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1098,6 +1134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1758,6 +1803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,6 +2444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,7 +2586,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "log",
  "memchr",
@@ -2893,6 +2953,19 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -3578,6 +3651,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.11.0",
 ]
 
 [[package]]

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -11,6 +11,7 @@ async-graphql = "7.2.1"
 async-graphql-axum = "7.2.1"
 axum = "0.8.9"
 clap = { version = "4.6.1", features = ["derive"] }
+config = { version = "0.15.23", default-features = false, features = ["yaml", "json", "toml"] }
 datalens-sdk = { git = "https://github.com/ringecosystem/datalens", rev = "1744283cd1547240e0bc290b5fa3c5d1c55e74d6" }
 ethabi = "18.0.0"
 figment = { version = "0.10.19", features = ["env"] }

--- a/apps/indexer/indexer.example.yml
+++ b/apps/indexer/indexer.example.yml
@@ -1,0 +1,46 @@
+# DeGov Datalens indexer example configuration.
+#
+# Load this file with:
+#   DEGOV_INDEXER_CONFIG_FILE=apps/indexer/indexer.example.yml
+#
+# Keep DATALENS_TOKEN in the environment or a secret manager. It is intentionally
+# omitted here. Environment variables override values from this file.
+#
+# Set DEGOV_INDEXER_DAO_CODE to run one contract set. Leave it unset to run all
+# configured contract sets when every contract has daoCode.
+
+datalens:
+  endpoint: https://datalens.ringdao.com
+  application: degov-live
+  finality: durable_only
+  dataset:
+    family: evm
+    name: logs
+  queryLimits:
+    blockRangeLimit: 1000
+
+chains:
+  - chainId: 1
+    networkName: ethereum
+    contracts:
+      - daoCode: ens-dao
+        governor: "0x0000000000000000000000000000000000000001"
+        governorToken: "0x0000000000000000000000000000000000000002"
+        tokenStandard: ERC20
+        timelock: "0x0000000000000000000000000000000000000003"
+        startBlock: 13533418
+      - daoCode: demo-ethereum-dao
+        governor: "0x0000000000000000000000000000000000000004"
+        governorToken: "0x0000000000000000000000000000000000000005"
+        tokenStandard: ERC721
+        timelock: "0x0000000000000000000000000000000000000006"
+        startBlock: 18000000
+  - chainId: 1135
+    networkName: lisk
+    contracts:
+      - daoCode: lisk-dao
+        governor: "0x0000000000000000000000000000000000000007"
+        governorToken: "0x0000000000000000000000000000000000000008"
+        tokenStandard: ERC20
+        timelock: "0x0000000000000000000000000000000000000009"
+        startBlock: 568752

--- a/apps/indexer/src/config/env.rs
+++ b/apps/indexer/src/config/env.rs
@@ -2,13 +2,86 @@ use figment::{
     Figment,
     providers::{Env, Serialized},
 };
+use serde::{Deserialize, Serialize};
+use std::{env, path::Path};
 
 use crate::ConfigError;
 
-use super::RawDatalensConfig;
+use super::{RawDatalensChainConfig, RawDatalensConfig};
+
+pub(super) const DEGOV_INDEXER_CONFIG_FILE: &str = "DEGOV_INDEXER_CONFIG_FILE";
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct RawDatalensEnvOverlay {
+    datalens_endpoint: Option<String>,
+    datalens_application: Option<String>,
+    datalens_token: Option<String>,
+    datalens_timeout_seconds: Option<u64>,
+    datalens_finality: Option<String>,
+    datalens_chain_family: Option<String>,
+    datalens_chain_name: Option<String>,
+    datalens_chain_id: Option<i32>,
+    datalens_dataset_family: Option<String>,
+    datalens_dataset_name: Option<String>,
+    datalens_query_block_range_limit: Option<u32>,
+    datalens_governor_address: Option<String>,
+    datalens_governor_token_address: Option<String>,
+    datalens_governor_token_standard: Option<String>,
+    datalens_timelock_address: Option<String>,
+    datalens_chains_json: Option<String>,
+    degov_indexer_dao_code: Option<String>,
+    degov_indexer_start_block: Option<i64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct RawIndexerFileConfig {
+    datalens: Option<RawDatalensFileConfig>,
+    chains: Option<Vec<RawDatalensChainConfig>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawDatalensFileConfig {
+    endpoint: Option<String>,
+    application: Option<String>,
+    token: Option<String>,
+    timeout_seconds: Option<u64>,
+    finality: Option<String>,
+    chain_family: Option<String>,
+    chain_name: Option<String>,
+    chain_id: Option<i32>,
+    dataset: Option<RawDatalensDatasetFileConfig>,
+    query_limits: Option<RawDatalensQueryLimitFileConfig>,
+    governor_address: Option<String>,
+    governor_token_address: Option<String>,
+    governor_token_standard: Option<String>,
+    timelock_address: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawDatalensDatasetFileConfig {
+    family: Option<String>,
+    name: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawDatalensQueryLimitFileConfig {
+    block_range_limit: Option<u32>,
+}
 
 pub(super) fn load_raw_from_env() -> Result<RawDatalensConfig, ConfigError> {
-    Figment::from(Serialized::defaults(RawDatalensConfig::default()))
+    let mut raw = RawDatalensConfig::default();
+    if let Some(config_file) = optional_config_file()? {
+        raw.apply_file(load_raw_from_file(&config_file)?)?;
+    }
+    raw.apply_env(load_env_overlay()?)?;
+    Ok(raw)
+}
+
+fn load_env_overlay() -> Result<RawDatalensEnvOverlay, ConfigError> {
+    Figment::from(Serialized::defaults(RawDatalensEnvOverlay::default()))
         .merge(Env::raw().only(&[
             "DATALENS_ENDPOINT",
             "DATALENS_APPLICATION",
@@ -31,4 +104,142 @@ pub(super) fn load_raw_from_env() -> Result<RawDatalensConfig, ConfigError> {
         ]))
         .extract()
         .map_err(|error| ConfigError::Load(error.to_string()))
+}
+
+fn optional_config_file() -> Result<Option<String>, ConfigError> {
+    match env::var(DEGOV_INDEXER_CONFIG_FILE) {
+        Ok(value) if value.trim().is_empty() => Ok(None),
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(ConfigError::Load(format!(
+            "failed to read {DEGOV_INDEXER_CONFIG_FILE}: {error}"
+        ))),
+    }
+}
+
+fn load_raw_from_file(config_file: &str) -> Result<RawIndexerFileConfig, ConfigError> {
+    ::config::Config::builder()
+        .add_source(::config::File::from(Path::new(config_file)))
+        .build()
+        .map_err(|error| {
+            ConfigError::Load(format!(
+                "failed to load {DEGOV_INDEXER_CONFIG_FILE}: {error}"
+            ))
+        })?
+        .try_deserialize()
+        .map_err(|error| {
+            ConfigError::Load(format!(
+                "failed to parse {DEGOV_INDEXER_CONFIG_FILE}: {error}"
+            ))
+        })
+}
+
+impl RawDatalensConfig {
+    fn apply_file(&mut self, file: RawIndexerFileConfig) -> Result<(), ConfigError> {
+        if let Some(datalens) = file.datalens {
+            assign_if_some(&mut self.datalens_endpoint, datalens.endpoint);
+            assign_if_some(&mut self.datalens_application, datalens.application);
+            assign_if_some(&mut self.datalens_token, datalens.token);
+            assign_value_if_some(&mut self.datalens_timeout_seconds, datalens.timeout_seconds);
+            assign_value_if_some(&mut self.datalens_finality, datalens.finality);
+            assign_value_if_some(&mut self.datalens_chain_family, datalens.chain_family);
+            assign_value_if_some(&mut self.datalens_chain_name, datalens.chain_name);
+            assign_if_some(&mut self.datalens_chain_id, datalens.chain_id);
+            assign_if_some(
+                &mut self.datalens_governor_address,
+                datalens.governor_address,
+            );
+            assign_if_some(
+                &mut self.datalens_governor_token_address,
+                datalens.governor_token_address,
+            );
+            assign_if_some(
+                &mut self.datalens_governor_token_standard,
+                datalens.governor_token_standard,
+            );
+            assign_if_some(
+                &mut self.datalens_timelock_address,
+                datalens.timelock_address,
+            );
+
+            if let Some(dataset) = datalens.dataset {
+                assign_value_if_some(&mut self.datalens_dataset_family, dataset.family);
+                assign_value_if_some(&mut self.datalens_dataset_name, dataset.name);
+            }
+            if let Some(query_limits) = datalens.query_limits {
+                assign_value_if_some(
+                    &mut self.datalens_query_block_range_limit,
+                    query_limits.block_range_limit,
+                );
+            }
+        }
+
+        if let Some(chains) = file.chains {
+            self.datalens_chains_json = Some(
+                serde_json::to_string(&chains)
+                    .map_err(|error| ConfigError::Load(error.to_string()))?,
+            );
+        }
+
+        Ok(())
+    }
+
+    fn apply_env(&mut self, env: RawDatalensEnvOverlay) -> Result<(), ConfigError> {
+        assign_if_some(&mut self.datalens_endpoint, env.datalens_endpoint);
+        assign_if_some(&mut self.datalens_application, env.datalens_application);
+        assign_if_some(&mut self.datalens_token, env.datalens_token);
+        assign_value_if_some(
+            &mut self.datalens_timeout_seconds,
+            env.datalens_timeout_seconds,
+        );
+        assign_value_if_some(&mut self.datalens_finality, env.datalens_finality);
+        assign_value_if_some(&mut self.datalens_chain_family, env.datalens_chain_family);
+        assign_value_if_some(&mut self.datalens_chain_name, env.datalens_chain_name);
+        assign_if_some(&mut self.datalens_chain_id, env.datalens_chain_id);
+        assign_value_if_some(
+            &mut self.datalens_dataset_family,
+            env.datalens_dataset_family,
+        );
+        assign_value_if_some(&mut self.datalens_dataset_name, env.datalens_dataset_name);
+        assign_value_if_some(
+            &mut self.datalens_query_block_range_limit,
+            env.datalens_query_block_range_limit,
+        );
+        assign_if_some(
+            &mut self.datalens_governor_address,
+            env.datalens_governor_address,
+        );
+        assign_if_some(
+            &mut self.datalens_governor_token_address,
+            env.datalens_governor_token_address,
+        );
+        assign_if_some(
+            &mut self.datalens_governor_token_standard,
+            env.datalens_governor_token_standard,
+        );
+        assign_if_some(
+            &mut self.datalens_timelock_address,
+            env.datalens_timelock_address,
+        );
+        assign_if_some(&mut self.datalens_chains_json, env.datalens_chains_json);
+        assign_if_some(&mut self.degov_indexer_dao_code, env.degov_indexer_dao_code);
+        assign_if_some(
+            &mut self.degov_indexer_start_block,
+            env.degov_indexer_start_block,
+        );
+
+        Ok(())
+    }
+}
+
+fn assign_if_some<T>(target: &mut Option<T>, value: Option<T>) {
+    if value.is_some() {
+        *target = value;
+    }
+}
+
+fn assign_value_if_some<T>(target: &mut T, value: Option<T>) {
+    if let Some(value) = value {
+        *target = value;
+    }
 }

--- a/apps/indexer/src/config/mod.rs
+++ b/apps/indexer/src/config/mod.rs
@@ -203,7 +203,7 @@ struct RawDatalensConfig {
     degov_indexer_start_block: Option<i64>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct RawDatalensChainConfig {
     #[serde(rename = "chainId", alias = "chain_id")]
     chain_id: Option<i32>,
@@ -212,7 +212,7 @@ struct RawDatalensChainConfig {
     contracts: Option<Vec<RawDatalensContractSetConfig>>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct RawDatalensContractSetConfig {
     #[serde(rename = "daoCode", alias = "dao_code")]
     dao_code: Option<String>,
@@ -680,7 +680,7 @@ fn parse_contract_config(
     parent_network_name: &str,
     raw: RawDatalensContractSetConfig,
 ) -> Result<DatalensContractSetConfig, ConfigError> {
-    let chain_id = required_i32_path(format!("{contract_path}.chainId"), raw.chain_id)?;
+    let chain_id = raw.chain_id.unwrap_or(parent_chain_id);
     validate_chain_id(format!("{contract_path}.chainId"), chain_id)?;
     if chain_id != parent_chain_id {
         return Err(ConfigError::InvalidField {
@@ -688,8 +688,9 @@ fn parse_contract_config(
             reason: format!("must match parent chainId {parent_chain_id}"),
         });
     }
-    let network_name =
-        required_string_path(format!("{contract_path}.networkName"), raw.network_name)?;
+    let network_name = raw
+        .network_name
+        .unwrap_or_else(|| parent_network_name.to_owned());
     if network_name != parent_network_name {
         return Err(ConfigError::InvalidField {
             field: format!("{contract_path}.networkName"),

--- a/apps/indexer/tests/config.rs
+++ b/apps/indexer/tests/config.rs
@@ -1,4 +1,9 @@
-use std::time::Duration;
+use std::{
+    fs,
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use degov_datalens_indexer::{
     ConfigError, DatalensConfig, DatalensFinality, GovernanceTokenStandard, SecretString,
@@ -6,6 +11,24 @@ use degov_datalens_indexer::{
 
 fn with_datalens_env<T>(vars: &[(&str, Option<&str>)], test: impl FnOnce() -> T) -> T {
     temp_env::with_vars(vars, test)
+}
+
+fn write_config_file(extension: &str, contents: &str) -> PathBuf {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after unix epoch")
+        .as_nanos();
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("degov-indexer-config-{timestamp}-{id}.{extension}"));
+    fs::write(&path, contents).expect("write config file fixture");
+    path
+}
+
+fn remove_config_file(path: PathBuf) {
+    fs::remove_file(path).expect("remove config file fixture");
 }
 
 #[test]
@@ -189,6 +212,283 @@ fn test_from_env_loads_multi_chain_contract_config_json() {
             assert_eq!(selected.start_block, 568752);
         },
     );
+}
+
+#[test]
+fn test_from_env_loads_yaml_config_file_with_env_secret() {
+    let path = write_config_file(
+        "yml",
+        r#"
+datalens:
+  endpoint: https://datalens.ringdao.com/
+  application: degov-live
+  finality: durable_only
+  dataset:
+    family: evm
+    name: logs
+  queryLimits:
+    blockRangeLimit: 777
+chains:
+  - chainId: 1
+    networkName: ethereum
+    contracts:
+      - daoCode: ens-dao
+        governor: "0x1111111111111111111111111111111111111111"
+        governorToken: "0x2222222222222222222222222222222222222222"
+        tokenStandard: ERC20
+        timelock: "0x3333333333333333333333333333333333333333"
+        startBlock: 13533418
+  - chainId: 1135
+    networkName: lisk
+    contracts:
+      - daoCode: lisk-dao
+        governor: "0x4444444444444444444444444444444444444444"
+        governorToken: "0x5555555555555555555555555555555555555555"
+        tokenStandard: ERC20
+        timelock: "0x6666666666666666666666666666666666666666"
+        startBlock: 568752
+"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+        ],
+        || {
+            let config = DatalensConfig::from_env().expect("load yaml config");
+
+            assert_eq!(config.endpoint, "https://datalens.ringdao.com");
+            assert_eq!(config.application, "degov-live");
+            assert_eq!(
+                config.bearer_token.expose_secret(),
+                "unit-test-redacted-value"
+            );
+            assert_eq!(config.query_limits.block_range_limit, 777);
+            assert_eq!(config.chains.len(), 2);
+            assert_eq!(config.chains[0].contracts[0].chain_id, 1);
+            assert_eq!(config.chains[0].contracts[0].network_name, "ethereum");
+            assert_eq!(
+                config.chains[1].contracts[0].dao_code.as_deref(),
+                Some("lisk-dao")
+            );
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_from_env_overrides_config_file_values() {
+    let path = write_config_file(
+        "yml",
+        r#"
+datalens:
+  endpoint: https://file-datalens.example
+  application: file-application
+  token: file-token-for-local-only
+  queryLimits:
+    blockRangeLimit: 1000
+chains:
+  - chainId: 1
+    networkName: ethereum
+    contracts:
+      - daoCode: file-dao
+        governor: "0x1111111111111111111111111111111111111111"
+        governorToken: "0x2222222222222222222222222222222222222222"
+        tokenStandard: ERC20
+        timelock: "0x3333333333333333333333333333333333333333"
+        startBlock: 100
+"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DATALENS_ENDPOINT", Some("https://env-datalens.example/")),
+            ("DATALENS_APPLICATION", Some("env-application")),
+            ("DATALENS_TOKEN", Some("env-token")),
+            ("DATALENS_QUERY_BLOCK_RANGE_LIMIT", Some("250")),
+            (
+                "DATALENS_CHAINS_JSON",
+                Some(
+                    r#"[
+                        {
+                            "chainId": 1135,
+                            "networkName": "lisk",
+                            "contracts": [
+                                {
+                                    "daoCode": "env-dao",
+                                    "governor": "0x4444444444444444444444444444444444444444",
+                                    "governorToken": "0x5555555555555555555555555555555555555555",
+                                    "tokenStandard": "ERC20",
+                                    "timelock": "0x6666666666666666666666666666666666666666",
+                                    "startBlock": 568752
+                                }
+                            ]
+                        }
+                    ]"#,
+                ),
+            ),
+        ],
+        || {
+            let config = DatalensConfig::from_env().expect("load config with env overrides");
+
+            assert_eq!(config.endpoint, "https://env-datalens.example");
+            assert_eq!(config.application, "env-application");
+            assert_eq!(config.bearer_token.expose_secret(), "env-token");
+            assert_eq!(config.query_limits.block_range_limit, 250);
+            assert_eq!(config.chains.len(), 1);
+            assert_eq!(config.chains[0].network_id, 1135);
+            assert_eq!(
+                config.chains[0].contracts[0].dao_code.as_deref(),
+                Some("env-dao")
+            );
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_from_env_loads_toml_config_file() {
+    let path = write_config_file(
+        "toml",
+        r#"
+[datalens]
+endpoint = "https://datalens.ringdao.com"
+application = "degov-live"
+
+[datalens.dataset]
+family = "evm"
+name = "logs"
+
+[[chains]]
+chainId = 1
+networkName = "ethereum"
+
+[[chains.contracts]]
+daoCode = "ens-dao"
+governor = "0x1111111111111111111111111111111111111111"
+governorToken = "0x2222222222222222222222222222222222222222"
+tokenStandard = "ERC20"
+timelock = "0x3333333333333333333333333333333333333333"
+startBlock = 13533418
+"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+        ],
+        || {
+            let config = DatalensConfig::from_env().expect("load toml config");
+
+            assert_eq!(config.chains.len(), 1);
+            assert_eq!(
+                config.chains[0].contracts[0].dao_code.as_deref(),
+                Some("ens-dao")
+            );
+            assert_eq!(config.dataset.key(), "evm.logs");
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_from_env_loads_json_config_file() {
+    let path = write_config_file(
+        "json",
+        r#"{
+  "datalens": {
+    "endpoint": "https://datalens.ringdao.com",
+    "application": "degov-live"
+  },
+  "chains": [
+    {
+      "chainId": 1135,
+      "networkName": "lisk",
+      "contracts": [
+        {
+          "daoCode": "lisk-dao",
+          "governor": "0x1111111111111111111111111111111111111111",
+          "governorToken": "0x2222222222222222222222222222222222222222",
+          "tokenStandard": "ERC20",
+          "timelock": "0x3333333333333333333333333333333333333333",
+          "startBlock": 568752
+        }
+      ]
+    }
+  ]
+}"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+        ],
+        || {
+            let config = DatalensConfig::from_env().expect("load json config");
+
+            assert_eq!(config.chains.len(), 1);
+            assert_eq!(config.chains[0].network_id, 1135);
+            assert_eq!(
+                config
+                    .select_contract_set("lisk-dao")
+                    .expect("select")
+                    .governor,
+                "0x1111111111111111111111111111111111111111"
+            );
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_from_env_config_file_still_requires_secret() {
+    let path = write_config_file(
+        "yml",
+        r#"
+datalens:
+  endpoint: https://datalens.ringdao.com
+  application: degov-live
+"#,
+    );
+
+    with_datalens_env(
+        &[(
+            "DEGOV_INDEXER_CONFIG_FILE",
+            Some(path.to_str().expect("utf8 path")),
+        )],
+        || {
+            let error = DatalensConfig::from_env().expect_err("missing token fails");
+
+            assert_eq!(
+                error,
+                ConfigError::MissingRequired {
+                    field: "DATALENS_TOKEN"
+                }
+            );
+        },
+    );
+
+    remove_config_file(path);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add optional `DEGOV_INDEXER_CONFIG_FILE` support for YAML, TOML, and JSON indexer config files using the Rust `config` crate
- keep current env-only startup and `DATALENS_CHAINS_JSON` compatibility intact
- layer config as built-in defaults < config file < environment variables
- add `apps/indexer/indexer.example.yml` with multi-chain and multi-contract examples and no secrets

## Config Precedence

1. Built-in defaults populate existing default Datalens values.
2. `DEGOV_INDEXER_CONFIG_FILE`, when set, loads file values into the same raw config model.
3. Existing environment variables override file values, including `DATALENS_CHAINS_JSON`, `DATALENS_TOKEN`, and `DEGOV_INDEXER_DAO_CODE`.

`DATALENS_TOKEN` remains intended for env/secret-manager usage. The loader supports a file token only for local development compatibility, and the example file intentionally omits it.

## Compatibility

- Existing single DAO env fields continue to work.
- Existing `DATALENS_CHAINS_JSON` multi-chain config continues to work.
- Runtime indexing behavior, DB schema, GraphQL schema, projection logic, Datalens query semantics, and onchain refresh semantics are unchanged.

## Validation

- `cargo fmt --all --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55444/indexer cargo test -p degov-datalens-indexer --locked`
- `cargo build -p degov-datalens-indexer --locked`
- `cd apps/indexer && node ./scripts/check-rust-conventions.mjs`
- `cd apps/indexer && node ./scripts/check-postgres-schema.mjs`

Refs HBX-300