### PR TITLE
DeGov indexer: report configured range progress and ETA

### DIFF
--- a/apps/indexer/src/checkpoint.rs
+++ b/apps/indexer/src/checkpoint.rs
@@ -29,6 +29,12 @@ pub struct CheckpointBlockRange {
     pub to_block: i64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ConfiguredRangeProgress {
+    pub remaining_blocks: i64,
+    pub synced_percentage: f64,
+}
+
 #[derive(Clone)]
 pub struct CheckpointRepository {
     pool: PgPool,
@@ -217,6 +223,43 @@ pub fn plan_next_checkpoint_range(
         from_block: checkpoint.next_block,
         to_block: limited_end.min(target_height),
     }))
+}
+
+pub fn configured_range_progress(
+    processed_height: Option<i64>,
+    start_block: i64,
+    target_height: i64,
+) -> ConfiguredRangeProgress {
+    if target_height < start_block {
+        return ConfiguredRangeProgress {
+            remaining_blocks: 0,
+            synced_percentage: 100.0,
+        };
+    }
+
+    let total_blocks = target_height.saturating_sub(start_block).saturating_add(1);
+    if total_blocks == 0 {
+        return ConfiguredRangeProgress {
+            remaining_blocks: 0,
+            synced_percentage: 100.0,
+        };
+    }
+
+    let processed_blocks = processed_height
+        .map(|height| {
+            height
+                .saturating_sub(start_block)
+                .saturating_add(1)
+                .clamp(0, total_blocks)
+        })
+        .unwrap_or(0);
+    let remaining_blocks = total_blocks.saturating_sub(processed_blocks);
+    let synced_percentage = ((processed_blocks as f64 / total_blocks as f64) * 100.0).min(100.0);
+
+    ConfiguredRangeProgress {
+        remaining_blocks,
+        synced_percentage,
+    }
 }
 
 fn checkpoint_from_row(row: &sqlx::postgres::PgRow) -> Result<IndexerCheckpoint, CheckpointError> {

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -21,6 +21,8 @@ use crate::{
     project_timelock_events_with_proposal_links, project_token_events, project_vote_events,
 };
 
+use crate::checkpoint::configured_range_progress;
+
 #[derive(Clone, Debug)]
 pub struct IndexerRunnerOptions {
     pub datalens_config: DatalensConfig,
@@ -44,6 +46,11 @@ pub struct IndexerRunnerProgress {
     pub processed_height: Option<i64>,
     pub target_height: i64,
     pub synced_percentage: f64,
+    pub configured_start_block: i64,
+    pub remaining_blocks: i64,
+    pub configured_range_synced_percentage: f64,
+    pub current_rate_blocks_per_second: Option<f64>,
+    pub eta_seconds: Option<f64>,
     pub onchain_refresh_allowed: bool,
 }
 
@@ -202,6 +209,41 @@ impl AdaptiveChunkSizer {
     }
 }
 
+impl ProgressRateEstimator {
+    fn record(&mut self, processed_height: i64, recorded_at: Instant) {
+        self.samples.push_back(ProgressRateSample {
+            recorded_at,
+            processed_height,
+        });
+        while self.samples.len() > 2 {
+            self.samples.pop_front();
+        }
+    }
+
+    fn blocks_per_second(&self) -> Option<f64> {
+        let first = self.samples.front()?;
+        let last = self.samples.back()?;
+        if first.processed_height == last.processed_height {
+            return None;
+        }
+
+        let elapsed_seconds = last
+            .recorded_at
+            .duration_since(first.recorded_at)
+            .as_secs_f64();
+        if elapsed_seconds <= 0.0 {
+            return None;
+        }
+
+        let processed_blocks = last.processed_height.saturating_sub(first.processed_height);
+        if processed_blocks <= 0 {
+            return None;
+        }
+
+        Some(processed_blocks as f64 / elapsed_seconds)
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum IndexerRunnerError {
     #[error("Datalens runner checkpoint error: {0}")]
@@ -310,6 +352,17 @@ struct ChunkProcessingResult {
     metrics: ChunkProcessingMetrics,
 }
 
+#[derive(Clone, Debug, Default)]
+struct ProgressRateEstimator {
+    samples: VecDeque<ProgressRateSample>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ProgressRateSample {
+    recorded_at: Instant,
+    processed_height: i64,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct ChunkProcessingMetrics {
     datalens_request_count: usize,
@@ -386,6 +439,7 @@ where
             AdaptiveChunkSizer::new(AdaptiveChunkSizerConfig::for_max_chunk_size(
                 self.options.datalens_config.query_limits.block_range_limit,
             ))?;
+        let mut progress_rate = ProgressRateEstimator::default();
         let mut chunks_processed = 0;
         let mut checkpoint = self
             .store
@@ -419,6 +473,8 @@ where
                     last_progress: progress(
                         checkpoint.processed_height,
                         effective_target,
+                        self.options.start_block,
+                        progress_rate.blocks_per_second(),
                         self.options.progress_refresh_lag_blocks,
                     ),
                 });
@@ -431,6 +487,8 @@ where
                     last_progress: progress(
                         checkpoint.processed_height,
                         effective_target,
+                        self.options.start_block,
+                        progress_rate.blocks_per_second(),
                         self.options.progress_refresh_lag_blocks,
                     ),
                 });
@@ -525,18 +583,22 @@ where
                 returned_row_count: processing.metrics.returned_row_count,
                 local_processing_write_duration,
             });
+            progress_rate.record(range.to_block, Instant::now());
             let chunk_progress = progress(
                 Some(range.to_block),
                 effective_target,
+                self.options.start_block,
+                progress_rate.blocks_per_second(),
                 self.options.progress_refresh_lag_blocks,
             );
             info!(
-                "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={}",
+                "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={}",
                 self.options.checkpoint_identity.dao_code,
                 self.options.checkpoint_identity.chain_id,
                 self.options.checkpoint_identity.contract_set_id,
                 self.options.checkpoint_identity.stream_id,
                 self.options.checkpoint_identity.data_source_version,
+                chunk_progress.configured_start_block,
                 range.from_block,
                 range.to_block,
                 effective_target,
@@ -558,6 +620,10 @@ where
                 range.to_block,
                 range.to_block + 1,
                 chunk_progress.synced_percentage,
+                chunk_progress.configured_range_synced_percentage,
+                chunk_progress.remaining_blocks,
+                optional_f64_log_value(chunk_progress.current_rate_blocks_per_second),
+                optional_f64_log_value(chunk_progress.eta_seconds),
                 sizing_decision.previous_chunk_size,
                 sizing_decision.current_chunk_size,
                 sizing_decision.reason
@@ -820,6 +886,8 @@ fn invalid_rows_payload_error(value: serde_json::Value) -> IndexerRunnerError {
 fn progress(
     processed_height: Option<i64>,
     target_height: i64,
+    configured_start_block: i64,
+    current_rate_blocks_per_second: Option<f64>,
     refresh_lag_blocks: i64,
 ) -> IndexerRunnerProgress {
     let synced_percentage = if target_height <= 0 {
@@ -829,6 +897,11 @@ fn progress(
             .map(|height| ((height as f64 / target_height as f64) * 100.0).min(100.0))
             .unwrap_or(0.0)
     };
+    let configured_progress =
+        configured_range_progress(processed_height, configured_start_block, target_height);
+    let eta_seconds = current_rate_blocks_per_second.and_then(|rate| {
+        (rate > 0.0).then_some(configured_progress.remaining_blocks as f64 / rate)
+    });
     let onchain_refresh_allowed = processed_height
         .map(|height| height.saturating_add(refresh_lag_blocks) >= target_height)
         .unwrap_or(false);
@@ -837,8 +910,19 @@ fn progress(
         processed_height,
         target_height,
         synced_percentage,
+        configured_start_block,
+        remaining_blocks: configured_progress.remaining_blocks,
+        configured_range_synced_percentage: configured_progress.synced_percentage,
+        current_rate_blocks_per_second,
+        eta_seconds,
         onchain_refresh_allowed,
     }
+}
+
+fn optional_f64_log_value(value: Option<f64>) -> String {
+    value
+        .map(|value| format!("{value:.2}"))
+        .unwrap_or_else(|| "null".to_owned())
 }
 
 fn to_checkpoint_error(error: impl fmt::Display) -> IndexerRunnerError {

--- a/apps/indexer/tests/checkpoint_plan.rs
+++ b/apps/indexer/tests/checkpoint_plan.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use degov_datalens_indexer::checkpoint::configured_range_progress;
 use degov_datalens_indexer::{
     AdaptiveChunkFeedback, AdaptiveChunkSizer, AdaptiveChunkSizerConfig, CheckpointBlockRange,
     IndexerCheckpoint, IndexerCheckpointIdentity, plan_next_checkpoint_range,
@@ -44,6 +45,43 @@ fn test_plan_next_checkpoint_range_returns_none_when_checkpoint_caught_up() {
     let range = plan_next_checkpoint_range(&checkpoint(111), 25, 110).expect("valid range");
 
     assert_eq!(range, None);
+}
+
+#[test]
+fn test_configured_range_progress_counts_from_start_block() {
+    let progress = configured_range_progress(Some(109), 100, 199);
+
+    assert_eq!(progress.remaining_blocks, 90);
+    assert_eq!(progress.synced_percentage, 10.0);
+}
+
+#[test]
+fn test_configured_range_progress_clamps_missing_and_below_start_progress() {
+    let missing = configured_range_progress(None, 100, 199);
+    let below_start = configured_range_progress(Some(99), 100, 199);
+
+    assert_eq!(missing.remaining_blocks, 100);
+    assert_eq!(missing.synced_percentage, 0.0);
+    assert_eq!(below_start.remaining_blocks, 100);
+    assert_eq!(below_start.synced_percentage, 0.0);
+}
+
+#[test]
+fn test_configured_range_progress_handles_invalid_ranges_as_complete() {
+    let progress = configured_range_progress(None, 200, 199);
+
+    assert_eq!(progress.remaining_blocks, 0);
+    assert_eq!(progress.synced_percentage, 100.0);
+}
+
+#[test]
+fn test_configured_range_progress_uses_updated_target_height() {
+    let first_target = configured_range_progress(Some(109), 100, 109);
+    let updated_target = configured_range_progress(Some(109), 100, 119);
+
+    assert_eq!(first_target.synced_percentage, 100.0);
+    assert_eq!(updated_target.remaining_blocks, 10);
+    assert_eq!(updated_target.synced_percentage, 50.0);
 }
 
 #[test]

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -71,6 +71,12 @@ fn test_runner_processes_multiple_chunks_and_advances_checkpoint_after_commits()
     assert_eq!(report.chunks_processed, 2);
     assert_eq!(report.last_progress.processed_height, Some(2));
     assert_eq!(report.last_progress.synced_percentage, 100.0);
+    assert_eq!(report.last_progress.configured_start_block, 1);
+    assert_eq!(
+        report.last_progress.configured_range_synced_percentage,
+        100.0
+    );
+    assert_eq!(report.last_progress.remaining_blocks, 0);
     assert!(report.last_progress.onchain_refresh_allowed);
     assert_eq!(
         runner.store().checkpoint().expect("checkpoint").next_block,
@@ -88,6 +94,106 @@ fn test_runner_processes_multiple_chunks_and_advances_checkpoint_after_commits()
     assert_eq!(
         runner.store().token_repository().delegate_changed().len(),
         1
+    );
+}
+
+#[test]
+fn test_runner_reports_configured_range_progress_for_nonzero_start_block() {
+    let mut options = options();
+    options.start_block = 100;
+    options.datalens_config.query_limits.block_range_limit = 10;
+    let mut runner = runner_with_store(
+        vec![vec![row(100, 0, 0)]],
+        ScriptedDecoder,
+        options,
+        InMemoryIndexerRunnerStore::new(identity(), 100),
+    );
+    runner.request_shutdown_after_chunks(1);
+
+    let report = runner.run_to_target(199).expect("runner succeeds");
+
+    assert_eq!(report.chunks_processed, 1);
+    assert_eq!(report.last_progress.processed_height, Some(109));
+    assert_eq!(report.last_progress.target_height, 199);
+    assert_eq!(report.last_progress.configured_start_block, 100);
+    assert_eq!(report.last_progress.remaining_blocks, 90);
+    assert_eq!(
+        report.last_progress.configured_range_synced_percentage,
+        10.0
+    );
+    assert_eq!(report.last_progress.eta_seconds, None);
+}
+
+#[test]
+fn test_runner_updates_configured_range_progress_when_target_height_changes() {
+    let mut options = options();
+    options.datalens_config.query_limits.block_range_limit = 10;
+    let store = InMemoryIndexerRunnerStore::new(identity(), 1);
+    let mut runner = runner_with_store(
+        vec![vec![row(1, 0, 0)], vec![row(11, 0, 0)]],
+        ScriptedDecoder,
+        options,
+        store,
+    );
+
+    let first_report = runner.run_to_target(10).expect("first run succeeds");
+    let second_report = runner.run_to_target(20).expect("second run succeeds");
+
+    assert_eq!(first_report.last_progress.processed_height, Some(10));
+    assert_eq!(first_report.last_progress.synced_percentage, 100.0);
+    assert_eq!(
+        first_report
+            .last_progress
+            .configured_range_synced_percentage,
+        100.0
+    );
+    assert_eq!(second_report.last_progress.processed_height, Some(20));
+    assert_eq!(second_report.last_progress.synced_percentage, 100.0);
+    assert_eq!(
+        second_report
+            .last_progress
+            .configured_range_synced_percentage,
+        100.0
+    );
+    assert_eq!(second_report.last_progress.remaining_blocks, 0);
+}
+
+#[test]
+fn test_runner_reports_unavailable_eta_with_insufficient_samples() {
+    let mut runner = runner(vec![vec![row(1, 0, 0)]], ScriptedDecoder);
+    runner.request_shutdown_after_chunks(1);
+
+    let report = runner.run_to_target(3).expect("runner stops cleanly");
+
+    assert_eq!(report.chunks_processed, 1);
+    assert_eq!(report.last_progress.remaining_blocks, 2);
+    assert_eq!(report.last_progress.current_rate_blocks_per_second, None);
+    assert_eq!(report.last_progress.eta_seconds, None);
+}
+
+#[test]
+fn test_runner_reports_eta_after_enough_progress_samples() {
+    let mut runner = runner(
+        vec![vec![row(1, 0, 0)], vec![row(2, 0, 0)]],
+        ScriptedDecoder,
+    );
+    runner.request_shutdown_after_chunks(2);
+
+    let report = runner.run_to_target(4).expect("runner stops cleanly");
+
+    assert_eq!(report.chunks_processed, 2);
+    assert_eq!(report.last_progress.remaining_blocks, 2);
+    assert!(
+        report
+            .last_progress
+            .current_rate_blocks_per_second
+            .is_some_and(|rate| rate > 0.0)
+    );
+    assert!(
+        report
+            .last_progress
+            .eta_seconds
+            .is_some_and(|eta| eta > 0.0)
     );
 }
 
@@ -576,13 +682,27 @@ fn runner_with_decoder<D: IndexerEventDecoder>(
     decoder: D,
     options: IndexerRunnerOptions,
 ) -> IndexerRunner<ScriptedDatalensReader, InMemoryIndexerRunnerStore, D> {
+    runner_with_store(
+        rows,
+        decoder,
+        options,
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+    )
+}
+
+fn runner_with_store<D: IndexerEventDecoder>(
+    rows: Vec<Vec<Value>>,
+    decoder: D,
+    options: IndexerRunnerOptions,
+    store: InMemoryIndexerRunnerStore,
+) -> IndexerRunner<ScriptedDatalensReader, InMemoryIndexerRunnerStore, D> {
     IndexerRunner::new(
         options,
         contexts(),
         ScriptedDatalensReader {
             rows: VecDeque::from(rows),
         },
-        InMemoryIndexerRunnerStore::new(identity(), 1),
+        store,
         decoder,
     )
 }


### PR DESCRIPTION
## Summary
- add configured-range progress math based on `(processed_height - start_block + 1) / (target_height - start_block + 1)`
- keep existing `synced_percentage` behavior while adding configured start block, remaining blocks, configured-range percentage, current rate, and ETA to runner reports
- log configured-range progress fields on completed indexer chunks

## Tests
- `cargo fmt --package degov-datalens-indexer -- --check`
- `git diff --check`
- `cargo test -p degov-datalens-indexer --test checkpoint_plan --test indexer_runner`
- `just test-unit` stops in `tests/checkpoint_repository.rs` because `DEGOV_INDEXER_TEST_DATABASE_URL is required`; earlier non-DB tests in that run passed before the env-gated file.
