### PR TITLE
fix(indexer): use Datalens SDK retry for log queries

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -1,8 +1,10 @@
+use std::time::Instant;
+
 use datalens_sdk::{
-    DatalensClient, RetryConfig,
+    ApiErrorKind, DatalensClient, Error as DatalensSdkError, RetryConfig,
     native::{ChainHeadFinalityInput, QueryInput},
 };
-use log::info;
+use log::{info, warn};
 
 use crate::{DatalensConfig, DatalensError, DatalensFinality, DatalensLogQueryReader};
 
@@ -21,13 +23,18 @@ pub struct ServiceReadiness {
 
 pub struct DatalensNativeClient {
     client: DatalensClient,
+    retry_config: RetryConfig,
 }
 
 impl DatalensNativeClient {
     pub fn from_config(config: &DatalensConfig) -> Result<Self, DatalensError> {
+        let retry_config = RetryConfig::default();
         let client = DatalensClient::new(config.sdk_config())
             .map_err(|error| DatalensError::SdkConfig(error.to_string()))?;
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            retry_config,
+        })
     }
 
     pub fn from_config_with_retry_config(
@@ -45,10 +52,88 @@ impl DatalensNativeClient {
             retry_config.jitter,
             retry_config.jitter_factor
         );
-        let client = DatalensClient::new_with_retry_config(config.sdk_config(), retry_config)
-            .map_err(|error| DatalensError::SdkConfig(error.to_string()))?;
-        Ok(Self { client })
+        let client =
+            DatalensClient::new_with_retry_config(config.sdk_config(), retry_config.clone())
+                .map_err(|error| DatalensError::SdkConfig(error.to_string()))?;
+        Ok(Self {
+            client,
+            retry_config,
+        })
     }
+
+    fn query_with_transient_fallback(
+        &self,
+        input: QueryInput,
+    ) -> Result<serde_json::Value, DatalensSdkError> {
+        let started_at = Instant::now();
+        let mut attempt = 1;
+        loop {
+            match self.client.native().query(input.clone()) {
+                Ok(response) => return Ok(response.rows),
+                Err(error) => {
+                    let Some(delay) =
+                        fallback_retry_delay(&self.retry_config, &error, attempt, started_at)
+                    else {
+                        return Err(error);
+                    };
+                    warn!(
+                        "Datalens query transient fallback retry scheduled attempt={} max_attempts={} delay_ms={} error={}",
+                        attempt + 1,
+                        self.retry_config.max_attempts,
+                        delay.as_millis(),
+                        error
+                    );
+                    std::thread::sleep(delay);
+                    attempt += 1;
+                }
+            }
+        }
+    }
+}
+
+fn fallback_retry_delay(
+    retry_config: &RetryConfig,
+    error: &DatalensSdkError,
+    failed_attempt: u32,
+    started_at: Instant,
+) -> Option<std::time::Duration> {
+    if error.is_retryable() || !is_transient_sdk_api_error(error) {
+        return None;
+    }
+    let delay = retry_config.delay_for_attempt(
+        failed_attempt,
+        error
+            .retry_after_seconds()
+            .map(std::time::Duration::from_secs),
+    )?;
+    if let Some(max_elapsed) = retry_config.max_elapsed
+        && started_at.elapsed().saturating_add(delay) > max_elapsed
+    {
+        return None;
+    }
+    Some(delay)
+}
+
+fn is_transient_sdk_api_error(error: &DatalensSdkError) -> bool {
+    if let Some(api_error) = error.api_error() {
+        return matches!(
+            api_error.kind,
+            ApiErrorKind::ProviderFailure
+                | ApiErrorKind::ProviderTimeout
+                | ApiErrorKind::StorageReadFailure
+                | ApiErrorKind::StorageWriteFailure
+                | ApiErrorKind::ManifestUpdateFailure
+                | ApiErrorKind::Internal
+                | ApiErrorKind::UnavailableHead
+        ) || api_error
+            .status
+            .is_some_and(|status| (500..600).contains(&status));
+    }
+
+    matches!(
+        error,
+        DatalensSdkError::HttpStatus { status, .. } if (500..600).contains(status)
+    )
 }
 
 impl DatalensNativeReader for DatalensNativeClient {
@@ -65,10 +150,7 @@ impl DatalensNativeReader for DatalensNativeClient {
 
 impl DatalensLogQueryReader for DatalensNativeClient {
     fn query_logs(&mut self, input: QueryInput) -> Result<serde_json::Value, DatalensError> {
-        self.client
-            .native()
-            .query(input)
-            .map(|response| response.rows)
+        self.query_with_transient_fallback(input)
             .map_err(|error| DatalensError::Query(error.to_string()))
     }
 }

--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -1,7 +1,8 @@
 use datalens_sdk::{
-    DatalensClient,
+    DatalensClient, RetryConfig,
     native::{ChainHeadFinalityInput, QueryInput},
 };
+use log::info;
 
 use crate::{DatalensConfig, DatalensError, DatalensFinality, DatalensLogQueryReader};
 
@@ -25,6 +26,26 @@ pub struct DatalensNativeClient {
 impl DatalensNativeClient {
     pub fn from_config(config: &DatalensConfig) -> Result<Self, DatalensError> {
         let client = DatalensClient::new(config.sdk_config())
+            .map_err(|error| DatalensError::SdkConfig(error.to_string()))?;
+        Ok(Self { client })
+    }
+
+    pub fn from_config_with_retry_config(
+        config: &DatalensConfig,
+        retry_config: RetryConfig,
+    ) -> Result<Self, DatalensError> {
+        info!(
+            "Datalens SDK retry/backoff configured max_attempts={} initial_delay_ms={} max_delay_ms={} max_elapsed_ms={:?} jitter={} jitter_factor={} per_attempt_delays_managed_by_sdk=true",
+            retry_config.max_attempts,
+            retry_config.initial_delay.as_millis(),
+            retry_config.max_delay.as_millis(),
+            retry_config
+                .max_elapsed
+                .map(|duration| duration.as_millis()),
+            retry_config.jitter,
+            retry_config.jitter_factor
+        );
+        let client = DatalensClient::new_with_retry_config(config.sdk_config(), retry_config)
             .map_err(|error| DatalensError::SdkConfig(error.to_string()))?;
         Ok(Self { client })
     }

--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -130,10 +130,11 @@ fn is_transient_sdk_api_error(error: &DatalensSdkError) -> bool {
             .is_some_and(|status| (500..600).contains(&status));
     }
 
-    matches!(
-        error,
-        DatalensSdkError::HttpStatus { status, .. } if (500..600).contains(status)
-    )
+    match error {
+        DatalensSdkError::Transport(_) => true,
+        DatalensSdkError::HttpStatus { status, .. } => (500..600).contains(status),
+        _ => false,
+    }
 }
 
 impl DatalensNativeReader for DatalensNativeClient {

--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -109,31 +109,14 @@ pub fn plan_dao_log_queries(
 pub fn fetch_dao_log_pages(
     reader: &mut impl DatalensLogQueryReader,
     plans: &[DaoLogQueryPlan],
-    max_attempts: u32,
 ) -> Result<Vec<DatalensLogPage>, DatalensError> {
-    if max_attempts == 0 {
-        return Err(DatalensError::Query(
-            "Datalens log query attempts must be greater than zero".to_owned(),
-        ));
-    }
-
     let mut pages = Vec::new();
     for plan in plans {
-        let mut attempt = 0;
-        loop {
-            attempt += 1;
-            match reader.query_logs(plan.input.clone()) {
-                Ok(rows) => {
-                    pages.push(DatalensLogPage {
-                        plan: plan.clone(),
-                        rows,
-                    });
-                    break;
-                }
-                Err(_) if attempt < max_attempts => continue,
-                Err(error) => return Err(error),
-            }
-        }
+        let rows = reader.query_logs(plan.input.clone())?;
+        pages.push(DatalensLogPage {
+            plan: plan.clone(),
+            rows,
+        });
     }
 
     Ok(pages)

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -103,6 +103,6 @@ pub use runner::{
 pub use runtime_config::{
     GraphqlRuntimeConfig, IndexerContractSetMode, IndexerContractSetRuntimeConfig,
     IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshRpcChainConfig,
-    OnchainRefreshRuntimeConfig, onchain_refresh_worker_enabled, parse_bool_env_value,
-    parse_i64_env_value, required_env,
+    OnchainRefreshRuntimeConfig, datalens_retry_config, onchain_refresh_worker_enabled,
+    parse_bool_env_value, parse_i64_env_value, required_env,
 };

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -26,7 +26,6 @@ pub struct IndexerRunnerOptions {
     pub addresses: DaoContractAddresses,
     pub checkpoint_identity: IndexerCheckpointIdentity,
     pub start_block: i64,
-    pub query_max_attempts: u32,
     pub safe_height: Option<i64>,
     pub progress_refresh_lag_blocks: i64,
 }
@@ -325,7 +324,7 @@ where
             range.from_block,
             range.to_block,
         )?;
-        let pages = fetch_dao_log_pages(&mut self.reader, &plans, self.options.query_max_attempts)?;
+        let pages = fetch_dao_log_pages(&mut self.reader, &plans)?;
         let decoded = self.decode_pages(pages)?;
 
         self.project_events(decoded, range, target_height)

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -6,7 +6,8 @@ use tokio::{task, time::sleep};
 use crate::{
     DaoContractAddresses, DaoEventDecoder, DatalensConfig, DatalensDurableHeadReader,
     DatalensNativeClient, IndexerContractSetRuntimeConfig, IndexerRunner, IndexerRunnerReport,
-    IndexerRuntimeConfig, IndexerTargetHeight, PostgresIndexerRunnerStore, required_env,
+    IndexerRuntimeConfig, IndexerTargetHeight, PostgresIndexerRunnerStore, datalens_retry_config,
+    required_env,
 };
 
 use super::{datalens::verify_datalens, migrate::apply_migrations};
@@ -113,8 +114,11 @@ async fn run_contract_set_pass(
     );
 
     task::spawn_blocking(move || -> Result<_> {
-        let client =
-            DatalensNativeClient::from_config(&config).context("create Datalens client")?;
+        let client = DatalensNativeClient::from_config_with_retry_config(
+            &config,
+            datalens_retry_config(runtime.query_max_attempts),
+        )
+        .context("create Datalens client")?;
         let store = PostgresIndexerRunnerStore::new(pool);
         let mut runner = IndexerRunner::new(
             runtime.options(&config, &contracts)?,
@@ -143,9 +147,11 @@ async fn resolve_contract_set_target_height(
         IndexerTargetHeight::Fixed(height) => Ok(height),
         IndexerTargetHeight::Latest => {
             let config = config.clone();
+            let retry_config = datalens_retry_config(runtime.query_max_attempts);
             task::spawn_blocking(move || -> Result<_> {
                 let mut client =
-                    DatalensNativeClient::from_config(&config).context("create Datalens client")?;
+                    DatalensNativeClient::from_config_with_retry_config(&config, retry_config)
+                        .context("create Datalens client")?;
                 client
                     .durable_head_height(&config)
                     .context("resolve latest Datalens durable head height")

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, env, net::SocketAddr, path::Path, time::Duration};
 
 use anyhow as runtime_anyhow;
+use datalens_sdk::RetryConfig;
 use runtime_anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
@@ -136,6 +137,14 @@ pub enum IndexerContractSetMode {
 pub enum IndexerTargetHeight {
     Latest,
     Fixed(i64),
+}
+
+pub fn datalens_retry_config(max_attempts: u32) -> RetryConfig {
+    RetryConfig {
+        max_attempts,
+        max_elapsed: None,
+        ..RetryConfig::default()
+    }
 }
 
 impl IndexerTargetHeight {
@@ -349,7 +358,6 @@ impl IndexerContractSetRuntimeConfig {
                 data_source_version: self.data_source_version.clone(),
             },
             start_block: self.start_block,
-            query_max_attempts: self.query_max_attempts,
             safe_height: None,
             progress_refresh_lag_blocks: self.progress_refresh_lag_blocks,
         })

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -2,7 +2,8 @@ use std::time::Duration;
 
 use degov_datalens_indexer::{
     DatalensConfig, GraphqlRuntimeConfig, IndexerContractSetMode, IndexerRuntimeConfig,
-    IndexerTargetHeight, onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value,
+    IndexerTargetHeight, datalens_retry_config, onchain_refresh_worker_enabled,
+    parse_bool_env_value, parse_i64_env_value,
 };
 
 #[test]
@@ -126,6 +127,15 @@ fn test_indexer_runtime_config_keeps_numeric_target_height_for_debug_runs() {
             assert_eq!(config.target_height, IndexerTargetHeight::Fixed(123));
         },
     );
+}
+
+#[test]
+fn test_datalens_retry_config_maps_query_max_attempts_to_sdk_retry_attempts() {
+    let retry_config = datalens_retry_config(5);
+
+    assert_eq!(retry_config.max_attempts, 5);
+    assert_eq!(retry_config.max_elapsed, None);
+    assert!(retry_config.jitter);
 }
 
 #[test]

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -94,7 +94,7 @@ fn test_datalens_durable_head_reader_uses_latest_finality_when_pending_enabled()
 #[test]
 fn test_datalens_log_query_retries_retryable_rate_limit_before_success() {
     let server = FakeQueryServer::start(vec![
-        api_error_response(429, "rate_limited", "request_rate_limit"),
+        api_error_response(429, "rate_limited", Some("request_rate_limit")),
         query_success_response(serde_json::json!([{ "block_number": 100 }])),
     ]);
     let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
@@ -119,9 +119,33 @@ fn test_datalens_log_query_retries_retryable_rate_limit_before_success() {
 }
 
 #[test]
+fn test_datalens_log_query_retries_provider_timeout_before_success() {
+    let server = FakeQueryServer::start(vec![
+        api_error_response(503, "provider_timeout", None),
+        query_success_response(serde_json::json!([{ "block_number": 101 }])),
+    ]);
+    let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(2))
+            .expect("client");
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+
+    let rows = client
+        .query_logs(plans[0].input.clone())
+        .expect("query retries and succeeds");
+
+    assert_eq!(rows, serde_json::json!([{ "block_number": 101 }]));
+    let requests = server.join();
+    assert_eq!(requests.len(), 2);
+}
+
+#[test]
 fn test_datalens_log_query_does_not_retry_non_retryable_quota_error() {
-    let server =
-        FakeQueryServer::start(vec![api_error_response(429, "rate_limited", "range_limit")]);
+    let server = FakeQueryServer::start(vec![api_error_response(
+        429,
+        "rate_limited",
+        Some("range_limit"),
+    )]);
     let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
     let mut client =
         DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(3))
@@ -230,34 +254,36 @@ fn query_success_response(rows: serde_json::Value) -> String {
         },
         "cache": {},
         "rows": rows
-    })
-    .to_string();
+    });
     http_response(200, body)
 }
 
-fn api_error_response(status: u16, kind: &str, quota_kind: &str) -> String {
-    let body = serde_json::json!({
+fn api_error_response(status: u16, kind: &str, quota_kind: Option<&str>) -> String {
+    let mut body = serde_json::json!({
         "error": {
             "kind": kind,
-            "message": format!("{quota_kind} exceeded"),
-            "quota": {
-                "kind": quota_kind,
-                "scope": "application",
-                "limit": 1,
-                "requested": 2,
-                "observed": 1,
-                "retry_after_seconds": 0
-            }
+            "message": format!("{kind} failed")
         }
-    })
-    .to_string();
+    });
+    if let Some(quota_kind) = quota_kind {
+        body["error"]["quota"] = serde_json::json!({
+            "kind": quota_kind,
+            "scope": "application",
+            "limit": 1,
+            "requested": 2,
+            "observed": 1,
+            "retry_after_seconds": 0
+        });
+    }
     http_response(status, body)
 }
 
-fn http_response(status: u16, body: String) -> String {
+fn http_response(status: u16, body: serde_json::Value) -> String {
+    let body = body.to_string();
     let reason = match status {
         200 => "OK",
         429 => "Too Many Requests",
+        503 => "Service Unavailable",
         _ => "Error",
     };
     format!(

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -5,10 +5,13 @@ use std::{
     time::Duration,
 };
 
+use datalens_sdk::RetryConfig;
 use degov_datalens_indexer::{
-    ChainFamily, ChainIdentityConfig, DatalensConfig, DatalensDurableHeadReader, DatalensError,
-    DatalensFinality, DatalensNativeClient, DatalensNativeReader, DatasetKeyConfig,
-    QueryLimitConfig, SecretString, ServiceReadiness, verify_datalens_service,
+    ChainFamily, ChainIdentityConfig, DaoContractAddresses, DatalensConfig,
+    DatalensDurableHeadReader, DatalensError, DatalensFinality, DatalensLogQueryReader,
+    DatalensNativeClient, DatalensNativeReader, DatasetKeyConfig, GovernanceTokenStandard,
+    QueryLimitConfig, SecretString, ServiceReadiness, plan_dao_log_queries,
+    verify_datalens_service,
 };
 
 struct MockDatalensReader {
@@ -88,6 +91,52 @@ fn test_datalens_durable_head_reader_uses_latest_finality_when_pending_enabled()
     assert!(!request.contains(r#""end":2147483647"#));
 }
 
+#[test]
+fn test_datalens_log_query_retries_retryable_rate_limit_before_success() {
+    let server = FakeQueryServer::start(vec![
+        api_error_response(429, "rate_limited", "request_rate_limit"),
+        query_success_response(serde_json::json!([{ "block_number": 100 }])),
+    ]);
+    let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(2))
+            .expect("client");
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+
+    let rows = client
+        .query_logs(plans[0].input.clone())
+        .expect("query retries and succeeds");
+
+    assert_eq!(rows, serde_json::json!([{ "block_number": 100 }]));
+    let requests = server.join();
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.starts_with("POST /v1/query ")),
+        "{requests:?}"
+    );
+}
+
+#[test]
+fn test_datalens_log_query_does_not_retry_non_retryable_quota_error() {
+    let server =
+        FakeQueryServer::start(vec![api_error_response(429, "rate_limited", "range_limit")]);
+    let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(3))
+            .expect("client");
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+
+    let error = client
+        .query_logs(plans[0].input.clone())
+        .expect_err("range limit is not retryable");
+
+    assert!(error.to_string().contains("range_limit"));
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+}
+
 struct FakeHeadServer {
     endpoint: String,
     handle: thread::JoinHandle<String>,
@@ -112,6 +161,39 @@ impl FakeHeadServer {
     }
 }
 
+struct FakeQueryServer {
+    endpoint: String,
+    handle: thread::JoinHandle<Vec<String>>,
+}
+
+impl FakeQueryServer {
+    fn start(responses: Vec<String>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake Datalens query server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let handle = thread::spawn(move || {
+            let mut requests = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener
+                    .accept()
+                    .expect("accept fake Datalens query request");
+                requests.push(read_http_request(&mut stream));
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write fake Datalens query response");
+            }
+            requests
+        });
+
+        Self { endpoint, handle }
+    }
+
+    fn join(self) -> Vec<String> {
+        self.handle
+            .join()
+            .expect("fake Datalens query server joins")
+    }
+}
+
 fn handle_head_request(mut stream: TcpStream, height: u64, finality: &'static str) -> String {
     let request = read_http_request(&mut stream);
     let body = serde_json::json!({
@@ -133,6 +215,56 @@ fn handle_head_request(mut stream: TcpStream, height: u64, finality: &'static st
         .expect("write fake Datalens head response");
 
     request
+}
+
+fn query_success_response(rows: serde_json::Value) -> String {
+    let body = serde_json::json!({
+        "chain": {
+            "configured_name": "ethereum"
+        },
+        "dataset_key": "evm.logs",
+        "range": {
+            "kind": "block",
+            "start": 100,
+            "end": 100
+        },
+        "cache": {},
+        "rows": rows
+    })
+    .to_string();
+    http_response(200, body)
+}
+
+fn api_error_response(status: u16, kind: &str, quota_kind: &str) -> String {
+    let body = serde_json::json!({
+        "error": {
+            "kind": kind,
+            "message": format!("{quota_kind} exceeded"),
+            "quota": {
+                "kind": quota_kind,
+                "scope": "application",
+                "limit": 1,
+                "requested": 2,
+                "observed": 1,
+                "retry_after_seconds": 0
+            }
+        }
+    })
+    .to_string();
+    http_response(status, body)
+}
+
+fn http_response(status: u16, body: String) -> String {
+    let reason = match status {
+        200 => "OK",
+        429 => "Too Many Requests",
+        _ => "Error",
+    };
+    format!(
+        "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
 }
 
 fn read_http_request(stream: &mut TcpStream) -> String {
@@ -171,6 +303,26 @@ fn content_length(headers: &[u8]) -> Option<usize> {
             None
         }
     })
+}
+
+fn retry_config_with_attempts(max_attempts: u32) -> RetryConfig {
+    RetryConfig {
+        max_attempts,
+        initial_delay: Duration::from_millis(0),
+        max_delay: Duration::from_millis(0),
+        max_elapsed: None,
+        jitter: false,
+        jitter_factor: 0.0,
+    }
+}
+
+fn addresses() -> DaoContractAddresses {
+    DaoContractAddresses {
+        governor: "0x1111111111111111111111111111111111111111".to_owned(),
+        governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+        governor_token_standard: GovernanceTokenStandard::Erc20,
+        timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+    }
 }
 
 fn datalens_config(endpoint: &str, finality: DatalensFinality) -> DatalensConfig {

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -140,6 +140,29 @@ fn test_datalens_log_query_retries_provider_timeout_before_success() {
 }
 
 #[test]
+fn test_datalens_log_query_retries_transport_failure_before_success() {
+    let server = FakeQueryServer::start_steps(vec![
+        FakeQueryResponse::CloseWithoutResponse,
+        FakeQueryResponse::Http(query_success_response(serde_json::json!([{
+            "block_number": 102
+        }]))),
+    ]);
+    let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(2))
+            .expect("client");
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+
+    let rows = client
+        .query_logs(plans[0].input.clone())
+        .expect("query retries and succeeds");
+
+    assert_eq!(rows, serde_json::json!([{ "block_number": 102 }]));
+    let requests = server.join();
+    assert_eq!(requests.len(), 2);
+}
+
+#[test]
 fn test_datalens_log_query_does_not_retry_non_retryable_quota_error() {
     let server = FakeQueryServer::start(vec![api_error_response(
         429,
@@ -190,8 +213,17 @@ struct FakeQueryServer {
     handle: thread::JoinHandle<Vec<String>>,
 }
 
+enum FakeQueryResponse {
+    Http(String),
+    CloseWithoutResponse,
+}
+
 impl FakeQueryServer {
     fn start(responses: Vec<String>) -> Self {
+        Self::start_steps(responses.into_iter().map(FakeQueryResponse::Http).collect())
+    }
+
+    fn start_steps(responses: Vec<FakeQueryResponse>) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake Datalens query server");
         let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
         let handle = thread::spawn(move || {
@@ -201,9 +233,12 @@ impl FakeQueryServer {
                     .accept()
                     .expect("accept fake Datalens query request");
                 requests.push(read_http_request(&mut stream));
-                stream
-                    .write_all(response.as_bytes())
-                    .expect("write fake Datalens query response");
+                match response {
+                    FakeQueryResponse::Http(response) => stream
+                        .write_all(response.as_bytes())
+                        .expect("write fake Datalens query response"),
+                    FakeQueryResponse::CloseWithoutResponse => {}
+                }
             }
             requests
         });

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, time::Duration};
+use std::time::Duration;
 
 use datalens_sdk::native::{QueryInput, QueryRangeKindInput, SelectorKindInput};
 use degov_datalens_indexer::{
@@ -110,7 +110,7 @@ fn test_fetch_dao_log_pages_treats_empty_rows_as_successful_page() {
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
     let mut reader = MockLogReader::new(vec![Ok(serde_json::json!([]))]);
 
-    let pages = fetch_dao_log_pages(&mut reader, &plans[..1], 3).expect("pages");
+    let pages = fetch_dao_log_pages(&mut reader, &plans[..1]).expect("pages");
 
     assert_eq!(pages.len(), 1);
     assert_eq!(pages[0].plan, plans[0]);
@@ -119,7 +119,7 @@ fn test_fetch_dao_log_pages_treats_empty_rows_as_successful_page() {
 }
 
 #[test]
-fn test_fetch_dao_log_pages_retries_errors_before_returning_page() {
+fn test_fetch_dao_log_pages_returns_first_reader_error_without_local_retry() {
     let config = config(1_000, DatalensFinality::DurableOnly);
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
     let mut reader = MockLogReader::new(vec![
@@ -127,29 +127,25 @@ fn test_fetch_dao_log_pages_retries_errors_before_returning_page() {
         Ok(serde_json::json!([{ "blockNumber": 100 }])),
     ]);
 
-    let pages = fetch_dao_log_pages(&mut reader, &plans[..1], 3).expect("pages");
+    let error = fetch_dao_log_pages(&mut reader, &plans[..1]).expect_err("query error");
 
-    assert_eq!(pages.len(), 1);
-    assert_eq!(pages[0].rows, serde_json::json!([{ "blockNumber": 100 }]));
-    assert_eq!(reader.calls.len(), 2);
-    assert_eq!(reader.calls[0], reader.calls[1]);
+    assert!(error.to_string().contains("provider timeout"));
+    assert_eq!(reader.calls.len(), 1);
 }
 
 #[test]
-fn test_fetch_dao_log_pages_stops_without_later_pages_when_retries_are_exhausted() {
+fn test_fetch_dao_log_pages_stops_without_later_pages_on_reader_error() {
     let config = config(1_000, DatalensFinality::DurableOnly);
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
     let mut reader = MockLogReader::new(vec![
         Err(DatalensError::Query("rate limited".to_owned())),
-        Err(DatalensError::Query("rate limited".to_owned())),
         Ok(serde_json::json!([])),
     ]);
 
-    let error = fetch_dao_log_pages(&mut reader, &plans[..2], 2).expect_err("query error");
+    let error = fetch_dao_log_pages(&mut reader, &plans[..2]).expect_err("query error");
 
     assert!(error.to_string().contains("rate limited"));
-    assert_eq!(reader.calls.len(), 2);
-    assert_eq!(reader.calls[0], reader.calls[1]);
+    assert_eq!(reader.calls.len(), 1);
 }
 
 fn assert_query(
@@ -219,14 +215,14 @@ fn addresses() -> DaoContractAddresses {
 
 struct MockLogReader {
     calls: Vec<QueryInput>,
-    results: VecDeque<Result<serde_json::Value, DatalensError>>,
+    results: Vec<Result<serde_json::Value, DatalensError>>,
 }
 
 impl MockLogReader {
     fn new(results: Vec<Result<serde_json::Value, DatalensError>>) -> Self {
         Self {
             calls: Vec::new(),
-            results: results.into(),
+            results,
         }
     }
 }
@@ -234,6 +230,6 @@ impl MockLogReader {
 impl DatalensLogQueryReader for MockLogReader {
     fn query_logs(&mut self, input: QueryInput) -> Result<serde_json::Value, DatalensError> {
         self.calls.push(input);
-        self.results.pop_front().expect("mock result")
+        self.results.remove(0)
     }
 }

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -133,6 +133,30 @@ fn test_runner_keeps_checkpoint_unchanged_when_transaction_fails() {
 }
 
 #[test]
+fn test_runner_keeps_checkpoint_unchanged_when_datalens_query_fails() {
+    let mut runner = IndexerRunner::new(
+        options(),
+        contexts(),
+        FailingDatalensReader,
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+        ScriptedDecoder,
+    );
+
+    let error = runner.run_to_target(1).expect_err("query fails");
+
+    assert!(error.to_string().contains("rate limited"));
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        1
+    );
+    assert_eq!(runner.store().commit_count(), 0);
+    assert_eq!(
+        runner.store().vote_repository().data_metric().votes_count,
+        0
+    );
+}
+
+#[test]
 fn test_runner_replay_over_same_range_does_not_double_count_business_totals() {
     let mut runner = runner(
         vec![
@@ -204,6 +228,14 @@ impl DatalensLogQueryReader for ScriptedDatalensReader {
         Ok(Value::Array(
             self.rows.pop_front().expect("scripted query response"),
         ))
+    }
+}
+
+struct FailingDatalensReader;
+
+impl DatalensLogQueryReader for FailingDatalensReader {
+    fn query_logs(&mut self, _input: QueryInput) -> Result<Value, DatalensError> {
+        Err(DatalensError::Query("rate limited".to_owned()))
     }
 }
 
@@ -323,7 +355,6 @@ fn options() -> IndexerRunnerOptions {
         addresses: addresses(),
         checkpoint_identity: identity(),
         start_block: 1,
-        query_max_attempts: 1,
         safe_height: None,
         progress_refresh_lag_blocks: 0,
     }

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -520,7 +520,6 @@ fn options() -> IndexerRunnerOptions {
         addresses: addresses(),
         checkpoint_identity: identity(),
         start_block: 1,
-        query_max_attempts: 1,
         safe_height: None,
         progress_refresh_lag_blocks: 0,
     }


### PR DESCRIPTION
## Summary
- Configure the DeGov Datalens client with SDK RetryConfig derived from DEGOV_INDEXER_QUERY_MAX_ATTEMPTS
- Remove the planner-level tight retry loop so SDK retry/backoff owns retryable Datalens failures
- Add coverage for retryable quota errors, non-retryable quota errors, no local double retry, and unchanged checkpoints on query failure

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p degov-datalens-indexer --test datalens_planner --test datalens_client --test cli_runtime_config --test indexer_runner
- cargo test -p degov-datalens-indexer --test native_runner_integration
- cargo build -p degov-datalens-indexer
- cargo test -p degov-datalens-indexer (blocked: DEGOV_INDEXER_TEST_DATABASE_URL is required by checkpoint_repository tests)
