### PR TITLE
feat(indexer): add native indexer status graphql

### DIFF
--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -6,6 +6,29 @@ use super::order::*;
 use super::pagination::push_page;
 use super::types::*;
 
+pub(super) async fn query_indexer_status(
+    pool: &PgPool,
+    implicit_scope: &GraphqlScope,
+) -> GraphqlResult<Option<IndexerStatus>> {
+    let mut query = indexer_status_query();
+    push_indexer_status_where(&mut query, implicit_scope);
+    push_indexer_status_order(&mut query);
+    query.push(" LIMIT 1");
+
+    Ok(query.build_query_as().fetch_optional(pool).await?)
+}
+
+pub(super) async fn query_indexer_statuses(
+    pool: &PgPool,
+    implicit_scope: &GraphqlScope,
+) -> GraphqlResult<Vec<IndexerStatus>> {
+    let mut query = indexer_status_query();
+    push_indexer_status_where(&mut query, implicit_scope);
+    push_indexer_status_order(&mut query);
+
+    Ok(query.build_query_as().fetch_all(pool).await?)
+}
+
 pub(super) async fn query_proposals(
     pool: &PgPool,
     implicit_scope: &GraphqlScope,
@@ -49,6 +72,67 @@ pub(super) async fn count_proposals(
     push_proposal_where(&mut query, implicit_scope, where_);
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)
+}
+
+fn indexer_status_query<'a>() -> QueryBuilder<'a, Postgres> {
+    QueryBuilder::<Postgres>::new(
+        r#"
+        SELECT
+          dao_code,
+          chain_id,
+          contract_set_id,
+          processed_height::BIGINT AS processed_height,
+          target_height::BIGINT AS target_height,
+          CASE
+            WHEN target_height IS NULL THEN NULL
+            WHEN target_height <= 0 THEN 100.0::DOUBLE PRECISION
+            WHEN processed_height IS NULL THEN 0.0::DOUBLE PRECISION
+            ELSE LEAST(
+              (processed_height::DOUBLE PRECISION / target_height::DOUBLE PRECISION) * 100.0,
+              100.0
+            )
+          END AS synced_percentage,
+          CASE
+            WHEN processed_height IS NULL OR target_height IS NULL THEN FALSE
+            ELSE processed_height >= target_height
+          END AS is_synced,
+          updated_at::TEXT AS updated_at,
+          last_error
+        FROM degov_indexer_checkpoint
+        "#,
+    )
+}
+
+fn push_indexer_status_where<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    implicit_scope: &'a GraphqlScope,
+) {
+    if implicit_scope.dao_code.is_some()
+        || implicit_scope.chain_id.is_some()
+        || implicit_scope.contract_set_id.is_some()
+    {
+        query.push(" WHERE ");
+        let mut has_condition = false;
+        if let Some(chain_id) = implicit_scope.chain_id {
+            push_column_eq(query, &mut has_condition, "", "chain_id", chain_id);
+        }
+        if let Some(dao_code) = &implicit_scope.dao_code {
+            push_column_eq(query, &mut has_condition, "", "dao_code", dao_code);
+        }
+        if let Some(contract_set_id) = &implicit_scope.contract_set_id {
+            push_column_eq(
+                query,
+                &mut has_condition,
+                "",
+                "contract_set_id",
+                contract_set_id,
+            );
+        }
+    }
+}
+
+fn push_indexer_status_order(query: &mut QueryBuilder<'_, Postgres>) {
+    query.push(" ORDER BY dao_code ASC, chain_id ASC, contract_set_id ASC");
 }
 
 pub(super) async fn query_events<T>(

--- a/apps/indexer/src/graphql/schema.rs
+++ b/apps/indexer/src/graphql/schema.rs
@@ -173,22 +173,27 @@ impl QueryRoot {
         .await
     }
 
-    async fn squid_status(&self, ctx: &Context<'_>) -> GraphqlResult<SquidStatus> {
-        let pool = pool(ctx)?;
-        let status = sqlx::query_as::<_, SquidStatus>(
-            r#"
-            SELECT
-              COALESCE(MAX(processed_height), 0)::int8 AS finalized_height,
-              COALESCE(MAX(processed_height), 0)::int8 AS height,
-              (SELECT hash FROM squid_processor.status WHERE id = 0) AS hash,
-              (SELECT hash FROM squid_processor.status WHERE id = 0) AS finalized_hash
-            FROM degov_indexer_checkpoint
-            "#,
-        )
-        .fetch_one(pool)
-        .await?;
+    async fn indexer_status(&self, ctx: &Context<'_>) -> GraphqlResult<Option<IndexerStatus>> {
+        query_indexer_status(pool(ctx)?, scope(ctx)?).await
+    }
 
-        Ok(status)
+    async fn indexer_statuses(&self, ctx: &Context<'_>) -> GraphqlResult<Vec<IndexerStatus>> {
+        query_indexer_statuses(pool(ctx)?, scope(ctx)?).await
+    }
+
+    #[graphql(deprecation = "Use indexerStatus instead.")]
+    async fn squid_status(&self, ctx: &Context<'_>) -> GraphqlResult<SquidStatus> {
+        let height = query_indexer_status(pool(ctx)?, scope(ctx)?)
+            .await?
+            .and_then(|status| status.processed_height)
+            .unwrap_or_default();
+
+        Ok(SquidStatus {
+            height,
+            finalized_height: height,
+            hash: None,
+            finalized_hash: None,
+        })
     }
 
     async fn proposals_connection(

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -192,6 +192,20 @@ pub struct DelegateMapping {
 
 #[derive(Clone, Debug, FromRow, SimpleObject)]
 #[graphql(rename_fields = "camelCase")]
+pub struct IndexerStatus {
+    pub(super) dao_code: String,
+    pub(super) chain_id: i32,
+    pub(super) contract_set_id: String,
+    pub(super) processed_height: Option<i64>,
+    pub(super) target_height: Option<i64>,
+    pub(super) synced_percentage: Option<f64>,
+    pub(super) is_synced: bool,
+    pub(super) updated_at: String,
+    pub(super) last_error: Option<String>,
+}
+
+#[derive(Clone, Debug, FromRow, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
 pub struct SquidStatus {
     pub(super) height: i64,
     pub(super) finalized_height: i64,

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -630,6 +630,123 @@ async fn test_graphql_schema_applies_implicit_scope_to_queries_and_connections()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_schema_exposes_checkpoint_statuses_with_implicit_scope()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_other_scope_checkpoint(&database.pool).await?;
+
+    let admin_schema = graphql::build_schema(database.pool.clone());
+    let admin_response = admin_schema
+        .execute(Request::new(
+            r#"
+            query AdminStatuses {
+              indexerStatuses {
+                daoCode
+                chainId
+                contractSetId
+                processedHeight
+                targetHeight
+                syncedPercentage
+                isSynced
+                updatedAt
+                lastError
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        admin_response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        admin_response.errors
+    );
+
+    let admin_data = admin_response.data.into_json()?;
+    let statuses = admin_data["indexerStatuses"]
+        .as_array()
+        .expect("admin statuses");
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[0]["daoCode"], "ens-dao");
+    assert_eq!(statuses[0]["processedHeight"], 1200);
+    assert_eq!(statuses[0]["targetHeight"], 1200);
+    assert_eq!(statuses[0]["syncedPercentage"], 100.0);
+    assert_eq!(statuses[0]["isSynced"], true);
+    assert_eq!(statuses[0]["lastError"], "caught up after retry");
+    assert_eq!(statuses[1]["daoCode"], "lisk-dao");
+    assert_eq!(statuses[1]["processedHeight"], 900);
+    assert_eq!(statuses[1]["targetHeight"], 1000);
+    assert_eq!(statuses[1]["syncedPercentage"], 90.0);
+    assert_eq!(statuses[1]["isSynced"], false);
+    assert_eq!(statuses[1]["lastError"], serde_json::Value::Null);
+
+    let scoped_schema = graphql::build_schema_with_scope(
+        database.pool.clone(),
+        graphql::GraphqlScope {
+            dao_code: Some("lisk-dao".to_owned()),
+            chain_id: Some(1135),
+            governor_address: Some("0xgovernor".to_owned()),
+            contract_set_id: Some(CONTRACT_SET_ID.to_owned()),
+        },
+    );
+    let scoped_response = scoped_schema
+        .execute(Request::new(
+            r#"
+            query ScopedStatus {
+              indexerStatus {
+                daoCode
+                chainId
+                contractSetId
+                processedHeight
+                targetHeight
+                syncedPercentage
+                isSynced
+                updatedAt
+                lastError
+              }
+              indexerStatuses {
+                daoCode
+                processedHeight
+              }
+              squidStatus { height finalizedHeight hash finalizedHash }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        scoped_response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        scoped_response.errors
+    );
+
+    let scoped_data = scoped_response.data.into_json()?;
+    assert_eq!(scoped_data["indexerStatus"]["daoCode"], "lisk-dao");
+    assert_eq!(scoped_data["indexerStatus"]["processedHeight"], 900);
+    assert_eq!(scoped_data["indexerStatus"]["targetHeight"], 1000);
+    assert_eq!(scoped_data["indexerStatus"]["syncedPercentage"], 90.0);
+    assert_eq!(scoped_data["indexerStatus"]["isSynced"], false);
+    assert_eq!(
+        scoped_data["indexerStatuses"]
+            .as_array()
+            .expect("scoped statuses")
+            .len(),
+        1
+    );
+    assert_eq!(scoped_data["squidStatus"]["height"], 900);
+    assert_eq!(scoped_data["squidStatus"]["finalizedHeight"], 900);
+    assert_eq!(scoped_data["squidStatus"]["hash"], serde_json::Value::Null);
+    assert_eq!(
+        scoped_data["squidStatus"]["finalizedHash"],
+        serde_json::Value::Null
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_schema_scope_conflicts_return_no_rows() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_other_scope_rows(&database.pool).await?;
@@ -762,9 +879,9 @@ async fn test_graphql_http_dao_path_applies_path_scope_and_preserves_admin()
 async fn test_graphql_http_endpoint_serves_configured_dao_path() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     let schema = graphql::build_schema(database.pool.clone());
-    let app = graphql::build_router_with_paths(schema, ["/degov-demo-dao/graphql".to_owned()]);
+    let app = graphql::build_router_with_paths(schema, ["/lisk-dao/graphql".to_owned()]);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
-    let endpoint = format!("http://{}/degov-demo-dao/graphql", listener.local_addr()?);
+    let endpoint = format!("http://{}/lisk-dao/graphql", listener.local_addr()?);
     let server = tokio::spawn(async move { axum::serve(listener, app).await });
 
     let response: serde_json::Value = timeout(
@@ -828,6 +945,25 @@ async fn test_graphql_http_endpoint_serves_configured_dao_graphiql_path()
 fn unique_schema_name() -> String {
     let id = SCHEMA_COUNTER.fetch_add(1, Ordering::Relaxed);
     format!("graphql_service_test_{id}")
+}
+
+async fn seed_other_scope_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO degov_indexer_checkpoint (
+          dao_code, chain_id, contract_set_id, stream_id, data_source_version,
+          next_block, processed_height, target_height, updated_at, last_error
+        ) VALUES (
+          'ens-dao', 10, $1, 'evm.logs', 'datalens',
+          1201, 1200, 1200, now(), 'caught up after retry'
+        )
+        "#,
+    )
+    .bind(OTHER_CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 async fn seed_rows(pool: &PgPool) -> Result<(), sqlx::Error> {


### PR DESCRIPTION
## Summary
- Add native `indexerStatus` and `indexerStatuses` GraphQL fields backed by `degov_indexer_checkpoint`.
- Scope status reads by implicit `GraphqlScope` where checkpoint columns exist (`dao_code`, `chain_id`, `contract_set_id`).
- Keep `squidStatus` as a deprecated compatibility alias over the native checkpoint status and stop reading `squid_processor.status`.
- Cover one DB with two DAO checkpoint rows so scoped DAO responses do not use a global max height.

## Notes
- `lastError` is exposed from the existing `degov_indexer_checkpoint.last_error` column; no migration changes were needed.
- `squidStatus.hash` and `squidStatus.finalizedHash` now return `null` because checkpoint rows do not carry SQD status hashes.

## Validation
- `cargo fmt --all --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55444/indexer cargo test -p degov-datalens-indexer --locked --test graphql_service`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55444/indexer cargo test -p degov-datalens-indexer --locked --test checkpoint_repository`
- `cargo build -p degov-datalens-indexer --locked`
