### PR TITLE
Remove indexer re-export shim modules

### DIFF
--- a/apps/indexer/src/chain_tool.rs
+++ b/apps/indexer/src/chain_tool.rs
@@ -1,1 +1,0 @@
-pub use crate::chain::tool::*;

--- a/apps/indexer/src/dao_event.rs
+++ b/apps/indexer/src/dao_event.rs
@@ -1,1 +1,0 @@
-pub use crate::decode::dao_event::*;

--- a/apps/indexer/src/data_metric.rs
+++ b/apps/indexer/src/data_metric.rs
@@ -1,1 +1,0 @@
-pub use crate::projection::data_metric::*;

--- a/apps/indexer/src/evm_log.rs
+++ b/apps/indexer/src/evm_log.rs
@@ -1,1 +1,0 @@
-pub use crate::decode::evm_log::*;

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -1,36 +1,83 @@
 pub mod chain;
-pub mod chain_tool;
 pub mod checkpoint;
 pub mod config;
-pub mod dao_event;
-pub mod data_metric;
 pub mod datalens;
 pub mod decode;
 pub mod error;
-pub mod evm_log;
 pub mod graphql;
 pub mod onchain;
-pub mod onchain_refresh;
-pub mod planner;
-pub mod postgres_store;
-pub mod power_reconcile;
 pub mod projection;
-pub mod proposal_metadata;
-pub mod proposal_projection;
 pub mod runner;
 pub mod runtime;
 pub mod runtime_config;
 pub mod store;
-pub mod timelock_projection;
-pub mod token_projection;
-pub mod vote_projection;
 
-pub use chain_tool::{
+pub use crate::chain::tool::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadCapability,
     ChainReadExecutionPlan, ChainReadExecutionReport, ChainReadFailure, ChainReadFailureKind,
     ChainReadKey, ChainReadMetadata, ChainReadMethod, ChainReadMetrics, ChainReadPlan,
     ChainReadPlanBuilder, ChainReadReason, ChainReadRequest, ChainReadResult, ChainReadRetryPolicy,
     ChainReadValue, ChainTool, MulticallReadGroup, PartialChainReadFailureReport, ReadRequirement,
+};
+pub use crate::datalens::planner::{
+    DaoContractAddresses, DaoLogQueryPlan, DaoLogSource, DatalensLogPage, DatalensLogQueryReader,
+    fetch_dao_log_pages, plan_dao_log_queries,
+};
+pub use crate::decode::dao_event::{
+    CallExecutedEvent, CallSaltEvent, CallScheduledEvent, DaoEventDecodeError, DecodedDaoEvent,
+    DecodedGovernorEvent, DecodedTimelockEvent, DecodedTokenEvent, DelegateChangedEvent,
+    DelegateVotesChangedEvent, GovernanceTokenStandard, ParameterChangeEvent, ProposalCreatedEvent,
+    ProposalExtendedEvent, ProposalIdEvent, ProposalQueuedEvent, RoleAccountEvent,
+    RoleAdminChangedEvent, TimelockChangeEvent, TimelockOperationIdEvent, TokenTransferEvent,
+    UnsupportedTopicEvent, VoteCastEvent, VoteCastWithParamsEvent, decode_dao_log,
+};
+pub use crate::decode::evm_log::{
+    EvmLogNormalizationError, NormalizedEvmLog, normalize_evm_log_rows,
+};
+pub use crate::onchain::refresh::{
+    ChainToolOnchainRefreshReader, EvmRpcChainTool, MultiChainToolOnchainRefreshReader,
+    OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError,
+    OnchainRefreshRunReport, OnchainRefreshTask, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
+    OnchainRefreshWorkerError,
+};
+pub use crate::projection::data_metric::DataMetricWrite;
+pub use crate::projection::power_reconcile::{
+    PowerActivityReason, PowerFreshnessState, PowerReconcileCandidate, PowerReconcileContext,
+    PowerReconcileEvent, PowerReconcileMetrics, PowerReconcilePlan, PowerRefreshReadSource,
+    PowerRefreshStatus, PowerRefreshStatusRecord, plan_power_reconcile,
+};
+pub use crate::projection::proposal::{
+    InMemoryProposalProjectionRepository, ProposalActionWrite, ProposalCreatedWrite,
+    ProposalDeadlineExtensionWrite, ProposalEventCommon, ProposalExtendedWrite, ProposalIdWrite,
+    ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionError,
+    ProposalProjectionEvent, ProposalProjectionRepository, ProposalQueuedWrite,
+    ProposalRepositoryWriteError, ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite,
+    project_proposal_events,
+};
+pub use crate::projection::proposal_metadata::{ProposalTextMetadata, derive_proposal_metadata};
+pub use crate::projection::timelock::{
+    InMemoryTimelockProjectionRepository, TIMELOCK_POSTGRES_ADAPTER_GAP, TimelockCallWrite,
+    TimelockEventCommon, TimelockMinDelayChangeWrite, TimelockOperationHintWrite,
+    TimelockOperationWrite, TimelockProjectionBatch, TimelockProjectionContext,
+    TimelockProjectionError, TimelockProjectionEvent, TimelockProjectionRepository,
+    TimelockProposalActionLink, TimelockProposalLinkContext, TimelockRepositoryWriteError,
+    TimelockRoleEventWrite, project_timelock_events, project_timelock_events_with_proposal_links,
+};
+pub use crate::projection::token::{
+    ContributorWrite, DataMetricTokenDelta, DelegateChangedWrite, DelegateMappingWrite,
+    DelegateRollingWrite, DelegateVotesChangedWrite, DelegateWrite,
+    InMemoryTokenProjectionRepository, TokenEventCommon, TokenProjectionBatch,
+    TokenProjectionContext, TokenProjectionError, TokenProjectionEvent, TokenProjectionOperation,
+    TokenProjectionRepository, TokenRepositoryWriteError, TokenTransferWrite, project_token_events,
+};
+pub use crate::projection::vote::{
+    ContributorVoteSignalWrite, DataMetricVoteDelta, InMemoryVoteProjectionRepository,
+    ProposalVoteTotalWrite, VoteCastGroupWrite, VoteCastWithParamsWrite, VoteCastWrite,
+    VoteEventCommon, VoteProjectionBatch, VoteProjectionContext, VoteProjectionError,
+    VoteProjectionEvent, VoteProjectionRepository, VoteRepositoryWriteError, project_vote_events,
+};
+pub use crate::store::postgres::{
+    PostgresIndexerRunnerStore, PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
 };
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
@@ -41,49 +88,12 @@ pub use config::{
     DatalensContractSetConfig, DatalensFinality, DatalensRuntimeContractSet, DatasetKeyConfig,
     QueryLimitConfig, SecretString,
 };
-pub use dao_event::{
-    CallExecutedEvent, CallSaltEvent, CallScheduledEvent, DaoEventDecodeError, DecodedDaoEvent,
-    DecodedGovernorEvent, DecodedTimelockEvent, DecodedTokenEvent, DelegateChangedEvent,
-    DelegateVotesChangedEvent, GovernanceTokenStandard, ParameterChangeEvent, ProposalCreatedEvent,
-    ProposalExtendedEvent, ProposalIdEvent, ProposalQueuedEvent, RoleAccountEvent,
-    RoleAdminChangedEvent, TimelockChangeEvent, TimelockOperationIdEvent, TokenTransferEvent,
-    UnsupportedTopicEvent, VoteCastEvent, VoteCastWithParamsEvent, decode_dao_log,
-};
-pub use data_metric::DataMetricWrite;
 pub use datalens::{
     DatalensDurableHeadReader, DatalensNativeClient, DatalensNativeReader, ServiceReadiness,
     parse_datalens_durable_head_height, verify_datalens_service,
 };
 pub use error::{CheckpointError, ConfigError, DatalensError, IndexerError};
-pub use evm_log::{EvmLogNormalizationError, NormalizedEvmLog, normalize_evm_log_rows};
 pub use graphql::IndexerGraphqlSchema;
-pub use onchain_refresh::{
-    ChainToolOnchainRefreshReader, EvmRpcChainTool, MultiChainToolOnchainRefreshReader,
-    OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError,
-    OnchainRefreshRunReport, OnchainRefreshTask, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
-    OnchainRefreshWorkerError,
-};
-pub use planner::{
-    DaoContractAddresses, DaoLogQueryPlan, DaoLogSource, DatalensLogPage, DatalensLogQueryReader,
-    fetch_dao_log_pages, plan_dao_log_queries,
-};
-pub use postgres_store::{
-    PostgresIndexerRunnerStore, PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
-};
-pub use power_reconcile::{
-    PowerActivityReason, PowerFreshnessState, PowerReconcileCandidate, PowerReconcileContext,
-    PowerReconcileEvent, PowerReconcileMetrics, PowerReconcilePlan, PowerRefreshReadSource,
-    PowerRefreshStatus, PowerRefreshStatusRecord, plan_power_reconcile,
-};
-pub use proposal_metadata::{ProposalTextMetadata, derive_proposal_metadata};
-pub use proposal_projection::{
-    InMemoryProposalProjectionRepository, ProposalActionWrite, ProposalCreatedWrite,
-    ProposalDeadlineExtensionWrite, ProposalEventCommon, ProposalExtendedWrite, ProposalIdWrite,
-    ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionError,
-    ProposalProjectionEvent, ProposalProjectionRepository, ProposalQueuedWrite,
-    ProposalRepositoryWriteError, ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite,
-    project_proposal_events,
-};
 pub use runner::{
     DaoEventDecoder, InMemoryIndexerRunnerStore, InMemoryIndexerRunnerStoreError,
     IndexerEventDecoder, IndexerProjectionBatch, IndexerRunner, IndexerRunnerContexts,
@@ -95,25 +105,4 @@ pub use runtime_config::{
     IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshRpcChainConfig,
     OnchainRefreshRuntimeConfig, onchain_refresh_worker_enabled, parse_bool_env_value,
     parse_i64_env_value, required_env,
-};
-pub use timelock_projection::{
-    InMemoryTimelockProjectionRepository, TIMELOCK_POSTGRES_ADAPTER_GAP, TimelockCallWrite,
-    TimelockEventCommon, TimelockMinDelayChangeWrite, TimelockOperationHintWrite,
-    TimelockOperationWrite, TimelockProjectionBatch, TimelockProjectionContext,
-    TimelockProjectionError, TimelockProjectionEvent, TimelockProjectionRepository,
-    TimelockProposalActionLink, TimelockProposalLinkContext, TimelockRepositoryWriteError,
-    TimelockRoleEventWrite, project_timelock_events, project_timelock_events_with_proposal_links,
-};
-pub use token_projection::{
-    ContributorWrite, DataMetricTokenDelta, DelegateChangedWrite, DelegateMappingWrite,
-    DelegateRollingWrite, DelegateVotesChangedWrite, DelegateWrite,
-    InMemoryTokenProjectionRepository, TokenEventCommon, TokenProjectionBatch,
-    TokenProjectionContext, TokenProjectionError, TokenProjectionEvent, TokenProjectionOperation,
-    TokenProjectionRepository, TokenRepositoryWriteError, TokenTransferWrite, project_token_events,
-};
-pub use vote_projection::{
-    ContributorVoteSignalWrite, DataMetricVoteDelta, InMemoryVoteProjectionRepository,
-    ProposalVoteTotalWrite, VoteCastGroupWrite, VoteCastWithParamsWrite, VoteCastWrite,
-    VoteEventCommon, VoteProjectionBatch, VoteProjectionContext, VoteProjectionError,
-    VoteProjectionEvent, VoteProjectionRepository, VoteRepositoryWriteError, project_vote_events,
 };

--- a/apps/indexer/src/onchain_refresh.rs
+++ b/apps/indexer/src/onchain_refresh.rs
@@ -1,1 +1,0 @@
-pub use crate::onchain::refresh::*;

--- a/apps/indexer/src/planner.rs
+++ b/apps/indexer/src/planner.rs
@@ -1,1 +1,0 @@
-pub use crate::datalens::planner::*;

--- a/apps/indexer/src/postgres_store.rs
+++ b/apps/indexer/src/postgres_store.rs
@@ -1,1 +1,0 @@
-pub use crate::store::postgres::*;

--- a/apps/indexer/src/power_reconcile.rs
+++ b/apps/indexer/src/power_reconcile.rs
@@ -1,1 +1,0 @@
-pub use crate::projection::power_reconcile::*;

--- a/apps/indexer/src/proposal_metadata.rs
+++ b/apps/indexer/src/proposal_metadata.rs
@@ -1,1 +1,0 @@
-pub use crate::projection::proposal_metadata::*;

--- a/apps/indexer/src/proposal_projection.rs
+++ b/apps/indexer/src/proposal_projection.rs
@@ -1,1 +1,0 @@
-pub use crate::projection::proposal::*;

--- a/apps/indexer/src/timelock_projection.rs
+++ b/apps/indexer/src/timelock_projection.rs
@@ -1,1 +1,0 @@
-pub use crate::projection::timelock::*;

--- a/apps/indexer/src/token_projection.rs
+++ b/apps/indexer/src/token_projection.rs
@@ -1,1 +1,0 @@
-pub use crate::projection::token::*;

--- a/apps/indexer/src/vote_projection.rs
+++ b/apps/indexer/src/vote_projection.rs
@@ -1,1 +1,0 @@
-pub use crate::projection::vote::*;


### PR DESCRIPTION
## Summary
- Remove pure top-level indexer shim modules that only re-export deeper implementation modules.
- Keep root crate exports by pointing `apps/indexer/src/lib.rs` directly at the real module paths.
- Leave implementation modules under `chain`, `decode`, `projection`, `store`, `onchain`, and `datalens` intact.

## Validation
- `cargo fmt --all --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://datalens:datalens@localhost:5432/datalens_test cargo test -p degov-datalens-indexer --locked`
- `cargo build -p degov-datalens-indexer --locked`
- `rg -n "pub mod (chain_tool|dao_event|data_metric|evm_log|onchain_refresh|planner|postgres_store|power_reconcile|proposal_metadata|proposal_projection|timelock_projection|token_projection|vote_projection)" apps/indexer/src/lib.rs`
- `rg -n "(crate|degov_datalens_indexer)::(chain_tool|dao_event|data_metric|evm_log|onchain_refresh|planner|postgres_store|power_reconcile|proposal_metadata|proposal_projection|timelock_projection|token_projection|vote_projection)::" apps/indexer/src apps/indexer/tests`

Note: the indexer tests require `DEGOV_INDEXER_TEST_DATABASE_URL`; the first run without it failed with that missing-env error, then passed with the CI-style local Postgres URL above.