### PR TITLE
fix(indexer): update Datalens SDK REST query contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ DEGOV_INDEXER_GRAPHQL_INTERNAL_ENDPOINT=http://indexer-graphql:4350/graphql
 DEGOV_CONFIG_INDEXER_ENDPOINT=http://127.0.0.1:4350/degov-demo-dao/graphql
 
 # Datalens-native indexer.
-# Keep DATALENS_ENDPOINT as the service base URL; the Rust SDK derives /native/graphql.
+# Keep DATALENS_ENDPOINT as the service base URL for SDK REST and native endpoints.
 DATALENS_ENDPOINT=https://datalens.ringdao.com
 DATALENS_APPLICATION=degov-live
 DATALENS_TOKEN=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datalens-sdk"
 version = "0.1.0"
-source = "git+https://github.com/ringecosystem/datalens?rev=6978b8bf552fdbdc2c894f724d7dd8a72c038958#6978b8bf552fdbdc2c894f724d7dd8a72c038958"
+source = "git+https://github.com/ringecosystem/datalens?rev=86ac2e3cf26947659b85eb6a101ed2fd337520a6#86ac2e3cf26947659b85eb6a101ed2fd337520a6"
 dependencies = [
  "reqwest",
  "serde",
@@ -3648,7 +3648,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -12,7 +12,7 @@ async-graphql-axum = "7.2.1"
 axum = "0.8.9"
 clap = { version = "4.6.1", features = ["derive"] }
 config = { version = "0.15.23", default-features = false, features = ["yaml", "json", "toml"] }
-datalens-sdk = { git = "https://github.com/ringecosystem/datalens", rev = "6978b8bf552fdbdc2c894f724d7dd8a72c038958" }
+datalens-sdk = { git = "https://github.com/ringecosystem/datalens", rev = "86ac2e3cf26947659b85eb6a101ed2fd337520a6" }
 ethabi = "18.0.0"
 figment = { version = "0.10.19", features = ["env"] }
 hex = "0.4.3"


### PR DESCRIPTION
## Summary
- update `datalens-sdk` to Datalens commit `86ac2e3cf26947659b85eb6a101ed2fd337520a6`
- refresh `Cargo.lock` via Cargo for the new SDK git source
- clarify that `DATALENS_ENDPOINT` is the Datalens service base URL for SDK REST and native endpoints

## Validation
- `cargo check -p degov-datalens-indexer`
- `cargo test -p degov-datalens-indexer --test datalens_planner`
- `cargo test -p degov-datalens-indexer --test config`
- `cargo test -p degov-datalens-indexer --test cli_runtime_config`
- `cargo check -p degov-datalens-indexer --locked`
- `node apps/indexer/scripts/runtime-packaging.test.mjs`

Refs HBX-324
