### PR TITLE
feat(indexer): support rpc chains for onchain refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,12 @@ DATALENS_GOVERNOR_TOKEN_STANDARD=ERC20
 DATALENS_TIMELOCK_ADDRESS=
 
 # Onchain refresh worker.
-# Set true only with DEGOV_ONCHAIN_REFRESH_RPC_URL configured.
+# Set true only with rpc.chains urlEnv variables or legacy DEGOV_ONCHAIN_REFRESH_RPC_URL configured.
 DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED=false
+# Referenced by apps/indexer/indexer.example.yml rpc.chains.
+ETHEREUM_RPC_URL=
+LISK_RPC_URL=
+# Legacy single-chain fallback when rpc.chains is not configured.
 DEGOV_ONCHAIN_REFRESH_RPC_URL=
 DEGOV_ONCHAIN_REFRESH_RUN_ONCE=false
 

--- a/apps/indexer/indexer.example.yml
+++ b/apps/indexer/indexer.example.yml
@@ -21,6 +21,13 @@ datalens:
   queryLimits:
     blockRangeLimit: 1000
 
+rpc:
+  chains:
+    "1":
+      urlEnv: ETHEREUM_RPC_URL
+    "1135":
+      urlEnv: LISK_RPC_URL
+
 chains:
   - chainId: 1
     networkName: ethereum

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -58,9 +58,10 @@ pub use error::{CheckpointError, ConfigError, DatalensError, IndexerError};
 pub use evm_log::{EvmLogNormalizationError, NormalizedEvmLog, normalize_evm_log_rows};
 pub use graphql::IndexerGraphqlSchema;
 pub use onchain_refresh::{
-    ChainToolOnchainRefreshReader, EvmRpcChainTool, OnchainRefreshReadValue, OnchainRefreshReader,
-    OnchainRefreshReaderError, OnchainRefreshRunReport, OnchainRefreshTask, OnchainRefreshWorker,
-    OnchainRefreshWorkerConfig, OnchainRefreshWorkerError,
+    ChainToolOnchainRefreshReader, EvmRpcChainTool, MultiChainToolOnchainRefreshReader,
+    OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError,
+    OnchainRefreshRunReport, OnchainRefreshTask, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
+    OnchainRefreshWorkerError,
 };
 pub use planner::{
     DaoContractAddresses, DaoLogQueryPlan, DaoLogSource, DatalensLogPage, DatalensLogQueryReader,
@@ -91,8 +92,9 @@ pub use runner::{
 };
 pub use runtime_config::{
     GraphqlRuntimeConfig, IndexerContractSetMode, IndexerContractSetRuntimeConfig,
-    IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshRuntimeConfig,
-    onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value, required_env,
+    IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshRpcChainConfig,
+    OnchainRefreshRuntimeConfig, onchain_refresh_worker_enabled, parse_bool_env_value,
+    parse_i64_env_value, required_env,
 };
 pub use timelock_projection::{
     InMemoryTimelockProjectionRepository, TIMELOCK_POSTGRES_ADAPTER_GAP, TimelockCallWrite,

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -137,34 +137,42 @@ where
             completed: 0,
             failed: 0,
         };
-        let values = match self.reader.read_tasks(&tasks) {
-            Ok(values) => values
-                .into_iter()
-                .map(|value| (value.task_id.clone(), value))
-                .collect::<BTreeMap<_, _>>(),
-            Err(error) => {
-                let message = error.to_string();
-                self.mark_tasks_failed(&tasks, &message, now_ms).await?;
-                report.failed = tasks.len();
 
-                return Ok(report);
-            }
-        };
-
+        let mut tasks_by_chain = BTreeMap::<i32, Vec<OnchainRefreshTask>>::new();
         for task in tasks {
-            match values.get(&task.id) {
-                Some(value) => match self.apply_success(&task, value, now_ms).await {
-                    Ok(()) => report.completed += 1,
-                    Err(error) => {
-                        let message = error.to_string();
-                        self.mark_task_failed(&task.id, &message, now_ms).await?;
+            tasks_by_chain.entry(task.chain_id).or_default().push(task);
+        }
+
+        for (_chain_id, tasks) in tasks_by_chain {
+            let values = match self.reader.read_tasks(&tasks) {
+                Ok(values) => values
+                    .into_iter()
+                    .map(|value| (value.task_id.clone(), value))
+                    .collect::<BTreeMap<_, _>>(),
+                Err(error) => {
+                    let message = error.to_string();
+                    self.mark_tasks_failed(&tasks, &message, now_ms).await?;
+                    report.failed += tasks.len();
+
+                    continue;
+                }
+            };
+
+            for task in tasks {
+                match values.get(&task.id) {
+                    Some(value) => match self.apply_success(&task, value, now_ms).await {
+                        Ok(()) => report.completed += 1,
+                        Err(error) => {
+                            let message = error.to_string();
+                            self.mark_task_failed(&task.id, &message, now_ms).await?;
+                            report.failed += 1;
+                        }
+                    },
+                    None => {
+                        self.mark_task_failed(&task.id, "missing reader result", now_ms)
+                            .await?;
                         report.failed += 1;
                     }
-                },
-                None => {
-                    self.mark_task_failed(&task.id, "missing reader result", now_ms)
-                        .await?;
-                    report.failed += 1;
                 }
             }
         }
@@ -329,6 +337,62 @@ where
         .await?;
 
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct MultiChainToolOnchainRefreshReader<T> {
+    chain_tools: BTreeMap<i32, T>,
+    read_plan_config: BatchReadPlanConfig,
+    current_power_method: ChainReadMethod,
+}
+
+impl<T> MultiChainToolOnchainRefreshReader<T> {
+    pub fn new(
+        chain_tools: BTreeMap<i32, T>,
+        read_plan_config: BatchReadPlanConfig,
+        current_power_method: ChainReadMethod,
+    ) -> Self {
+        Self {
+            chain_tools,
+            read_plan_config: read_plan_config.validated(),
+            current_power_method,
+        }
+    }
+}
+
+impl<T> OnchainRefreshReader for MultiChainToolOnchainRefreshReader<T>
+where
+    T: ChainTool + Clone + Send + Sync + 'static,
+{
+    fn read_tasks(
+        &self,
+        tasks: &[OnchainRefreshTask],
+    ) -> Result<Vec<OnchainRefreshReadValue>, OnchainRefreshReaderError> {
+        let mut tasks_by_chain = BTreeMap::<i32, Vec<OnchainRefreshTask>>::new();
+        for task in tasks {
+            tasks_by_chain
+                .entry(task.chain_id)
+                .or_default()
+                .push(task.clone());
+        }
+
+        let mut values = Vec::new();
+        for (chain_id, tasks) in tasks_by_chain {
+            let chain_tool = self.chain_tools.get(&chain_id).ok_or_else(|| {
+                OnchainRefreshReaderError::new(format!(
+                    "missing onchain refresh RPC configuration for chain_id {chain_id}"
+                ))
+            })?;
+            let reader = ChainToolOnchainRefreshReader::new(
+                chain_tool.clone(),
+                self.read_plan_config,
+                self.current_power_method,
+            );
+            values.extend(reader.read_tasks(&tasks)?);
+        }
+
+        Ok(values)
     }
 }
 

--- a/apps/indexer/src/runtime/worker.rs
+++ b/apps/indexer/src/runtime/worker.rs
@@ -1,4 +1,4 @@
-use std::future;
+use std::{collections::BTreeMap, future};
 
 use anyhow as runtime_anyhow;
 use runtime_anyhow::{Context, Result};
@@ -6,7 +6,7 @@ use sqlx::postgres::PgPoolOptions;
 use tokio::time::sleep;
 
 use crate::{
-    ChainToolOnchainRefreshReader, EvmRpcChainTool, OnchainRefreshRuntimeConfig,
+    EvmRpcChainTool, MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig,
     OnchainRefreshWorker, required_env,
 };
 
@@ -39,10 +39,21 @@ pub async fn run_worker() -> Result<()> {
         .context("connect to DeGov indexer Postgres")?;
     apply_migrations(&pool).await?;
 
-    let chain_tool = EvmRpcChainTool::new(runtime.rpc_url.clone(), runtime.request_timeout)
-        .context("create onchain refresh RPC ChainTool")?;
-    let reader = ChainToolOnchainRefreshReader::new(
-        chain_tool,
+    let chain_tools = runtime
+        .rpc_chains
+        .iter()
+        .map(|(chain_id, rpc)| {
+            let chain_tool =
+                EvmRpcChainTool::new(rpc.url.expose_secret().to_owned(), runtime.request_timeout)
+                    .with_context(|| {
+                    format!("create onchain refresh RPC ChainTool for chain_id {chain_id}")
+                })?;
+
+            Ok((*chain_id, chain_tool))
+        })
+        .collect::<Result<BTreeMap<_, _>>>()?;
+    let reader = MultiChainToolOnchainRefreshReader::new(
+        chain_tools,
         runtime.read_plan_config(),
         runtime.current_power_method,
     );

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -1,12 +1,13 @@
-use std::{env, net::SocketAddr, time::Duration};
+use std::{collections::BTreeMap, env, net::SocketAddr, path::Path, time::Duration};
 
 use anyhow as runtime_anyhow;
 use runtime_anyhow::{Context, Result, bail};
+use serde::Deserialize;
 
 use crate::{
     BatchReadPlanConfig, ChainContracts, ChainReadMethod, DatalensConfig,
     DatalensRuntimeContractSet, IndexerCheckpointIdentity, IndexerRunnerContexts,
-    IndexerRunnerOptions, OnchainRefreshWorkerConfig, ProposalProjectionContext,
+    IndexerRunnerOptions, OnchainRefreshWorkerConfig, ProposalProjectionContext, SecretString,
     TimelockProjectionContext, TokenProjectionContext, VoteProjectionContext,
 };
 
@@ -405,7 +406,7 @@ impl IndexerContractSetRuntimeConfig {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OnchainRefreshRuntimeConfig {
     pub enabled: bool,
-    pub rpc_url: String,
+    pub rpc_chains: BTreeMap<i32, OnchainRefreshRpcChainConfig>,
     pub batch_size: usize,
     pub max_attempts: i32,
     pub max_batches_per_poll: usize,
@@ -420,14 +421,33 @@ pub struct OnchainRefreshRuntimeConfig {
     pub current_power_method: ChainReadMethod,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OnchainRefreshRpcChainConfig {
+    pub chain_id: i32,
+    pub url_env: String,
+    pub url: SecretString,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct RawOnchainRefreshFileConfig {
+    rpc: Option<RawRpcFileConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct RawRpcFileConfig {
+    chains: Option<BTreeMap<String, RawRpcChainFileConfig>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct RawRpcChainFileConfig {
+    #[serde(rename = "urlEnv", alias = "url_env")]
+    url_env: Option<String>,
+}
+
 impl OnchainRefreshRuntimeConfig {
     pub fn from_env() -> Result<Self> {
         let enabled = optional_env_bool("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED")?.unwrap_or(true);
-        let rpc_url = if enabled {
-            required_env("DEGOV_ONCHAIN_REFRESH_RPC_URL")?
-        } else {
-            optional_env("DEGOV_ONCHAIN_REFRESH_RPC_URL")?.unwrap_or_default()
-        };
+        let rpc_chains = load_onchain_refresh_rpc_chains(enabled)?;
         let batch_size = optional_env_usize("DEGOV_ONCHAIN_REFRESH_BATCH_SIZE")?.unwrap_or(100);
         if batch_size == 0 {
             bail!("DEGOV_ONCHAIN_REFRESH_BATCH_SIZE must be greater than zero");
@@ -481,7 +501,7 @@ impl OnchainRefreshRuntimeConfig {
 
         Ok(Self {
             enabled,
-            rpc_url,
+            rpc_chains,
             batch_size,
             max_attempts,
             max_batches_per_poll,
@@ -516,6 +536,93 @@ impl OnchainRefreshRuntimeConfig {
     }
 }
 
+fn load_onchain_refresh_rpc_chains(
+    enabled: bool,
+) -> Result<BTreeMap<i32, OnchainRefreshRpcChainConfig>> {
+    let configured = load_rpc_chain_url_envs_from_config_file()?;
+    if !configured.is_empty() {
+        return configured
+            .into_iter()
+            .map(|(chain_id, url_env)| {
+                let url = if enabled {
+                    required_dynamic_env(&url_env).with_context(|| {
+                        format!("resolve rpc.chains chain_id {chain_id} urlEnv {url_env}")
+                    })?
+                } else {
+                    optional_dynamic_env(&url_env)?.unwrap_or_default()
+                };
+
+                Ok((
+                    chain_id,
+                    OnchainRefreshRpcChainConfig {
+                        chain_id,
+                        url_env,
+                        url: SecretString::new(url),
+                    },
+                ))
+            })
+            .collect();
+    }
+
+    let legacy_url = if enabled {
+        Some(required_env("DEGOV_ONCHAIN_REFRESH_RPC_URL")?)
+    } else {
+        optional_env("DEGOV_ONCHAIN_REFRESH_RPC_URL")?
+    };
+    let Some(legacy_url) = legacy_url else {
+        return Ok(BTreeMap::new());
+    };
+    let chain_id =
+        optional_env_i32("DATALENS_CHAIN_ID")?.unwrap_or(crate::config::DEFAULT_DATALENS_CHAIN_ID);
+
+    Ok(BTreeMap::from([(
+        chain_id,
+        OnchainRefreshRpcChainConfig {
+            chain_id,
+            url_env: "DEGOV_ONCHAIN_REFRESH_RPC_URL".to_owned(),
+            url: SecretString::new(legacy_url),
+        },
+    )]))
+}
+
+fn load_rpc_chain_url_envs_from_config_file() -> Result<BTreeMap<i32, String>> {
+    let Some(config_file) = optional_env("DEGOV_INDEXER_CONFIG_FILE")? else {
+        return Ok(BTreeMap::new());
+    };
+
+    let file: RawOnchainRefreshFileConfig = ::config::Config::builder()
+        .add_source(::config::File::from(Path::new(&config_file)))
+        .build()
+        .with_context(|| format!("failed to load DEGOV_INDEXER_CONFIG_FILE: {config_file}"))?
+        .try_deserialize()
+        .with_context(|| format!("failed to parse DEGOV_INDEXER_CONFIG_FILE: {config_file}"))?;
+
+    let Some(rpc) = file.rpc else {
+        return Ok(BTreeMap::new());
+    };
+    let Some(chains) = rpc.chains else {
+        return Ok(BTreeMap::new());
+    };
+
+    chains
+        .into_iter()
+        .map(|(chain_id, chain)| {
+            let parsed_chain_id = chain_id
+                .parse::<i32>()
+                .with_context(|| format!("rpc.chains contains invalid chain id {chain_id}"))?;
+            let url_env = chain
+                .url_env
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+                .with_context(|| {
+                    format!("rpc.chains chain_id {parsed_chain_id} requires urlEnv")
+                })?;
+
+            Ok((parsed_chain_id, url_env))
+        })
+        .collect()
+}
+
 pub fn required_env(name: &'static str) -> Result<String> {
     let value = env::var(name).with_context(|| format!("{name} is required"))?;
     let value = value.trim().to_owned();
@@ -527,7 +634,34 @@ pub fn required_env(name: &'static str) -> Result<String> {
     Ok(value)
 }
 
+fn required_dynamic_env(name: &str) -> Result<String> {
+    let value = env::var(name).with_context(|| format!("{name} is required"))?;
+    let value = value.trim().to_owned();
+
+    if value.is_empty() {
+        bail!("{name} must not be empty");
+    }
+
+    Ok(value)
+}
+
 fn optional_env(name: &'static str) -> Result<Option<String>> {
+    match env::var(name) {
+        Ok(value) => {
+            let value = value.trim().to_owned();
+
+            if value.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(value))
+            }
+        }
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read {name}")),
+    }
+}
+
+fn optional_dynamic_env(name: &str) -> Result<Option<String>> {
     match env::var(name) {
         Ok(value) => {
             let value = value.trim().to_owned();

--- a/apps/indexer/tests/config.rs
+++ b/apps/indexer/tests/config.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use degov_datalens_indexer::{
-    ConfigError, DatalensConfig, DatalensFinality, GovernanceTokenStandard, SecretString,
+    ConfigError, DatalensConfig, DatalensFinality, GovernanceTokenStandard,
+    OnchainRefreshRuntimeConfig, SecretString,
 };
 
 fn with_datalens_env<T>(vars: &[(&str, Option<&str>)], test: impl FnOnce() -> T) -> T {
@@ -458,6 +459,223 @@ fn test_from_env_loads_json_config_file() {
     );
 
     remove_config_file(path);
+}
+
+#[test]
+fn test_onchain_refresh_runtime_loads_yaml_rpc_chains() {
+    let path = write_config_file(
+        "yml",
+        r#"
+rpc:
+  chains:
+    "1":
+      urlEnv: ETHEREUM_RPC_URL
+    "1135":
+      urlEnv: LISK_RPC_URL
+"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DEGOV_ONCHAIN_REFRESH_RPC_URL", None),
+            (
+                "ETHEREUM_RPC_URL",
+                Some("https://ethereum.example/rpc-secret"),
+            ),
+            ("LISK_RPC_URL", Some("https://lisk.example/rpc-secret")),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("load runtime config");
+
+            assert_eq!(config.rpc_chains.len(), 2);
+            assert_eq!(
+                config.rpc_chains.get(&1).expect("ethereum rpc").url_env,
+                "ETHEREUM_RPC_URL"
+            );
+            assert_eq!(
+                config
+                    .rpc_chains
+                    .get(&1)
+                    .expect("ethereum rpc")
+                    .url
+                    .expose_secret(),
+                "https://ethereum.example/rpc-secret"
+            );
+            assert_eq!(
+                config
+                    .rpc_chains
+                    .get(&1135)
+                    .expect("lisk rpc")
+                    .url
+                    .expose_secret(),
+                "https://lisk.example/rpc-secret"
+            );
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_onchain_refresh_runtime_loads_toml_rpc_chains() {
+    let path = write_config_file(
+        "toml",
+        r#"
+[rpc.chains."1"]
+urlEnv = "ETHEREUM_RPC_URL"
+
+[rpc.chains."1135"]
+urlEnv = "LISK_RPC_URL"
+"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DEGOV_ONCHAIN_REFRESH_RPC_URL", None),
+            (
+                "ETHEREUM_RPC_URL",
+                Some("https://ethereum.example/rpc-secret"),
+            ),
+            ("LISK_RPC_URL", Some("https://lisk.example/rpc-secret")),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("load runtime config");
+
+            assert_eq!(
+                config
+                    .rpc_chains
+                    .get(&1135)
+                    .expect("lisk rpc")
+                    .url
+                    .expose_secret(),
+                "https://lisk.example/rpc-secret"
+            );
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_onchain_refresh_runtime_loads_json_rpc_chains() {
+    let path = write_config_file(
+        "json",
+        r#"{
+  "rpc": {
+    "chains": {
+      "1": {
+        "urlEnv": "ETHEREUM_RPC_URL"
+      },
+      "1135": {
+        "urlEnv": "LISK_RPC_URL"
+      }
+    }
+  }
+}"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DEGOV_ONCHAIN_REFRESH_RPC_URL", None),
+            (
+                "ETHEREUM_RPC_URL",
+                Some("https://ethereum.example/rpc-secret"),
+            ),
+            ("LISK_RPC_URL", Some("https://lisk.example/rpc-secret")),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("load runtime config");
+
+            assert_eq!(
+                config
+                    .rpc_chains
+                    .get(&1)
+                    .expect("ethereum rpc")
+                    .url
+                    .expose_secret(),
+                "https://ethereum.example/rpc-secret"
+            );
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_onchain_refresh_runtime_redacts_rpc_urls_in_debug_output() {
+    let path = write_config_file(
+        "yml",
+        r#"
+rpc:
+  chains:
+    "1":
+      urlEnv: ETHEREUM_RPC_URL
+"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DEGOV_ONCHAIN_REFRESH_RPC_URL", None),
+            (
+                "ETHEREUM_RPC_URL",
+                Some("https://ethereum.example/rpc-secret"),
+            ),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("load runtime config");
+            let debug = format!("{config:?}");
+
+            assert!(!debug.contains("https://ethereum.example/rpc-secret"));
+            assert!(debug.contains("<redacted>"));
+            assert!(debug.contains("ETHEREUM_RPC_URL"));
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_onchain_refresh_runtime_keeps_legacy_single_rpc_env_fallback() {
+    with_datalens_env(
+        &[
+            ("DEGOV_INDEXER_CONFIG_FILE", None),
+            ("DATALENS_CHAIN_ID", Some("46")),
+            (
+                "DEGOV_ONCHAIN_REFRESH_RPC_URL",
+                Some("https://darwinia.example/rpc-secret"),
+            ),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("load runtime config");
+
+            assert_eq!(config.rpc_chains.len(), 1);
+            assert_eq!(
+                config
+                    .rpc_chains
+                    .get(&46)
+                    .expect("legacy rpc")
+                    .url
+                    .expose_secret(),
+                "https://darwinia.example/rpc-secret"
+            );
+        },
+    );
 }
 
 #[test]

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -7,8 +7,10 @@ use std::{
 };
 
 use degov_datalens_indexer::{
-    ChainReadMethod, OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError,
-    OnchainRefreshTask, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
+    BatchReadPlanConfig, ChainReadExecutionReport, ChainReadMethod, ChainReadMetrics,
+    ChainReadPlan, ChainReadResult, ChainReadValue, ChainTool, MultiChainToolOnchainRefreshReader,
+    OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError, OnchainRefreshTask,
+    OnchainRefreshWorker, OnchainRefreshWorkerConfig, PartialChainReadFailureReport,
     runtime::apply_migrations,
 };
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
@@ -457,6 +459,103 @@ async fn test_onchain_refresh_worker_updates_only_matching_contract_set_contribu
     Ok(())
 }
 
+#[test]
+fn test_multi_chain_reader_routes_tasks_to_matching_chain_tool() {
+    let reader = MultiChainToolOnchainRefreshReader::new(
+        BTreeMap::from([
+            (1, StaticValueChainTool::new("101")),
+            (1135, StaticValueChainTool::new("202")),
+        ]),
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+
+    let values = reader
+        .read_tasks(&[
+            task_for_chain("task-one", 1, ACCOUNT_ONE),
+            task_for_chain("task-two", 1135, ACCOUNT_TWO),
+        ])
+        .expect("read tasks");
+    let values = values
+        .into_iter()
+        .map(|value| (value.task_id.clone(), value))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(
+        values.get("task-one").expect("task-one").power.as_deref(),
+        Some("101")
+    );
+    assert_eq!(
+        values.get("task-two").expect("task-two").power.as_deref(),
+        Some("202")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_fails_only_missing_rpc_chain_group()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task_with_scope(
+        &database.pool,
+        "task-one",
+        "ethereum-dao",
+        1,
+        "ethereum-dao",
+        GOVERNOR,
+        TOKEN,
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        false,
+        true,
+    )
+    .await?;
+    seed_task_with_scope(
+        &database.pool,
+        "task-two",
+        "lisk-dao",
+        1135,
+        "lisk-dao",
+        GOVERNOR_TWO,
+        TOKEN_TWO,
+        ACCOUNT_TWO,
+        "pending",
+        0,
+        false,
+        true,
+    )
+    .await?;
+
+    let reader = MultiChainToolOnchainRefreshReader::new(
+        BTreeMap::from([(1, StaticValueChainTool::new("101"))]),
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            max_attempts: 3,
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.claimed, 2);
+    assert_eq!(report.completed, 1);
+    assert_eq!(report.failed, 1);
+    assert_completed_task(&database.pool, "task-one", 1).await?;
+    assert_failed_task_error_contains(&database.pool, "task-two", "chain_id 1135").await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
 #[derive(Clone, Debug)]
 struct MockOnchainRefreshReader {
     values: BTreeMap<String, OnchainRefreshReadValue>,
@@ -498,6 +597,65 @@ impl OnchainRefreshReader for FailingOnchainRefreshReader {
         _tasks: &[OnchainRefreshTask],
     ) -> Result<Vec<OnchainRefreshReadValue>, OnchainRefreshReaderError> {
         Err(OnchainRefreshReaderError::new("mock reader failed"))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct StaticValueChainTool {
+    value: String,
+}
+
+impl StaticValueChainTool {
+    fn new(value: &str) -> Self {
+        Self {
+            value: value.to_owned(),
+        }
+    }
+}
+
+impl ChainTool for StaticValueChainTool {
+    fn execute_read_plan(
+        &self,
+        plan: &ChainReadPlan,
+    ) -> Result<ChainReadExecutionReport, PartialChainReadFailureReport> {
+        Ok(ChainReadExecutionReport {
+            metrics: ChainReadMetrics {
+                requested_reads: plan.metrics.requested_reads,
+                deduped_reads: plan.metrics.deduped_reads,
+                executed_rpc_calls: plan.reads.len(),
+                multicall_batch_size: plan.metrics.multicall_batch_size,
+                ..ChainReadMetrics::default()
+            },
+            results: plan
+                .reads
+                .iter()
+                .enumerate()
+                .map(|(read_index, read)| ChainReadResult {
+                    read_index,
+                    key: read.key.clone(),
+                    value: ChainReadValue::Integer(self.value.clone()),
+                })
+                .collect(),
+            ..ChainReadExecutionReport::default()
+        })
+    }
+}
+
+fn task_for_chain(task_id: &str, chain_id: i32, account: &str) -> OnchainRefreshTask {
+    OnchainRefreshTask {
+        id: task_id.to_owned(),
+        contract_set_id: format!("scope-{chain_id}"),
+        chain_id,
+        dao_code: Some(format!("dao-{chain_id}")),
+        governor_address: GOVERNOR.to_owned(),
+        token_address: TOKEN.to_owned(),
+        account: account.to_owned(),
+        refresh_balance: false,
+        refresh_power: true,
+        last_seen_block_number: "12".to_owned(),
+        last_seen_block_timestamp: "12000".to_owned(),
+        last_seen_transaction_hash: "0xtask".to_owned(),
+        attempts: 0,
     }
 }
 
@@ -769,6 +927,31 @@ async fn assert_completed_task(
     assert_eq!(row.get::<Option<String>, _>("locked_at"), None);
     assert_eq!(row.get::<Option<String>, _>("locked_by"), None);
     assert!(row.get::<Option<String>, _>("processed_at").is_some());
+
+    Ok(())
+}
+
+async fn assert_failed_task_error_contains(
+    pool: &PgPool,
+    task_id: &str,
+    expected_error: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT status, attempts, error
+         FROM onchain_refresh_task
+         WHERE id = $1",
+    )
+    .bind(task_id)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("status"), "failed");
+    assert_eq!(row.get::<i32, _>("attempts"), 1);
+    assert!(
+        row.get::<Option<String>, _>("error")
+            .expect("error")
+            .contains(expected_error)
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- load rpc.chains from indexer YAML/TOML/JSON config and resolve urlEnv values at runtime
- route onchain refresh reads through a chain_id keyed RPC reader while retrying only missing-chain groups
- document rpc.chains urlEnv examples and keep the legacy single RPC env fallback

## Validation
- cargo fmt --all --check
- cargo test -p degov-datalens-indexer --locked --test config
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55444/indexer cargo test -p degov-datalens-indexer --locked --test onchain_refresh_worker
- cargo build -p degov-datalens-indexer --locked