### PR TITLE
HBX-320 optimize token write cache

### DIFF
--- a/apps/indexer/src/store/postgres/data_metric.rs
+++ b/apps/indexer/src/store/postgres/data_metric.rs
@@ -12,6 +12,11 @@ async fn write_data_metric_timeline(
     vote: Option<&VoteProjectionBatch>,
     token: Option<&TokenProjectionBatch>,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let inserted_operation_keys = inserted_operation_keys
+        .iter()
+        .map(|(contract_set_id, id)| (contract_set_id.as_str(), id.as_str()))
+        .collect::<HashSet<_>>();
+    let mut delegate_mapping_cache = DelegateMappingCache::default();
     let mut items = Vec::new();
     if let Some(token) = token {
         items.extend(token.operations.iter().map(DataMetricTimelineItem::Token));
@@ -32,10 +37,9 @@ async fn write_data_metric_timeline(
     for item in items {
         match item {
             DataMetricTimelineItem::Token(operation) => {
-                if inserted_operation_keys.iter().any(|inserted| {
-                    (inserted.0.as_str(), inserted.1.as_str()) == token_operation_key(operation)
-                }) {
-                    apply_token_operation(transaction, operation).await?;
+                if inserted_operation_keys.contains(&token_operation_key(operation)) {
+                    apply_token_operation(transaction, &mut delegate_mapping_cache, operation)
+                        .await?;
                 }
             }
             DataMetricTimelineItem::Proposal(row) | DataMetricTimelineItem::Vote(row) => {

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -1,4 +1,8 @@
-use std::{fmt, future::Future};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    future::Future,
+};
 
 use sqlx::{PgPool, Postgres, Row, Transaction};
 

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -297,6 +297,7 @@ async fn insert_vote_power_checkpoint(
 
 async fn apply_token_operation(
     transaction: &mut Transaction<'_, Postgres>,
+    delegate_mapping_cache: &mut DelegateMappingCache,
     operation: &TokenProjectionOperation,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     match operation {
@@ -309,6 +310,7 @@ async fn apply_token_operation(
         } => {
             apply_delegate_changed_operation(
                 transaction,
+                delegate_mapping_cache,
                 common,
                 delegator,
                 from_delegate,
@@ -325,6 +327,7 @@ async fn apply_token_operation(
         } => {
             apply_delegate_votes_changed_operation(
                 transaction,
+                delegate_mapping_cache,
                 common,
                 delegate,
                 previous_votes,
@@ -339,12 +342,24 @@ async fn apply_token_operation(
             value,
             standard,
             ..
-        } => apply_transfer_operation(transaction, common, from, to, value, *standard).await,
+        } => {
+            apply_transfer_operation(
+                transaction,
+                delegate_mapping_cache,
+                common,
+                from,
+                to,
+                value,
+                *standard,
+            )
+            .await
+        }
     }
 }
 
 async fn apply_delegate_changed_operation(
     transaction: &mut Transaction<'_, Postgres>,
+    delegate_mapping_cache: &mut DelegateMappingCache,
     common: &TokenEventCommon,
     delegator: &str,
     from_delegate: &str,
@@ -353,7 +368,9 @@ async fn apply_delegate_changed_operation(
     if !is_zero_address(to_delegate) {
         ensure_contributor(transaction, to_delegate, common).await?;
     }
-    let previous_mapping = read_delegate_mapping(transaction, common, delegator).await?;
+    let previous_mapping =
+        read_delegate_mapping_cached(transaction, delegate_mapping_cache, common, delegator)
+            .await?;
     let is_noop = previous_mapping
         .as_ref()
         .is_some_and(|mapping| mapping.to == to_delegate && from_delegate == to_delegate);
@@ -383,11 +400,7 @@ async fn apply_delegate_changed_operation(
             },
         )
         .await?;
-        sqlx::query("DELETE FROM delegate_mapping WHERE contract_set_id = $1 AND id = $2")
-            .bind(&common.contract_set_id)
-            .bind(delegate_mapping_ref(common, delegator))
-            .execute(&mut **transaction)
-            .await?;
+        delete_delegate_mapping(transaction, delegate_mapping_cache, common, delegator).await?;
     }
 
     if is_zero_address(to_delegate) {
@@ -395,13 +408,22 @@ async fn apply_delegate_changed_operation(
     }
 
     apply_delegate_count_delta(transaction, common, to_delegate, 1, 0).await?;
-    upsert_delegate_mapping(transaction, common, delegator, to_delegate, "0").await?;
+    upsert_delegate_mapping(
+        transaction,
+        delegate_mapping_cache,
+        common,
+        delegator,
+        to_delegate,
+        "0",
+    )
+    .await?;
 
     Ok(())
 }
 
 async fn apply_delegate_votes_changed_operation(
     transaction: &mut Transaction<'_, Postgres>,
+    delegate_mapping_cache: &mut DelegateMappingCache,
     common: &TokenEventCommon,
     delegate: &str,
     previous_votes: &str,
@@ -431,6 +453,7 @@ async fn apply_delegate_votes_changed_operation(
             .await?;
             apply_delegate_delta(
                 transaction,
+                delegate_mapping_cache,
                 common,
                 &rolling_match.delegator,
                 &rolling_match.from_delegate,
@@ -453,6 +476,7 @@ async fn apply_delegate_votes_changed_operation(
             .await?;
             apply_delegate_delta(
                 transaction,
+                delegate_mapping_cache,
                 common,
                 &rolling_match.delegator,
                 &rolling_match.to_delegate,
@@ -465,6 +489,7 @@ async fn apply_delegate_votes_changed_operation(
 
 async fn apply_transfer_operation(
     transaction: &mut Transaction<'_, Postgres>,
+    delegate_mapping_cache: &mut DelegateMappingCache,
     common: &TokenEventCommon,
     from: &str,
     to: &str,
@@ -472,9 +497,12 @@ async fn apply_transfer_operation(
     standard: GovernanceTokenStandard,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     let value = transfer_units(value, standard);
-    if let Some(mapping) = read_delegate_mapping(transaction, common, from).await? {
+    if let Some(mapping) =
+        read_delegate_mapping_cached(transaction, delegate_mapping_cache, common, from).await?
+    {
         apply_delegate_delta(
             transaction,
+            delegate_mapping_cache,
             common,
             &mapping.from,
             &mapping.to,
@@ -482,8 +510,18 @@ async fn apply_transfer_operation(
         )
         .await?;
     }
-    if let Some(mapping) = read_delegate_mapping(transaction, common, to).await? {
-        apply_delegate_delta(transaction, common, &mapping.from, &mapping.to, &value).await?;
+    if let Some(mapping) =
+        read_delegate_mapping_cached(transaction, delegate_mapping_cache, common, to).await?
+    {
+        apply_delegate_delta(
+            transaction,
+            delegate_mapping_cache,
+            common,
+            &mapping.from,
+            &mapping.to,
+            &value,
+        )
+        .await?;
     }
 
     Ok(())
@@ -491,6 +529,7 @@ async fn apply_transfer_operation(
 
 async fn apply_delegate_delta(
     transaction: &mut Transaction<'_, Postgres>,
+    delegate_mapping_cache: &mut DelegateMappingCache,
     common: &TokenEventCommon,
     from_delegate: &str,
     to_delegate: &str,
@@ -500,15 +539,16 @@ async fn apply_delegate_delta(
         return Ok(());
     }
 
-    let previous_mapping_power = read_delegate_mapping(transaction, common, from_delegate)
-        .await?
-        .filter(|mapping| mapping.to == to_delegate)
-        .map(|mapping| mapping.power)
-        .unwrap_or_else(|| "0".to_owned());
+    let previous_mapping_power =
+        read_delegate_mapping_cached(transaction, delegate_mapping_cache, common, from_delegate)
+            .await?
+            .filter(|mapping| mapping.to == to_delegate)
+            .map(|mapping| mapping.power)
+            .unwrap_or_else(|| "0".to_owned());
     let next_mapping_power =
         add_signed_decimal(transaction, &previous_mapping_power, delta).await?;
 
-    sqlx::query(
+    let result = sqlx::query(
         r#"UPDATE delegate_mapping
            SET chain_id = $3, dao_code = $4, governor_address = $5, token_address = $6,
                contract_address = $7, log_index = $8, transaction_index = $9,
@@ -538,6 +578,17 @@ async fn apply_delegate_delta(
     .bind(to_delegate)
     .execute(&mut **transaction)
     .await?;
+    if result.rows_affected() > 0 {
+        delegate_mapping_cache.set(
+            common,
+            from_delegate,
+            Some(DelegateMappingSnapshot {
+                from: from_delegate.to_owned(),
+                to: to_delegate.to_owned(),
+                power: next_mapping_power.clone(),
+            }),
+        );
+    }
 
     let previous_effective = is_nonzero_decimal(&previous_mapping_power);
     let next_effective = is_nonzero_decimal(&next_mapping_power);
@@ -639,6 +690,7 @@ async fn upsert_delegate_snapshot(
 
 async fn upsert_delegate_mapping(
     transaction: &mut Transaction<'_, Postgres>,
+    delegate_mapping_cache: &mut DelegateMappingCache,
     common: &TokenEventCommon,
     from: &str,
     to: &str,
@@ -692,6 +744,31 @@ async fn upsert_delegate_mapping(
     .bind(&common.transaction_hash)
     .execute(&mut **transaction)
     .await?;
+    delegate_mapping_cache.set(
+        common,
+        from,
+        Some(DelegateMappingSnapshot {
+            from: from.to_owned(),
+            to: to.to_owned(),
+            power: power.to_owned(),
+        }),
+    );
+
+    Ok(())
+}
+
+async fn delete_delegate_mapping(
+    transaction: &mut Transaction<'_, Postgres>,
+    delegate_mapping_cache: &mut DelegateMappingCache,
+    common: &TokenEventCommon,
+    from: &str,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    sqlx::query("DELETE FROM delegate_mapping WHERE contract_set_id = $1 AND id = $2")
+        .bind(&common.contract_set_id)
+        .bind(delegate_mapping_ref(common, from))
+        .execute(&mut **transaction)
+        .await?;
+    delegate_mapping_cache.set(common, from, None);
 
     Ok(())
 }
@@ -844,6 +921,37 @@ struct DelegateMappingSnapshot {
     power: String,
 }
 
+#[derive(Debug, Default)]
+struct DelegateMappingCache {
+    mappings: HashMap<(String, String), Option<DelegateMappingSnapshot>>,
+}
+
+impl DelegateMappingCache {
+    fn get(
+        &self,
+        common: &TokenEventCommon,
+        from: &str,
+    ) -> Option<Option<DelegateMappingSnapshot>> {
+        self.mappings.get(&self.key(common, from)).cloned()
+    }
+
+    fn set(
+        &mut self,
+        common: &TokenEventCommon,
+        from: &str,
+        snapshot: Option<DelegateMappingSnapshot>,
+    ) {
+        self.mappings.insert(self.key(common, from), snapshot);
+    }
+
+    fn key(&self, common: &TokenEventCommon, from: &str) -> (String, String) {
+        (
+            common.contract_set_id.clone(),
+            delegate_mapping_ref(common, from),
+        )
+    }
+}
+
 #[derive(Clone, Debug)]
 struct DelegateRollingSnapshot {
     id: String,
@@ -868,6 +976,22 @@ struct DelegateRollingMatch {
     from_delegate: String,
     to_delegate: String,
     side: RollingSide,
+}
+
+async fn read_delegate_mapping_cached(
+    transaction: &mut Transaction<'_, Postgres>,
+    delegate_mapping_cache: &mut DelegateMappingCache,
+    common: &TokenEventCommon,
+    from: &str,
+) -> Result<Option<DelegateMappingSnapshot>, PostgresIndexerRunnerStoreError> {
+    if let Some(snapshot) = delegate_mapping_cache.get(common, from) {
+        return Ok(snapshot);
+    }
+
+    let snapshot = read_delegate_mapping(transaction, common, from).await?;
+    delegate_mapping_cache.set(common, from, snapshot.clone());
+
+    Ok(snapshot)
 }
 
 async fn read_delegate_mapping(

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -15,12 +15,12 @@ use std::{
 use degov_datalens_indexer::{
     BatchReadPlanConfig, CallExecutedEvent, CallScheduledEvent, ChainContracts, ChainReadMethod,
     DecodedGovernorEvent, DecodedTimelockEvent, DecodedTokenEvent, DelegateChangedEvent,
-    GovernanceTokenStandard, IndexerProjectionBatch, IndexerRunnerStore, IndexerRunnerTransaction,
-    NormalizedEvmLog, PostgresIndexerRunnerStore, ProposalCreatedEvent, ProposalExtendedEvent,
-    ProposalProjectionContext, ProposalProjectionEvent, ProposalQueuedEvent,
+    DelegateVotesChangedEvent, GovernanceTokenStandard, IndexerProjectionBatch, IndexerRunnerStore,
+    IndexerRunnerTransaction, NormalizedEvmLog, PostgresIndexerRunnerStore, ProposalCreatedEvent,
+    ProposalExtendedEvent, ProposalProjectionContext, ProposalProjectionEvent, ProposalQueuedEvent,
     TimelockProjectionContext, TimelockProjectionEvent, TimelockProposalLinkContext,
-    TokenProjectionContext, TokenProjectionEvent, VoteCastEvent, VoteProjectionContext,
-    VoteProjectionEvent, project_proposal_events, project_timelock_events,
+    TokenProjectionContext, TokenProjectionEvent, TokenTransferEvent, VoteCastEvent,
+    VoteProjectionContext, VoteProjectionEvent, project_proposal_events, project_timelock_events,
     project_timelock_events_with_proposal_links, project_token_events, project_vote_events,
     runtime::apply_migrations,
 };
@@ -540,6 +540,168 @@ async fn test_postgres_data_metric_event_snapshots_follow_mixed_batch_event_orde
         Some("0".to_owned())
     );
     assert_eq!(metric.get::<Option<i32>, _>("member_count"), Some(1));
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_same_batch_mapping_mutations_remain_ordered()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let initial = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000001-delegate", 1, 0, 1),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: DELEGATOR.to_owned(),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: DELEGATE.to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000002-votes", 1, 0, 2),
+                event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                    delegate: DELEGATE.to_owned(),
+                    previous_votes: "0".to_owned(),
+                    new_votes: "100".to_owned(),
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("initial token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(initial),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let same_batch = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000003-transfer", 2, 0, 1),
+                event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                    from: DELEGATOR.to_owned(),
+                    to: RECEIVER.to_owned(),
+                    value: "40".to_owned(),
+                    standard: GovernanceTokenStandard::Erc20,
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000004-redelegate", 2, 0, 2),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: DELEGATOR.to_owned(),
+                    from_delegate: DELEGATE.to_owned(),
+                    to_delegate: SECOND_DELEGATE.to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000005-new-votes", 2, 0, 3),
+                event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                    delegate: SECOND_DELEGATE.to_owned(),
+                    previous_votes: "0".to_owned(),
+                    new_votes: "60".to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000006-second-transfer", 2, 0, 4),
+                event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                    from: DELEGATOR.to_owned(),
+                    to: RECEIVER.to_owned(),
+                    value: "10".to_owned(),
+                    standard: GovernanceTokenStandard::Erc20,
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("same-batch token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(same_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let mapping = sqlx::query(
+        r#"SELECT "to", power::TEXT AS power
+           FROM delegate_mapping
+           WHERE contract_set_id = $1 AND "from" = $2"#,
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATOR)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(mapping.get::<String, _>("to"), SECOND_DELEGATE);
+    assert_eq!(mapping.get::<String, _>("power"), "50");
+
+    let previous_relation = sqlx::query(
+        "SELECT power::TEXT AS power, is_current
+         FROM delegate
+         WHERE contract_set_id = $1 AND from_delegate = $2 AND to_delegate = $3",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATOR)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(previous_relation.get::<String, _>("power"), "60");
+    assert!(!previous_relation.get::<bool, _>("is_current"));
+
+    let current_relation = sqlx::query(
+        "SELECT power::TEXT AS power, is_current
+         FROM delegate
+         WHERE contract_set_id = $1 AND from_delegate = $2 AND to_delegate = $3",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATOR)
+    .bind(SECOND_DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(current_relation.get::<String, _>("power"), "50");
+    assert!(current_relation.get::<bool, _>("is_current"));
+
+    let previous_delegate_counts = sqlx::query(
+        "SELECT delegates_count_all, delegates_count_effective
+         FROM contributor
+         WHERE contract_set_id = $1 AND id = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(
+        previous_delegate_counts.get::<i32, _>("delegates_count_all"),
+        0
+    );
+    assert_eq!(
+        previous_delegate_counts.get::<i32, _>("delegates_count_effective"),
+        0
+    );
+
+    let current_delegate_counts = sqlx::query(
+        "SELECT delegates_count_all, delegates_count_effective
+         FROM contributor
+         WHERE contract_set_id = $1 AND id = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(SECOND_DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(
+        current_delegate_counts.get::<i32, _>("delegates_count_all"),
+        1
+    );
+    assert_eq!(
+        current_delegate_counts.get::<i32, _>("delegates_count_effective"),
+        1
+    );
 
     database.cleanup().await?;
 
@@ -1759,6 +1921,7 @@ const VOTER: &str = "0x0000000000000000000000000000000000000b01";
 const DELEGATOR: &str = "0x0000000000000000000000000000000000000c01";
 const DELEGATE: &str = "0x0000000000000000000000000000000000000c02";
 const RECEIVER: &str = "0x0000000000000000000000000000000000000c03";
+const SECOND_DELEGATE: &str = "0x0000000000000000000000000000000000000c04";
 const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
 const OPERATION_ID: &str = "0x0101010101010101010101010101010101010101010101010101010101010101";
 const ZERO_OPERATION_ID: &str =


### PR DESCRIPTION
## Summary
- add a write-transaction-local read-through cache for delegate_mapping reads in the Postgres token operation path
- keep the cache coherent after delegate_mapping upsert, delete, and apply_delegate_delta updates
- replace dense timeline inserted-operation scans with a HashSet lookup
- add a Postgres regression for same-batch transfer/redelegation/cache mutation ordering

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p degov-datalens-indexer --test token_projection
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/degov_test cargo test -p degov-datalens-indexer --test postgres_runtime_run
- cargo build -p degov-datalens-indexer
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/degov_test cargo test -p degov-datalens-indexer
