### PR TITLE
fix(indexer): resolve latest height via Datalens head API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datalens-sdk"
 version = "0.1.0"
-source = "git+https://github.com/ringecosystem/datalens?rev=1744283cd1547240e0bc290b5fa3c5d1c55e74d6#1744283cd1547240e0bc290b5fa3c5d1c55e74d6"
+source = "git+https://github.com/ringecosystem/datalens?rev=6978b8bf552fdbdc2c894f724d7dd8a72c038958#6978b8bf552fdbdc2c894f724d7dd8a72c038958"
 dependencies = [
  "reqwest",
  "serde",

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -12,7 +12,7 @@ async-graphql-axum = "7.2.1"
 axum = "0.8.9"
 clap = { version = "4.6.1", features = ["derive"] }
 config = { version = "0.15.23", default-features = false, features = ["yaml", "json", "toml"] }
-datalens-sdk = { git = "https://github.com/ringecosystem/datalens", rev = "1744283cd1547240e0bc290b5fa3c5d1c55e74d6" }
+datalens-sdk = { git = "https://github.com/ringecosystem/datalens", rev = "6978b8bf552fdbdc2c894f724d7dd8a72c038958" }
 ethabi = "18.0.0"
 figment = { version = "0.10.19", features = ["env"] }
 hex = "0.4.3"

--- a/apps/indexer/src/config/mod.rs
+++ b/apps/indexer/src/config/mod.rs
@@ -266,7 +266,7 @@ impl DatalensConfig {
 
     pub fn sdk_config(&self) -> ClientConfig {
         ClientConfig {
-            endpoint: format!("{}/native/graphql", self.endpoint.trim_end_matches('/')),
+            endpoint: self.endpoint.trim_end_matches('/').to_owned(),
             bearer_token: Some(self.bearer_token.clone().into_inner()),
             application: Some(self.application.clone()),
             timeout: Some(self.timeout),

--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -1,13 +1,9 @@
 use datalens_sdk::{
     DatalensClient,
-    native::{
-        ChainFamilyInput, ChainFamilyKindInput, ChainIdentityInput, DatasetKeyInput,
-        EvmLogsSelectorInput, FieldSelectionInput, NetworkIdInput, QueryInput, QueryRangeInput,
-        QueryRangeKindInput, QuerySelectorInput, SelectorKindInput,
-    },
+    native::{ChainHeadFinalityInput, QueryInput},
 };
 
-use crate::{DatalensConfig, DatalensError, DatalensLogQueryReader};
+use crate::{DatalensConfig, DatalensError, DatalensFinality, DatalensLogQueryReader};
 
 pub trait DatalensNativeReader {
     fn service_readiness(&self) -> Result<ServiceReadiness, DatalensError>;
@@ -58,30 +54,23 @@ impl DatalensLogQueryReader for DatalensNativeClient {
 
 impl DatalensDurableHeadReader for DatalensNativeClient {
     fn durable_head_height(&mut self, config: &DatalensConfig) -> Result<i64, DatalensError> {
-        match self.client.native().query(durable_head_probe_input(config)) {
-            Ok(_) => Ok(i64::from(i32::MAX)),
-            Err(error) => parse_datalens_durable_head_height(&error.to_string()),
-        }
+        let finality = match config.finality {
+            DatalensFinality::DurableOnly => ChainHeadFinalityInput::Safe,
+            DatalensFinality::IncludePending => ChainHeadFinalityInput::Latest,
+        };
+        let response = self
+            .client
+            .native()
+            .chain_head(&config.chain.configured_name, Some(finality))
+            .map_err(|error| DatalensError::Query(error.to_string()))?;
+
+        i64::try_from(response.height).map_err(|_| {
+            DatalensError::Query(format!(
+                "Datalens chain head height {} exceeds supported indexer height",
+                response.height
+            ))
+        })
     }
-}
-
-pub fn parse_datalens_durable_head_height(message: &str) -> Result<i64, DatalensError> {
-    const MARKER: &str = "safe/finalized height ";
-    let Some((_, height)) = message.rsplit_once(MARKER) else {
-        return Err(DatalensError::Query(format!(
-            "Datalens durable head height was not available: {message}"
-        )));
-    };
-    let height = height
-        .split(|character: char| !character.is_ascii_digit())
-        .next()
-        .unwrap_or("");
-
-    height.parse::<i64>().map_err(|_| {
-        DatalensError::Query(format!(
-            "Datalens durable head height was not available: {message}"
-        ))
-    })
 }
 
 pub fn verify_datalens_service(
@@ -94,41 +83,4 @@ pub fn verify_datalens_service(
         ));
     }
     Ok(readiness)
-}
-
-fn durable_head_probe_input(config: &DatalensConfig) -> QueryInput {
-    QueryInput {
-        chain: ChainIdentityInput {
-            family: ChainFamilyInput {
-                kind: ChainFamilyKindInput::Evm,
-                other: None,
-            },
-            configured_name: config.chain.configured_name.clone(),
-            network_id: config.chain.network_id.map(|numeric| NetworkIdInput {
-                numeric: Some(numeric),
-                textual: None,
-            }),
-        },
-        dataset_key: DatasetKeyInput {
-            family: config.dataset.family.clone(),
-            name: config.dataset.name.clone(),
-        },
-        selector: QuerySelectorInput {
-            kind: SelectorKindInput::EvmLogs,
-            evm_logs: Some(EvmLogsSelectorInput {
-                addresses: Vec::new(),
-                topics: Vec::new(),
-            }),
-            other: None,
-        },
-        range: QueryRangeInput {
-            kind: QueryRangeKindInput::Block,
-            start: 0,
-            end: i32::MAX,
-        },
-        finality: Some("durable_only".to_owned()),
-        fields: Some(FieldSelectionInput {
-            include: Vec::new(),
-        }),
-    }
 }

--- a/apps/indexer/src/datalens/mod.rs
+++ b/apps/indexer/src/datalens/mod.rs
@@ -3,7 +3,7 @@ pub mod planner;
 
 pub use client::{
     DatalensDurableHeadReader, DatalensNativeClient, DatalensNativeReader, ServiceReadiness,
-    parse_datalens_durable_head_height, verify_datalens_service,
+    verify_datalens_service,
 };
 pub use planner::{
     DaoContractAddresses, DaoLogQueryPlan, DaoLogSource, DatalensLogPage, DatalensLogQueryReader,

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -90,7 +90,7 @@ pub use config::{
 };
 pub use datalens::{
     DatalensDurableHeadReader, DatalensNativeClient, DatalensNativeReader, ServiceReadiness,
-    parse_datalens_durable_head_height, verify_datalens_service,
+    verify_datalens_service,
 };
 pub use error::{CheckpointError, ConfigError, DatalensError, IndexerError};
 pub use graphql::IndexerGraphqlSchema;

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -155,3 +155,59 @@ async fn resolve_contract_set_target_height(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::{
+        ChainFamily, ChainIdentityConfig, DatalensFinality, DatasetKeyConfig, QueryLimitConfig,
+        SecretString,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_resolve_contract_set_target_height_keeps_fixed_numeric_target_without_datalens() {
+        let runtime = IndexerRuntimeConfig {
+            dao_filter: Some("demo-dao".to_owned()),
+            contract_set_mode: crate::IndexerContractSetMode::Single,
+            target_height: IndexerTargetHeight::Fixed(568800),
+            poll_interval: Duration::from_millis(10),
+            run_once: true,
+            max_chunks_per_run: None,
+            database_max_connections: 1,
+            checkpoint_stream_id: "datalens-native".to_owned(),
+            data_source_version: "datalens-v1".to_owned(),
+            query_max_attempts: 1,
+            progress_refresh_lag_blocks: 100,
+        };
+        let config = DatalensConfig {
+            endpoint: "http://127.0.0.1:1".to_owned(),
+            application: "degov-test".to_owned(),
+            bearer_token: SecretString::new("unit-test-redacted-value"),
+            timeout: Duration::from_secs(1),
+            finality: DatalensFinality::DurableOnly,
+            chain: ChainIdentityConfig {
+                family: ChainFamily::Evm,
+                configured_name: "ethereum".to_owned(),
+                network_id: Some(1),
+            },
+            dataset: DatasetKeyConfig {
+                family: "evm".to_owned(),
+                name: "logs".to_owned(),
+            },
+            query_limits: QueryLimitConfig {
+                block_range_limit: 1_000,
+            },
+            dao_contracts: None,
+            chains: Vec::new(),
+        };
+
+        let height = resolve_contract_set_target_height(&runtime, &config)
+            .await
+            .expect("fixed target height resolves without Datalens");
+
+        assert_eq!(height, 568800);
+    }
+}

--- a/apps/indexer/tests/config.rs
+++ b/apps/indexer/tests/config.rs
@@ -33,7 +33,7 @@ fn remove_config_file(path: PathBuf) {
 }
 
 #[test]
-fn test_from_env_with_required_datalens_fields_builds_sdk_graphql_endpoint() {
+fn test_from_env_with_required_datalens_fields_builds_sdk_service_base_endpoint() {
     with_datalens_env(
         &[
             ("DATALENS_ENDPOINT", Some("https://datalens.ringdao.com/")),
@@ -116,10 +116,7 @@ fn test_from_env_with_required_datalens_fields_builds_sdk_graphql_endpoint() {
             );
 
             let sdk_config = config.sdk_config();
-            assert_eq!(
-                sdk_config.endpoint,
-                "https://datalens.ringdao.com/native/graphql"
-            );
+            assert_eq!(sdk_config.endpoint, "https://datalens.ringdao.com");
             assert_eq!(
                 sdk_config.bearer_token.as_deref(),
                 Some("unit-test-redacted-value")

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -52,7 +52,7 @@ fn test_verify_datalens_service_rejects_mocked_unready_client() {
 
 #[test]
 fn test_datalens_durable_head_reader_uses_sdk_chain_head_safe_finality() {
-    let server = FakeHeadServer::start(568800);
+    let server = FakeHeadServer::start(568800, "safe");
     let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
     let mut client = DatalensNativeClient::from_config(&config).expect("client");
 
@@ -71,7 +71,7 @@ fn test_datalens_durable_head_reader_uses_sdk_chain_head_safe_finality() {
 
 #[test]
 fn test_datalens_durable_head_reader_uses_latest_finality_when_pending_enabled() {
-    let server = FakeHeadServer::start(568801);
+    let server = FakeHeadServer::start(568801, "latest");
     let config = datalens_config(&server.endpoint, DatalensFinality::IncludePending);
     let mut client = DatalensNativeClient::from_config(&config).expect("client");
 
@@ -94,14 +94,14 @@ struct FakeHeadServer {
 }
 
 impl FakeHeadServer {
-    fn start(height: u64) -> Self {
+    fn start(height: u64, finality: &'static str) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake Datalens head server");
         let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
         let handle = thread::spawn(move || {
             let (stream, _) = listener
                 .accept()
                 .expect("accept fake Datalens head request");
-            handle_head_request(stream, height)
+            handle_head_request(stream, height, finality)
         });
 
         Self { endpoint, handle }
@@ -112,14 +112,14 @@ impl FakeHeadServer {
     }
 }
 
-fn handle_head_request(mut stream: TcpStream, height: u64) -> String {
+fn handle_head_request(mut stream: TcpStream, height: u64, finality: &'static str) -> String {
     let request = read_http_request(&mut stream);
     let body = serde_json::json!({
         "chain": {
             "configured_name": "ethereum"
         },
         "height": height,
-        "finality": "safe",
+        "finality": finality,
         "range_kind": "block"
     })
     .to_string();

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -1,6 +1,14 @@
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    thread,
+    time::Duration,
+};
+
 use degov_datalens_indexer::{
-    DatalensError, DatalensNativeReader, ServiceReadiness, parse_datalens_durable_head_height,
-    verify_datalens_service,
+    ChainFamily, ChainIdentityConfig, DatalensConfig, DatalensDurableHeadReader, DatalensError,
+    DatalensFinality, DatalensNativeClient, DatalensNativeReader, DatasetKeyConfig,
+    QueryLimitConfig, SecretString, ServiceReadiness, verify_datalens_service,
 };
 
 struct MockDatalensReader {
@@ -43,19 +51,148 @@ fn test_verify_datalens_service_rejects_mocked_unready_client() {
 }
 
 #[test]
-fn test_parse_datalens_durable_head_height_extracts_safe_height() {
-    let height = parse_datalens_durable_head_height(
-        "datalens GraphQL error: range exceeds adapter safe/finalized height: requested end 2147483647, safe/finalized height 568800",
-    )
-    .expect("safe height parsed");
+fn test_datalens_durable_head_reader_uses_sdk_chain_head_safe_finality() {
+    let server = FakeHeadServer::start(568800);
+    let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    let mut client = DatalensNativeClient::from_config(&config).expect("client");
+
+    let height = client
+        .durable_head_height(&config)
+        .expect("durable head height");
 
     assert_eq!(height, 568800);
+    let request = server.join();
+    assert!(
+        request.starts_with("GET /v1/chains/ethereum/head?finality=safe "),
+        "{request}"
+    );
+    assert!(!request.contains(r#""end":2147483647"#));
 }
 
 #[test]
-fn test_parse_datalens_durable_head_height_rejects_unrelated_errors() {
-    let error = parse_datalens_durable_head_height("datalens GraphQL error: unauthorized")
-        .expect_err("unrelated error rejected");
+fn test_datalens_durable_head_reader_uses_latest_finality_when_pending_enabled() {
+    let server = FakeHeadServer::start(568801);
+    let config = datalens_config(&server.endpoint, DatalensFinality::IncludePending);
+    let mut client = DatalensNativeClient::from_config(&config).expect("client");
 
-    assert!(error.to_string().contains("durable head height"));
+    let height = client
+        .durable_head_height(&config)
+        .expect("durable head height");
+
+    assert_eq!(height, 568801);
+    let request = server.join();
+    assert!(
+        request.starts_with("GET /v1/chains/ethereum/head?finality=latest "),
+        "{request}"
+    );
+    assert!(!request.contains(r#""end":2147483647"#));
+}
+
+struct FakeHeadServer {
+    endpoint: String,
+    handle: thread::JoinHandle<String>,
+}
+
+impl FakeHeadServer {
+    fn start(height: u64) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake Datalens head server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener
+                .accept()
+                .expect("accept fake Datalens head request");
+            handle_head_request(stream, height)
+        });
+
+        Self { endpoint, handle }
+    }
+
+    fn join(self) -> String {
+        self.handle.join().expect("fake Datalens head server joins")
+    }
+}
+
+fn handle_head_request(mut stream: TcpStream, height: u64) -> String {
+    let request = read_http_request(&mut stream);
+    let body = serde_json::json!({
+        "chain": {
+            "configured_name": "ethereum"
+        },
+        "height": height,
+        "finality": "safe",
+        "range_kind": "block"
+    })
+    .to_string();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream
+        .write_all(response.as_bytes())
+        .expect("write fake Datalens head response");
+
+    request
+}
+
+fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut buffer = Vec::new();
+    let mut chunk = [0; 1024];
+
+    loop {
+        let read = stream.read(&mut chunk).expect("read fake Datalens request");
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+
+        if let Some(header_end) = find_header_end(&buffer) {
+            let content_length = content_length(&buffer[..header_end]).unwrap_or(0);
+            let body_start = header_end + 4;
+            if buffer.len().saturating_sub(body_start) >= content_length {
+                break;
+            }
+        }
+    }
+
+    String::from_utf8_lossy(&buffer).into_owned()
+}
+
+fn find_header_end(buffer: &[u8]) -> Option<usize> {
+    buffer.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn content_length(headers: &[u8]) -> Option<usize> {
+    String::from_utf8_lossy(headers).lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        if name.eq_ignore_ascii_case("content-length") {
+            value.trim().parse().ok()
+        } else {
+            None
+        }
+    })
+}
+
+fn datalens_config(endpoint: &str, finality: DatalensFinality) -> DatalensConfig {
+    DatalensConfig {
+        endpoint: endpoint.to_owned(),
+        application: "degov-test".to_owned(),
+        bearer_token: SecretString::new("unit-test-redacted-value"),
+        timeout: Duration::from_secs(5),
+        finality,
+        chain: ChainIdentityConfig {
+            family: ChainFamily::Evm,
+            configured_name: "ethereum".to_owned(),
+            network_id: Some(1),
+        },
+        dataset: DatasetKeyConfig {
+            family: "evm".to_owned(),
+            name: "logs".to_owned(),
+        },
+        query_limits: QueryLimitConfig {
+            block_range_limit: 1_000,
+        },
+        dao_contracts: None,
+        chains: Vec::new(),
+    }
 }

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -125,6 +125,7 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
 
     run_indexer_command(&database.database_url, &datalens.endpoint).await?;
 
+    assert_eq!(datalens.head_count.load(Ordering::Relaxed), 1);
     assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
     assert_table_count(&database.pool, "proposal_created", 1).await?;
     assert_table_count(&database.pool, "proposal", 1).await?;
@@ -153,6 +154,7 @@ async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
 
     run_indexer_all_contract_sets_command(&database.database_url, &datalens.endpoint).await?;
 
+    assert_eq!(datalens.head_count.load(Ordering::Relaxed), 0);
     assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
     assert_checkpoint_scope(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_scope(&database.pool, SECOND_CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
@@ -860,6 +862,7 @@ async fn run_indexer_all_contract_sets_command(
 
 struct FakeDatalensServer {
     endpoint: String,
+    head_count: Arc<AtomicU64>,
     query_count: Arc<AtomicU64>,
 }
 
@@ -867,7 +870,9 @@ impl FakeDatalensServer {
     fn start(governor_rows: Vec<Value>, token_rows: Vec<Value>, timelock_rows: Vec<Value>) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake Datalens server");
         let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let head_count = Arc::new(AtomicU64::new(0));
         let query_count = Arc::new(AtomicU64::new(0));
+        let server_head_count = head_count.clone();
         let server_query_count = query_count.clone();
 
         thread::spawn(move || {
@@ -877,6 +882,7 @@ impl FakeDatalensServer {
                     &governor_rows,
                     &token_rows,
                     &timelock_rows,
+                    &server_head_count,
                     &server_query_count,
                 );
             }
@@ -884,6 +890,7 @@ impl FakeDatalensServer {
 
         Self {
             endpoint,
+            head_count,
             query_count,
         }
     }
@@ -894,6 +901,7 @@ fn handle_datalens_request(
     governor_rows: &[Value],
     token_rows: &[Value],
     timelock_rows: &[Value],
+    head_count: &AtomicU64,
     query_count: &AtomicU64,
 ) {
     let request = read_http_request(&mut stream);
@@ -905,14 +913,15 @@ fn handle_datalens_request(
                 }
             }
         })
-    } else if request.contains(r#""end":2147483647"#) {
+    } else if request.starts_with("GET /v1/chains/ethereum/head?finality=safe ") {
+        head_count.fetch_add(1, Ordering::Relaxed);
         json!({
-            "data": null,
-            "errors": [
-                {
-                    "message": "range exceeds adapter safe/finalized height: requested end 2147483647, safe/finalized height 2"
-                }
-            ]
+            "chain": {
+                "configured_name": "ethereum"
+            },
+            "height": 2,
+            "finality": "safe",
+            "range_kind": "block"
         })
     } else {
         let query_index = query_count.fetch_add(1, Ordering::Relaxed);
@@ -924,15 +933,11 @@ fn handle_datalens_request(
         };
 
         json!({
-            "data": {
-                "query": {
-                    "chain": {},
-                    "datasetKey": "evm.logs",
-                    "range": {},
-                    "cache": {},
-                    "rows": rows
-                }
-            }
+            "chain": {},
+            "dataset_key": "evm.logs",
+            "range": {},
+            "cache": {},
+            "rows": rows
         })
     }
     .to_string();


### PR DESCRIPTION
## Summary
- update the Datalens Rust SDK pin to the latest main commit with REST native head support
- replace the old latest-height resolver that parsed Datalens range errors with `native().chain_head(...)`
- keep numeric `DEGOV_INDEXER_TARGET_HEIGHT` behavior unchanged for bounded debug runs
- keep log indexing independent from chain RPC

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p degov-datalens-indexer --test datalens_client
- cargo test -p degov-datalens-indexer --test config
- cargo test -p degov-datalens-indexer --test cli_runtime_config
- cargo test -p degov-datalens-indexer test_resolve_contract_set_target_height_keeps_fixed_numeric_target_without_datalens
- cargo test -p degov-datalens-indexer --test datalens_planner
- cargo build -p degov-datalens-indexer

Full package test still requires `DEGOV_INDEXER_TEST_DATABASE_URL` for DB-backed tests.

Plane: HBX-317