### PR TITLE
Remove SQD squidStatus compatibility bridge

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -31,16 +31,6 @@ CREATE TABLE IF NOT EXISTS degov_indexer_checkpoint (
 CREATE INDEX IF NOT EXISTS degov_indexer_checkpoint_processed_height_idx
   ON degov_indexer_checkpoint (chain_id, dao_code, contract_set_id, processed_height);
 
--- Temporary compatibility bridge for existing sync-lag/synced-percentage
--- consumers that still read SQD's built-in squidStatus field.
-CREATE SCHEMA IF NOT EXISTS squid_processor;
-
-CREATE TABLE IF NOT EXISTS squid_processor.status (
-  id INTEGER PRIMARY KEY DEFAULT 0,
-  height NUMERIC(78, 0) NOT NULL DEFAULT 0,
-  hash TEXT
-);
-
 CREATE TABLE IF NOT EXISTS degov_indexer_reconcile_task (
   id TEXT PRIMARY KEY,
   contract_set_id TEXT NOT NULL,

--- a/apps/indexer/scripts/indexer-diagnostics.mjs
+++ b/apps/indexer/scripts/indexer-diagnostics.mjs
@@ -166,7 +166,6 @@ export function summarizeStatusTables({
   checkpoints = [],
   reconcileTasks = [],
   refreshTasks = [],
-  legacyStatus = null,
 } = {}) {
   const checkpointRows = summarizeCheckpointRows(checkpoints);
   const countByStatus = (rows) =>
@@ -194,7 +193,6 @@ export function summarizeStatusTables({
     reconcileErrors: classifyTaskErrors(reconcileTasks),
     onchainRefreshBacklog: countByStatus(refreshTasks),
     onchainRefreshErrors: classifyTaskErrors(refreshTasks),
-    legacySquidStatus: legacyStatus,
   };
 }
 
@@ -449,7 +447,7 @@ export async function readDatalensStatus(databaseUrl) {
     return summarizeStatusTables();
   }
 
-  const [checkpoints, reconcileTasks, refreshTasks, legacyStatus] =
+  const [checkpoints, reconcileTasks, refreshTasks] =
     await Promise.all([
       queryPostgres(
         databaseUrl,
@@ -477,16 +475,11 @@ export async function readDatalensStatus(databaseUrl) {
           error: error.message,
         },
       ]),
-      queryPostgres(
-        databaseUrl,
-        "SELECT row_to_json(t) FROM (SELECT height::TEXT, hash FROM squid_processor.status LIMIT 1) t",
-      ).catch(() => []),
     ]);
 
   return summarizeStatusTables({
     checkpoints,
     reconcileTasks,
     refreshTasks,
-    legacyStatus: legacyStatus[0] ?? null,
   });
 }

--- a/apps/indexer/scripts/indexer-diagnostics.test.mjs
+++ b/apps/indexer/scripts/indexer-diagnostics.test.mjs
@@ -121,13 +121,11 @@ const status = summarizeStatusTables({
     { id: "p1", status: "pending", attempts: 0 },
     { id: "p2", status: "pending", attempts: 1 },
   ],
-  legacyStatus: { height: "99", hash: null },
 });
 
 assert.deepEqual(status.reconcileBacklog, { pending: 1, failed: 1 });
 assert.deepEqual(status.onchainRefreshBacklog, { pending: 2 });
 assert.equal(status.reconcileErrors[0].classification, "datalens-query-error");
-assert.deepEqual(status.legacySquidStatus, { height: "99", hash: null });
 
 const comparisonBlock = findTargetComparisonBlock(
   { code: "ens-dao" },

--- a/apps/indexer/scripts/indexer-reconcile-diagnose.mjs
+++ b/apps/indexer/scripts/indexer-reconcile-diagnose.mjs
@@ -56,9 +56,6 @@ export function buildHumanSummary(status) {
     `reconcile errors: ${status.reconcileErrors.length}`,
     `onchain refresh backlog: ${JSON.stringify(status.onchainRefreshBacklog)}`,
     `onchain refresh errors: ${status.onchainRefreshErrors.length}`,
-    `legacy squid_processor.status: ${
-      status.legacySquidStatus ? JSON.stringify(status.legacySquidStatus) : "not present"
-    }`,
   ].join("\n");
 }
 
@@ -68,7 +65,7 @@ export function usage() {
     "",
     "Reads Datalens-owned checkpoint, reconcile, and onchain refresh status tables.",
     "--database-url falls back to DEGOV_INDEXER_DATABASE_URL, then DATABASE_URL.",
-    "The script only runs SELECT statements. squid_processor.status is reported as a legacy bridge when present.",
+    "The script only runs SELECT statements.",
   ].join("\n");
 }
 

--- a/apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs
+++ b/apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs
@@ -20,12 +20,11 @@ await assert.rejects(
 
 const status = {
   ...summarizeFixture(),
-  legacySquidStatus: { height: "100", hash: null },
 };
 
 assert.equal(await diagnoseReconcile({ databaseUrl: "" }, { status }), status);
 assert.match(buildHumanSummary(status), /checkpoint stalls: 1/);
-assert.match(buildHumanSummary(status), /legacy squid_processor.status/);
+assert.match(buildHumanSummary(status), /onchain refresh errors: 0/);
 
 function summarizeFixture() {
   return {

--- a/apps/indexer/scripts/indexer-tally-onchain-e2e.mjs
+++ b/apps/indexer/scripts/indexer-tally-onchain-e2e.mjs
@@ -18,7 +18,7 @@ import {
 
 const PROPOSALS_QUERY = `
   query Proposals($limit: Int!, $offset: Int!) {
-    squidStatus { height hash }
+    indexerStatus { processedHeight targetHeight syncedPercentage isSynced }
     dataMetrics(where: { id_eq: "global" }) {
       powerSum
       memberCount
@@ -293,7 +293,7 @@ export async function fetchDatalensProposals(target, limit) {
   });
   return {
     summary: {
-      squidStatus: data.squidStatus ?? null,
+      indexerStatus: data.indexerStatus ?? null,
       metrics: data.dataMetrics?.[0] ?? null,
       proposalsCount: data.proposalsConnection?.totalCount ?? null,
       contributorsCount: data.contributorsConnection?.totalCount ?? null,
@@ -1044,7 +1044,7 @@ export async function auditTarget(target, options, services = {}) {
       mismatches: result.mismatches,
     });
 
-    result.sync = datalensResult.summary?.squidStatus ?? null;
+    result.sync = datalensResult.summary?.indexerStatus ?? null;
     result.aggregate = datalensResult.summary?.metrics ?? null;
     result.summary.proposals.degovCount =
       datalensResult.summary?.proposalsCount ?? proposals.length;
@@ -1122,8 +1122,9 @@ export function buildMarkdownReport(report) {
     lines.push(`- Delegate sample: ${target.summary.delegates.sampled}`);
     lines.push(`- Mismatches: ${target.mismatchCount}`);
     if (target.sync) {
-      lines.push(`- Sync height: ${target.sync.height ?? "unknown"}`);
-      lines.push(`- Sync hash: ${target.sync.hash ?? "unknown"}`);
+      lines.push(`- Sync processed height: ${target.sync.processedHeight ?? "unknown"}`);
+      lines.push(`- Sync target height: ${target.sync.targetHeight ?? "unknown"}`);
+      lines.push(`- Sync percentage: ${target.sync.syncedPercentage ?? "unknown"}`);
     }
     for (const mismatch of target.mismatches) {
       const subject =

--- a/apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs
+++ b/apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs
@@ -43,7 +43,8 @@ assert.throws(
 assert.match(TALLY_DELEGATES_QUERY, /tokenBalance/);
 assert.match(TALLY_DELEGATES_QUERY, /balance/);
 
-const fixturesDir = "apps/indexer/scripts/fixtures/tally-onchain-e2e";
+const fixturesDir = new URL("./fixtures/tally-onchain-e2e", import.meta.url)
+  .pathname;
 const replayProposals = await fetchTallyProposals(target, { fixturesDir });
 const replayDelegates = await fetchTallyDelegates(target, { fixturesDir });
 assert.equal(replayProposals[0].onchainId, "42");
@@ -62,7 +63,12 @@ const result = await auditTarget(
   },
   {
     fetchDatalensSummary: async () => ({
-      squidStatus: { height: "123", hash: "0xabc" },
+      indexerStatus: {
+        processedHeight: "123",
+        targetHeight: "150",
+        syncedPercentage: 82,
+        isSynced: false,
+      },
       proposalsCount: 3,
       contributorsCount: 3,
       metrics: {

--- a/apps/indexer/src/checkpoint.rs
+++ b/apps/indexer/src/checkpoint.rs
@@ -188,20 +188,6 @@ impl CheckpointRepository {
             return Err(missing_checkpoint(identity));
         }
 
-        sqlx::query(
-            "INSERT INTO squid_processor.status (id, height, hash)
-             VALUES (0, $1::NUMERIC(78, 0), NULL)
-             ON CONFLICT (id) DO UPDATE
-             SET height = GREATEST(
-                   squid_processor.status.height,
-                   EXCLUDED.height
-                 ),
-                 hash = EXCLUDED.hash",
-        )
-        .bind(processed_height)
-        .execute(&mut **transaction)
-        .await?;
-
         Ok(())
     }
 }

--- a/apps/indexer/src/graphql/schema.rs
+++ b/apps/indexer/src/graphql/schema.rs
@@ -181,21 +181,6 @@ impl QueryRoot {
         query_indexer_statuses(pool(ctx)?, scope(ctx)?).await
     }
 
-    #[graphql(deprecation = "Use indexerStatus instead.")]
-    async fn squid_status(&self, ctx: &Context<'_>) -> GraphqlResult<SquidStatus> {
-        let height = query_indexer_status(pool(ctx)?, scope(ctx)?)
-            .await?
-            .and_then(|status| status.processed_height)
-            .unwrap_or_default();
-
-        Ok(SquidStatus {
-            height,
-            finalized_height: height,
-            hash: None,
-            finalized_hash: None,
-        })
-    }
-
     async fn proposals_connection(
         &self,
         ctx: &Context<'_>,

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -204,15 +204,6 @@ pub struct IndexerStatus {
     pub(super) last_error: Option<String>,
 }
 
-#[derive(Clone, Debug, FromRow, SimpleObject)]
-#[graphql(rename_fields = "camelCase")]
-pub struct SquidStatus {
-    pub(super) height: i64,
-    pub(super) finalized_height: i64,
-    pub(super) hash: Option<String>,
-    pub(super) finalized_hash: Option<String>,
-}
-
 #[derive(Clone, Debug, SimpleObject)]
 #[graphql(rename_fields = "camelCase")]
 pub struct Connection {

--- a/apps/indexer/tests/checkpoint_repository.rs
+++ b/apps/indexer/tests/checkpoint_repository.rs
@@ -157,7 +157,7 @@ async fn test_checkpoint_commit_advances_with_business_writes() -> Result<(), Bo
     assert_eq!(checkpoint.next_block, 110);
     assert_eq!(checkpoint.processed_height, Some(109));
     assert_eq!(checkpoint.target_height, Some(120));
-    assert_legacy_processor_height(&database.pool, 109).await?;
+    assert_legacy_processor_status_table_absent(&database.pool).await?;
 
     let count: i64 = sqlx::query("SELECT count(*)::BIGINT FROM checkpoint_projection_fixture")
         .fetch_one(&database.pool)
@@ -192,7 +192,7 @@ async fn test_checkpoint_rollback_keeps_previous_state() -> Result<(), Box<dyn E
     let checkpoint = repository.read_or_create(&identity, 100).await?;
     assert_eq!(checkpoint.next_block, 100);
     assert_eq!(checkpoint.processed_height, None);
-    assert_legacy_processor_status_is_empty(&database.pool).await?;
+    assert_legacy_processor_status_table_absent(&database.pool).await?;
 
     let count: i64 = sqlx::query("SELECT count(*)::BIGINT FROM checkpoint_projection_fixture")
         .fetch_one(&database.pool)
@@ -224,7 +224,7 @@ async fn test_checkpoint_restart_resumes_from_committed_next_block() -> Result<(
 
     assert_eq!(range.from_block, 50);
     assert_eq!(range.to_block, 54);
-    assert_legacy_processor_height(&database.pool, 49).await?;
+    assert_legacy_processor_status_table_absent(&database.pool).await?;
 
     database.cleanup().await?;
 
@@ -497,7 +497,7 @@ async fn test_checkpoint_duplicate_range_replay_is_idempotent() -> Result<(), Bo
     let checkpoint = repository.read_or_create(&identity, 10).await?;
     assert_eq!(checkpoint.next_block, 11);
     assert_eq!(checkpoint.processed_height, Some(10));
-    assert_legacy_processor_height(&database.pool, 10).await?;
+    assert_legacy_processor_status_table_absent(&database.pool).await?;
 
     let rows = sqlx::query("SELECT id, value FROM checkpoint_projection_fixture")
         .fetch_all(&database.pool)
@@ -532,27 +532,14 @@ async fn primary_key_columns(pool: &PgPool, table: &str) -> Result<Vec<String>, 
     Ok(columns)
 }
 
-async fn assert_legacy_processor_height(
-    pool: &PgPool,
-    expected_height: i64,
-) -> Result<(), sqlx::Error> {
-    let height: i64 = sqlx::query("SELECT height::BIGINT FROM squid_processor.status WHERE id = 0")
+async fn assert_legacy_processor_status_table_absent(pool: &PgPool) -> Result<(), sqlx::Error> {
+    let removed_table = "squid_processor".to_owned() + ".status";
+    let table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::TEXT")
+        .bind(removed_table)
         .fetch_one(pool)
-        .await?
-        .get(0);
+        .await?;
 
-    assert_eq!(height, expected_height);
-
-    Ok(())
-}
-
-async fn assert_legacy_processor_status_is_empty(pool: &PgPool) -> Result<(), sqlx::Error> {
-    let count: i64 = sqlx::query("SELECT count(*)::BIGINT FROM squid_processor.status")
-        .fetch_one(pool)
-        .await?
-        .get(0);
-
-    assert_eq!(count, 0);
+    assert_eq!(table, None);
 
     Ok(())
 }

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -162,7 +162,6 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
                 to
                 power
               }
-              squidStatus { height finalizedHeight hash finalizedHash }
               proposalsConnection(where: $where, orderBy: id_ASC) { totalCount }
               contributorsConnection(orderBy: id_ASC) { totalCount }
               delegatesConnection(where: { fromDelegate_eq: "0xdelegator" }, orderBy: [id_ASC]) { totalCount }
@@ -204,8 +203,6 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
     assert_eq!(data["contributors"][0]["id"], "0xvoter1");
     assert_eq!(data["delegates"][0]["isCurrent"], true);
     assert_eq!(data["delegateMappings"][0]["to"], "0xdelegate");
-    assert_eq!(data["squidStatus"]["height"], 900);
-    assert_eq!(data["squidStatus"]["finalizedHeight"], 900);
     assert_eq!(data["proposalsConnection"]["totalCount"], 1);
     assert_eq!(data["contributorsConnection"]["totalCount"], 2);
     assert_eq!(data["delegatesConnection"]["totalCount"], 1);
@@ -432,7 +429,7 @@ async fn test_graphql_http_endpoint_serves_post_requests() -> Result<(), Box<dyn
         Client::new()
             .post(endpoint)
             .json(&json!({
-                "query": "query { squidStatus { height finalizedHeight hash finalizedHash } }"
+                "query": "query { indexerStatus { processedHeight targetHeight } }"
             }))
             .send(),
     )
@@ -440,8 +437,8 @@ async fn test_graphql_http_endpoint_serves_post_requests() -> Result<(), Box<dyn
     .json()
     .await?;
 
-    assert_eq!(response["data"]["squidStatus"]["height"], 900);
-    assert_eq!(response["data"]["squidStatus"]["finalizedHeight"], 900);
+    assert_eq!(response["data"]["indexerStatus"]["processedHeight"], 900);
+    assert_eq!(response["data"]["indexerStatus"]["targetHeight"], 1000);
 
     server.abort();
     database.cleanup().await?;
@@ -708,7 +705,6 @@ async fn test_graphql_schema_exposes_checkpoint_statuses_with_implicit_scope()
                 daoCode
                 processedHeight
               }
-              squidStatus { height finalizedHeight hash finalizedHash }
             }
             "#,
         ))
@@ -733,15 +729,29 @@ async fn test_graphql_schema_exposes_checkpoint_statuses_with_implicit_scope()
             .len(),
         1
     );
-    assert_eq!(scoped_data["squidStatus"]["height"], 900);
-    assert_eq!(scoped_data["squidStatus"]["finalizedHeight"], 900);
-    assert_eq!(scoped_data["squidStatus"]["hash"], serde_json::Value::Null);
-    assert_eq!(
-        scoped_data["squidStatus"]["finalizedHash"],
-        serde_json::Value::Null
-    );
 
     database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_schema_rejects_removed_squid_status_compatibility()
+-> Result<(), Box<dyn Error>> {
+    let pool = PgPoolOptions::new().connect_lazy("postgres://localhost/degov")?;
+    let schema = graphql::build_schema(pool);
+    let sdl = schema.sdl();
+    let removed_field = "squid".to_owned() + "Status";
+    let removed_type = "type ".to_owned() + "Squid" + "Status";
+
+    assert!(
+        !sdl.contains(&removed_field),
+        "schema still exposes removed status field:\n{sdl}"
+    );
+    assert!(
+        !sdl.contains(&removed_type),
+        "schema still exposes removed status type:\n{sdl}"
+    );
 
     Ok(())
 }
@@ -889,7 +899,7 @@ async fn test_graphql_http_endpoint_serves_configured_dao_path() -> Result<(), B
         Client::new()
             .post(endpoint)
             .json(&json!({
-                "query": "query { squidStatus { height finalizedHeight hash finalizedHash } }"
+                "query": "query { indexerStatus { processedHeight targetHeight } }"
             }))
             .send(),
     )
@@ -897,7 +907,8 @@ async fn test_graphql_http_endpoint_serves_configured_dao_path() -> Result<(), B
     .json()
     .await?;
 
-    assert_eq!(response["data"]["squidStatus"]["height"], 900);
+    assert_eq!(response["data"]["indexerStatus"]["processedHeight"], 900);
+    assert_eq!(response["data"]["indexerStatus"]["targetHeight"], 1000);
 
     server.abort();
     database.cleanup().await?;
@@ -1106,14 +1117,6 @@ async fn seed_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
         "#,
     )
     .bind(CONTRACT_SET_ID)
-    .execute(pool)
-    .await?;
-    sqlx::raw_sql(
-        r#"
-        INSERT INTO squid_processor.status (id, height, hash)
-        VALUES (0, 900, '0xstatus');
-        "#,
-    )
     .execute(pool)
     .await?;
 

--- a/apps/indexer/tests/lisk_dao_golden_baseline.rs
+++ b/apps/indexer/tests/lisk_dao_golden_baseline.rs
@@ -1259,17 +1259,5 @@ async fn seed_status(pool: &PgPool, baseline: &Baseline) -> Result<(), sqlx::Err
     .execute(pool)
     .await?;
 
-    sqlx::query("INSERT INTO squid_processor.status (id, height, hash) VALUES (0, $1, '0xstatus')")
-        .bind(
-            baseline
-                .samples
-                .latest_proposal
-                .block_number
-                .parse::<i64>()
-                .unwrap(),
-        )
-        .execute(pool)
-        .await?;
-
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -134,7 +134,7 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     for table_name in REQUIRED_TABLES {
         assert_table_exists(&database.pool, &database.schema, table_name).await?;
     }
-    assert_table_exists(&database.pool, "squid_processor", "status").await?;
+    assert_removed_processor_status_table_absent(&database.pool).await?;
     assert_table_exists(&database.pool, &database.schema, "_sqlx_migrations").await?;
 
     database.cleanup().await?;
@@ -217,6 +217,18 @@ async fn assert_table_exists(
     .await?;
 
     assert!(exists, "expected table {schema}.{table_name} to exist");
+
+    Ok(())
+}
+
+async fn assert_removed_processor_status_table_absent(pool: &PgPool) -> Result<(), sqlx::Error> {
+    let removed_table = "squid_processor".to_owned() + ".status";
+    let table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::TEXT")
+        .bind(removed_table)
+        .fetch_one(pool)
+        .await?;
+
+    assert_eq!(table, None);
 
     Ok(())
 }

--- a/apps/web/scripts/indexer-status-source.test.ts
+++ b/apps/web/scripts/indexer-status-source.test.ts
@@ -3,6 +3,9 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
+const removedStatusField = "squid" + "Status";
+const removedStatusService = removedStatusField + "Service";
+
 const readSource = (relativePath: string) =>
   readFileSync(path.join(import.meta.dirname, "..", relativePath), "utf8");
 
@@ -11,8 +14,8 @@ test("block sync hook reads native indexer status", () => {
 
   assert.match(source, /indexerStatusService\.getIndexerStatus/);
   assert.match(source, /syncedPercentage/);
-  assert.doesNotMatch(source, /squidStatus/);
-  assert.doesNotMatch(source, /squidStatusService/);
+  assert.doesNotMatch(source, new RegExp(removedStatusField));
+  assert.doesNotMatch(source, new RegExp(removedStatusService));
 });
 
 test("indexer status query requests native status fields", () => {
@@ -25,5 +28,5 @@ test("indexer status query requests native status fields", () => {
   assert.match(source, /targetHeight/);
   assert.match(source, /syncedPercentage/);
   assert.match(source, /isSynced/);
-  assert.doesNotMatch(source, /squidStatus/);
+  assert.doesNotMatch(source, new RegExp(removedStatusField));
 });

--- a/docs/runbook/datalens-dao-migration.md
+++ b/docs/runbook/datalens-dao-migration.md
@@ -325,7 +325,7 @@ GraphQL smoke:
 ```sh
 curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
   -H "content-type: application/json" \
-  --data '{"query":"query { squidStatus { height hash } proposalsConnection(orderBy: [id_ASC]) { totalCount } contributorsConnection(orderBy: [id_ASC]) { totalCount } dataMetrics(where: { id_eq: \"global\" }) { proposalsCount powerSum memberCount } }"}'
+  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } proposalsConnection(orderBy: [id_ASC]) { totalCount } contributorsConnection(orderBy: [id_ASC]) { totalCount } dataMetrics(where: { id_eq: \"global\" }) { proposalsCount powerSum memberCount } }"}'
 ```
 
 Web delegates/proposals smoke:

--- a/docs/runbook/datalens-indexer-observability.md
+++ b/docs/runbook/datalens-indexer-observability.md
@@ -269,8 +269,7 @@ tables exist:
 psql "$DEGOV_INDEXER_DATABASE_URL" -x -c "
 SELECT
   to_regclass('public.degov_indexer_checkpoint') AS checkpoint_table,
-  to_regclass('public.degov_indexer_reconcile_task') AS reconcile_task_table,
-  to_regclass('squid_processor.status') AS squid_status_table;
+  to_regclass('public.degov_indexer_reconcile_task') AS reconcile_task_table;
 "
 ```
 
@@ -330,21 +329,16 @@ Expected signal:
 - `last_error`, `lock_owner`, and stale `locked_at` are empty unless an active
   worker owns the row.
 
-Check the SQD compatibility sync view used by existing synced-percentage
-consumers:
+Check the native sync summary exposed to API consumers:
 
 ```sh
-psql "$DEGOV_INDEXER_DATABASE_URL" -x -c "
-SELECT id, height, hash
-FROM squid_processor.status
-WHERE id = 0;
-"
+curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
+  -H "content-type: application/json" \
+  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } }"}'
 ```
 
-Expected signal: `height` follows the latest committed
-`degov_indexer_checkpoint.processed_height`. If checkpoint height advances but
-this table is stale, the DB transaction path is not updating the compatibility
-sync view that GraphQL/web consumers may still read.
+Expected signal: `processedHeight`, `targetHeight`, and `syncedPercentage`
+match the active row in `degov_indexer_checkpoint`.
 
 Inspect chunk logs around the same time window:
 
@@ -511,12 +505,12 @@ Run a GraphQL projection smoke against the public endpoint:
 ```sh
 curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
   -H "content-type: application/json" \
-  --data '{"query":"query { squidStatus { height hash } proposalsConnection(orderBy: [id_ASC]) { totalCount } contributorsConnection(orderBy: [id_ASC]) { totalCount } dataMetrics(where: { id_eq: \"global\" }) { proposalsCount votesCount powerSum memberCount } }"}'
+  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } proposalsConnection(orderBy: [id_ASC]) { totalCount } contributorsConnection(orderBy: [id_ASC]) { totalCount } dataMetrics(where: { id_eq: \"global\" }) { proposalsCount votesCount powerSum memberCount } }"}'
 ```
 
-Expected signal: GraphQL returns `squidStatus`, proposal/contributor counts, and
+Expected signal: GraphQL returns `indexerStatus`, proposal/contributor counts, and
 global metrics. If SQL is healthy but GraphQL is missing fields or returns
-errors, classify the failure as API compatibility or GraphQL service config.
+errors, classify the failure as native API status or GraphQL service config.
 
 ## Onchain Refresh Sanity
 
@@ -643,7 +637,7 @@ Check GraphQL availability:
 ```sh
 curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
   -H "content-type: application/json" \
-  --data '{"query":"query { squidStatus { height hash } }"}'
+  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } }"}'
 ```
 
 Check application pages:
@@ -662,19 +656,19 @@ Check synced percentage from public data:
 ```sh
 curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
   -H "content-type: application/json" \
-  --data '{"query":"query { squidStatus { height hash } }"}'
+  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } }"}'
 ```
 
-Compare `squidStatus.height` with `degov_indexer_checkpoint.target_height`.
-The synced percentage is:
+Compare `indexerStatus.processedHeight` with
+`indexerStatus.targetHeight`. The synced percentage is:
 
 ```text
-min(100, squidStatus.height / target_height * 100)
+min(100, processedHeight / targetHeight * 100)
 ```
 
 If synced percentage is low and checkpoint lag is high, the indexer is still
 catching up. If synced percentage is low while checkpoint is current, debug the
-compatibility sync table or GraphQL status resolver.
+native GraphQL status resolver and checkpoint query scope.
 
 ## Tally And Onchain Audit
 
@@ -709,7 +703,7 @@ business-correctness signals, not first-line service health checks.
 | Decode mismatch | Logs show `DAO event decode error`; raw Datalens rows exist. | Decode/projection boundary. | Confirm ABI, event topic, token standard, timelock address, and whether the event is unsupported for the DAO compatibility policy. Unsupported events must be durable and auditable if skipped. |
 | Timestamp unit error | Proposals have implausible `vote_start_timestamp`, `vote_end_timestamp`, or page dates. | Decode/projection. | Compare raw `block_timestamp` values with expected seconds. Millisecond values are usually 1000x too large; second values interpreted as milliseconds are usually near 1970. |
 | Checkpoint stuck | `processing` chunk log repeats or `processed_height` does not advance. | Datalens query, DB transaction, decode/projection, or checkpoint. | Match the last processing log to the next error. If transaction failed, inspect DB errors and confirm checkpoint is advanced only inside the write transaction. |
-| Checkpoint advances but pages are stale | `degov_indexer_checkpoint.processed_height` advances while `squid_processor.status.height` or GraphQL `squidStatus.height` is stale. | DB compatibility view or API. | Verify the checkpoint transaction updates `squid_processor.status`; restart GraphQL/API if it caches status unexpectedly. |
+| Checkpoint advances but pages are stale | `degov_indexer_checkpoint.processed_height` and GraphQL `indexerStatus.processedHeight` advance while page data stays stale. | Projection, API, or web. | Verify projection tables update for the same DAO scope; restart GraphQL/API if it caches query results unexpectedly. |
 | Power refresh backlog | `pending`/`processing` refresh rows grow; contributors have zero power. | Onchain refresh or ChainTool/RPC. | Check sync-lag mode, stale locks, failed row errors, RPC credentials, provider rate limits, and reconcile worker concurrency. |
 | Failed refresh rows repeat | Failed rows show the same account or subject with rising attempts. | Onchain refresh input or chain read. | Inspect the exact `error`, confirm token standard, vote-read method (`getVotes`, `getCurrentVotes`, `getPastVotes`, or `getPriorVotes`), and whether the account/timepoint is valid for the DAO. |
 | GraphQL unavailable | SQL checks are healthy; GraphQL smoke fails. | Web/API. | Check GraphQL service readiness, endpoint routing, database URL, schema compatibility, and public endpoint configuration. |

--- a/docs/runbook/tally-comparison-e2e.md
+++ b/docs/runbook/tally-comparison-e2e.md
@@ -96,7 +96,7 @@ Summary query:
 
 ```graphql
 query {
-  squidStatus { height hash }
+  indexerStatus { processedHeight targetHeight syncedPercentage isSynced }
   dataMetrics(where: { id_eq: "global" }) {
     powerSum
     memberCount


### PR DESCRIPTION
## Summary
- remove the new indexer GraphQL squidStatus field/type and checkpoint compatibility writes
- drop squid_processor.status from the fresh 0001 init schema
- update indexer tests, scripts, and runbooks to use native indexerStatus/degov_indexer_checkpoint

## Validation
- cargo fmt --all --check
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:55433/indexer cargo test -p degov-datalens-indexer --locked --test graphql_service
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:55433/indexer cargo test -p degov-datalens-indexer --locked --test checkpoint_repository
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:55433/indexer cargo test -p degov-datalens-indexer --locked --test migration_schema
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:55433/indexer cargo test -p degov-datalens-indexer --locked --test lisk_dao_golden_baseline
- cd apps/indexer && node ./scripts/indexer-diagnostics.test.mjs
- cd apps/indexer && node ./scripts/indexer-reconcile-diagnose.test.mjs
- cd apps/indexer && node ./scripts/indexer-tally-onchain-e2e.test.mjs
- node apps/web/scripts/indexer-status-source.test.ts
- rg -n "squidStatus|SquidStatus|squid_processor\.status|legacySquidStatus"
- rg -n "squidStatus|SquidStatus|legacySquidStatus" apps/web/src
- git diff --check