### PR TITLE
HBX-307 update unified Datalens deployment model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,10 @@ DEGOV_DB_PORT=5432
 DEGOV_DB_PASSWORD=password
 DEGOV_DB_NAME=postgres
 DEGOV_INDEXER_DATABASE_URL=postgresql://postgres:password@localhost:5432/indexer
-DEGOV_INDEXER_DAO_CODE=degov-demo-dao
-DEGOV_INDEXER_START_BLOCK=5873342
+DEGOV_INDEXER_CONFIG_FILE=apps/indexer/indexer.example.yml
+# all runs every daoCode in DEGOV_INDEXER_CONFIG_FILE. Set DEGOV_INDEXER_DAO_CODE only to filter a debug run.
+DEGOV_INDEXER_CONTRACT_SET_MODE=all
+DEGOV_INDEXER_DAO_CODE=
 # Use latest for production durable-head tracking; numeric heights are for debug or bounded test runs.
 DEGOV_INDEXER_TARGET_HEIGHT=latest
 DEGOV_INDEXER_RUN_ONCE=false
@@ -32,7 +34,8 @@ DATALENS_CHAIN_ID=46
 DATALENS_DATASET_FAMILY=evm
 DATALENS_DATASET_NAME=logs
 DATALENS_QUERY_BLOCK_RANGE_LIMIT=1000
-DATALENS_CHAINS_JSON=[{"chainId":46,"networkName":"darwinia","contracts":[{"daoCode":"degov-demo-dao","governor":"0xC9EA55E644F496D6CaAEDcBAD91dE7481Dcd7517","governorToken":"0xbC9f58566810F7e853e1eef1b9957ac82F9971df","tokenStandard":"ERC20","timelock":"0x6AB15C6ada9515A8E21321e241013dB457C8576c","startBlock":5873342}]}]
+# Prefer DEGOV_INDEXER_CONFIG_FILE for multi-chain contract sets. DATALENS_CHAINS_JSON is retained only for legacy single-env runs.
+DATALENS_CHAINS_JSON=
 DATALENS_GOVERNOR_ADDRESS=
 DATALENS_GOVERNOR_TOKEN_ADDRESS=
 DATALENS_GOVERNOR_TOKEN_STANDARD=ERC20
@@ -44,6 +47,7 @@ DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED=false
 # Referenced by apps/indexer/indexer.example.yml rpc.chains.
 ETHEREUM_RPC_URL=
 LISK_RPC_URL=
+DARWINIA_RPC_URL=
 # Legacy single-chain fallback when rpc.chains is not configured.
 DEGOV_ONCHAIN_REFRESH_RPC_URL=
 DEGOV_ONCHAIN_REFRESH_RUN_ONCE=false

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -16,6 +16,13 @@ identity, dataset key, and query block range limit at startup. The bearer token
 is loaded from environment or secret-backed configuration and is redacted by
 config formatting.
 
+The default deployment model is one shared Postgres indexer database, one
+all-mode indexer process, one GraphQL service, one onchain refresh worker, and
+scoped DAO routes or hostnames. Use `DEGOV_INDEXER_CONFIG_FILE` for multi-chain
+contract sets and set `DEGOV_INDEXER_CONTRACT_SET_MODE=all` for normal
+staging/production runs. `DEGOV_INDEXER_DAO_CODE` is a temporary debug filter,
+not the default deployment unit.
+
 ## PostgreSQL schema ownership
 
 `migrations/0001_init.sql` is the canonical fresh PostgreSQL initialization

--- a/apps/indexer/scripts/runtime-packaging.test.mjs
+++ b/apps/indexer/scripts/runtime-packaging.test.mjs
@@ -82,6 +82,21 @@ assert.match(
   /DEGOV_INDEXER_GRAPHQL_ENDPOINT: \$\{DEGOV_INDEXER_GRAPHQL_BIND_ENDPOINT:-http:\/\/0\.0\.0\.0:4350\/graphql\}/,
   "compose GraphQL service must bind on the GraphQL path",
 );
+assert.match(
+  composeYaml,
+  /DEGOV_INDEXER_CONFIG_FILE: \$\{DEGOV_INDEXER_CONFIG_FILE:-\/app\/indexer\.yml\}/,
+  "compose must pass the config file path into indexer workloads",
+);
+assert.match(
+  composeYaml,
+  /DEGOV_INDEXER_CONTRACT_SET_MODE: \$\{DEGOV_INDEXER_CONTRACT_SET_MODE:-all\}/,
+  "compose must default the indexer to all contract set mode",
+);
+assert.match(
+  composeYaml,
+  /\.\/apps\/indexer\/indexer\.example\.yml:\/app\/indexer\.yml:ro/,
+  "compose must mount the config-file based multi-chain contract sets",
+);
 assert.equal(
   defaultServicesWithoutEnvFile.web?.depends_on?.["indexer-graphql"],
   undefined,
@@ -126,7 +141,12 @@ assert.match(composeYaml, /DATALENS_ENDPOINT/, "compose must pass Datalens envir
 assert.match(
   composeYaml,
   /DATALENS_CHAINS_JSON/,
-  "compose must pass structured Datalens chain configuration",
+  "compose may retain legacy structured Datalens chain env compatibility",
+);
+assert.match(
+  composeYaml,
+  /DEGOV_INDEXER_CONTRACT_SET_MODE/,
+  "compose must pass the contract set mode",
 );
 assert.match(
   composeYaml,
@@ -150,7 +170,9 @@ assert.doesNotMatch(
 );
 
 assert.match(envExample, /DATALENS_ENDPOINT=/);
-assert.match(envExample, /DATALENS_CHAINS_JSON=\[/);
+assert.match(envExample, /DEGOV_INDEXER_CONFIG_FILE=apps\/indexer\/indexer\.example\.yml/);
+assert.match(envExample, /DEGOV_INDEXER_CONTRACT_SET_MODE=all/);
+assert.match(envExample, /^DATALENS_CHAINS_JSON=$/m);
 assert.match(envExample, /DEGOV_INDEXER_DATABASE_URL=/);
 assert.match(
   envExample,

--- a/apps/indexer/scripts/staging-deployment-contract.test.mjs
+++ b/apps/indexer/scripts/staging-deployment-contract.test.mjs
@@ -40,65 +40,81 @@ assert.equal(contract.datalens.applicationEnv, "DATALENS_APPLICATION");
 assert.equal(contract.datalens.application, "degov-staging");
 assert.equal(contract.datalens.dataset.family, "evm");
 assert.equal(contract.datalens.dataset.name, "logs");
+assert.deepEqual(contract.deploymentModel, {
+  database: "one shared fresh Datalens indexer database",
+  indexer: "one all-mode Datalens indexer workload",
+  graphql: "one GraphQL service with scoped DAO routes",
+  onchainRefreshWorker: "one shared worker workload",
+});
+assert.equal(contract.database.urlEnv, "DEGOV_INDEXER_DATABASE_URL");
+assert.equal(contract.database.databaseName, "degov_datalens_migration_all_contract_sets");
+assert.equal(contract.database.freshInitOnly, true);
+assert.equal(contract.database.migration, "apps/indexer/migrations/0001_init.sql");
+assert.equal(contract.configFile.env, "DEGOV_INDEXER_CONFIG_FILE");
+assert.equal(contract.configFile.mountPath, "/app/indexer.yml");
+assert.equal(contract.configFile.contractSetMode, "all");
 assert.equal(contract.graphql.endpointEnv, "DEGOV_INDEXER_GRAPHQL_ENDPOINT");
 assert.equal(contract.graphql.bindEndpoint, "http://0.0.0.0:4350/graphql");
 assert.equal(contract.graphql.port, 4350);
 assert.equal(contract.graphql.path, "/graphql");
-assert.match(contract.graphql.routePolicy, /without removing existing DAO hostnames/i);
+assert.match(contract.graphql.routePolicy, /multiple scoped DAO hostnames/i);
+assert.ok(
+  contract.graphql.scopedRoutes.length >= 2,
+  "staging contract must expose multiple scoped DAO routes",
+);
+for (const route of contract.graphql.scopedRoutes) {
+  assert.ok(route.daoCode, "scoped route DAO code is required");
+  assert.match(route.path, new RegExp(`^/${route.daoCode}/graphql$`));
+  assert.match(route.publicEndpoint, new RegExp(`/${route.daoCode}/graphql$`));
+}
 
-assert.ok(contract.daos.length >= 1, "staging contract must include selected DAOs");
+assert.deepEqual(contract.runtimeEnv.DEGOV_INDEXER_CONFIG_FILE, contract.configFile.mountPath);
+assert.equal(contract.runtimeEnv.DEGOV_INDEXER_CONTRACT_SET_MODE, "all");
+assert.equal(contract.runtimeEnv.DEGOV_INDEXER_TARGET_HEIGHT, "latest");
+assert.equal(contract.runtimeEnv.DEGOV_INDEXER_RUN_ONCE, "false");
+assert.equal(contract.runtimeEnv.DATALENS_APPLICATION, contract.datalens.application);
+assert.equal(contract.runtimeEnv.DATALENS_DATASET_FAMILY, contract.datalens.dataset.family);
+assert.equal(contract.runtimeEnv.DATALENS_DATASET_NAME, contract.datalens.dataset.name);
+assert.equal(contract.runtimeEnv.DATALENS_CHAINS_JSON, undefined);
+assert.equal(contract.runtimeEnv.DATALENS_GOVERNOR_ADDRESS, undefined);
+assert.equal(contract.runtimeEnv.DATALENS_GOVERNOR_TOKEN_ADDRESS, undefined);
+assert.equal(contract.runtimeEnv.DATALENS_GOVERNOR_TOKEN_STANDARD, undefined);
+assert.equal(contract.runtimeEnv.DATALENS_TIMELOCK_ADDRESS, undefined);
+assert.equal(contract.runtimeEnv.DEGOV_INDEXER_DAO_CODE, undefined);
+
+assert.ok(
+  contract.contractSets.length >= 2,
+  "staging contract must include multi-chain contract sets",
+);
 
 const daoCodes = new Set();
-const databaseNames = new Set();
-for (const dao of contract.daos) {
-  assert.ok(dao.code, "DAO code is required");
-  assert.ok(!daoCodes.has(dao.code), `duplicate DAO code ${dao.code}`);
-  daoCodes.add(dao.code);
-
-  assert.match(
-    dao.databaseName,
-    /^degov_datalens_migration_[a-z0-9_]+$/,
-    `${dao.code} must use a fresh Datalens migration DB name`,
-  );
+const chainIds = new Set();
+for (const chain of contract.contractSets) {
+  assert.ok(Number.isInteger(chain.chainId), "chain id is required");
+  assert.ok(chain.networkName, "network name is required");
+  chainIds.add(chain.chainId);
   assert.ok(
-    !databaseNames.has(dao.databaseName),
-    `duplicate database name ${dao.databaseName}`,
+    chain.contracts.length >= 1,
+    `${chain.networkName} must include at least one contract set`,
   );
-  databaseNames.add(dao.databaseName);
-
-  assert.equal(dao.env.DATALENS_APPLICATION, contract.datalens.application);
-  assert.equal(dao.env.DEGOV_INDEXER_DAO_CODE, dao.code);
-  assert.equal(dao.env.DEGOV_INDEXER_START_BLOCK, dao.startBlock);
-  assert.equal(dao.env.DEGOV_INDEXER_TARGET_HEIGHT, dao.targetHeight);
-  assert.equal(
-    dao.env.DEGOV_INDEXER_GRAPHQL_ENDPOINT,
-    contract.graphql.bindEndpoint,
-  );
-  assert.ok(
-    dao.env.DEGOV_INDEXER_TARGET_HEIGHT >= dao.env.DEGOV_INDEXER_START_BLOCK,
-  );
-  assert.equal(dao.env.DATALENS_DATASET_FAMILY, contract.datalens.dataset.family);
-  assert.equal(dao.env.DATALENS_DATASET_NAME, contract.datalens.dataset.name);
-  assert.equal(dao.env.DATALENS_QUERY_ROW_LIMIT, undefined);
-  assert.equal(dao.env.DATALENS_CHAIN_FAMILY, "evm");
-  assert.ok(dao.env.DATALENS_CHAIN_NAME);
-  assert.ok(Number.isInteger(dao.env.DATALENS_CHAIN_ID));
-  assert.equal(typeof dao.env.DATALENS_CHAINS_JSON, "string");
-  const chains = JSON.parse(dao.env.DATALENS_CHAINS_JSON);
-  assert.ok(chains.length >= 1, `${dao.code} must include structured chains`);
-  assert.ok(
-    chains.some((chain) =>
-      chain.contracts?.some((contract) => contract.daoCode === dao.code),
-    ),
-    `${dao.code} must appear in DATALENS_CHAINS_JSON`,
-  );
-  assert.match(dao.env.DATALENS_GOVERNOR_ADDRESS, /^0x[0-9a-fA-F]{40}$/);
-  assert.match(dao.env.DATALENS_GOVERNOR_TOKEN_ADDRESS, /^0x[0-9a-fA-F]{40}$/);
-  assert.match(dao.env.DATALENS_GOVERNOR_TOKEN_STANDARD, /^ERC(20|721)$/);
-  if (dao.env.DATALENS_TIMELOCK_ADDRESS) {
-    assert.match(dao.env.DATALENS_TIMELOCK_ADDRESS, /^0x[0-9a-fA-F]{40}$/);
+  for (const configured of chain.contracts) {
+    assert.ok(configured.daoCode, "contract set DAO code is required");
+    assert.ok(!daoCodes.has(configured.daoCode), `duplicate DAO code ${configured.daoCode}`);
+    daoCodes.add(configured.daoCode);
+    assert.match(configured.governor, /^0x[0-9a-fA-F]{40}$/);
+    assert.match(configured.governorToken, /^0x[0-9a-fA-F]{40}$/);
+    assert.match(configured.tokenStandard, /^ERC(20|721)$/);
+    assert.match(configured.timelock, /^0x[0-9a-fA-F]{40}$/);
+    assert.ok(Number.isInteger(configured.startBlock));
   }
 }
+assert.ok(chainIds.size >= 2, "staging contract must cover multiple chains");
+assert.deepEqual(
+  new Set(contract.graphql.scopedRoutes.map((route) => route.daoCode)),
+  daoCodes,
+  "each configured contract set must have a scoped GraphQL route",
+);
+assert.equal(contract.daos, undefined);
 
 assert.match(
   releaseYaml,
@@ -110,18 +126,29 @@ assert.deepEqual(contract.requiredRuntimeChecks, [
   "pod-readiness",
   "graphql-availability",
 ]);
-assert.equal(contract.onchainRefreshWorker.rpcUrlEnv, "DEGOV_ONCHAIN_REFRESH_RPC_URL");
+assert.deepEqual(contract.onchainRefreshWorker.rpcChainUrlEnvs, [
+  "DARWINIA_RPC_URL",
+  "LISK_RPC_URL",
+]);
 assert.equal(
   contract.onchainRefreshWorker.env.DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED,
   "false",
 );
-assert.equal(contract.onchainRefreshWorker.env.DEGOV_ONCHAIN_REFRESH_RPC_URL, "");
+assert.equal(contract.onchainRefreshWorker.env.DEGOV_ONCHAIN_REFRESH_RPC_URL, undefined);
 assert.equal(
   contract.onchainRefreshWorker.env.DEGOV_ONCHAIN_REFRESH_CURRENT_POWER_METHOD,
   "getVotes",
 );
 assert.equal(
   contract.sharedSecretKeys.includes("DEGOV_ONCHAIN_REFRESH_RPC_URL"),
+  false,
+);
+assert.equal(
+  contract.sharedSecretKeys.includes("DARWINIA_RPC_URL"),
+  true,
+);
+assert.equal(
+  contract.sharedSecretKeys.includes("LISK_RPC_URL"),
   true,
 );
 assert.deepEqual(contract.futureRuntimeChecks, [

--- a/deploy/staging/datalens-indexer-daos.json
+++ b/deploy/staging/datalens-indexer-daos.json
@@ -10,6 +10,12 @@
     "graphql": ["graphql"],
     "onchainRefreshWorker": ["worker"]
   },
+  "deploymentModel": {
+    "database": "one shared fresh Datalens indexer database",
+    "indexer": "one all-mode Datalens indexer workload",
+    "graphql": "one GraphQL service with scoped DAO routes",
+    "onchainRefreshWorker": "one shared worker workload"
+  },
   "datalens": {
     "endpointEnv": "DATALENS_ENDPOINT",
     "tokenEnv": "DATALENS_TOKEN",
@@ -22,22 +28,56 @@
   },
   "database": {
     "urlEnv": "DEGOV_INDEXER_DATABASE_URL",
-    "freshDatabasePrefix": "degov_datalens_migration_"
+    "databaseName": "degov_datalens_migration_all_contract_sets",
+    "freshInitOnly": true,
+    "migration": "apps/indexer/migrations/0001_init.sql"
+  },
+  "configFile": {
+    "env": "DEGOV_INDEXER_CONFIG_FILE",
+    "mountPath": "/app/indexer.yml",
+    "source": "GitOps-managed config file rendered from contractSets and rpc.chains",
+    "contractSetMode": "all"
+  },
+  "runtimeEnv": {
+    "DEGOV_INDEXER_CONFIG_FILE": "/app/indexer.yml",
+    "DEGOV_INDEXER_CONTRACT_SET_MODE": "all",
+    "DEGOV_INDEXER_TARGET_HEIGHT": "latest",
+    "DEGOV_INDEXER_RUN_ONCE": "false",
+    "DEGOV_INDEXER_POLL_INTERVAL_MS": 10000,
+    "DATALENS_APPLICATION": "degov-staging",
+    "DATALENS_FINALITY": "durable_only",
+    "DATALENS_DATASET_FAMILY": "evm",
+    "DATALENS_DATASET_NAME": "logs",
+    "DATALENS_QUERY_BLOCK_RANGE_LIMIT": 1000
   },
   "graphql": {
     "endpointEnv": "DEGOV_INDEXER_GRAPHQL_ENDPOINT",
     "bindEndpoint": "http://0.0.0.0:4350/graphql",
     "port": 4350,
     "path": "/graphql",
-    "routePolicy": "Add the Datalens GraphQL route for validation without removing existing DAO hostnames or endpoints."
+    "routePolicy": "Expose multiple scoped DAO hostnames or paths through the single GraphQL service without removing existing DAO hostnames until cutover is validated.",
+    "scopedRoutes": [
+      {
+        "daoCode": "degov-demo-dao",
+        "hostname": "indexer.next.degov.ai",
+        "path": "/degov-demo-dao/graphql",
+        "publicEndpoint": "https://indexer.next.degov.ai/degov-demo-dao/graphql"
+      },
+      {
+        "daoCode": "lisk-dao",
+        "hostname": "indexer.next.degov.ai",
+        "path": "/lisk-dao/graphql",
+        "publicEndpoint": "https://indexer.next.degov.ai/lisk-dao/graphql"
+      }
+    ]
   },
   "onchainRefreshWorker": {
     "enabled": false,
-    "rpcUrlEnv": "DEGOV_ONCHAIN_REFRESH_RPC_URL",
+    "rpcChainUrlEnvs": ["DARWINIA_RPC_URL", "LISK_RPC_URL"],
     "enableWhen": "Enable only after checkpoint/status integration can prove refresh tasks are created, processed, retried, and surfaced in diagnostics.",
     "env": {
+      "DEGOV_INDEXER_CONFIG_FILE": "/app/indexer.yml",
       "DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED": "false",
-      "DEGOV_ONCHAIN_REFRESH_RPC_URL": "",
       "DEGOV_ONCHAIN_REFRESH_CURRENT_POWER_METHOD": "getVotes",
       "DEGOV_ONCHAIN_REFRESH_BATCH_SIZE": 100,
       "DEGOV_ONCHAIN_REFRESH_MAX_ATTEMPTS": 3,
@@ -53,40 +93,42 @@
       "DEGOV_ONCHAIN_REFRESH_REQUEST_TIMEOUT_MS": 15000
     }
   },
-  "daos": [
+  "contractSets": [
     {
-      "code": "degov-demo-dao",
-      "databaseName": "degov_datalens_migration_degov_demo_dao",
-      "registryConfigPath": "degov.yml",
-      "graphqlPath": "/degov-demo-dao/graphql",
-      "startBlock": 5873342,
-      "targetHeight": 5874342,
-      "env": {
-        "DEGOV_INDEXER_DAO_CODE": "degov-demo-dao",
-        "DEGOV_INDEXER_START_BLOCK": 5873342,
-        "DEGOV_INDEXER_TARGET_HEIGHT": 5874342,
-        "DEGOV_INDEXER_GRAPHQL_ENDPOINT": "http://0.0.0.0:4350/graphql",
-        "DATALENS_APPLICATION": "degov-staging",
-        "DATALENS_FINALITY": "durable_only",
-        "DATALENS_CHAIN_FAMILY": "evm",
-        "DATALENS_CHAIN_NAME": "darwinia",
-        "DATALENS_CHAIN_ID": 46,
-        "DATALENS_DATASET_FAMILY": "evm",
-        "DATALENS_DATASET_NAME": "logs",
-        "DATALENS_QUERY_BLOCK_RANGE_LIMIT": 1000,
-        "DATALENS_CHAINS_JSON": "[{\"chainId\":46,\"networkName\":\"darwinia\",\"contracts\":[{\"daoCode\":\"degov-demo-dao\",\"governor\":\"0xC9EA55E644F496D6CaAEDcBAD91dE7481Dcd7517\",\"governorToken\":\"0xbC9f58566810F7e853e1eef1b9957ac82F9971df\",\"tokenStandard\":\"ERC20\",\"timelock\":\"0x6AB15C6ada9515A8E21321e241013dB457C8576c\",\"startBlock\":5873342}]}]",
-        "DATALENS_GOVERNOR_ADDRESS": "0xC9EA55E644F496D6CaAEDcBAD91dE7481Dcd7517",
-        "DATALENS_GOVERNOR_TOKEN_ADDRESS": "0xbC9f58566810F7e853e1eef1b9957ac82F9971df",
-        "DATALENS_GOVERNOR_TOKEN_STANDARD": "ERC20",
-        "DATALENS_TIMELOCK_ADDRESS": "0x6AB15C6ada9515A8E21321e241013dB457C8576c"
-      }
+      "chainId": 46,
+      "networkName": "darwinia",
+      "contracts": [
+        {
+          "daoCode": "degov-demo-dao",
+          "governor": "0xC9EA55E644F496D6CaAEDcBAD91dE7481Dcd7517",
+          "governorToken": "0xbC9f58566810F7e853e1eef1b9957ac82F9971df",
+          "tokenStandard": "ERC20",
+          "timelock": "0x6AB15C6ada9515A8E21321e241013dB457C8576c",
+          "startBlock": 5873342
+        }
+      ]
+    },
+    {
+      "chainId": 1135,
+      "networkName": "lisk",
+      "contracts": [
+        {
+          "daoCode": "lisk-dao",
+          "governor": "0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568",
+          "governorToken": "0x2eE6Eca46d2406454708a1C80356a6E63b57D404",
+          "tokenStandard": "ERC20",
+          "timelock": "0x2294A7f24187B84995A2A28112f82f07BE1BceAD",
+          "startBlock": 568752
+        }
+      ]
     }
   ],
   "sharedSecretKeys": [
     "DATALENS_ENDPOINT",
     "DATALENS_TOKEN",
     "DEGOV_INDEXER_DATABASE_URL",
-    "DEGOV_ONCHAIN_REFRESH_RPC_URL"
+    "DARWINIA_RPC_URL",
+    "LISK_RPC_URL"
   ],
   "requiredRuntimeChecks": [
     "pod-readiness",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,13 @@ services:
       context: .
       dockerfile: docker/indexer.Dockerfile
     command: run
+    volumes:
+      - ./apps/indexer/indexer.example.yml:/app/indexer.yml:ro
     environment:
       DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/indexer
+      DEGOV_INDEXER_CONFIG_FILE: ${DEGOV_INDEXER_CONFIG_FILE:-/app/indexer.yml}
+      DEGOV_INDEXER_CONTRACT_SET_MODE: ${DEGOV_INDEXER_CONTRACT_SET_MODE:-all}
       DEGOV_INDEXER_DAO_CODE: ${DEGOV_INDEXER_DAO_CODE:-}
-      DEGOV_INDEXER_START_BLOCK: ${DEGOV_INDEXER_START_BLOCK:-0}
       DEGOV_INDEXER_TARGET_HEIGHT: ${DEGOV_INDEXER_TARGET_HEIGHT:-latest}
       DEGOV_INDEXER_RUN_ONCE: ${DEGOV_INDEXER_RUN_ONCE:-false}
       DEGOV_INDEXER_POLL_INTERVAL_MS: ${DEGOV_INDEXER_POLL_INTERVAL_MS:-10000}
@@ -68,8 +71,11 @@ services:
       context: .
       dockerfile: docker/indexer.Dockerfile
     command: worker
+    volumes:
+      - ./apps/indexer/indexer.example.yml:/app/indexer.yml:ro
     environment:
       DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/indexer
+      DEGOV_INDEXER_CONFIG_FILE: ${DEGOV_INDEXER_CONFIG_FILE:-/app/indexer.yml}
       DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED: ${DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED:-false}
       DEGOV_ONCHAIN_REFRESH_RPC_URL: ${DEGOV_ONCHAIN_REFRESH_RPC_URL:-}
       DEGOV_ONCHAIN_REFRESH_RUN_ONCE: ${DEGOV_ONCHAIN_REFRESH_RUN_ONCE:-false}

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ or API/data-model reference material unless a newer document says otherwise.
 - [Datalens DAO production migration runbook](./runbook/datalens-dao-migration.md)
 - [Datalens staging deployment runbook](./runbook/datalens-staging-deployment.md)
 - [Datalens indexer observability runbook](./runbook/datalens-indexer-observability.md)
+- [Datalens unified deployment config contract](./config/contracts/datalens-indexer-unified-deployment.md)
 - [Accuracy research summary](./research/20260401__indexer_accuracy_research.md)
 - [Architecture overview](./architecture/20260325__indexer_architecture.md)
 - [Datalens indexer architecture contract](./spec/datalens-indexer-architecture-contract.md)

--- a/docs/config/contracts/datalens-indexer-unified-deployment.md
+++ b/docs/config/contracts/datalens-indexer-unified-deployment.md
@@ -1,0 +1,123 @@
+# Datalens Indexer Unified Deployment Contract
+
+> Purpose: define the DEGOV-side config contract GitOps should render for the
+> unified Datalens indexer deployment.
+>
+> Read this when: preparing local, staging, or production deployment config for
+> the all-contract-set Datalens indexer.
+>
+> This does not contain cluster-specific manifests, sealed secrets, or external
+> GitOps repository edits.
+
+## Deployment shape
+
+Local, staging, and production should use the same shape:
+
+- one fresh Postgres indexer database;
+- one `migrate` job or command applying the existing
+  `apps/indexer/migrations/0001_init.sql`;
+- one `run` workload with `DEGOV_INDEXER_CONTRACT_SET_MODE=all`;
+- one `graphql` workload backed by the shared DB;
+- one `worker` workload backed by the shared DB and the same config file;
+- multiple scoped DAO routes or hostnames pointing at the single GraphQL
+  service.
+
+Do not add migration files for this rollout. Moving from the old SQD/v4 runtime
+to the Datalens-native runtime remains a fresh DB initialization and reindex.
+
+## Required runtime env
+
+All indexer workloads need:
+
+```text
+DEGOV_INDEXER_DATABASE_URL=<shared-fresh-postgres-url>
+DEGOV_INDEXER_CONFIG_FILE=/app/indexer.yml
+DATALENS_ENDPOINT=<datalens-service-base-url>
+DATALENS_APPLICATION=<degov-staging-or-degov-live>
+DATALENS_TOKEN=<secret-backed-token>
+DATALENS_DATASET_FAMILY=evm
+DATALENS_DATASET_NAME=logs
+```
+
+The `run` workload additionally needs:
+
+```text
+DEGOV_INDEXER_CONTRACT_SET_MODE=all
+DEGOV_INDEXER_TARGET_HEIGHT=latest
+DEGOV_INDEXER_RUN_ONCE=false
+```
+
+Leave `DEGOV_INDEXER_DAO_CODE` unset for normal all-mode runs. Set it only for
+a temporary debug filter against the shared config file.
+
+## Config file
+
+Render a mounted config file at `DEGOV_INDEXER_CONFIG_FILE`. The file should
+contain the multi-chain contract sets and worker RPC env references:
+
+```yaml
+datalens:
+  endpoint: https://datalens.ringdao.com
+  application: degov-live
+  finality: durable_only
+  dataset:
+    family: evm
+    name: logs
+  queryLimits:
+    blockRangeLimit: 1000
+
+rpc:
+  chains:
+    "46":
+      urlEnv: DARWINIA_RPC_URL
+    "1135":
+      urlEnv: LISK_RPC_URL
+
+chains:
+  - chainId: 46
+    networkName: darwinia
+    contracts:
+      - daoCode: degov-demo-dao
+        governor: "0xC9EA55E644F496D6CaAEDcBAD91dE7481Dcd7517"
+        governorToken: "0xbC9f58566810F7e853e1eef1b9957ac82F9971df"
+        tokenStandard: ERC20
+        timelock: "0x6AB15C6ada9515A8E21321e241013dB457C8576c"
+        startBlock: 5873342
+  - chainId: 1135
+    networkName: lisk
+    contracts:
+      - daoCode: lisk-dao
+        governor: "0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568"
+        governorToken: "0x2eE6Eca46d2406454708a1C80356a6E63b57D404"
+        tokenStandard: ERC20
+        timelock: "0x2294A7f24187B84995A2A28112f82f07BE1BceAD"
+        startBlock: 568752
+```
+
+Environment variables override file values. Keep `DATALENS_TOKEN`,
+`DEGOV_INDEXER_DATABASE_URL`, and each `rpc.chains.*.urlEnv` value in secrets.
+
+## GraphQL routes
+
+Run one GraphQL service and route scoped DAO endpoints to it:
+
+```text
+/graphql
+/<dao-code>/graphql
+```
+
+The service derives extra scoped paths from
+`DEGOV_INDEXER_GRAPHQL_ENDPOINT` or `DEGOV_INDEXER_GRAPHQL_PATH`. Preserve
+existing DAO hostnames during validation, then repoint them to the shared
+GraphQL service after DB, indexer, worker, GraphQL, and web checks pass.
+
+## Rollout guardrails
+
+- Render one shared DB secret for the Datalens-native indexer.
+- Mount the same config file into the `run` and `worker` workloads.
+- Keep old DAO-specific DBs and runtimes available until scoped route cutover
+  and rollback validation pass.
+- Enable the worker only when `rpc.chains` URL envs are secret-backed and
+  checkpoint/status/onchain diagnostics are ready for the deployed package.
+- Do not edit external GitOps repositories from the DEGOV code change; apply
+  this contract in the GitOps repo as a separate rollout step.

--- a/docs/runbook/datalens-dao-migration.md
+++ b/docs/runbook/datalens-dao-migration.md
@@ -14,10 +14,12 @@
 ## Migration Contract
 
 This is an incompatible indexer migration. The normal production path is a
-fresh target Postgres database, Datalens-native schema initialization, and a
-clean reindex from the DAO's configured start block. Reusing an existing SQD/v4
-database is not allowed unless that specific DAO has a written, validated DB
-reuse path with parity evidence and rollback coverage.
+fresh shared Postgres indexer database, Datalens-native schema initialization,
+and a clean reindex from each configured DAO's start block. The HBX-307
+deployment model is one DB, one `DEGOV_INDEXER_CONTRACT_SET_MODE=all` indexer,
+one GraphQL service, one worker, and scoped DAO routes or hostnames. Reusing an
+existing SQD/v4 database is not allowed unless that specific deployment has a
+written, validated DB reuse path with parity evidence and rollback coverage.
 
 DB migrations alone cannot rewrite historical projections that were already
 indexed under the old runtime. A schema migration can create or reshape tables,
@@ -81,6 +83,9 @@ All preconditions must be true before scheduling production cutover.
 - Target DB initialization is ready: a new database can be created, credentials
   can be mounted, and `pnpm run indexer:migrate` can initialize the
   Datalens-native schema.
+- The production indexer config file can be mounted through
+  `DEGOV_INDEXER_CONFIG_FILE` and contains every contract set in the rollout
+  plus `rpc.chains` URL env names for the shared worker.
 - Production web/API cutover path is known: DB pointer, image tag, runtime
   entrypoint, GraphQL endpoint, and web config changes can be reverted
   independently.
@@ -99,7 +104,9 @@ export DATALENS_DATASET_FAMILY=evm
 export DATALENS_DATASET_NAME=logs
 export DATALENS_APPLICATION=<production-datalens-application>
 export DATALENS_ENDPOINT=<datalens-service-base-url>
-export TARGET_DB_URL=<new-datalens-postgres-url>
+export DEGOV_INDEXER_CONFIG_FILE=<mounted-indexer-config-file>
+export DEGOV_INDEXER_CONTRACT_SET_MODE=all
+export TARGET_DB_URL=<new-shared-datalens-postgres-url>
 export OLD_DB_URL=<current-sqd-v4-postgres-url>
 export CANDIDATE_IMAGE=ghcr.io/ringecosystem/degov/indexer:sha-<git-sha>
 export DEGOV_INDEXER_GRAPHQL_ENDPOINT=<production-or-validation-graphql-url>
@@ -112,14 +119,16 @@ or committed files.
 
 ## Staging Proof Gate
 
-Complete staging proof before production cutover. For each DAO:
+Complete staging proof before production cutover. For the shared deployment:
 
-1. Deploy the Datalens-backed staging indexer with a fresh staging DB.
+1. Deploy the Datalens-backed staging indexer with a fresh shared staging DB,
+   `DEGOV_INDEXER_CONTRACT_SET_MODE=all`, and the same config-file shape.
 2. Confirm Datalens server, application auth, chain dataset, and cache checks
    pass.
 3. Confirm the current package boundary is understood for the deployed image.
-4. After projection packages land, wait for the staging checkpoint to reach the
-   intended target height and verify proposal/delegate/metric counts.
+4. After projection packages land, wait for every configured staging
+   checkpoint to reach the intended target height and verify
+   proposal/delegate/metric counts by DAO scope.
 5. After worker packages land and if the DAO supports refresh, run onchain
    refresh and verify queue drain.
 6. Run side-by-side checks against the old runtime, Tally, and direct onchain
@@ -130,31 +139,34 @@ Complete staging proof before production cutover. For each DAO:
 For detailed commands, use the staging and observability runbooks instead of
 duplicating all checks here.
 
-## One-DAO Production Cutover
+## Shared Production Cutover
 
-Use this sequence for a single DAO. For a batch, run the same sequence per DAO
-and apply the batching controls in the next section.
+Use this sequence for the shared production deployment. Individual DAO cutover
+still happens through scoped routes, web config, and validation targets, not
+through separate Datalens-native databases.
 
 ### 1. Freeze The Cutover Scope
 
-Record the exact DAO, image tag, current production DB, target DB name, current
-production image/env, and rollback commit or GitOps revision. Keep this record
-outside the production DB being changed.
+Record the exact DAO set, image tag, current production DB pointers, shared
+target DB name, current production image/env, scoped routes, and rollback
+commit or GitOps revision. Keep this record outside the production DB being
+changed.
 
 Do not include unsupported DAOs. If compatibility preflight classifies a DAO as
 unsupported, exclude it from active production workloads before continuing.
 
 ### 2. Create The Target DB
 
-Create a new production target database for the DAO. Use a name that clearly
-marks it as Datalens-native and production, for example:
+Create one new production target database for the all-mode Datalens-native
+deployment. Use a name that clearly marks it as shared, Datalens-native, and
+production, for example:
 
 ```text
-degov_datalens_prod_<dao_code>
+degov_datalens_prod_all_contract_sets
 ```
 
 Do not point the Datalens-native indexer at the existing SQD/v4 database unless
-there is a validated DB reuse path for this exact DAO.
+there is a validated DB reuse path for this exact deployment.
 
 Initialize the target DB:
 
@@ -168,15 +180,15 @@ cutover and keep production on the old runtime.
 
 ### 3. Deploy The Datalens-Backed Indexer
 
-Deploy a production validation workload for the DAO using:
+Deploy production validation workloads using:
 
 - image `CANDIDATE_IMAGE`;
-- `run` entrypoint for the indexer;
+- one `run` entrypoint with `DEGOV_INDEXER_CONTRACT_SET_MODE=all`;
 - `graphql` entrypoint only after DB initialization is complete;
 - `worker` entrypoint only when worker task processing is supported and enabled
-  for this DAO;
-- production Datalens endpoint, application, chain/dataset, governor, token,
-  and optional timelock environment;
+  for the configured contract sets;
+- production Datalens endpoint, application, dataset, and mounted config file
+  containing chain/dataset contract sets plus `rpc.chains`;
 - `DEGOV_INDEXER_DATABASE_URL="$TARGET_DB_URL"`.
 
 Keep the old SQD/v4 runtime serving production while the Datalens workload
@@ -363,15 +375,18 @@ After production traffic is served by the Datalens-backed DB/image/env and the
 public smoke checks pass, stop or scale down the old SQD/v4 runtime for this
 DAO. Do not delete the old DB, volumes, secrets, or SQD-specific resources yet.
 
-## Batched DAO Migration
+## Scoped DAO Route Cutover
 
-Use batches only after at least one DAO has completed the one-DAO path and
-validated rollback. A batch is a list of independent one-DAO migrations with a
-shared release window, not a single all-or-nothing DB operation.
+Use scoped route cutovers only after at least one DAO has completed validation
+against the shared Datalens deployment and rollback is understood. A batch is a
+list of DAO routes/web configs cut over to the shared DB-backed GraphQL service,
+not a set of separate Datalens-native DBs.
 
 Batch controls:
 
-- Keep one target DB per DAO. Do not share target DBs across DAOs.
+- Keep one shared target DB for the all-mode Datalens deployment. Do not create
+  new DAO-specific Datalens-native DBs unless rollback requires a temporary
+  validation fork.
 - Require every DAO in the batch to pass compatibility preflight and staging
   proof before the batch starts.
 - Freeze one image tag for the batch unless a DAO has a documented exception.
@@ -381,12 +396,12 @@ Batch controls:
 - Roll back only the affected DAO when failures are DAO-specific. Roll back the
   whole batch only when the failure is shared infrastructure, image, schema, or
   Datalens application behavior.
-- Track old and target DB pointers per DAO so rollback never depends on memory
-  or shell history.
+- Track old DB pointers, shared target DB pointer, and scoped route/web config
+  per DAO so rollback never depends on memory or shell history.
 
 Minimum batch record:
 
-| DAO | Old DB | Target DB | Image | Target height | Refresh supported | Validation owner | Cutover status |
+| DAO | Old DB | Shared target DB | Image | Target height | Refresh supported | Validation owner | Cutover status |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `<dao-code>` | `<old-db>` | `<target-db>` | `<sha-tag>` | `<height>` | `yes/no` | `<owner>` | `<pending/done/rollback>` |
 

--- a/docs/runbook/datalens-indexer-observability.md
+++ b/docs/runbook/datalens-indexer-observability.md
@@ -20,13 +20,16 @@ Collect these values before running checks:
 - Datalens application identity, such as `degov-live`.
 - Secret-backed Datalens bearer token. Do not print or paste the token into
   issue comments, logs, shell history, or committed files.
-- DeGov indexer database URL. Deployed services use
-  `DEGOV_INDEXER_DATABASE_URL`; the examples below use the same name.
-- DeGov GraphQL endpoint, for example
-  `https://indexer.next.degov.ai/<dao-code>/graphql`. Deployed services use
-  `DEGOV_INDEXER_GRAPHQL_ENDPOINT`; the GraphQL service binds with
-  `DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS` and also serves
-  `DEGOV_INDEXER_GRAPHQL_PATH` when set.
+- Shared DeGov indexer database URL. Deployed services use
+  `DEGOV_INDEXER_DATABASE_URL`; the examples below use the same name and filter
+  by DAO scope where needed.
+- Mounted indexer config file. Deployed all-mode services use
+  `DEGOV_INDEXER_CONFIG_FILE` plus `DEGOV_INDEXER_CONTRACT_SET_MODE=all`; the
+  file contains `chains` contract sets and worker `rpc.chains` URL env names.
+- Scoped DeGov GraphQL endpoint, for example
+  `https://indexer.next.degov.ai/<dao-code>/graphql`. One GraphQL service
+  serves the shared DB and exposes `/graphql` plus scoped DAO paths derived from
+  `DEGOV_INDEXER_GRAPHQL_ENDPOINT` or `DEGOV_INDEXER_GRAPHQL_PATH`.
 - DeGov web base URL for the environment under test.
 
 Use placeholders in the examples below:
@@ -46,6 +49,8 @@ export DATALENS_ENDPOINT=<datalens-service-base-url>
 export DATALENS_APPLICATION=<datalens-application>
 export DATALENS_TOKEN=<secret-backed-token>
 export DEGOV_INDEXER_DATABASE_URL=<postgres-url>
+export DEGOV_INDEXER_CONFIG_FILE=<mounted-indexer-config-file>
+export DEGOV_INDEXER_CONTRACT_SET_MODE=all
 export DEGOV_INDEXER_GRAPHQL_ENDPOINT=<degov-graphql-url>
 export DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS=0.0.0.0:4350
 export DEGOV_INDEXER_GRAPHQL_PATH=/<dao-code>/graphql

--- a/docs/runbook/datalens-staging-deployment.md
+++ b/docs/runbook/datalens-staging-deployment.md
@@ -1,7 +1,7 @@
 # Datalens Staging Deployment Runbook
 
-> Purpose: define the staging deployment path for selected DAOs running the
-> Datalens-native DeGov indexer.
+> Purpose: define the staging deployment path for selected DAOs running through
+> one shared Datalens-native DeGov indexer deployment.
 >
 > Read this when: preparing or reviewing GitOps changes for the HBX-244 manual
 > migration wave.
@@ -13,8 +13,8 @@
 
 Use `deploy/staging/datalens-indexer-daos.json` as the source-controlled
 staging contract. It pins the Datalens-native image repository,
-`degov-datalens-indexer` entrypoints, selected DAO env, fresh migration DB
-names, and worker state.
+`degov-datalens-indexer` entrypoints, the shared fresh migration DB, all-mode
+contract set config, scoped GraphQL routes, and worker state.
 
 The release workflow publishes the indexer image as:
 
@@ -22,41 +22,55 @@ The release workflow publishes the indexer image as:
 ghcr.io/ringecosystem/degov/indexer:sha-<git-sha>
 ```
 
-Deploy one workload set per selected DAO. Keep staging namespace, database
-name, image tag, and GraphQL route separate from production. Do not share a
-production DB, production GraphQL route, or production web config with a
-Datalens migration validation pod.
+Deploy one workload set for the selected contract sets:
 
-The Datalens GraphQL route is additive during validation. Do not remove or
-repoint existing DAO hostnames/endpoints until the new indexer DB reset,
-indexing workload, GraphQL service, and web reads have been validated together.
+- one fresh Postgres index database initialized by
+  `apps/indexer/migrations/0001_init.sql`;
+- one `run` workload with `DEGOV_INDEXER_CONTRACT_SET_MODE=all`;
+- one `graphql` workload backed by the shared DB;
+- one `worker` workload backed by the shared DB and config-file `rpc.chains`;
+- one or more scoped DAO hostnames or paths routed to the single GraphQL
+  service.
+
+Keep staging namespace, database name, image tag, and scoped GraphQL routes
+separate from production. Do not share a production DB, production GraphQL
+route, or production web config with a Datalens migration validation pod.
+
+The Datalens GraphQL routes are additive during validation. Do not remove or
+repoint existing DAO hostnames/endpoints until the new shared indexer DB reset,
+all-mode indexing workload, GraphQL service, scoped routes, and web reads have
+been validated together.
 
 ## Required environment
 
-Each DAO indexer deployment must receive:
+The shared indexer, GraphQL service, and worker must receive:
 
-- `DEGOV_INDEXER_DATABASE_URL`: points to a fresh DB whose name starts with
-  `degov_datalens_migration_`.
+- `DEGOV_INDEXER_DATABASE_URL`: points to the fresh shared DB, for example
+  `degov_datalens_migration_all_contract_sets`.
+- `DEGOV_INDEXER_CONFIG_FILE`: path to the mounted config file containing
+  `chains` contract sets and `rpc.chains` URL env names.
+- `DEGOV_INDEXER_CONTRACT_SET_MODE=all`: runs every configured contract set.
+  Set `DEGOV_INDEXER_DAO_CODE` only for a temporary debug filter.
 - `DATALENS_ENDPOINT`: Datalens service base URL, not `/native/graphql`.
 - `DATALENS_TOKEN`: application bearer token from GitOps-managed secrets.
 - `DATALENS_APPLICATION`: `degov-staging` for staging validation.
-- `DATALENS_CHAIN_FAMILY`, `DATALENS_CHAIN_NAME`, and `DATALENS_CHAIN_ID`.
 - `DATALENS_DATASET_FAMILY` and `DATALENS_DATASET_NAME`.
-- `DATALENS_CHAINS_JSON` when running structured multi-chain or multi-contract
-  indexing. Keep the legacy single-contract envs during transition only when a
-  single selected DAO still needs them.
-- `DATALENS_GOVERNOR_ADDRESS`, `DATALENS_GOVERNOR_TOKEN_ADDRESS`,
-  `DATALENS_GOVERNOR_TOKEN_STANDARD`, and `DATALENS_TIMELOCK_ADDRESS`.
 - `DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS`: local socket address for the service,
   for example `0.0.0.0:4350`.
-- `DEGOV_INDEXER_GRAPHQL_ENDPOINT`: public GraphQL URL consumed by web and
-  smoke checks, for example `https://indexer.next.degov.ai/<dao-code>/graphql`.
-- `DEGOV_INDEXER_GRAPHQL_PATH`: public route path mounted by the service when
-  it is not just `/graphql`, for example `/<dao-code>/graphql`.
+- `DEGOV_INDEXER_GRAPHQL_ENDPOINT`: public GraphQL URL used by the service to
+  derive an extra scoped path, for example
+  `https://indexer.next.degov.ai/<dao-code>/graphql`.
+- `DEGOV_INDEXER_GRAPHQL_PATH`: additional scoped route path when the public
+  endpoint is not enough, for example `/<dao-code>/graphql`.
 
-Run `migrate` against the fresh DB before starting `run`. Start `graphql` only
-after the DB schema exists and the staging web route points at the staging
-GraphQL endpoint.
+The mounted config file is the source of truth for chain ids, network names,
+governor/token/timelock addresses, start blocks, and worker RPC env names. Keep
+legacy `DATALENS_CHAINS_JSON` and single-contract envs only for local or
+emergency single-DAO debug runs.
+
+Run `migrate` against the fresh shared DB before starting `run`. Start
+`graphql` only after the DB schema exists and the scoped staging web routes
+point at the staging GraphQL service.
 
 ## Datalens dependency gate
 
@@ -83,10 +97,11 @@ retried, and surfaced in diagnostics. The staging contract records this as
 `onchainRefreshWorker.enabled=false`.
 
 When the worker is enabled later, deploy it as a separate workload using the
-`worker` entrypoint. Provide `DEGOV_ONCHAIN_REFRESH_RPC_URL` from secrets and
-keep `DEGOV_ONCHAIN_REFRESH_CURRENT_POWER_METHOD=getVotes` unless a DAO
-requires `getCurrentVotes`. Power refresh must come from onchain RPC reads, not
-log-derived fallback mode. Monitor `onchainRefreshBacklog` plus
+`worker` entrypoint. Prefer `rpc.chains` in `DEGOV_INDEXER_CONFIG_FILE` and
+provide each referenced URL env from secrets, such as `DARWINIA_RPC_URL` or
+`LISK_RPC_URL`. Keep `DEGOV_ONCHAIN_REFRESH_CURRENT_POWER_METHOD=getVotes`
+unless a DAO requires `getCurrentVotes`. Power refresh must come from onchain
+RPC reads, not log-derived fallback mode. Monitor `onchainRefreshBacklog` plus
 `onchainRefreshErrors`.
 
 ## Rollout checks
@@ -97,16 +112,16 @@ target the staging cluster and namespace; in Helixbox workspaces use
 
 ```bash
 kubectl --kubeconfig=avault/.kube/<cluster>.config \
-  -n <staging-namespace> rollout status deploy/<dao>-degov-datalens-indexer
+  -n <staging-namespace> rollout status deploy/degov-datalens-indexer
 
 kubectl --kubeconfig=avault/.kube/<cluster>.config \
-  -n <staging-namespace> logs deploy/<dao>-degov-datalens-indexer --since=10m
+  -n <staging-namespace> logs deploy/degov-datalens-indexer --since=10m
 ```
 
-Look for pod startup, configured DAO, chain, dataset, DB migration, GraphQL
-startup, and projection error fields in logs. Any projection error should
-include enough context to identify the DAO, stream, block range, and failing
-projection.
+Look for pod startup, configured contract sets, chain, dataset, DB migration,
+GraphQL startup, and projection error fields in logs. Any projection error
+should include enough context to identify the DAO, stream, block range,
+contract set, and failing projection.
 
 Check GraphQL availability:
 
@@ -150,14 +165,15 @@ pnpm run audit:tally-onchain -- \
 
 ## Rollback
 
-Rollback does not require an in-place DB migration because staging uses fresh
-Datalens migration databases.
+Rollback does not require an in-place DB migration because staging uses a fresh
+Datalens migration database.
 
 1. Revert the staging GitOps image tag to the previous known-good image.
-2. Restore the previous env/config secret set for the selected DAO.
-3. Repoint the staging web GraphQL endpoint to the previous staging endpoint.
+2. Restore the previous env/config secret set and mounted indexer config file.
+3. Repoint scoped staging web GraphQL endpoints to the previous staging
+   endpoints.
 4. Keep or set `DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED=false`.
-5. Leave the failed `degov_datalens_migration_*` DB intact for inspection, or
-   delete it only after the validation notes have been captured.
+5. Leave the failed shared `degov_datalens_migration_*` DB intact for
+   inspection, or delete it only after the validation notes have been captured.
 6. Re-run pod readiness and GraphQL availability checks against the restored
    deployment.

--- a/docs/spec/datalens-indexer-architecture-contract.md
+++ b/docs/spec/datalens-indexer-architecture-contract.md
@@ -84,8 +84,9 @@ Recommended indexer environment variables:
 | `DATALENS_ENDPOINT` | Shared service base URL, such as `https://datalens.ringdao.com`. |
 | `DATALENS_APPLICATION` | Datalens application identity, such as `degov-live`. |
 | `DATALENS_TOKEN` | Bearer token loaded from secret management. |
-| `DEGOV_DATABASE_URL` | DeGov application database URL. |
-| `DEGOV_CONFIG_PATH` | DAO/workload config path. |
+| `DEGOV_INDEXER_DATABASE_URL` | Shared DeGov indexer database URL. |
+| `DEGOV_INDEXER_CONFIG_FILE` | Mounted DAO/workload config path. |
+| `DEGOV_INDEXER_CONTRACT_SET_MODE` | `all` for shared staging and production deployments. |
 | `DEGOV_RESET_CHECKPOINT` | Explicit fresh replay/reset-index switch. |
 
 ## Crate and package boundaries


### PR DESCRIPTION
## Summary
- Update local compose and env examples for one shared Datalens indexer DB, all-mode contract set execution, and config-file based multi-chain contract sets.
- Replace the staging deployment contract with a shared DB/indexer/graphql/worker model plus scoped DAO routes.
- Update focused runbooks and config contract docs for local/staging/prod rollout guidance without editing external GitOps repos.

## Validation
- `cargo fmt --all --check`
- `cd apps/indexer && node ./scripts/runtime-packaging.test.mjs`
- `cd apps/indexer && node ./scripts/staging-deployment-contract.test.mjs`
- `cargo build -p degov-datalens-indexer --locked`

## Notes
- Migration remains fresh DB initialization through `apps/indexer/migrations/0001_init.sql`; no migration files were added.
- Worker remains disabled in the staging contract until checkpoint/status/onchain diagnostics are ready.
