### PR TITLE
HBX-318: Merge DAO Datalens log queries

### DIFF
--- a/apps/indexer/src/datalens/mod.rs
+++ b/apps/indexer/src/datalens/mod.rs
@@ -6,6 +6,6 @@ pub use client::{
     verify_datalens_service,
 };
 pub use planner::{
-    DaoContractAddresses, DaoLogQueryPlan, DaoLogSource, DatalensLogPage, DatalensLogQueryReader,
-    fetch_dao_log_pages, plan_dao_log_queries,
+    DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan, DaoLogSource, DatalensLogPage,
+    DatalensLogQueryReader, fetch_dao_log_pages, plan_dao_log_queries,
 };

--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -22,8 +22,14 @@ pub enum DaoLogSource {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DaoLogQueryPlan {
+pub struct DaoLogAddressSource {
+    pub address: String,
     pub source: DaoLogSource,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DaoLogQueryPlan {
+    pub sources: Vec<DaoLogAddressSource>,
     pub from_block: i32,
     pub to_block: i32,
     pub input: QueryInput,
@@ -72,30 +78,7 @@ pub fn plan_dao_log_queries(
             DatalensError::Query("Datalens log range end exceeds SDK limit".to_owned())
         })?;
 
-        plans.push(query_plan(
-            config,
-            DaoLogSource::Governor,
-            &addresses.governor,
-            GOVERNOR_TOPIC0_FILTERS,
-            range_start,
-            range_end,
-        ));
-        plans.push(query_plan(
-            config,
-            DaoLogSource::GovernorToken,
-            &addresses.governor_token,
-            GOVERNOR_TOKEN_TOPIC0_FILTERS,
-            range_start,
-            range_end,
-        ));
-        plans.push(query_plan(
-            config,
-            DaoLogSource::Timelock,
-            &addresses.timelock,
-            TIMELOCK_TOPIC0_FILTERS,
-            range_start,
-            range_end,
-        ));
+        plans.push(query_plan(config, addresses, range_start, range_end));
 
         if chunk_end == to_block {
             break;
@@ -124,14 +107,33 @@ pub fn fetch_dao_log_pages(
 
 fn query_plan(
     config: &DatalensConfig,
-    source: DaoLogSource,
-    address: &str,
-    topic0_filters: &[&str],
+    addresses: &DaoContractAddresses,
     from_block: i32,
     to_block: i32,
 ) -> DaoLogQueryPlan {
+    let sources = vec![
+        DaoLogAddressSource {
+            address: addresses.governor.clone(),
+            source: DaoLogSource::Governor,
+        },
+        DaoLogAddressSource {
+            address: addresses.governor_token.clone(),
+            source: DaoLogSource::GovernorToken,
+        },
+        DaoLogAddressSource {
+            address: addresses.timelock.clone(),
+            source: DaoLogSource::Timelock,
+        },
+    ];
+    let topic0_filters = GOVERNOR_TOPIC0_FILTERS
+        .iter()
+        .chain(GOVERNOR_TOKEN_TOPIC0_FILTERS)
+        .chain(TIMELOCK_TOPIC0_FILTERS)
+        .map(|topic| topic.to_string())
+        .collect();
+
     DaoLogQueryPlan {
-        source,
+        sources,
         from_block,
         to_block,
         input: QueryInput {
@@ -153,13 +155,12 @@ fn query_plan(
             selector: QuerySelectorInput {
                 kind: SelectorKindInput::EvmLogs,
                 evm_logs: Some(EvmLogsSelectorInput {
-                    addresses: vec![address.to_owned()],
-                    topics: vec![
-                        topic0_filters
-                            .iter()
-                            .map(|topic| topic.to_string())
-                            .collect(),
+                    addresses: vec![
+                        addresses.governor.clone(),
+                        addresses.governor_token.clone(),
+                        addresses.timelock.clone(),
                     ],
+                    topics: vec![topic0_filters],
                 }),
                 other: None,
             },

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -20,8 +20,8 @@ pub use crate::chain::tool::{
     ChainReadValue, ChainTool, MulticallReadGroup, PartialChainReadFailureReport, ReadRequirement,
 };
 pub use crate::datalens::planner::{
-    DaoContractAddresses, DaoLogQueryPlan, DaoLogSource, DatalensLogPage, DatalensLogQueryReader,
-    fetch_dao_log_pages, plan_dao_log_queries,
+    DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan, DaoLogSource, DatalensLogPage,
+    DatalensLogQueryReader, fetch_dao_log_pages, plan_dao_log_queries,
 };
 pub use crate::decode::dao_event::{
     CallExecutedEvent, CallSaltEvent, CallScheduledEvent, DaoEventDecodeError, DecodedDaoEvent,

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
 
 use log::{error, info};
@@ -336,6 +336,12 @@ where
     ) -> Result<Vec<(NormalizedEvmLog, DecodedDaoEvent)>, IndexerRunnerError> {
         let mut decoded = Vec::new();
         for page in pages {
+            let sources = page
+                .plan
+                .sources
+                .iter()
+                .map(|source| (source.address.to_ascii_lowercase(), source.source))
+                .collect::<BTreeMap<_, _>>();
             let rows = page_rows(page.rows)?;
             let logs = normalize_evm_log_rows(self.options.checkpoint_identity.chain_id, rows)
                 .map_err(|error| IndexerRunnerError::Normalize(error.to_string()))?;
@@ -350,11 +356,17 @@ where
                     );
                     continue;
                 }
-                let token_standard = (page.plan.source == DaoLogSource::GovernorToken)
+                let Some(source) = sources.get(&log.address).copied() else {
+                    return Err(IndexerRunnerError::Normalize(format!(
+                        "Datalens log address {} was not part of the DAO log query plan",
+                        log.address
+                    )));
+                };
+                let token_standard = (source == DaoLogSource::GovernorToken)
                     .then_some(self.options.addresses.governor_token_standard);
                 let event = self.decoder.decode(
                     &self.options.checkpoint_identity.dao_code,
-                    page.plan.source,
+                    source,
                     token_standard,
                     &log,
                 )?;

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -2,9 +2,9 @@ use std::time::Duration;
 
 use datalens_sdk::native::{QueryInput, QueryRangeKindInput, SelectorKindInput};
 use degov_datalens_indexer::{
-    ChainFamily, ChainIdentityConfig, DaoContractAddresses, DaoLogQueryPlan, DaoLogSource,
-    DatalensConfig, DatalensError, DatalensFinality, DatalensLogQueryReader, DatasetKeyConfig,
-    GovernanceTokenStandard, QueryLimitConfig, SecretString, fetch_dao_log_pages,
+    ChainFamily, ChainIdentityConfig, DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan,
+    DaoLogSource, DatalensConfig, DatalensError, DatalensFinality, DatalensLogQueryReader,
+    DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig, SecretString, fetch_dao_log_pages,
     plan_dao_log_queries,
 };
 
@@ -13,11 +13,23 @@ fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelo
     let config = config(1_000, DatalensFinality::DurableOnly);
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 3);
+    assert_eq!(plans.len(), 1);
     assert_query(
         &plans[0],
-        DaoLogSource::Governor,
-        "0x1111111111111111111111111111111111111111",
+        &[
+            DaoLogAddressSource {
+                address: "0x1111111111111111111111111111111111111111".to_owned(),
+                source: DaoLogSource::Governor,
+            },
+            DaoLogAddressSource {
+                address: "0x2222222222222222222222222222222222222222".to_owned(),
+                source: DaoLogSource::GovernorToken,
+            },
+            DaoLogAddressSource {
+                address: "0x3333333333333333333333333333333333333333".to_owned(),
+                source: DaoLogSource::Timelock,
+            },
+        ],
         &[
             "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0",
             "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892",
@@ -32,29 +44,9 @@ fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelo
             "0x08f74ea46ef7894f65eabfb5e6e695de773a000b47c529ab559178069b226401",
             "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4",
             "0xe2babfbac5889a709b63bb7f598b324e08bc5a4fb9ec647fb3cbc9ec07eb8712",
-        ],
-        100,
-        199,
-        "durable_only",
-    );
-    assert_query(
-        &plans[1],
-        DaoLogSource::GovernorToken,
-        "0x2222222222222222222222222222222222222222",
-        &[
             "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
             "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f",
             "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
-        ],
-        100,
-        199,
-        "durable_only",
-    );
-    assert_query(
-        &plans[2],
-        DaoLogSource::Timelock,
-        "0x3333333333333333333333333333333333333333",
-        &[
             "0x4cf4410cc57040e44862ef0f45f3dd5a5e02db8eb8add648d4b0e236f1d07dca",
             "0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58",
             "0x20fda5fd27a1ea7bf5b9567f143ac5470bb059374a27e8f67cb44f946f6d0387",
@@ -76,7 +68,6 @@ fn test_plan_dao_log_queries_chunks_ranges_by_config_limit() {
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 220).expect("plans");
     let ranges = plans
         .iter()
-        .filter(|plan| plan.source == DaoLogSource::Governor)
         .map(|plan| (plan.from_block, plan.to_block))
         .collect::<Vec<_>>();
 
@@ -135,8 +126,8 @@ fn test_fetch_dao_log_pages_returns_first_reader_error_without_local_retry() {
 
 #[test]
 fn test_fetch_dao_log_pages_stops_without_later_pages_on_reader_error() {
-    let config = config(1_000, DatalensFinality::DurableOnly);
-    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
+    let config = config(1, DatalensFinality::DurableOnly);
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 101).expect("plans");
     let mut reader = MockLogReader::new(vec![
         Err(DatalensError::Query("rate limited".to_owned())),
         Ok(serde_json::json!([])),
@@ -150,14 +141,13 @@ fn test_fetch_dao_log_pages_stops_without_later_pages_on_reader_error() {
 
 fn assert_query(
     plan: &DaoLogQueryPlan,
-    source: DaoLogSource,
-    address: &str,
+    sources: &[DaoLogAddressSource],
     topic0_values: &[&str],
     from_block: i32,
     to_block: i32,
     finality: &str,
 ) {
-    assert_eq!(plan.source, source);
+    assert_eq!(plan.sources, sources);
     assert_eq!(plan.from_block, from_block);
     assert_eq!(plan.to_block, to_block);
     assert_eq!(plan.input.chain.configured_name, "ethereum");
@@ -170,7 +160,13 @@ fn assert_query(
     assert_eq!(plan.input.finality.as_deref(), Some(finality));
 
     let evm_logs = plan.input.selector.evm_logs.as_ref().expect("evm logs");
-    assert_eq!(evm_logs.addresses, vec![address.to_owned()]);
+    assert_eq!(
+        evm_logs.addresses,
+        sources
+            .iter()
+            .map(|source| source.address.clone())
+            .collect::<Vec<_>>()
+    );
     assert_eq!(
         evm_logs.topics,
         vec![

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -56,12 +56,11 @@ fn test_page_rows_rejects_malformed_response() {
 fn test_runner_processes_multiple_chunks_and_advances_checkpoint_after_commits() {
     let mut runner = runner(
         vec![
-            vec![row(1, 0, 0)],
-            vec![],
-            vec![],
+            vec![
+                row(1, 0, 0),
+                row_at_address(1, 0, 1, &TOKEN.to_ascii_uppercase()),
+            ],
             vec![row(2, 0, 0)],
-            vec![],
-            vec![],
         ],
         ScriptedDecoder,
     );
@@ -85,6 +84,10 @@ fn test_runner_processes_multiple_chunks_and_advances_checkpoint_after_commits()
             .votes_weight_for_sum,
         "30"
     );
+    assert_eq!(
+        runner.store().token_repository().delegate_changed().len(),
+        1
+    );
 }
 
 #[test]
@@ -92,7 +95,7 @@ fn test_runner_skips_removed_logs_before_decode_and_still_advances_checkpoint() 
     let mut options = options();
     options.datalens_config.finality = DatalensFinality::IncludePending;
     let mut runner = runner_with_decoder(
-        vec![vec![removed_row(1, 0, 0)], vec![], vec![]],
+        vec![vec![removed_row(1, 0, 0)]],
         RejectRemovedDecoder,
         options,
     );
@@ -113,7 +116,7 @@ fn test_runner_skips_removed_logs_before_decode_and_still_advances_checkpoint() 
 
 #[test]
 fn test_runner_keeps_checkpoint_unchanged_when_transaction_fails() {
-    let mut runner = runner(vec![vec![row(1, 0, 0)], vec![], vec![]], ScriptedDecoder);
+    let mut runner = runner(vec![vec![row(1, 0, 0)]], ScriptedDecoder);
     runner
         .store_mut()
         .fail_next_commit("projection write failed");
@@ -159,14 +162,7 @@ fn test_runner_keeps_checkpoint_unchanged_when_datalens_query_fails() {
 #[test]
 fn test_runner_replay_over_same_range_does_not_double_count_business_totals() {
     let mut runner = runner(
-        vec![
-            vec![row(1, 0, 0)],
-            vec![],
-            vec![],
-            vec![row(1, 0, 0)],
-            vec![],
-            vec![],
-        ],
+        vec![vec![row(1, 0, 0)], vec![row(1, 0, 0)]],
         ScriptedDecoder,
     );
 
@@ -196,14 +192,7 @@ fn test_runner_replay_over_same_range_does_not_double_count_business_totals() {
 #[test]
 fn test_runner_stops_gracefully_between_chunks() {
     let mut runner = runner(
-        vec![
-            vec![row(1, 0, 0)],
-            vec![],
-            vec![],
-            vec![row(2, 0, 0)],
-            vec![],
-            vec![],
-        ],
+        vec![vec![row(1, 0, 0)], vec![row(2, 0, 0)]],
         ScriptedDecoder,
     );
     runner.request_shutdown_after_chunks(1);
@@ -247,36 +236,45 @@ impl IndexerEventDecoder for ScriptedDecoder {
         &self,
         _dao_code: &str,
         source: DaoLogSource,
-        _token_standard: Option<GovernanceTokenStandard>,
+        token_standard: Option<GovernanceTokenStandard>,
         log: &NormalizedEvmLog,
     ) -> Result<DecodedDaoEvent, DaoEventDecodeError> {
         match source {
-            DaoLogSource::Governor => Ok(DecodedDaoEvent::Governor(
-                DecodedGovernorEvent::VoteCast(VoteCastEvent {
-                    voter: format!("0x{:040}", log.block_number),
-                    proposal_id: "42".to_owned(),
-                    support: 1,
-                    weight: (log.block_number * 10).to_string(),
-                    reason: String::new(),
-                }),
-            )),
-            DaoLogSource::GovernorToken => Ok(DecodedDaoEvent::Token(
-                DecodedTokenEvent::DelegateChanged(degov_datalens_indexer::DelegateChangedEvent {
-                    delegator: "0x0000000000000000000000000000000000000001".to_owned(),
-                    from_delegate: "0x0000000000000000000000000000000000000000".to_owned(),
-                    to_delegate: "0x0000000000000000000000000000000000000002".to_owned(),
-                }),
-            )),
-            DaoLogSource::Timelock => Ok(DecodedDaoEvent::UnsupportedTopic(
-                degov_datalens_indexer::UnsupportedTopicEvent {
-                    dao_code: "demo-dao".to_owned(),
-                    source,
-                    block_number: log.block_number,
-                    transaction_hash: log.transaction_hash.clone(),
-                    address: log.address.clone(),
-                    topic0: log.topics[0].clone(),
-                },
-            )),
+            DaoLogSource::Governor => {
+                assert_eq!(token_standard, None);
+                Ok(DecodedDaoEvent::Governor(DecodedGovernorEvent::VoteCast(
+                    VoteCastEvent {
+                        voter: format!("0x{:040}", log.block_number),
+                        proposal_id: "42".to_owned(),
+                        support: 1,
+                        weight: (log.block_number * 10).to_string(),
+                        reason: String::new(),
+                    },
+                )))
+            }
+            DaoLogSource::GovernorToken => {
+                assert_eq!(token_standard, Some(GovernanceTokenStandard::Erc20));
+                Ok(DecodedDaoEvent::Token(DecodedTokenEvent::DelegateChanged(
+                    degov_datalens_indexer::DelegateChangedEvent {
+                        delegator: "0x0000000000000000000000000000000000000001".to_owned(),
+                        from_delegate: "0x0000000000000000000000000000000000000000".to_owned(),
+                        to_delegate: "0x0000000000000000000000000000000000000002".to_owned(),
+                    },
+                )))
+            }
+            DaoLogSource::Timelock => {
+                assert_eq!(token_standard, None);
+                Ok(DecodedDaoEvent::UnsupportedTopic(
+                    degov_datalens_indexer::UnsupportedTopicEvent {
+                        dao_code: "demo-dao".to_owned(),
+                        source,
+                        block_number: log.block_number,
+                        transaction_hash: log.transaction_hash.clone(),
+                        address: log.address.clone(),
+                        topic0: log.topics[0].clone(),
+                    },
+                ))
+            }
         }
     }
 }
@@ -417,17 +415,27 @@ fn addresses() -> DaoContractAddresses {
 }
 
 fn row(block_number: u64, transaction_index: u64, log_index: u64) -> Value {
-    row_with_removed(block_number, transaction_index, log_index, false)
+    row_at_address(block_number, transaction_index, log_index, GOVERNOR)
+}
+
+fn row_at_address(
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+    address: &str,
+) -> Value {
+    row_with_removed(block_number, transaction_index, log_index, address, false)
 }
 
 fn removed_row(block_number: u64, transaction_index: u64, log_index: u64) -> Value {
-    row_with_removed(block_number, transaction_index, log_index, true)
+    row_with_removed(block_number, transaction_index, log_index, GOVERNOR, true)
 }
 
 fn row_with_removed(
     block_number: u64,
     transaction_index: u64,
     log_index: u64,
+    address: &str,
     removed: bool,
 ) -> Value {
     json!({
@@ -437,9 +445,12 @@ fn row_with_removed(
         "transaction_hash": format!("0xtx{block_number}"),
         "transaction_index": transaction_index,
         "log_index": log_index,
-        "address": "0x1111111111111111111111111111111111111111",
+        "address": address,
         "topics": ["0x0000000000000000000000000000000000000000000000000000000000000000"],
         "data": "0x",
         "removed": removed
     })
 }
+
+const GOVERNOR: &str = "0x1111111111111111111111111111111111111111";
+const TOKEN: &str = "0x2222222222222222222222222222222222222222";

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -103,11 +103,7 @@ fn test_native_runner_links_timelock_to_proposal_actions_from_previous_range() {
     let mut runner = native_runner_with_options(
         vec![
             vec![proposal_created_row()],
-            vec![],
-            vec![],
-            vec![proposal_queued_row()],
-            vec![],
-            vec![call_scheduled_row()],
+            vec![proposal_queued_row(), call_scheduled_row()],
         ],
         CapturingStore::new(identity(), 1),
         options,
@@ -595,19 +591,16 @@ fn addresses() -> DaoContractAddresses {
 }
 
 fn scripted_pages() -> Vec<Vec<Value>> {
-    vec![
-        vec![
-            vote_cast_row(),
-            proposal_created_row(),
-            proposal_queued_row(),
-        ],
-        vec![
-            delegate_changed_row(),
-            delegate_votes_changed_row(),
-            erc20_transfer_row(),
-        ],
-        vec![call_executed_row(), call_scheduled_row()],
-    ]
+    vec![vec![
+        call_executed_row(),
+        delegate_changed_row(),
+        vote_cast_row(),
+        proposal_created_row(),
+        call_scheduled_row(),
+        delegate_votes_changed_row(),
+        erc20_transfer_row(),
+        proposal_queued_row(),
+    ]]
 }
 
 fn proposal_created_row() -> Value {

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -126,7 +126,7 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
     run_indexer_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 1);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
     assert_table_count(&database.pool, "proposal_created", 1).await?;
     assert_table_count(&database.pool, "proposal", 1).await?;
     assert_table_count(&database.pool, "vote_cast", 1).await?;
@@ -155,7 +155,7 @@ async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
     run_indexer_all_contract_sets_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 0);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
     assert_checkpoint_scope(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_scope(&database.pool, SECOND_CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_row_count(&database.pool, 2).await?;
@@ -924,13 +924,13 @@ fn handle_datalens_request(
             "range_kind": "block"
         })
     } else {
-        let query_index = query_count.fetch_add(1, Ordering::Relaxed);
-        let rows = match query_index {
-            0 => governor_rows.to_vec(),
-            1 => token_rows.to_vec(),
-            2 => timelock_rows.to_vec(),
-            _ => Vec::new(),
-        };
+        query_count.fetch_add(1, Ordering::Relaxed);
+        let rows = governor_rows
+            .iter()
+            .chain(token_rows)
+            .chain(timelock_rows)
+            .cloned()
+            .collect::<Vec<_>>();
 
         json!({
             "chain": {},


### PR DESCRIPTION
## Summary
- merge standard DAO governor, token, and timelock log reads into one multi-address Datalens query per block chunk
- carry address-to-source mappings in query plans and classify normalized log addresses before decoding
- update runner and runtime tests for one request per chunk and mixed-address merged pages

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p degov-datalens-indexer --test datalens_planner
- cargo test -p degov-datalens-indexer --test indexer_runner
- cargo test -p degov-datalens-indexer --test native_runner_integration
- cargo build -p degov-datalens-indexer

## Notes
- cargo test -p degov-datalens-indexer --test postgres_runtime_run is blocked locally because DEGOV_INDEXER_TEST_DATABASE_URL is not set.