### PR TITLE
DeGov indexer auto-ensures Datalens warmup

### DIFF
--- a/apps/indexer/indexer.example.yml
+++ b/apps/indexer/indexer.example.yml
@@ -20,6 +20,9 @@ datalens:
     name: logs
   queryLimits:
     blockRangeLimit: 1000
+  warmup:
+    enabled: true
+    ensureOnStartup: true
 
 rpc:
   chains:

--- a/apps/indexer/src/config/env.rs
+++ b/apps/indexer/src/config/env.rs
@@ -24,6 +24,9 @@ struct RawDatalensEnvOverlay {
     datalens_dataset_family: Option<String>,
     datalens_dataset_name: Option<String>,
     datalens_query_block_range_limit: Option<u32>,
+    datalens_warmup_enabled: Option<bool>,
+    datalens_warmup_ensure_on_startup: Option<bool>,
+    datalens_warmup_kind: Option<String>,
     datalens_governor_address: Option<String>,
     datalens_governor_token_address: Option<String>,
     datalens_governor_token_standard: Option<String>,
@@ -52,6 +55,7 @@ struct RawDatalensFileConfig {
     chain_id: Option<i32>,
     dataset: Option<RawDatalensDatasetFileConfig>,
     query_limits: Option<RawDatalensQueryLimitFileConfig>,
+    warmup: Option<RawDatalensWarmupFileConfig>,
     governor_address: Option<String>,
     governor_token_address: Option<String>,
     governor_token_standard: Option<String>,
@@ -69,6 +73,14 @@ struct RawDatalensDatasetFileConfig {
 #[serde(rename_all = "camelCase")]
 struct RawDatalensQueryLimitFileConfig {
     block_range_limit: Option<u32>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawDatalensWarmupFileConfig {
+    enabled: Option<bool>,
+    ensure_on_startup: Option<bool>,
+    kind: Option<String>,
 }
 
 pub(super) fn load_raw_from_env() -> Result<RawDatalensConfig, ConfigError> {
@@ -94,6 +106,9 @@ fn load_env_overlay() -> Result<RawDatalensEnvOverlay, ConfigError> {
             "DATALENS_DATASET_FAMILY",
             "DATALENS_DATASET_NAME",
             "DATALENS_QUERY_BLOCK_RANGE_LIMIT",
+            "DATALENS_WARMUP_ENABLED",
+            "DATALENS_WARMUP_ENSURE_ON_STARTUP",
+            "DATALENS_WARMUP_KIND",
             "DATALENS_GOVERNOR_ADDRESS",
             "DATALENS_GOVERNOR_TOKEN_ADDRESS",
             "DATALENS_GOVERNOR_TOKEN_STANDARD",
@@ -172,6 +187,14 @@ impl RawDatalensConfig {
                     query_limits.block_range_limit,
                 );
             }
+            if let Some(warmup) = datalens.warmup {
+                assign_value_if_some(&mut self.datalens_warmup_enabled, warmup.enabled);
+                assign_value_if_some(
+                    &mut self.datalens_warmup_ensure_on_startup,
+                    warmup.ensure_on_startup,
+                );
+                assign_value_if_some(&mut self.datalens_warmup_kind, warmup.kind);
+            }
         }
 
         if let Some(chains) = file.chains {
@@ -205,6 +228,15 @@ impl RawDatalensConfig {
             &mut self.datalens_query_block_range_limit,
             env.datalens_query_block_range_limit,
         );
+        assign_value_if_some(
+            &mut self.datalens_warmup_enabled,
+            env.datalens_warmup_enabled,
+        );
+        assign_value_if_some(
+            &mut self.datalens_warmup_ensure_on_startup,
+            env.datalens_warmup_ensure_on_startup,
+        );
+        assign_value_if_some(&mut self.datalens_warmup_kind, env.datalens_warmup_kind);
         assign_if_some(
             &mut self.datalens_governor_address,
             env.datalens_governor_address,

--- a/apps/indexer/src/config/mod.rs
+++ b/apps/indexer/src/config/mod.rs
@@ -3,7 +3,10 @@ use std::{fmt, str::FromStr, time::Duration};
 use datalens_sdk::ClientConfig;
 use serde::{Deserialize, Serialize};
 
-use crate::{ConfigError, DaoContractAddresses, GovernanceTokenStandard};
+use crate::{
+    ConfigError, DaoContractAddresses, GovernanceTokenStandard,
+    datalens::warmup::{DatalensWarmupConfig, DatalensWarmupKind},
+};
 
 mod env;
 
@@ -177,6 +180,7 @@ pub struct DatalensConfig {
     pub chain: ChainIdentityConfig,
     pub dataset: DatasetKeyConfig,
     pub query_limits: QueryLimitConfig,
+    pub warmup: DatalensWarmupConfig,
     pub dao_contracts: Option<DaoContractAddresses>,
     pub chains: Vec<DatalensChainConfig>,
 }
@@ -194,6 +198,9 @@ struct RawDatalensConfig {
     datalens_dataset_family: String,
     datalens_dataset_name: String,
     datalens_query_block_range_limit: u32,
+    datalens_warmup_enabled: bool,
+    datalens_warmup_ensure_on_startup: bool,
+    datalens_warmup_kind: String,
     datalens_governor_address: Option<String>,
     datalens_governor_token_address: Option<String>,
     datalens_governor_token_standard: Option<String>,
@@ -244,6 +251,9 @@ impl Default for RawDatalensConfig {
             datalens_dataset_family: DEFAULT_DATALENS_DATASET_FAMILY.to_owned(),
             datalens_dataset_name: DEFAULT_DATALENS_DATASET_NAME.to_owned(),
             datalens_query_block_range_limit: DEFAULT_DATALENS_QUERY_BLOCK_RANGE_LIMIT,
+            datalens_warmup_enabled: DatalensWarmupConfig::default().enabled,
+            datalens_warmup_ensure_on_startup: DatalensWarmupConfig::default().ensure_on_startup,
+            datalens_warmup_kind: DatalensWarmupKind::default().as_str().to_owned(),
             datalens_governor_address: None,
             datalens_governor_token_address: None,
             datalens_governor_token_standard: None,
@@ -491,6 +501,11 @@ impl DatalensConfig {
             },
             query_limits: QueryLimitConfig {
                 block_range_limit: raw.datalens_query_block_range_limit,
+            },
+            warmup: DatalensWarmupConfig {
+                enabled: raw.datalens_warmup_enabled,
+                ensure_on_startup: raw.datalens_warmup_ensure_on_startup,
+                kind: raw.datalens_warmup_kind.parse()?,
             },
             dao_contracts,
             chains,

--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -24,6 +24,10 @@ pub struct ServiceReadiness {
 pub struct DatalensNativeClient {
     client: DatalensClient,
     retry_config: RetryConfig,
+    service_base_endpoint: String,
+    application: String,
+    bearer_token: crate::SecretString,
+    http: reqwest::blocking::Client,
 }
 
 impl DatalensNativeClient {
@@ -34,6 +38,14 @@ impl DatalensNativeClient {
         Ok(Self {
             client,
             retry_config,
+            service_base_endpoint: config.endpoint.clone(),
+            application: config.application.clone(),
+            bearer_token: config.bearer_token.clone(),
+            http: reqwest::blocking::Client::builder()
+                .timeout(config.timeout)
+                .user_agent(crate::config::DEGOV_DATALENS_USER_AGENT)
+                .build()
+                .map_err(|error| DatalensError::SdkConfig(error.to_string()))?,
         })
     }
 
@@ -58,7 +70,31 @@ impl DatalensNativeClient {
         Ok(Self {
             client,
             retry_config,
+            service_base_endpoint: config.endpoint.clone(),
+            application: config.application.clone(),
+            bearer_token: config.bearer_token.clone(),
+            http: reqwest::blocking::Client::builder()
+                .timeout(config.timeout)
+                .user_agent(crate::config::DEGOV_DATALENS_USER_AGENT)
+                .build()
+                .map_err(|error| DatalensError::SdkConfig(error.to_string()))?,
         })
+    }
+
+    pub(crate) fn service_base_endpoint(&self) -> &str {
+        &self.service_base_endpoint
+    }
+
+    pub(crate) fn application(&self) -> &str {
+        &self.application
+    }
+
+    pub(crate) fn bearer_token(&self) -> &str {
+        self.bearer_token.expose_secret()
+    }
+
+    pub(crate) fn blocking_http(&self) -> &reqwest::blocking::Client {
+        &self.http
     }
 
     fn query_with_transient_fallback(

--- a/apps/indexer/src/datalens/mod.rs
+++ b/apps/indexer/src/datalens/mod.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod planner;
+pub mod warmup;
 
 pub use client::{
     DatalensDurableHeadReader, DatalensNativeClient, DatalensNativeReader, ServiceReadiness,
@@ -8,4 +9,8 @@ pub use client::{
 pub use planner::{
     DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan, DaoLogSource, DatalensLogPage,
     DatalensLogQueryReader, fetch_dao_log_pages, plan_dao_log_queries,
+};
+pub use warmup::{
+    DatalensWarmupConfig, DatalensWarmupEnsureOutcome, DatalensWarmupEnsurer, DatalensWarmupKind,
+    DatalensWarmupSubmitRequest, ensure_datalens_warmup_task, follow_query_request,
 };

--- a/apps/indexer/src/datalens/warmup.rs
+++ b/apps/indexer/src/datalens/warmup.rs
@@ -71,7 +71,6 @@ pub struct DatalensWarmupSubmitRequest {
     pub start: u64,
     pub end: Option<u64>,
     pub mode: String,
-    pub finality: Option<String>,
     pub chunk_policy: WarmupChunkPolicy,
 }
 
@@ -166,7 +165,6 @@ pub fn follow_query_request(
         start: start_block as u64,
         end: None,
         mode: "follow_query".to_owned(),
-        finality: query.input.finality.clone(),
         chunk_policy: WarmupChunkPolicy {
             max_range_len: config.query_limits.block_range_limit,
         },

--- a/apps/indexer/src/datalens/warmup.rs
+++ b/apps/indexer/src/datalens/warmup.rs
@@ -165,7 +165,7 @@ pub fn follow_query_request(
         range_kind: warmup_range_kind(&query.input.range.kind)?,
         start: start_block as u64,
         end: None,
-        mode: "follow_safe_height".to_owned(),
+        mode: "follow_query".to_owned(),
         finality: query.input.finality.clone(),
         chunk_policy: WarmupChunkPolicy {
             max_range_len: config.query_limits.block_range_limit,

--- a/apps/indexer/src/datalens/warmup.rs
+++ b/apps/indexer/src/datalens/warmup.rs
@@ -1,0 +1,302 @@
+use std::fmt;
+
+use datalens_sdk::native::{
+    EvmLogsSelectorInput, QueryRangeKindInput, QuerySelectorInput, SelectorKindInput,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ChainFamily, ChainIdentityConfig, DaoContractAddresses, DatalensConfig, DatalensError,
+    DatasetKeyConfig,
+};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatalensWarmupKind {
+    #[default]
+    FollowQuery,
+}
+
+impl DatalensWarmupKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FollowQuery => "follow_query",
+        }
+    }
+}
+
+impl std::str::FromStr for DatalensWarmupKind {
+    type Err = crate::ConfigError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "follow_query" => Ok(Self::FollowQuery),
+            value => Err(crate::ConfigError::InvalidField {
+                field: "DATALENS_WARMUP_KIND".to_owned(),
+                reason: format!("unsupported warmup kind {value}"),
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DatalensWarmupConfig {
+    pub enabled: bool,
+    pub ensure_on_startup: bool,
+    pub kind: DatalensWarmupKind,
+}
+
+impl Default for DatalensWarmupConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ensure_on_startup: true,
+            kind: DatalensWarmupKind::FollowQuery,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DatalensWarmupEnsureOutcome {
+    Disabled,
+    Submitted { task_id: String, created: bool },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DatalensWarmupSubmitRequest {
+    pub chain: WarmupChainIdentity,
+    pub dataset_key: String,
+    pub selector: WarmupEvmLogsSelector,
+    pub range_kind: String,
+    pub start: u64,
+    pub end: Option<u64>,
+    pub mode: String,
+    pub finality: Option<String>,
+    pub chunk_policy: WarmupChunkPolicy,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupChainIdentity {
+    pub family: serde_json::Value,
+    pub configured_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_id: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupEvmLogsSelector {
+    pub addresses: Vec<String>,
+    pub topics: Vec<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupChunkPolicy {
+    pub max_range_len: u32,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct WarmupSubmitResponse {
+    task_id: WarmupTaskIdResponse,
+    created: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+enum WarmupTaskIdResponse {
+    String(String),
+    Object { task_id: String },
+}
+
+impl fmt::Display for WarmupTaskIdResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::String(value) => formatter.write_str(value),
+            Self::Object { task_id } => formatter.write_str(task_id),
+        }
+    }
+}
+
+pub trait DatalensWarmupEnsurer {
+    fn ensure_warmup_task(
+        &mut self,
+        request: DatalensWarmupSubmitRequest,
+    ) -> Result<DatalensWarmupEnsureOutcome, DatalensError>;
+}
+
+pub fn ensure_datalens_warmup_task(
+    ensurer: &mut impl DatalensWarmupEnsurer,
+    config: &DatalensConfig,
+    addresses: &DaoContractAddresses,
+    start_block: i64,
+) -> Result<DatalensWarmupEnsureOutcome, DatalensError> {
+    if !config.warmup.enabled || !config.warmup.ensure_on_startup {
+        return Ok(DatalensWarmupEnsureOutcome::Disabled);
+    }
+
+    match config.warmup.kind {
+        DatalensWarmupKind::FollowQuery => {
+            ensurer.ensure_warmup_task(follow_query_request(config, addresses, start_block)?)
+        }
+    }
+}
+
+pub fn follow_query_request(
+    config: &DatalensConfig,
+    addresses: &DaoContractAddresses,
+    start_block: i64,
+) -> Result<DatalensWarmupSubmitRequest, DatalensError> {
+    if start_block < 0 {
+        return Err(DatalensError::Warmup(format!(
+            "Datalens warmup start block must be non-negative: {start_block}"
+        )));
+    }
+    let query = crate::plan_dao_log_queries(config, addresses, start_block, start_block)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| DatalensError::Warmup("Datalens warmup query plan was empty".to_owned()))?;
+    let selector = query.input.selector.evm_logs.as_ref().ok_or_else(|| {
+        DatalensError::Warmup("Datalens warmup selector is not evm_logs".to_owned())
+    })?;
+
+    Ok(DatalensWarmupSubmitRequest {
+        chain: warmup_chain_identity(&config.chain)?,
+        dataset_key: warmup_dataset_key(&config.dataset),
+        selector: warmup_evm_logs_selector(&query.input.selector, selector)?,
+        range_kind: warmup_range_kind(&query.input.range.kind)?,
+        start: start_block as u64,
+        end: None,
+        mode: "follow_safe_height".to_owned(),
+        finality: query.input.finality.clone(),
+        chunk_policy: WarmupChunkPolicy {
+            max_range_len: config.query_limits.block_range_limit,
+        },
+    })
+}
+
+impl DatalensWarmupEnsurer for crate::DatalensNativeClient {
+    fn ensure_warmup_task(
+        &mut self,
+        request: DatalensWarmupSubmitRequest,
+    ) -> Result<DatalensWarmupEnsureOutcome, DatalensError> {
+        self.submit_warmup_task(request)
+    }
+}
+
+impl crate::DatalensNativeClient {
+    pub(crate) fn submit_warmup_task(
+        &self,
+        request: DatalensWarmupSubmitRequest,
+    ) -> Result<DatalensWarmupEnsureOutcome, DatalensError> {
+        let response = self
+            .blocking_http()
+            .post(format!("{}/v1/warmup/tasks", self.service_base_endpoint()))
+            .bearer_auth(self.bearer_token())
+            .header("x-datalens-application", self.application())
+            .json(&warmup_api_request(request))
+            .send()
+            .map_err(|error| DatalensError::Warmup(format!("submit warmup task: {error}")))?;
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .map_err(|error| DatalensError::Warmup(format!("read warmup response: {error}")))?;
+        if !(200..300).contains(&status) {
+            return Err(DatalensError::Warmup(format!(
+                "Datalens warmup submit failed with status {status}: {body}"
+            )));
+        }
+        let response: WarmupSubmitResponse = serde_json::from_str(&body)
+            .map_err(|error| DatalensError::Warmup(format!("decode warmup response: {error}")))?;
+        Ok(DatalensWarmupEnsureOutcome::Submitted {
+            task_id: response.task_id.to_string(),
+            created: response.created,
+        })
+    }
+}
+
+fn warmup_api_request(request: DatalensWarmupSubmitRequest) -> serde_json::Value {
+    serde_json::json!({
+        "chain": warmup_api_chain(&request.chain),
+        "dataset_key": request.dataset_key,
+        "selector": {
+            "kind": "evm_logs",
+            "value": {
+                "addresses": request.selector.addresses,
+                "topics": request
+                    .selector
+                    .topics
+                    .into_iter()
+                    .map(serde_json::Value::from)
+                    .collect::<Vec<_>>()
+            }
+        },
+        "range_kind": { "kind": request.range_kind },
+        "start": request.start,
+        "end": request.end,
+        "mode": request.mode,
+        "chunk_policy": request.chunk_policy
+    })
+}
+
+fn warmup_api_chain(chain: &WarmupChainIdentity) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "family": chain.family,
+        "configured_name": chain.configured_name,
+    });
+    if let Some(network_id) = chain.network_id {
+        value["network_id"] = serde_json::json!({
+            "kind": "numeric",
+            "value": network_id,
+        });
+    }
+    value
+}
+
+fn warmup_chain_identity(
+    chain: &ChainIdentityConfig,
+) -> Result<WarmupChainIdentity, DatalensError> {
+    let family = match chain.family {
+        ChainFamily::Evm => serde_json::Value::String("Evm".to_owned()),
+    };
+    let network_id = chain
+        .network_id
+        .map(|value| {
+            u64::try_from(value).map_err(|_| {
+                DatalensError::Warmup(format!(
+                    "Datalens warmup chain id must be non-negative: {value}"
+                ))
+            })
+        })
+        .transpose()?;
+    Ok(WarmupChainIdentity {
+        family,
+        configured_name: chain.configured_name.clone(),
+        network_id,
+    })
+}
+
+fn warmup_dataset_key(dataset: &DatasetKeyConfig) -> String {
+    dataset.key()
+}
+
+fn warmup_evm_logs_selector(
+    selector: &QuerySelectorInput,
+    evm_logs: &EvmLogsSelectorInput,
+) -> Result<WarmupEvmLogsSelector, DatalensError> {
+    if selector.kind != SelectorKindInput::EvmLogs {
+        return Err(DatalensError::Warmup(
+            "Datalens warmup selector kind is not evm_logs".to_owned(),
+        ));
+    }
+    Ok(WarmupEvmLogsSelector {
+        addresses: evm_logs.addresses.clone(),
+        topics: evm_logs.topics.clone(),
+    })
+}
+
+fn warmup_range_kind(kind: &QueryRangeKindInput) -> Result<String, DatalensError> {
+    match kind {
+        QueryRangeKindInput::Block => Ok("block".to_owned()),
+        QueryRangeKindInput::Slot => Ok("slot".to_owned()),
+        QueryRangeKindInput::Height => Ok("height".to_owned()),
+    }
+}

--- a/apps/indexer/src/error.rs
+++ b/apps/indexer/src/error.rs
@@ -43,6 +43,9 @@ pub enum DatalensError {
 
     #[error("Datalens log query failed: {0}")]
     Query(String),
+
+    #[error("Datalens warmup failed: {0}")]
+    Warmup(String),
 }
 
 #[derive(Debug, Error)]

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -23,6 +23,10 @@ pub use crate::datalens::planner::{
     DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan, DaoLogSource, DatalensLogPage,
     DatalensLogQueryReader, fetch_dao_log_pages, plan_dao_log_queries,
 };
+pub use crate::datalens::warmup::{
+    DatalensWarmupConfig, DatalensWarmupEnsureOutcome, DatalensWarmupEnsurer, DatalensWarmupKind,
+    DatalensWarmupSubmitRequest, ensure_datalens_warmup_task, follow_query_request,
+};
 pub use crate::decode::dao_event::{
     CallExecutedEvent, CallSaltEvent, CallScheduledEvent, DaoEventDecodeError, DecodedDaoEvent,
     DecodedGovernorEvent, DecodedTimelockEvent, DecodedTokenEvent, DelegateChangedEvent,

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -5,9 +5,9 @@ use tokio::{task, time::sleep};
 
 use crate::{
     DaoContractAddresses, DaoEventDecoder, DatalensConfig, DatalensDurableHeadReader,
-    DatalensNativeClient, IndexerContractSetRuntimeConfig, IndexerRunner, IndexerRunnerReport,
-    IndexerRuntimeConfig, IndexerTargetHeight, PostgresIndexerRunnerStore, datalens_retry_config,
-    required_env,
+    DatalensNativeClient, DatalensWarmupEnsureOutcome, IndexerContractSetRuntimeConfig,
+    IndexerRunner, IndexerRunnerReport, IndexerRuntimeConfig, IndexerTargetHeight,
+    PostgresIndexerRunnerStore, datalens_retry_config, ensure_datalens_warmup_task, required_env,
 };
 
 use super::{datalens::verify_datalens, migrate::apply_migrations};
@@ -33,6 +33,7 @@ pub async fn run_indexer() -> Result<()> {
         .await
         .context("connect to DeGov indexer Postgres")?;
     apply_migrations(&pool).await?;
+    ensure_warmup_on_startup(&runtime, &config).await?;
 
     loop {
         let contract_sets = runtime
@@ -92,6 +93,60 @@ pub async fn run_indexer() -> Result<()> {
 
         sleep(runtime.poll_interval).await;
     }
+}
+
+async fn ensure_warmup_on_startup(
+    runtime: &IndexerRuntimeConfig,
+    config: &DatalensConfig,
+) -> Result<()> {
+    if !config.warmup.enabled || !config.warmup.ensure_on_startup {
+        log::info!(
+            "Datalens follow_query warmup startup ensure disabled enabled={} ensure_on_startup={}",
+            config.warmup.enabled,
+            config.warmup.ensure_on_startup
+        );
+        return Ok(());
+    }
+
+    let contract_sets = runtime
+        .configured_contract_sets(config)
+        .context("select Datalens warmup contract sets")?;
+    let retry_config = datalens_retry_config(runtime.query_max_attempts);
+
+    for contract_set in contract_sets {
+        let config = contract_set.config.clone();
+        let addresses = contract_set.addresses.clone();
+        let dao_code = contract_set.dao_code.clone();
+        let contract_set_id = contract_set.contract_set_id.clone();
+        let chain_id = contract_set.contract.chain_id;
+        let start_block = contract_set.contract.start_block;
+        let retry_config = retry_config.clone();
+        let outcome = task::spawn_blocking(move || -> Result<_> {
+            let mut client =
+                DatalensNativeClient::from_config_with_retry_config(&config, retry_config)
+                    .context("create Datalens client")?;
+            ensure_datalens_warmup_task(&mut client, &config, &addresses, start_block)
+                .context("ensure Datalens follow_query warmup task")
+        })
+        .await
+        .context("join Datalens warmup ensure task")??;
+
+        match outcome {
+            DatalensWarmupEnsureOutcome::Disabled => {}
+            DatalensWarmupEnsureOutcome::Submitted { task_id, created } => {
+                log::info!(
+                    "Datalens follow_query warmup task ensured dao_code={} chain_id={} contract_set_id={} task_id={} created={}",
+                    dao_code,
+                    chain_id,
+                    contract_set_id,
+                    task_id,
+                    created
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 async fn run_contract_set_pass(
@@ -206,6 +261,7 @@ mod tests {
             query_limits: QueryLimitConfig {
                 block_range_limit: 1_000,
             },
+            warmup: Default::default(),
             dao_contracts: None,
             chains: Vec::new(),
         };

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -158,6 +158,7 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
         query_limits: degov_datalens_indexer::QueryLimitConfig {
             block_range_limit: 1_000,
         },
+        warmup: Default::default(),
         dao_contracts: None,
         chains: vec![degov_datalens_indexer::DatalensChainConfig {
             family: degov_datalens_indexer::ChainFamily::Evm,
@@ -228,6 +229,7 @@ fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
         query_limits: degov_datalens_indexer::QueryLimitConfig {
             block_range_limit: 1_000,
         },
+        warmup: Default::default(),
         dao_contracts: None,
         chains: vec![degov_datalens_indexer::DatalensChainConfig {
             family: degov_datalens_indexer::ChainFamily::Evm,

--- a/apps/indexer/tests/config.rs
+++ b/apps/indexer/tests/config.rs
@@ -226,6 +226,9 @@ datalens:
     name: logs
   queryLimits:
     blockRangeLimit: 777
+  warmup:
+    enabled: true
+    ensureOnStartup: true
 chains:
   - chainId: 1
     networkName: ethereum
@@ -265,6 +268,9 @@ chains:
                 config.bearer_token.expose_secret(),
                 "unit-test-redacted-value"
             );
+            assert_eq!(config.warmup.enabled, true);
+            assert_eq!(config.warmup.ensure_on_startup, true);
+            assert_eq!(config.warmup.kind.as_str(), "follow_query");
             assert_eq!(config.query_limits.block_range_limit, 777);
             assert_eq!(config.chains.len(), 2);
             assert_eq!(config.chains[0].contracts[0].chain_id, 1);
@@ -273,6 +279,50 @@ chains:
                 config.chains[1].contracts[0].dao_code.as_deref(),
                 Some("lisk-dao")
             );
+        },
+    );
+
+    remove_config_file(path);
+}
+
+#[test]
+fn test_from_env_loads_warmup_disabled_for_local_development() {
+    let path = write_config_file(
+        "yml",
+        r#"
+datalens:
+  endpoint: https://datalens.ringdao.com
+  application: degov-live
+  warmup:
+    enabled: false
+    ensureOnStartup: false
+chains:
+  - chainId: 1
+    networkName: ethereum
+    contracts:
+      - daoCode: ens-dao
+        governor: "0x1111111111111111111111111111111111111111"
+        governorToken: "0x2222222222222222222222222222222222222222"
+        tokenStandard: ERC20
+        timelock: "0x3333333333333333333333333333333333333333"
+        startBlock: 13533418
+"#,
+    );
+
+    with_datalens_env(
+        &[
+            (
+                "DEGOV_INDEXER_CONFIG_FILE",
+                Some(path.to_str().expect("utf8 path")),
+            ),
+            ("DATALENS_TOKEN", Some("unit-test-redacted-value")),
+        ],
+        || {
+            let config = DatalensConfig::from_env().expect("load yaml config");
+
+            assert_eq!(config.warmup.enabled, false);
+            assert_eq!(config.warmup.ensure_on_startup, false);
+            assert_eq!(config.warmup.kind.as_str(), "follow_query");
         },
     );
 

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -405,6 +405,7 @@ fn datalens_config(endpoint: &str, finality: DatalensFinality) -> DatalensConfig
         query_limits: QueryLimitConfig {
             block_range_limit: 1_000,
         },
+        warmup: Default::default(),
         dao_contracts: None,
         chains: Vec::new(),
     }

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -195,6 +195,7 @@ fn config(block_range_limit: u32, finality: DatalensFinality) -> DatalensConfig 
             name: "logs".to_owned(),
         },
         query_limits: QueryLimitConfig { block_range_limit },
+        warmup: Default::default(),
         dao_contracts: None,
         chains: Vec::new(),
     }

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -43,7 +43,6 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
     assert_eq!(request.mode, "follow_query");
     assert_eq!(request.selector.addresses.len(), 3);
     assert_eq!(request.selector.topics.len(), 1);
-    assert_eq!(request.finality.as_deref(), Some("durable_only"));
 }
 
 #[test]

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -1,0 +1,149 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use degov_datalens_indexer::{
+    ChainFamily, ChainIdentityConfig, DaoContractAddresses, DatalensConfig, DatalensFinality,
+    DatalensWarmupEnsureOutcome, DatalensWarmupEnsurer, DatasetKeyConfig, GovernanceTokenStandard,
+    QueryLimitConfig, SecretString, ensure_datalens_warmup_task,
+};
+
+#[test]
+fn test_ensure_datalens_warmup_task_skips_when_disabled() {
+    let mut config = config();
+    config.warmup.enabled = false;
+    config.warmup.ensure_on_startup = true;
+    let mut ensurer = MockWarmupEnsurer::default();
+
+    let outcome =
+        ensure_datalens_warmup_task(&mut ensurer, &config, &addresses(), 100).expect("ensure");
+
+    assert_eq!(outcome, DatalensWarmupEnsureOutcome::Disabled);
+    assert!(ensurer.requests.is_empty());
+}
+
+#[test]
+fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
+    let config = config();
+    let mut ensurer = MockWarmupEnsurer::default();
+
+    let outcome =
+        ensure_datalens_warmup_task(&mut ensurer, &config, &addresses(), 100).expect("ensure");
+
+    assert!(matches!(
+        outcome,
+        DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
+    ));
+    assert_eq!(ensurer.requests.len(), 1);
+    let request = &ensurer.requests[0];
+    assert_eq!(request.chain.configured_name, "ethereum");
+    assert_eq!(request.chain.network_id, Some(1));
+    assert_eq!(request.dataset_key, "evm.logs");
+    assert_eq!(request.range_kind, "block");
+    assert_eq!(request.start, 100);
+    assert_eq!(request.end, None);
+    assert_eq!(request.mode, "follow_safe_height");
+    assert_eq!(request.selector.addresses.len(), 3);
+    assert_eq!(request.selector.topics.len(), 1);
+    assert_eq!(request.finality.as_deref(), Some("durable_only"));
+}
+
+#[test]
+fn test_ensure_datalens_warmup_task_reuses_existing_matching_task() {
+    let config = config();
+    let mut ensurer = MockWarmupEnsurer::default();
+
+    let first =
+        ensure_datalens_warmup_task(&mut ensurer, &config, &addresses(), 100).expect("first");
+    let second =
+        ensure_datalens_warmup_task(&mut ensurer, &config, &addresses(), 100).expect("second");
+
+    assert!(matches!(
+        first,
+        DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
+    ));
+    assert!(matches!(
+        second,
+        DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
+    ));
+    assert_eq!(ensurer.created_tasks.len(), 1);
+}
+
+#[test]
+fn test_ensure_datalens_warmup_task_submits_distinct_task_for_selector_mismatch() {
+    let config = config();
+    let mut ensurer = MockWarmupEnsurer::default();
+    let mut other_addresses = addresses();
+    other_addresses.timelock = "0x4444444444444444444444444444444444444444".to_owned();
+
+    ensure_datalens_warmup_task(&mut ensurer, &config, &addresses(), 100).expect("first");
+    let second =
+        ensure_datalens_warmup_task(&mut ensurer, &config, &other_addresses, 100).expect("second");
+
+    assert!(matches!(
+        second,
+        DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
+    ));
+    assert_eq!(ensurer.created_tasks.len(), 2);
+}
+
+fn config() -> DatalensConfig {
+    let mut warmup = degov_datalens_indexer::DatalensWarmupConfig::default();
+    warmup.enabled = true;
+    warmup.ensure_on_startup = true;
+
+    DatalensConfig {
+        endpoint: "https://datalens.ringdao.com".to_owned(),
+        application: "degov-live".to_owned(),
+        bearer_token: SecretString::new("redacted"),
+        timeout: Duration::from_secs(60),
+        finality: DatalensFinality::DurableOnly,
+        chain: ChainIdentityConfig {
+            family: ChainFamily::Evm,
+            configured_name: "ethereum".to_owned(),
+            network_id: Some(1),
+        },
+        dataset: DatasetKeyConfig {
+            family: "evm".to_owned(),
+            name: "logs".to_owned(),
+        },
+        query_limits: QueryLimitConfig {
+            block_range_limit: 1_000,
+        },
+        warmup,
+        dao_contracts: None,
+        chains: Vec::new(),
+    }
+}
+
+fn addresses() -> DaoContractAddresses {
+    DaoContractAddresses {
+        governor: "0x1111111111111111111111111111111111111111".to_owned(),
+        governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+        governor_token_standard: GovernanceTokenStandard::Erc20,
+        timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+    }
+}
+
+#[derive(Default)]
+struct MockWarmupEnsurer {
+    requests: Vec<degov_datalens_indexer::DatalensWarmupSubmitRequest>,
+    created_tasks: BTreeMap<String, String>,
+}
+
+impl DatalensWarmupEnsurer for MockWarmupEnsurer {
+    fn ensure_warmup_task(
+        &mut self,
+        request: degov_datalens_indexer::DatalensWarmupSubmitRequest,
+    ) -> Result<DatalensWarmupEnsureOutcome, degov_datalens_indexer::DatalensError> {
+        self.requests.push(request.clone());
+        let key = serde_json::to_string(&request).expect("request serializes");
+        let (task_id, created) = match self.created_tasks.get(&key) {
+            Some(task_id) => (task_id.clone(), false),
+            None => {
+                let task_id = format!("warmup-{}", self.created_tasks.len() + 1);
+                self.created_tasks.insert(key, task_id.clone());
+                (task_id, true)
+            }
+        };
+        Ok(DatalensWarmupEnsureOutcome::Submitted { task_id, created })
+    }
+}

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -40,7 +40,7 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
     assert_eq!(request.range_kind, "block");
     assert_eq!(request.start, 100);
     assert_eq!(request.end, None);
-    assert_eq!(request.mode, "follow_safe_height");
+    assert_eq!(request.mode, "follow_query");
     assert_eq!(request.selector.addresses.len(), 3);
     assert_eq!(request.selector.topics.len(), 1);
     assert_eq!(request.finality.as_deref(), Some("durable_only"));

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -607,6 +607,7 @@ fn options() -> IndexerRunnerOptions {
             query_limits: QueryLimitConfig {
                 block_range_limit: 1,
             },
+            warmup: Default::default(),
             dao_contracts: Some(addresses()),
             chains: Vec::new(),
         },

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -510,6 +510,7 @@ fn options() -> IndexerRunnerOptions {
             query_limits: QueryLimitConfig {
                 block_range_limit: 10,
             },
+            warmup: Default::default(),
             dao_contracts: Some(addresses()),
             chains: Vec::new(),
         },


### PR DESCRIPTION
## Summary
- Add Datalens warmup config for `datalens.warmup.enabled` and `ensureOnStartup`, defaulting enabled configs to `follow_query` behavior.
- Build follow-query warmup requests from the same Datalens log query selector inputs accepted by the warmup submit API: chain, dataset, EVM log addresses/topics, block range kind, start block, and chunk policy.
- Ensure one matching Datalens warmup task per selected contract set on indexer startup, relying on Datalens task dedupe to reuse existing matching tasks without canceling or mutating unrelated warmups.

## Validation
- `cargo fmt -p degov-datalens-indexer -- --check`
- `cargo test -p degov-datalens-indexer --test datalens_warmup` — 4 passed
- `cargo test -p degov-datalens-indexer --test config` — 28 passed
- `cargo test -p degov-datalens-indexer --lib` — 1 passed
- `cargo test -p degov-datalens-indexer --test datalens_client --test datalens_planner --test cli_runtime_config --test indexer_runner --test native_runner_integration` — 45 passed

## Broader Test Note
- `cargo test -p degov-datalens-indexer` reaches DB-backed `checkpoint_repository` tests and fails because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set. The failing tests all report `DEGOV_INDEXER_TEST_DATABASE_URL is required`.
