### PR TITLE
fix(indexer): split datalens provider-limit ranges

### DIFF
--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
 use std::time::{Duration, Instant};
 
-use log::{error, info};
+use log::{error, info, warn};
 use thiserror::Error;
 
 use crate::{
@@ -94,6 +94,7 @@ pub struct AdaptiveChunkSizingDecision {
 pub enum AdaptiveChunkSizingReason {
     DenseReturnedRows,
     SlowLocalProcessing,
+    ProviderLimit,
     StableSparseRange,
     Hold,
 }
@@ -103,6 +104,7 @@ impl fmt::Display for AdaptiveChunkSizingReason {
         match self {
             Self::DenseReturnedRows => formatter.write_str("dense_returned_rows"),
             Self::SlowLocalProcessing => formatter.write_str("slow_local_processing"),
+            Self::ProviderLimit => formatter.write_str("provider_limit"),
             Self::StableSparseRange => formatter.write_str("stable_sparse_range"),
             Self::Hold => formatter.write_str("hold"),
         }
@@ -179,6 +181,23 @@ impl AdaptiveChunkSizer {
             previous_chunk_size,
             current_chunk_size: self.current_chunk_size,
             reason,
+        }
+    }
+
+    pub fn record_provider_limit(
+        &mut self,
+        failed_range_block_count: u32,
+    ) -> AdaptiveChunkSizingDecision {
+        let previous_chunk_size = self.current_chunk_size;
+        self.stable_chunks = 0;
+        self.current_chunk_size = (failed_range_block_count / 2)
+            .max(self.config.min_chunk_size)
+            .min(previous_chunk_size);
+
+        AdaptiveChunkSizingDecision {
+            previous_chunk_size,
+            current_chunk_size: self.current_chunk_size,
+            reason: AdaptiveChunkSizingReason::ProviderLimit,
         }
     }
 }
@@ -434,6 +453,32 @@ where
             let processing = match self.process_range(range, effective_target) {
                 Ok(processing) => processing,
                 Err(error) => {
+                    let failed_range_block_count = range_block_count(range);
+                    if is_provider_limit_error(&error) && failed_range_block_count > 1 {
+                        let sizing_decision =
+                            chunk_sizer.record_provider_limit(failed_range_block_count);
+                        let retry_to_block = range
+                            .from_block
+                            .saturating_add(i64::from(sizing_decision.current_chunk_size))
+                            .saturating_sub(1)
+                            .min(range.to_block);
+                        warn!(
+                            "Datalens indexer chunk provider limit split dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} from_block={} previous_to_block={} retry_to_block={} previous_chunk_size={} new_chunk_size={} reason={}",
+                            self.options.checkpoint_identity.dao_code,
+                            self.options.checkpoint_identity.chain_id,
+                            self.options.checkpoint_identity.contract_set_id,
+                            self.options.checkpoint_identity.stream_id,
+                            self.options.checkpoint_identity.data_source_version,
+                            range.from_block,
+                            range.to_block,
+                            retry_to_block,
+                            sizing_decision.previous_chunk_size,
+                            sizing_decision.current_chunk_size,
+                            sizing_decision.reason
+                        );
+                        continue;
+                    }
+
                     error!(
                         "Datalens indexer chunk failed before transaction dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} from_block={} to_block={} target_height={} chunk_size={} datalens_retry_attempts=unavailable error={}",
                         self.options.checkpoint_identity.dao_code,
@@ -796,6 +841,25 @@ fn transaction_error(
         error
     );
     IndexerRunnerError::Transaction(error.to_string())
+}
+
+fn range_block_count(range: CheckpointBlockRange) -> u32 {
+    range
+        .to_block
+        .saturating_sub(range.from_block)
+        .saturating_add(1)
+        .try_into()
+        .unwrap_or(u32::MAX)
+}
+
+fn is_provider_limit_error(error: &IndexerRunnerError) -> bool {
+    let message = match error {
+        IndexerRunnerError::Datalens(DatalensError::Query(message)) => message,
+        _ => return false,
+    };
+    let normalized = message.to_ascii_lowercase();
+
+    normalized.contains("provider_limit") || normalized.contains("narrow your filter")
 }
 
 #[derive(Clone, Debug, Eq, Error, PartialEq)]

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use datalens_sdk::native::QueryInput;
@@ -147,7 +148,7 @@ fn test_runner_keeps_checkpoint_unchanged_when_datalens_query_fails() {
 
     let error = runner.run_to_target(1).expect_err("query fails");
 
-    assert!(error.to_string().contains("rate limited"));
+    assert!(error.to_string().contains("rate_limited"));
     assert_eq!(
         runner.store().checkpoint().expect("checkpoint").next_block,
         1
@@ -156,6 +157,64 @@ fn test_runner_keeps_checkpoint_unchanged_when_datalens_query_fails() {
     assert_eq!(
         runner.store().vote_repository().data_metric().votes_count,
         0
+    );
+}
+
+#[test]
+fn test_runner_splits_provider_limit_range_and_advances_checkpoint_after_subranges() {
+    let mut options = options();
+    options.datalens_config.query_limits.block_range_limit = 1_000;
+    let observed_ranges = Arc::new(Mutex::new(Vec::new()));
+    let reader = ProviderLimitDatalensReader::new(500, observed_ranges.clone());
+    let mut runner = IndexerRunner::new(
+        options,
+        contexts(),
+        reader,
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+        ScriptedDecoder,
+    );
+
+    let report = runner.run_to_target(1_000).expect("runner succeeds");
+
+    assert_eq!(report.chunks_processed, 2);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        1_001
+    );
+    assert_eq!(runner.store().commit_count(), 2);
+    assert_eq!(
+        *observed_ranges.lock().expect("observed ranges"),
+        vec![(1, 1_000), (1, 500), (501, 1_000)]
+    );
+}
+
+#[test]
+fn test_runner_fails_single_block_provider_limit_without_advancing_checkpoint() {
+    let mut options = options();
+    options.datalens_config.query_limits.block_range_limit = 1;
+    let observed_ranges = Arc::new(Mutex::new(Vec::new()));
+    let reader = ProviderLimitDatalensReader::new(0, observed_ranges.clone());
+    let mut runner = IndexerRunner::new(
+        options,
+        contexts(),
+        reader,
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+        ScriptedDecoder,
+    );
+
+    let error = runner
+        .run_to_target(1)
+        .expect_err("single-block provider limit fails");
+
+    assert!(error.to_string().contains("provider_limit"));
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        1
+    );
+    assert_eq!(runner.store().commit_count(), 0);
+    assert_eq!(
+        *observed_ranges.lock().expect("observed ranges"),
+        vec![(1, 1)]
     );
 }
 
@@ -224,7 +283,43 @@ struct FailingDatalensReader;
 
 impl DatalensLogQueryReader for FailingDatalensReader {
     fn query_logs(&mut self, _input: QueryInput) -> Result<Value, DatalensError> {
-        Err(DatalensError::Query("rate limited".to_owned()))
+        Err(DatalensError::Query(
+            r#"datalens HTTP error 429: {"error":{"kind":"rate_limited","message":"rate limited"}}"#
+                .to_owned(),
+        ))
+    }
+}
+
+struct ProviderLimitDatalensReader {
+    max_successful_blocks: i32,
+    observed_ranges: Arc<Mutex<Vec<(i32, i32)>>>,
+}
+
+impl ProviderLimitDatalensReader {
+    fn new(max_successful_blocks: i32, observed_ranges: Arc<Mutex<Vec<(i32, i32)>>>) -> Self {
+        Self {
+            max_successful_blocks,
+            observed_ranges,
+        }
+    }
+}
+
+impl DatalensLogQueryReader for ProviderLimitDatalensReader {
+    fn query_logs(&mut self, input: QueryInput) -> Result<Value, DatalensError> {
+        let range = (input.range.start, input.range.end);
+        self.observed_ranges
+            .lock()
+            .expect("observed ranges")
+            .push(range);
+        let block_count = input.range.end - input.range.start + 1;
+        if block_count > self.max_successful_blocks {
+            return Err(DatalensError::Query(
+                r#"datalens HTTP error 429: {"error":{"kind":"provider_limit","message":"query returns too many logs, narrow your filter: 20000"}}"#
+                    .to_owned(),
+            ));
+        }
+
+        Ok(Value::Array(Vec::new()))
     }
 }
 


### PR DESCRIPTION
## Summary
- Split Datalens provider-limit ranges during bootstrap by shrinking the adaptive chunk size and retrying from the same checkpoint.
- Keep single-block provider-limit failures clear without advancing checkpoints.
- Add runner regressions for provider_limit splitting, single-block failure, and non-provider rate_limited 429 handling.

## Tests
- cargo test -p degov-datalens-indexer --test indexer_runner --locked
- cargo check -p degov-datalens-indexer --locked
- cargo test -p degov-datalens-indexer --locked (fails without DEGOV_INDEXER_TEST_DATABASE_URL in existing checkpoint_repository tests)