### PR TITLE
feat(indexer): add scoped graphql context

### DIFF
--- a/apps/indexer/src/graphql/filters.rs
+++ b/apps/indexer/src/graphql/filters.rs
@@ -4,12 +4,22 @@ use super::types::*;
 
 pub(super) fn push_proposal_where<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
+    implicit_scope: &'a GraphqlScope,
     where_: Option<&'a ProposalWhereInput>,
 ) {
-    if let Some(where_) = where_ {
+    if !implicit_scope.is_empty() || where_.is_some() {
         query.push(" WHERE ");
         let mut has_condition = false;
-        push_proposal_filters(query, &mut has_condition, where_, "proposal");
+        push_implicit_scope_filters(query, &mut has_condition, implicit_scope, "proposal", true);
+        if let Some(where_) = where_ {
+            push_proposal_filters(
+                query,
+                &mut has_condition,
+                implicit_scope,
+                where_,
+                "proposal",
+            );
+        }
         if !has_condition {
             query.push("TRUE");
         }
@@ -19,6 +29,7 @@ pub(super) fn push_proposal_where<'a>(
 pub(super) fn push_proposal_filters<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
     has_condition: &mut bool,
+    implicit_scope: &'a GraphqlScope,
     where_: &'a ProposalWhereInput,
     table_alias: &str,
 ) {
@@ -47,12 +58,13 @@ pub(super) fn push_proposal_filters<'a>(
         push_and(query, has_condition);
         query.push("EXISTS (SELECT 1 FROM vote_cast_group v WHERE v.proposal_id = proposal.id");
         let mut nested_has_condition = true;
+        push_implicit_scope_filters(query, &mut nested_has_condition, implicit_scope, "v", true);
         push_vote_cast_group_filters(query, &mut nested_has_condition, voters_some, "v");
         query.push(")");
     }
     if let Some(or) = &where_.or {
         push_or_group(query, has_condition, or, |query, has_condition, filter| {
-            push_proposal_filters(query, has_condition, filter, table_alias);
+            push_proposal_filters(query, has_condition, implicit_scope, filter, table_alias);
         });
     }
 }
@@ -60,8 +72,10 @@ pub(super) fn push_proposal_filters<'a>(
 pub(super) fn push_vote_cast_group_where<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
     has_condition: &mut bool,
+    implicit_scope: &'a GraphqlScope,
     where_: Option<&'a VoteCastGroupWhereInput>,
 ) {
+    push_implicit_scope_filters(query, has_condition, implicit_scope, "", true);
     if let Some(where_) = where_ {
         push_vote_cast_group_filters(query, has_condition, where_, "");
     }
@@ -88,14 +102,18 @@ pub(super) fn push_vote_cast_group_filters<'a>(
 
 pub(super) fn push_event_where<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
+    implicit_scope: &'a GraphqlScope,
     where_: Option<&'a impl ProposalEventWhere>,
 ) {
-    if let Some(where_) = where_ {
+    if !implicit_scope.is_empty() || where_.is_some() {
         query.push(" WHERE ");
         let mut has_condition = false;
-        push_scope_filters(query, &mut has_condition, where_.scope(), "");
-        if let Some(proposal_id) = where_.proposal_id_eq() {
-            push_column_eq(query, &mut has_condition, "", "proposal_id", proposal_id);
+        push_implicit_event_scope_filters(query, &mut has_condition, implicit_scope, "");
+        if let Some(where_) = where_ {
+            push_scope_filters(query, &mut has_condition, where_.scope(), "");
+            if let Some(proposal_id) = where_.proposal_id_eq() {
+                push_column_eq(query, &mut has_condition, "", "proposal_id", proposal_id);
+            }
         }
         if !has_condition {
             query.push("TRUE");
@@ -105,12 +123,16 @@ pub(super) fn push_event_where<'a>(
 
 pub(super) fn push_data_metric_where<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
+    implicit_scope: &'a GraphqlScope,
     where_: Option<&'a DataMetricWhereInput>,
 ) {
-    if let Some(where_) = where_ {
+    if !implicit_scope.is_empty() || where_.is_some() {
         query.push(" WHERE ");
         let mut has_condition = false;
-        push_data_metric_filters(query, &mut has_condition, where_, "");
+        push_implicit_scope_filters(query, &mut has_condition, implicit_scope, "", true);
+        if let Some(where_) = where_ {
+            push_data_metric_filters(query, &mut has_condition, where_, "");
+        }
         if !has_condition {
             query.push("TRUE");
         }
@@ -199,12 +221,16 @@ pub(super) fn push_data_metric_filters<'a>(
 
 pub(super) fn push_contributor_where<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
+    implicit_scope: &'a GraphqlScope,
     where_: Option<&'a ContributorWhereInput>,
 ) {
-    if let Some(where_) = where_ {
+    if !implicit_scope.is_empty() || where_.is_some() {
         query.push(" WHERE ");
         let mut has_condition = false;
-        push_contributor_filters(query, &mut has_condition, where_, "");
+        push_implicit_scope_filters(query, &mut has_condition, implicit_scope, "", true);
+        if let Some(where_) = where_ {
+            push_contributor_filters(query, &mut has_condition, where_, "");
+        }
         if !has_condition {
             query.push("TRUE");
         }
@@ -245,12 +271,16 @@ pub(super) fn push_contributor_filters<'a>(
 
 pub(super) fn push_delegate_where<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
+    implicit_scope: &'a GraphqlScope,
     where_: Option<&'a DelegateWhereInput>,
 ) {
-    if let Some(where_) = where_ {
+    if !implicit_scope.is_empty() || where_.is_some() {
         query.push(" WHERE ");
         let mut has_condition = false;
-        push_delegate_filters(query, &mut has_condition, where_, "");
+        push_implicit_scope_filters(query, &mut has_condition, implicit_scope, "", true);
+        if let Some(where_) = where_ {
+            push_delegate_filters(query, &mut has_condition, where_, "");
+        }
         if !has_condition {
             query.push("TRUE");
         }
@@ -299,17 +329,21 @@ pub(super) fn push_delegate_filters<'a>(
 
 pub(super) fn push_delegate_mapping_where<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
+    implicit_scope: &'a GraphqlScope,
     where_: Option<&'a DelegateMappingWhereInput>,
 ) {
-    if let Some(where_) = where_ {
+    if !implicit_scope.is_empty() || where_.is_some() {
         query.push(" WHERE ");
         let mut has_condition = false;
-        push_scope_filters(query, &mut has_condition, &where_.scope, "");
-        if let Some(from) = &where_.from_eq {
-            push_column_eq(query, &mut has_condition, "", r#""from""#, from);
-        }
-        if let Some(to) = &where_.to_eq {
-            push_column_eq(query, &mut has_condition, "", r#""to""#, to);
+        push_implicit_scope_filters(query, &mut has_condition, implicit_scope, "", true);
+        if let Some(where_) = where_ {
+            push_scope_filters(query, &mut has_condition, &where_.scope, "");
+            if let Some(from) = &where_.from_eq {
+                push_column_eq(query, &mut has_condition, "", r#""from""#, from);
+            }
+            if let Some(to) = &where_.to_eq {
+                push_column_eq(query, &mut has_condition, "", r#""to""#, to);
+            }
         }
         if !has_condition {
             query.push("TRUE");
@@ -337,6 +371,62 @@ pub(super) fn push_scope_filters<'a>(
     }
     if let Some(dao_code) = &scope.dao_code_eq {
         push_column_eq(query, has_condition, table_alias, "dao_code", dao_code);
+    }
+}
+
+pub(super) fn push_implicit_scope_filters<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    scope: &'a GraphqlScope,
+    table_alias: &str,
+    include_contract_set_id: bool,
+) {
+    if let Some(chain_id) = scope.chain_id {
+        push_column_eq(query, has_condition, table_alias, "chain_id", chain_id);
+    }
+    if let Some(governor_address) = &scope.governor_address {
+        push_column_eq(
+            query,
+            has_condition,
+            table_alias,
+            "governor_address",
+            governor_address,
+        );
+    }
+    if let Some(dao_code) = &scope.dao_code {
+        push_column_eq(query, has_condition, table_alias, "dao_code", dao_code);
+    }
+    if include_contract_set_id {
+        if let Some(contract_set_id) = &scope.contract_set_id {
+            push_column_eq(
+                query,
+                has_condition,
+                table_alias,
+                "contract_set_id",
+                contract_set_id,
+            );
+        }
+    }
+}
+
+pub(super) fn push_implicit_event_scope_filters<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    scope: &'a GraphqlScope,
+    table_alias: &str,
+) {
+    push_implicit_scope_filters(query, has_condition, scope, table_alias, false);
+    if let Some(contract_set_id) = &scope.contract_set_id {
+        push_and(query, has_condition);
+        query.push("EXISTS (SELECT 1 FROM proposal p WHERE p.contract_set_id = ");
+        query.push_bind(contract_set_id);
+        query.push(" AND p.proposal_id = ");
+        push_qualified_column(query, table_alias, "proposal_id");
+        query.push(" AND p.chain_id IS NOT DISTINCT FROM ");
+        push_qualified_column(query, table_alias, "chain_id");
+        query.push(" AND p.governor_address IS NOT DISTINCT FROM ");
+        push_qualified_column(query, table_alias, "governor_address");
+        query.push(")");
     }
 }
 

--- a/apps/indexer/src/graphql/mod.rs
+++ b/apps/indexer/src/graphql/mod.rs
@@ -6,8 +6,12 @@ mod router;
 mod schema;
 mod types;
 
-pub use router::{IndexerGraphqlSchema, build_router, build_router_with_paths, build_schema};
+pub use router::{
+    IndexerGraphqlSchema, build_router, build_router_with_paths, build_router_with_scoped_paths,
+    build_schema, build_schema_with_scope,
+};
 pub use schema::QueryRoot;
+pub use types::GraphqlScope;
 
 #[derive(Clone)]
 pub(super) struct GraphqlState {

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -8,6 +8,7 @@ use super::types::*;
 
 pub(super) async fn query_proposals(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&ProposalWhereInput>,
     order_by: Option<&[ProposalOrderByInput]>,
     offset: Option<i32>,
@@ -15,22 +16,24 @@ pub(super) async fn query_proposals(
 ) -> GraphqlResult<Vec<Proposal>> {
     let mut query = QueryBuilder::<Postgres>::new(
         r#"
-        SELECT id, chain_id, dao_code, governor_address, proposal_id, proposer, targets, values,
-          signatures, calldatas, vote_start::text AS vote_start, vote_end::text AS vote_end,
-          description, block_number::text AS block_number, block_timestamp::text AS block_timestamp,
-          transaction_hash, metrics_votes_count, metrics_votes_with_params_count,
-          metrics_votes_without_params_count, metrics_votes_weight_for_sum::text AS metrics_votes_weight_for_sum,
+        SELECT id, contract_set_id, chain_id, dao_code, governor_address, proposal_id, proposer,
+          targets, values, signatures, calldatas, vote_start::text AS vote_start,
+          vote_end::text AS vote_end, description, block_number::text AS block_number,
+          block_timestamp::text AS block_timestamp, transaction_hash, metrics_votes_count,
+          metrics_votes_with_params_count, metrics_votes_without_params_count,
+          metrics_votes_weight_for_sum::text AS metrics_votes_weight_for_sum,
           metrics_votes_weight_against_sum::text AS metrics_votes_weight_against_sum,
-          metrics_votes_weight_abstain_sum::text AS metrics_votes_weight_abstain_sum, title,
-          vote_start_timestamp::text AS vote_start_timestamp, vote_end_timestamp::text AS vote_end_timestamp,
-          block_interval, clock_mode, proposal_deadline::text AS proposal_deadline,
-          proposal_eta::text AS proposal_eta, queue_ready_at::text AS queue_ready_at,
-          queue_expires_at::text AS queue_expires_at, quorum::text AS quorum, decimals::text AS decimals,
-          timelock_address, timelock_grace_period::text AS timelock_grace_period
+          metrics_votes_weight_abstain_sum::text AS metrics_votes_weight_abstain_sum,
+          title, vote_start_timestamp::text AS vote_start_timestamp,
+          vote_end_timestamp::text AS vote_end_timestamp, block_interval, clock_mode,
+          proposal_deadline::text AS proposal_deadline, proposal_eta::text AS proposal_eta,
+          queue_ready_at::text AS queue_ready_at, queue_expires_at::text AS queue_expires_at,
+          quorum::text AS quorum, decimals::text AS decimals, timelock_address,
+          timelock_grace_period::text AS timelock_grace_period
         FROM proposal
         "#,
     );
-    push_proposal_where(&mut query, where_);
+    push_proposal_where(&mut query, implicit_scope, where_);
     push_proposal_order(&mut query, order_by);
     push_page(&mut query, offset, limit);
 
@@ -39,16 +42,18 @@ pub(super) async fn query_proposals(
 
 pub(super) async fn count_proposals(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&ProposalWhereInput>,
 ) -> GraphqlResult<i64> {
     let mut query = QueryBuilder::<Postgres>::new("SELECT COUNT(*)::int8 AS total FROM proposal");
-    push_proposal_where(&mut query, where_);
+    push_proposal_where(&mut query, implicit_scope, where_);
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)
 }
 
 pub(super) async fn query_events<T>(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     table: &'static str,
     where_: Option<&impl ProposalEventWhere>,
     order_by: Option<&[EventOrderByInput]>,
@@ -65,7 +70,7 @@ where
         FROM {table}
         "#
     ));
-    push_event_where(&mut query, where_);
+    push_event_where(&mut query, implicit_scope, where_);
     push_event_order(&mut query, table, order_by);
     push_page(&mut query, offset, limit);
 
@@ -74,6 +79,7 @@ where
 
 pub(super) async fn query_data_metrics(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&DataMetricWhereInput>,
     order_by: Option<&[DataMetricOrderByInput]>,
     offset: Option<i32>,
@@ -90,7 +96,7 @@ pub(super) async fn query_data_metrics(
         FROM data_metric
         "#,
     );
-    push_data_metric_where(&mut query, where_);
+    push_data_metric_where(&mut query, implicit_scope, where_);
     push_data_metric_order(&mut query, order_by);
     push_page(&mut query, offset, limit);
 
@@ -99,17 +105,19 @@ pub(super) async fn query_data_metrics(
 
 pub(super) async fn count_data_metrics(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&DataMetricWhereInput>,
 ) -> GraphqlResult<i64> {
     let mut query =
         QueryBuilder::<Postgres>::new("SELECT COUNT(*)::int8 AS total FROM data_metric");
-    push_data_metric_where(&mut query, where_);
+    push_data_metric_where(&mut query, implicit_scope, where_);
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)
 }
 
 pub(super) async fn query_contributors(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&ContributorWhereInput>,
     order_by: Option<&[ContributorOrderByInput]>,
     offset: Option<i32>,
@@ -124,7 +132,7 @@ pub(super) async fn query_contributors(
         FROM contributor
         "#,
     );
-    push_contributor_where(&mut query, where_);
+    push_contributor_where(&mut query, implicit_scope, where_);
     push_contributor_order(&mut query, order_by);
     push_page(&mut query, offset, limit);
 
@@ -133,6 +141,7 @@ pub(super) async fn query_contributors(
 
 pub(super) async fn query_delegates(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&DelegateWhereInput>,
     order_by: Option<&[DelegateOrderByInput]>,
     offset: Option<i32>,
@@ -146,7 +155,7 @@ pub(super) async fn query_delegates(
         FROM delegate
         "#,
     );
-    push_delegate_where(&mut query, where_);
+    push_delegate_where(&mut query, implicit_scope, where_);
     push_delegate_order(&mut query, order_by);
     push_page(&mut query, offset, limit);
 
@@ -155,6 +164,7 @@ pub(super) async fn query_delegates(
 
 pub(super) async fn query_delegate_mappings(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&DelegateMappingWhereInput>,
     order_by: Option<&[DelegateMappingOrderByInput]>,
     offset: Option<i32>,
@@ -168,7 +178,7 @@ pub(super) async fn query_delegate_mappings(
         FROM delegate_mapping
         "#,
     );
-    push_delegate_mapping_where(&mut query, where_);
+    push_delegate_mapping_where(&mut query, implicit_scope, where_);
     push_delegate_mapping_order(&mut query, order_by);
     push_page(&mut query, offset, limit);
 
@@ -177,32 +187,35 @@ pub(super) async fn query_delegate_mappings(
 
 pub(super) async fn count_contributors(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&ContributorWhereInput>,
 ) -> GraphqlResult<i64> {
     let mut query =
         QueryBuilder::<Postgres>::new("SELECT COUNT(*)::int8 AS total FROM contributor");
-    push_contributor_where(&mut query, where_);
+    push_contributor_where(&mut query, implicit_scope, where_);
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)
 }
 
 pub(super) async fn count_delegates(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&DelegateWhereInput>,
 ) -> GraphqlResult<i64> {
     let mut query = QueryBuilder::<Postgres>::new("SELECT COUNT(*)::int8 AS total FROM delegate");
-    push_delegate_where(&mut query, where_);
+    push_delegate_where(&mut query, implicit_scope, where_);
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)
 }
 
 pub(super) async fn count_delegate_mappings(
     pool: &PgPool,
+    implicit_scope: &GraphqlScope,
     where_: Option<&DelegateMappingWhereInput>,
 ) -> GraphqlResult<i64> {
     let mut query =
         QueryBuilder::<Postgres>::new("SELECT COUNT(*)::int8 AS total FROM delegate_mapping");
-    push_delegate_mapping_where(&mut query, where_);
+    push_delegate_mapping_where(&mut query, implicit_scope, where_);
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)
 }

--- a/apps/indexer/src/graphql/router.rs
+++ b/apps/indexer/src/graphql/router.rs
@@ -3,17 +3,23 @@ use async_graphql::{EmptyMutation, EmptySubscription, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
     Router,
+    extract::State,
     response::{Html, IntoResponse},
     routing::{get, post},
 };
 
-use super::{GraphqlState, QueryRoot};
+use super::{GraphqlScope, GraphqlState, QueryRoot};
 
 pub type IndexerGraphqlSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
 pub fn build_schema(pool: sqlx::PgPool) -> IndexerGraphqlSchema {
+    build_schema_with_scope(pool, GraphqlScope::default())
+}
+
+pub fn build_schema_with_scope(pool: sqlx::PgPool, scope: GraphqlScope) -> IndexerGraphqlSchema {
     Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
         .data(GraphqlState { pool })
+        .data(scope)
         .finish()
 }
 
@@ -26,26 +32,56 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
+    build_router_with_scoped_paths(
+        schema,
+        paths.into_iter().map(|path| {
+            let path = path.as_ref().to_owned();
+            let scope = GraphqlScope::from_graphql_path(&path);
+            (path, scope)
+        }),
+    )
+}
+
+pub fn build_router_with_scoped_paths<I, S>(schema: IndexerGraphqlSchema, paths: I) -> Router
+where
+    I: IntoIterator<Item = (S, GraphqlScope)>,
+    S: AsRef<str>,
+{
     let mut router = Router::new();
-    for path in paths {
+    for (path, scope) in paths {
         let graphql_path = path.as_ref().to_owned();
         let graphiql_path = graphiql_path_for_graphql_path(&graphql_path);
-        router = router.route(&graphql_path, post(graphql_handler)).route(
-            &graphiql_path,
-            get({
-                let endpoint = graphql_path.clone();
-                move || graphql_graphiql(endpoint.clone())
-            }),
-        );
+        router = router
+            .route(
+                &graphql_path,
+                post({
+                    let scope = scope.clone();
+                    move |State(schema): State<IndexerGraphqlSchema>, request: GraphQLRequest| {
+                        let scope = scope.clone();
+                        async move { graphql_handler(schema, request, scope).await }
+                    }
+                }),
+            )
+            .route(
+                &graphiql_path,
+                get({
+                    let endpoint = graphql_path.clone();
+                    move || graphql_graphiql(endpoint.clone())
+                }),
+            );
     }
     router.with_state(schema)
 }
 
 async fn graphql_handler(
-    axum::extract::State(schema): axum::extract::State<IndexerGraphqlSchema>,
+    schema: IndexerGraphqlSchema,
     request: GraphQLRequest,
+    scope: GraphqlScope,
 ) -> GraphQLResponse {
-    schema.execute(request.into_inner()).await.into()
+    schema
+        .execute(request.into_inner().data(scope))
+        .await
+        .into()
 }
 
 async fn graphql_graphiql(endpoint: String) -> impl IntoResponse {

--- a/apps/indexer/src/graphql/schema.rs
+++ b/apps/indexer/src/graphql/schema.rs
@@ -22,7 +22,15 @@ impl QueryRoot {
         limit: Option<i32>,
     ) -> GraphqlResult<Vec<Proposal>> {
         let pool = pool(ctx)?;
-        query_proposals(pool, where_.as_ref(), order_by.as_deref(), offset, limit).await
+        query_proposals(
+            pool,
+            scope(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
     }
 
     async fn proposal_canceleds(
@@ -35,6 +43,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Vec<ProposalCanceled>> {
         query_events(
             pool(ctx)?,
+            scope(ctx)?,
             "proposal_canceled",
             where_.as_ref(),
             order_by.as_deref(),
@@ -54,6 +63,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Vec<ProposalExecuted>> {
         query_events(
             pool(ctx)?,
+            scope(ctx)?,
             "proposal_executed",
             where_.as_ref(),
             order_by.as_deref(),
@@ -80,7 +90,7 @@ impl QueryRoot {
             FROM proposal_queued
             "#,
         );
-        push_event_where(&mut query, where_.as_ref());
+        push_event_where(&mut query, scope(ctx)?, where_.as_ref());
         push_event_order(&mut query, "proposal_queued", order_by.as_deref());
         push_page(&mut query, offset, limit);
 
@@ -97,6 +107,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Vec<DataMetric>> {
         query_data_metrics(
             pool(ctx)?,
+            scope(ctx)?,
             where_.as_ref(),
             order_by.as_deref(),
             offset,
@@ -115,6 +126,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Vec<Contributor>> {
         query_contributors(
             pool(ctx)?,
+            scope(ctx)?,
             where_.as_ref(),
             order_by.as_deref(),
             offset,
@@ -133,6 +145,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Vec<Delegate>> {
         query_delegates(
             pool(ctx)?,
+            scope(ctx)?,
             where_.as_ref(),
             order_by.as_deref(),
             offset,
@@ -151,6 +164,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Vec<DelegateMapping>> {
         query_delegate_mappings(
             pool(ctx)?,
+            scope(ctx)?,
             where_.as_ref(),
             order_by.as_deref(),
             offset,
@@ -185,7 +199,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Connection> {
         let _ = order_by;
         Ok(Connection {
-            total_count: count_proposals(pool(ctx)?, where_.as_ref()).await?,
+            total_count: count_proposals(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
         })
     }
 
@@ -197,7 +211,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Connection> {
         let _ = order_by;
         Ok(Connection {
-            total_count: count_contributors(pool(ctx)?, where_.as_ref()).await?,
+            total_count: count_contributors(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
         })
     }
 
@@ -209,7 +223,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Connection> {
         let _ = order_by;
         Ok(Connection {
-            total_count: count_delegates(pool(ctx)?, where_.as_ref()).await?,
+            total_count: count_delegates(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
         })
     }
 
@@ -221,7 +235,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Connection> {
         let _ = order_by;
         Ok(Connection {
-            total_count: count_delegate_mappings(pool(ctx)?, where_.as_ref()).await?,
+            total_count: count_delegate_mappings(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
         })
     }
 
@@ -233,7 +247,7 @@ impl QueryRoot {
     ) -> GraphqlResult<Connection> {
         let _ = order_by;
         Ok(Connection {
-            total_count: count_data_metrics(pool(ctx)?, where_.as_ref()).await?,
+            total_count: count_data_metrics(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
         })
     }
 }
@@ -258,10 +272,14 @@ impl Proposal {
             "#,
         );
         query
-            .push(" WHERE (proposal_id = ")
+            .push(" WHERE ((proposal_id = ")
             .push_bind(&self.id)
-            .push(" OR (ref_proposal_id = ")
-            .push_bind(&self.proposal_id);
+            .push(" AND contract_set_id = ")
+            .push_bind(&self.contract_set_id)
+            .push(") OR (ref_proposal_id = ")
+            .push_bind(&self.proposal_id)
+            .push(" AND contract_set_id = ")
+            .push_bind(&self.contract_set_id);
         if let Some(chain_id) = self.chain_id {
             query.push(" AND chain_id = ").push_bind(chain_id);
         }
@@ -275,7 +293,7 @@ impl Proposal {
         }
         query.push("))");
         let mut has_condition = true;
-        push_vote_cast_group_where(&mut query, &mut has_condition, where_.as_ref());
+        push_vote_cast_group_where(&mut query, &mut has_condition, scope(ctx)?, where_.as_ref());
         push_vote_cast_group_order(&mut query, order_by.as_deref());
         push_page(&mut query, offset, limit);
 
@@ -285,4 +303,8 @@ impl Proposal {
 
 fn pool<'a>(ctx: &'a Context<'_>) -> GraphqlResult<&'a sqlx::PgPool> {
     Ok(&ctx.data::<GraphqlState>()?.pool)
+}
+
+fn scope<'a>(ctx: &'a Context<'_>) -> GraphqlResult<&'a GraphqlScope> {
+    Ok(ctx.data::<GraphqlScope>()?)
 }

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -1,10 +1,44 @@
 use async_graphql::{Enum, InputObject, SimpleObject};
 use sqlx::FromRow;
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct GraphqlScope {
+    pub dao_code: Option<String>,
+    pub chain_id: Option<i32>,
+    pub governor_address: Option<String>,
+    pub contract_set_id: Option<String>,
+}
+
+impl GraphqlScope {
+    pub(super) fn is_empty(&self) -> bool {
+        self.dao_code.is_none()
+            && self.chain_id.is_none()
+            && self.governor_address.is_none()
+            && self.contract_set_id.is_none()
+    }
+
+    pub(super) fn from_graphql_path(path: &str) -> Self {
+        let Some(prefix) = path.strip_suffix("/graphql") else {
+            return Self::default();
+        };
+        let dao_code = prefix.trim_matches('/');
+        if dao_code.is_empty() || dao_code.contains('/') {
+            return Self::default();
+        }
+
+        Self {
+            dao_code: Some(dao_code.to_owned()),
+            ..Self::default()
+        }
+    }
+}
+
 #[derive(Clone, Debug, FromRow, SimpleObject)]
 #[graphql(rename_fields = "camelCase", complex)]
 pub struct Proposal {
     pub(super) id: String,
+    #[graphql(skip)]
+    pub(super) contract_set_id: String,
     pub(super) chain_id: Option<i32>,
     pub(super) dao_code: Option<String>,
     pub(super) governor_address: Option<String>,

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -15,6 +15,7 @@ use tokio::sync::{Mutex, MutexGuard};
 use tokio::time::timeout;
 
 const CONTRACT_SET_ID: &str = "dao=lisk-dao|chain=1135|datalens_chain=lisk|dataset=evm.logs|governor=0xgovernor|token=0xtoken|token_standard=erc20|timelock=0xtimelock";
+const OTHER_CONTRACT_SET_ID: &str = "dao=ens-dao|chain=10|datalens_chain=ethereum|dataset=evm.logs|governor=0xensgovernor|token=0xenstoken|token_standard=erc20";
 static SCHEMA_COUNTER: AtomicU64 = AtomicU64::new(0);
 static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
@@ -542,6 +543,222 @@ async fn test_graphql_schema_serves_indexer_accuracy_audit_queries() -> Result<(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_schema_applies_implicit_scope_to_queries_and_connections()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_other_scope_rows(&database.pool).await?;
+    let schema = graphql::build_schema_with_scope(
+        database.pool.clone(),
+        graphql::GraphqlScope {
+            dao_code: Some("lisk-dao".to_owned()),
+            chain_id: Some(1135),
+            governor_address: Some("0xgovernor".to_owned()),
+            contract_set_id: Some(CONTRACT_SET_ID.to_owned()),
+        },
+    );
+
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query ScopedQueries {
+              proposals(orderBy: [id_ASC]) {
+                proposalId
+                daoCode
+                voters(orderBy: [id_ASC]) { voter }
+              }
+              proposalCanceleds(orderBy: [id_ASC]) { proposalId }
+              proposalExecuteds(orderBy: [id_ASC]) { proposalId }
+              proposalQueueds(orderBy: [id_ASC]) { proposalId etaSeconds }
+              dataMetrics(orderBy: id_ASC) { id daoCode }
+              contributors(orderBy: [id_ASC]) { id daoCode }
+              delegates(orderBy: [id_ASC]) { id daoCode }
+              delegateMappings(orderBy: [id_ASC]) { id daoCode }
+              proposalsConnection { totalCount }
+              dataMetricsConnection { totalCount }
+              contributorsConnection { totalCount }
+              delegatesConnection { totalCount }
+              delegateMappingsConnection { totalCount }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+
+    let data = response.data.into_json()?;
+    assert_eq!(data["proposals"].as_array().expect("proposals").len(), 2);
+    assert_eq!(data["proposals"][0]["daoCode"], "lisk-dao");
+    assert_eq!(
+        data["proposals"][0]["voters"]
+            .as_array()
+            .expect("voters")
+            .len(),
+        2
+    );
+    assert_eq!(
+        data["proposalCanceleds"]
+            .as_array()
+            .expect("canceled")
+            .len(),
+        1
+    );
+    assert_eq!(
+        data["proposalExecuteds"]
+            .as_array()
+            .expect("executed")
+            .len(),
+        1
+    );
+    assert_eq!(data["proposalQueueds"].as_array().expect("queued").len(), 1);
+    assert_eq!(data["dataMetricsConnection"]["totalCount"], 3);
+    assert_eq!(data["contributorsConnection"]["totalCount"], 2);
+    assert_eq!(data["delegatesConnection"]["totalCount"], 1);
+    assert_eq!(data["delegateMappingsConnection"]["totalCount"], 1);
+    assert_eq!(data["proposalsConnection"]["totalCount"], 2);
+    assert_eq!(data["dataMetrics"][0]["daoCode"], "lisk-dao");
+    assert_eq!(data["contributors"][0]["daoCode"], "lisk-dao");
+    assert_eq!(data["delegates"][0]["daoCode"], "lisk-dao");
+    assert_eq!(data["delegateMappings"][0]["daoCode"], "lisk-dao");
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_schema_scope_conflicts_return_no_rows() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_other_scope_rows(&database.pool).await?;
+    let schema = graphql::build_schema_with_scope(
+        database.pool.clone(),
+        graphql::GraphqlScope {
+            dao_code: Some("lisk-dao".to_owned()),
+            chain_id: Some(1135),
+            governor_address: Some("0xgovernor".to_owned()),
+            contract_set_id: Some(CONTRACT_SET_ID.to_owned()),
+        },
+    );
+
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query ScopedConflicts {
+              proposals(where: { daoCode_eq: "ens-dao" }) { id }
+              proposalCanceleds(where: { daoCode_eq: "ens-dao" }) { id }
+              proposalExecuteds(where: { daoCode_eq: "ens-dao" }) { id }
+              proposalQueueds(where: { daoCode_eq: "ens-dao" }) { id }
+              dataMetrics(where: { daoCode_eq: "ens-dao" }) { id }
+              contributors(where: { daoCode_eq: "ens-dao" }) { id }
+              delegates(where: { daoCode_eq: "ens-dao" }) { id }
+              delegateMappings(where: { daoCode_eq: "ens-dao" }) { id }
+              proposalsConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              dataMetricsConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              contributorsConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              delegatesConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              delegateMappingsConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+
+    let data = response.data.into_json()?;
+    for field in [
+        "proposals",
+        "proposalCanceleds",
+        "proposalExecuteds",
+        "proposalQueueds",
+        "dataMetrics",
+        "contributors",
+        "delegates",
+        "delegateMappings",
+    ] {
+        assert_eq!(data[field].as_array().expect(field).len(), 0, "{field}");
+    }
+    for field in [
+        "proposalsConnection",
+        "dataMetricsConnection",
+        "contributorsConnection",
+        "delegatesConnection",
+        "delegateMappingsConnection",
+    ] {
+        assert_eq!(data[field]["totalCount"], 0, "{field}");
+    }
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_http_dao_path_applies_path_scope_and_preserves_admin()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_other_scope_rows(&database.pool).await?;
+    let schema = graphql::build_schema(database.pool.clone());
+    let app = graphql::build_router_with_paths(
+        schema,
+        ["/graphql".to_owned(), "/ens-dao/graphql".to_owned()],
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let admin_endpoint = format!("http://{}/graphql", listener.local_addr()?);
+    let ens_endpoint = format!("http://{}/ens-dao/graphql", listener.local_addr()?);
+    let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let admin_response: serde_json::Value = timeout(
+        Duration::from_secs(5),
+        Client::new()
+            .post(admin_endpoint)
+            .json(&json!({
+                "query": "query { contributorsConnection { totalCount } contributors(orderBy: [id_ASC]) { daoCode } }"
+            }))
+            .send(),
+    )
+    .await??
+    .json()
+    .await?;
+    let ens_response: serde_json::Value = timeout(
+        Duration::from_secs(5),
+        Client::new()
+            .post(ens_endpoint)
+            .json(&json!({
+                "query": "query { contributorsConnection { totalCount } contributors(orderBy: [id_ASC]) { daoCode } }"
+            }))
+            .send(),
+    )
+    .await??
+    .json()
+    .await?;
+
+    assert_eq!(
+        admin_response["data"]["contributorsConnection"]["totalCount"],
+        3
+    );
+    assert_eq!(
+        ens_response["data"]["contributorsConnection"]["totalCount"],
+        1
+    );
+    assert_eq!(
+        ens_response["data"]["contributors"][0]["daoCode"],
+        "ens-dao"
+    );
+
+    server.abort();
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_http_endpoint_serves_configured_dao_path() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     let schema = graphql::build_schema(database.pool.clone());
@@ -761,6 +978,104 @@ async fn seed_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
         VALUES (0, 900, '0xstatus');
         "#,
     )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn seed_other_scope_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO proposal (
+          id, contract_set_id, chain_id, dao_code, governor_address, contract_address, log_index, transaction_index,
+          proposal_id, proposer, targets, values, signatures, calldatas, vote_start, vote_end,
+          description, block_number, block_timestamp, transaction_hash,
+          metrics_votes_count, metrics_votes_with_params_count, metrics_votes_without_params_count,
+          metrics_votes_weight_for_sum, metrics_votes_weight_against_sum, metrics_votes_weight_abstain_sum,
+          title, vote_start_timestamp, vote_end_timestamp, clock_mode, quorum, decimals
+        ) VALUES (
+          'proposal:10:0xensgovernor:201', $1, 10, 'ens-dao', '0xensgovernor', '0xensgovernor', 1, 0,
+          '201', '0xensproposer', ARRAY['0xenstarget'], ARRAY['0'], ARRAY['transfer(address,uint256)'], ARRAY['0x'],
+          1000, 2000, 'ENS treasury program', 900, 1700001100, '0xensproposal',
+          1, 0, 1, 50, 0, 0, 'ENS treasury program', 1700001000, 1700002000, 'mode=blocknumber&from=default', 40, 18
+        )
+        "#,
+    )
+    .bind(OTHER_CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO vote_cast_group (
+          id, contract_set_id, chain_id, dao_code, governor_address, contract_address, log_index, transaction_index,
+          proposal_id, type, voter, ref_proposal_id, support, weight, reason, params,
+          block_number, block_timestamp, transaction_hash
+        ) VALUES (
+          'vote:201:1', $1, 10, 'ens-dao', '0xensgovernor', '0xensgovernor', 2, 0,
+          'proposal:10:0xensgovernor:201', 'vote-cast', '0xensvoter', '201', 1, 50, 'yes', NULL,
+          905, 1700001110, '0xensvote'
+        )
+        "#,
+    )
+    .bind(OTHER_CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+    sqlx::raw_sql(
+        r#"
+        INSERT INTO proposal_canceled (id, chain_id, dao_code, governor_address, proposal_id, block_number, block_timestamp, transaction_hash)
+        VALUES ('cancel:201', 10, 'ens-dao', '0xensgovernor', '201', 910, 1700001130, '0xenscancel');
+        INSERT INTO proposal_executed (id, chain_id, dao_code, governor_address, proposal_id, block_number, block_timestamp, transaction_hash)
+        VALUES ('execute:201', 10, 'ens-dao', '0xensgovernor', '201', 920, 1700001140, '0xensexecute');
+        INSERT INTO proposal_queued (id, chain_id, dao_code, governor_address, proposal_id, eta_seconds, block_number, block_timestamp, transaction_hash)
+        VALUES ('queue:201', 10, 'ens-dao', '0xensgovernor', '201', 1700001200, 915, 1700001135, '0xensqueue');
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO data_metric (
+          id, contract_set_id, chain_id, dao_code, governor_address, votes_count, votes_with_params_count,
+          votes_without_params_count, votes_weight_for_sum, votes_weight_against_sum,
+          votes_weight_abstain_sum, power_sum, member_count, proposals_count
+        ) VALUES ('global', $1, 10, 'ens-dao', '0xensgovernor', 1, 0, 1, 50, 0, 0, 50, 1, 1)
+        "#,
+    )
+    .bind(OTHER_CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO contributor (
+          id, contract_set_id, chain_id, dao_code, governor_address, block_number, block_timestamp, transaction_hash,
+          last_vote_block_number, last_vote_timestamp, power, balance, delegates_count_all, delegates_count_effective
+        ) VALUES ('0xensvoter', $1, 10, 'ens-dao', '0xensgovernor', 905, 1700001110, '0xensvote', 905, 1700001110, 50, 5, 1, 1)
+        "#,
+    )
+    .bind(OTHER_CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO delegate (
+          id, contract_set_id, chain_id, dao_code, governor_address, from_delegate, to_delegate, block_number,
+          block_timestamp, transaction_hash, is_current, power
+        ) VALUES ('0xensdelegator_0xensdelegate', $1, 10, 'ens-dao', '0xensgovernor', '0xensdelegator', '0xensdelegate', 907, 1700001125, '0xensdelegate', TRUE, 50)
+        "#,
+    )
+    .bind(OTHER_CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO delegate_mapping (
+          id, contract_set_id, chain_id, dao_code, governor_address, "from", "to", power, block_number,
+          block_timestamp, transaction_hash
+        ) VALUES ('0xensdelegator', $1, 10, 'ens-dao', '0xensgovernor', '0xensdelegator', '0xensdelegate', 50, 907, 1700001125, '0xensmapping')
+        "#,
+    )
+    .bind(OTHER_CONTRACT_SET_ID)
     .execute(pool)
     .await?;
 


### PR DESCRIPTION
## Summary
- add `GraphqlScope` for implicit DAO, chain, governor, and contract-set context
- apply implicit scope across GraphQL queries, connections, events, nested voter filters, and proposal voters
- derive DAO scope for single-segment `/<dao>/graphql` paths while preserving unscoped `/graphql` admin behavior

## Validation
- `cargo fmt --all --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55444/indexer cargo test -p degov-datalens-indexer --locked --test graphql_service`
- `cargo build -p degov-datalens-indexer --locked`

HBX-303