### PR TITLE
feat(indexer): add Datalens warmup effectiveness logs

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -100,12 +100,19 @@ impl DatalensNativeClient {
     fn query_with_transient_fallback(
         &self,
         input: QueryInput,
-    ) -> Result<serde_json::Value, DatalensSdkError> {
+    ) -> Result<crate::DatalensLogQueryResult, DatalensSdkError> {
         let started_at = Instant::now();
         let mut attempt = 1;
         loop {
             match self.client.native().query(input.clone()) {
-                Ok(response) => return Ok(response.rows),
+                Ok(response) => {
+                    return Ok(crate::DatalensLogQueryResult {
+                        rows: response.rows,
+                        cache: crate::DatalensLogQueryCacheSummary::from_datalens_cache_json(
+                            &response.cache,
+                        ),
+                    });
+                }
                 Err(error) => {
                     let Some(delay) =
                         fallback_retry_delay(&self.retry_config, &error, attempt, started_at)
@@ -186,7 +193,10 @@ impl DatalensNativeReader for DatalensNativeClient {
 }
 
 impl DatalensLogQueryReader for DatalensNativeClient {
-    fn query_logs(&mut self, input: QueryInput) -> Result<serde_json::Value, DatalensError> {
+    fn query_logs(
+        &mut self,
+        input: QueryInput,
+    ) -> Result<crate::DatalensLogQueryResult, DatalensError> {
         self.query_with_transient_fallback(input)
             .map_err(|error| DatalensError::Query(error.to_string()))
     }

--- a/apps/indexer/src/datalens/effectiveness.rs
+++ b/apps/indexer/src/datalens/effectiveness.rs
@@ -1,0 +1,224 @@
+use std::fmt;
+use std::time::Duration;
+
+use datalens_sdk::native::QuerySelectorInput;
+use sha3::{Digest, Keccak256};
+
+use crate::IndexerCheckpointIdentity;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DatalensLogQueryCacheOutcome {
+    FullHit,
+    PartialHit,
+    Miss,
+    Empty,
+    Unavailable,
+}
+
+impl fmt::Display for DatalensLogQueryCacheOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FullHit => formatter.write_str("full_hit"),
+            Self::PartialHit => formatter.write_str("partial_hit"),
+            Self::Miss => formatter.write_str("miss"),
+            Self::Empty => formatter.write_str("empty"),
+            Self::Unavailable => formatter.write_str("unavailable"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensLogQueryCacheSummary {
+    pub outcome: DatalensLogQueryCacheOutcome,
+    pub hit_range_count: Option<usize>,
+    pub missing_range_count: Option<usize>,
+    pub durable_hit_range_count: Option<usize>,
+    pub hot_hit_range_count: Option<usize>,
+    pub provider_fill_range_count: Option<usize>,
+}
+
+impl DatalensLogQueryCacheSummary {
+    pub fn unavailable() -> Self {
+        Self {
+            outcome: DatalensLogQueryCacheOutcome::Unavailable,
+            hit_range_count: None,
+            missing_range_count: None,
+            durable_hit_range_count: None,
+            hot_hit_range_count: None,
+            provider_fill_range_count: None,
+        }
+    }
+
+    pub fn from_datalens_cache_json(cache: &serde_json::Value) -> Self {
+        let hit_range_count = range_count(cache, "hit_ranges");
+        let missing_range_count = range_count(cache, "missing_ranges");
+        let outcome = match (hit_range_count, missing_range_count) {
+            (Some(hit), Some(missing)) if hit > 0 && missing == 0 => {
+                DatalensLogQueryCacheOutcome::FullHit
+            }
+            (Some(hit), Some(missing)) if hit > 0 && missing > 0 => {
+                DatalensLogQueryCacheOutcome::PartialHit
+            }
+            (Some(0), Some(missing)) if missing > 0 => DatalensLogQueryCacheOutcome::Miss,
+            (Some(0), Some(0)) => DatalensLogQueryCacheOutcome::Empty,
+            _ => DatalensLogQueryCacheOutcome::Unavailable,
+        };
+
+        Self {
+            outcome,
+            hit_range_count,
+            missing_range_count,
+            durable_hit_range_count: range_count(cache, "durable_hit_ranges"),
+            hot_hit_range_count: range_count(cache, "hot_hit_ranges"),
+            provider_fill_range_count: range_count(cache, "provider_fill_ranges"),
+        }
+    }
+}
+
+fn range_count(cache: &serde_json::Value, field: &str) -> Option<usize> {
+    cache
+        .get(field)
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DatalensLogQueryResult {
+    pub rows: serde_json::Value,
+    pub cache: DatalensLogQueryCacheSummary,
+}
+
+impl DatalensLogQueryResult {
+    pub fn rows_only(rows: serde_json::Value) -> Self {
+        Self {
+            rows,
+            cache: DatalensLogQueryCacheSummary::unavailable(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DatalensWarmupEffectivenessAggregation {
+    pub query_count: usize,
+    pub full_hit_count: usize,
+    pub partial_hit_count: usize,
+    pub miss_count: usize,
+    pub empty_count: usize,
+    pub unavailable_count: usize,
+    pub provider_fill_range_count: usize,
+    pub provider_limit_count: usize,
+    query_duration_min: Option<Duration>,
+    query_duration_max: Option<Duration>,
+    query_duration_total: Duration,
+}
+
+impl DatalensWarmupEffectivenessAggregation {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_query(&mut self, cache: DatalensLogQueryCacheSummary, duration: Duration) {
+        self.query_count += 1;
+        match cache.outcome {
+            DatalensLogQueryCacheOutcome::FullHit => self.full_hit_count += 1,
+            DatalensLogQueryCacheOutcome::PartialHit => self.partial_hit_count += 1,
+            DatalensLogQueryCacheOutcome::Miss => self.miss_count += 1,
+            DatalensLogQueryCacheOutcome::Empty => self.empty_count += 1,
+            DatalensLogQueryCacheOutcome::Unavailable => self.unavailable_count += 1,
+        }
+        self.provider_fill_range_count += cache.provider_fill_range_count.unwrap_or(0);
+        self.query_duration_total += duration;
+        self.query_duration_min = Some(
+            self.query_duration_min
+                .map_or(duration, |current| current.min(duration)),
+        );
+        self.query_duration_max = Some(
+            self.query_duration_max
+                .map_or(duration, |current| current.max(duration)),
+        );
+    }
+
+    pub fn record_provider_limit(&mut self) {
+        self.provider_limit_count += 1;
+    }
+
+    pub fn record_provider_limits(&mut self, count: usize) {
+        self.provider_limit_count += count;
+    }
+
+    pub fn query_duration_min_ms(&self) -> Option<u128> {
+        self.query_duration_min.map(|duration| duration.as_millis())
+    }
+
+    pub fn query_duration_avg_ms(&self) -> Option<u128> {
+        if self.query_count == 0 {
+            return None;
+        }
+        Some(self.query_duration_total.as_millis() / self.query_count as u128)
+    }
+
+    pub fn query_duration_max_ms(&self) -> Option<u128> {
+        self.query_duration_max.map(|duration| duration.as_millis())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensWarmupEffectivenessLogFields {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub contract_set_id: String,
+    pub selector_fingerprint: String,
+    pub query_watermark: Option<i64>,
+    pub current_checkpoint: Option<i64>,
+    pub warmup_task_id: String,
+    pub warmup_cursor: String,
+    pub warmup_lead_blocks: String,
+    pub full_hit_count: usize,
+    pub partial_hit_count: usize,
+    pub miss_count: usize,
+    pub empty_count: usize,
+    pub unavailable_count: usize,
+    pub provider_fill_range_count: usize,
+    pub provider_limit_count: usize,
+    pub query_duration_min_ms: Option<u128>,
+    pub query_duration_avg_ms: Option<u128>,
+    pub query_duration_max_ms: Option<u128>,
+}
+
+impl DatalensWarmupEffectivenessLogFields {
+    pub fn from_aggregation(
+        identity: &IndexerCheckpointIdentity,
+        selector_fingerprint: impl Into<String>,
+        current_checkpoint: Option<i64>,
+        query_watermark: Option<i64>,
+        aggregation: &DatalensWarmupEffectivenessAggregation,
+    ) -> Self {
+        Self {
+            dao_code: identity.dao_code.clone(),
+            chain_id: identity.chain_id,
+            contract_set_id: identity.contract_set_id.clone(),
+            selector_fingerprint: selector_fingerprint.into(),
+            query_watermark,
+            current_checkpoint,
+            warmup_task_id: "unavailable".to_owned(),
+            warmup_cursor: "unavailable".to_owned(),
+            warmup_lead_blocks: "unavailable".to_owned(),
+            full_hit_count: aggregation.full_hit_count,
+            partial_hit_count: aggregation.partial_hit_count,
+            miss_count: aggregation.miss_count,
+            empty_count: aggregation.empty_count,
+            unavailable_count: aggregation.unavailable_count,
+            provider_fill_range_count: aggregation.provider_fill_range_count,
+            provider_limit_count: aggregation.provider_limit_count,
+            query_duration_min_ms: aggregation.query_duration_min_ms(),
+            query_duration_avg_ms: aggregation.query_duration_avg_ms(),
+            query_duration_max_ms: aggregation.query_duration_max_ms(),
+        }
+    }
+}
+
+pub fn datalens_selector_fingerprint(selector: &QuerySelectorInput) -> String {
+    let bytes = serde_json::to_vec(selector).unwrap_or_default();
+    let digest = Keccak256::digest(bytes);
+    hex::encode(digest)
+}

--- a/apps/indexer/src/datalens/mod.rs
+++ b/apps/indexer/src/datalens/mod.rs
@@ -1,10 +1,16 @@
 pub mod client;
+pub mod effectiveness;
 pub mod planner;
 pub mod warmup;
 
 pub use client::{
     DatalensDurableHeadReader, DatalensNativeClient, DatalensNativeReader, ServiceReadiness,
     verify_datalens_service,
+};
+pub use effectiveness::{
+    DatalensLogQueryCacheOutcome, DatalensLogQueryCacheSummary, DatalensLogQueryResult,
+    DatalensWarmupEffectivenessAggregation, DatalensWarmupEffectivenessLogFields,
+    datalens_selector_fingerprint,
 };
 pub use planner::{
     DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan, DaoLogSource, DatalensLogPage,

--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -1,10 +1,15 @@
+use std::time::{Duration, Instant};
+
 use datalens_sdk::native::{
     ChainFamilyInput, ChainFamilyKindInput, ChainIdentityInput, DatasetKeyInput,
     EvmLogsSelectorInput, NetworkIdInput, QueryInput, QueryRangeInput, QueryRangeKindInput,
     QuerySelectorInput, SelectorKindInput,
 };
 
-use crate::{DatalensConfig, DatalensError, GovernanceTokenStandard};
+use crate::{
+    DatalensConfig, DatalensError, DatalensLogQueryCacheSummary, DatalensLogQueryResult,
+    GovernanceTokenStandard,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DaoContractAddresses {
@@ -39,10 +44,12 @@ pub struct DaoLogQueryPlan {
 pub struct DatalensLogPage {
     pub plan: DaoLogQueryPlan,
     pub rows: serde_json::Value,
+    pub cache: DatalensLogQueryCacheSummary,
+    pub query_duration: Duration,
 }
 
 pub trait DatalensLogQueryReader {
-    fn query_logs(&mut self, input: QueryInput) -> Result<serde_json::Value, DatalensError>;
+    fn query_logs(&mut self, input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError>;
 }
 
 pub fn plan_dao_log_queries(
@@ -95,10 +102,13 @@ pub fn fetch_dao_log_pages(
 ) -> Result<Vec<DatalensLogPage>, DatalensError> {
     let mut pages = Vec::new();
     for plan in plans {
-        let rows = reader.query_logs(plan.input.clone())?;
+        let query_started_at = Instant::now();
+        let result = reader.query_logs(plan.input.clone())?;
         pages.push(DatalensLogPage {
             plan: plan.clone(),
-            rows,
+            rows: result.rows,
+            cache: result.cache,
+            query_duration: query_started_at.elapsed(),
         });
     }
 

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -27,6 +27,11 @@ pub use crate::datalens::warmup::{
     DatalensWarmupConfig, DatalensWarmupEnsureOutcome, DatalensWarmupEnsurer, DatalensWarmupKind,
     DatalensWarmupSubmitRequest, ensure_datalens_warmup_task, follow_query_request,
 };
+pub use crate::datalens::{
+    DatalensLogQueryCacheOutcome, DatalensLogQueryCacheSummary, DatalensLogQueryResult,
+    DatalensWarmupEffectivenessAggregation, DatalensWarmupEffectivenessLogFields,
+    datalens_selector_fingerprint,
+};
 pub use crate::decode::dao_event::{
     CallExecutedEvent, CallSaltEvent, CallScheduledEvent, DaoEventDecodeError, DecodedDaoEvent,
     DecodedGovernorEvent, DecodedTimelockEvent, DecodedTokenEvent, DelegateChangedEvent,

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -7,7 +7,8 @@ use thiserror::Error;
 
 use crate::{
     CheckpointBlockRange, CheckpointError, DaoContractAddresses, DaoEventDecodeError, DaoLogSource,
-    DatalensConfig, DatalensError, DatalensLogPage, DatalensLogQueryReader, DecodedDaoEvent,
+    DatalensConfig, DatalensError, DatalensLogPage, DatalensLogQueryReader,
+    DatalensWarmupEffectivenessAggregation, DatalensWarmupEffectivenessLogFields, DecodedDaoEvent,
     GovernanceTokenStandard, InMemoryProposalProjectionRepository,
     InMemoryTimelockProjectionRepository, InMemoryTokenProjectionRepository,
     InMemoryVoteProjectionRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
@@ -16,8 +17,8 @@ use crate::{
     TimelockProjectionEvent, TimelockProjectionRepository, TimelockProposalLinkContext,
     TokenProjectionBatch, TokenProjectionContext, TokenProjectionEvent, TokenProjectionRepository,
     VoteProjectionBatch, VoteProjectionContext, VoteProjectionEvent, VoteProjectionRepository,
-    decode_dao_log, fetch_dao_log_pages, normalize_evm_log_rows, plan_dao_log_queries,
-    plan_next_checkpoint_range, project_proposal_events,
+    datalens_selector_fingerprint, decode_dao_log, fetch_dao_log_pages, normalize_evm_log_rows,
+    plan_dao_log_queries, plan_next_checkpoint_range, project_proposal_events,
     project_timelock_events_with_proposal_links, project_token_events, project_vote_events,
 };
 
@@ -363,12 +364,14 @@ struct ProgressRateSample {
     processed_height: i64,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ChunkProcessingMetrics {
     datalens_request_count: usize,
     returned_row_count: usize,
     decoded_count: usize,
     projection_event_counts: ProjectionEventCounts,
+    warmup_effectiveness: DatalensWarmupEffectivenessAggregation,
+    selector_fingerprint: String,
     read_duration: Duration,
     decode_duration: Duration,
     project_duration: Duration,
@@ -441,6 +444,7 @@ where
             ))?;
         let mut progress_rate = ProgressRateEstimator::default();
         let mut chunks_processed = 0;
+        let mut provider_limit_count_since_summary = 0;
         let mut checkpoint = self
             .store
             .read_or_create_checkpoint(&self.options.checkpoint_identity, self.options.start_block)
@@ -513,6 +517,7 @@ where
                 Err(error) => {
                     let failed_range_block_count = range_block_count(range);
                     if is_provider_limit_error(&error) && failed_range_block_count > 1 {
+                        provider_limit_count_since_summary += 1;
                         let sizing_decision =
                             chunk_sizer.record_provider_limit(failed_range_block_count);
                         let retry_to_block = range
@@ -628,6 +633,40 @@ where
                 sizing_decision.current_chunk_size,
                 sizing_decision.reason
             );
+            let mut warmup_effectiveness_aggregation =
+                processing.metrics.warmup_effectiveness.clone();
+            warmup_effectiveness_aggregation
+                .record_provider_limits(provider_limit_count_since_summary);
+            provider_limit_count_since_summary = 0;
+            let warmup_effectiveness = DatalensWarmupEffectivenessLogFields::from_aggregation(
+                &self.options.checkpoint_identity,
+                processing.metrics.selector_fingerprint.clone(),
+                Some(checkpoint_next_block_before),
+                Some(range.to_block),
+                &warmup_effectiveness_aggregation,
+            );
+            info!(
+                "Datalens follow_query warmup effectiveness summary dao_code={} chain_id={} contract_set_id={} selector_fingerprint={} query_watermark={} current_checkpoint={} warmup_task_id={} warmup_cursor={} warmup_lead_blocks={} full_hit_count={} partial_hit_count={} miss_count={} empty_count={} unavailable_count={} provider_fill_range_count={} provider_limit_count={} query_duration_min_ms={} query_duration_avg_ms={} query_duration_max_ms={}",
+                warmup_effectiveness.dao_code,
+                warmup_effectiveness.chain_id,
+                warmup_effectiveness.contract_set_id,
+                warmup_effectiveness.selector_fingerprint,
+                optional_i64_log_value(warmup_effectiveness.query_watermark),
+                optional_i64_log_value(warmup_effectiveness.current_checkpoint),
+                warmup_effectiveness.warmup_task_id,
+                warmup_effectiveness.warmup_cursor,
+                warmup_effectiveness.warmup_lead_blocks,
+                warmup_effectiveness.full_hit_count,
+                warmup_effectiveness.partial_hit_count,
+                warmup_effectiveness.miss_count,
+                warmup_effectiveness.empty_count,
+                warmup_effectiveness.unavailable_count,
+                warmup_effectiveness.provider_fill_range_count,
+                warmup_effectiveness.provider_limit_count,
+                optional_u128_log_value(warmup_effectiveness.query_duration_min_ms),
+                optional_u128_log_value(warmup_effectiveness.query_duration_avg_ms),
+                optional_u128_log_value(warmup_effectiveness.query_duration_max_ms)
+            );
             checkpoint = self
                 .store
                 .read_or_create_checkpoint(
@@ -651,8 +690,16 @@ where
             range.to_block,
         )?;
         let datalens_request_count = plans.len();
+        let selector_fingerprint = plans
+            .first()
+            .map(|plan| datalens_selector_fingerprint(&plan.input.selector))
+            .unwrap_or_else(|| "unavailable".to_owned());
         let pages = fetch_dao_log_pages(&mut self.reader, &plans)?;
         let read_duration = read_started_at.elapsed();
+        let mut warmup_effectiveness = DatalensWarmupEffectivenessAggregation::new();
+        for page in &pages {
+            warmup_effectiveness.record_query(page.cache.clone(), page.query_duration);
+        }
         let decode_started_at = Instant::now();
         let decoded = self.decode_pages(pages)?;
         let decode_duration = decode_started_at.elapsed();
@@ -669,6 +716,8 @@ where
                 returned_row_count,
                 decoded_count,
                 projection_event_counts: projected.event_counts,
+                warmup_effectiveness,
+                selector_fingerprint,
                 read_duration,
                 decode_duration,
                 project_duration,
@@ -923,6 +972,18 @@ fn optional_f64_log_value(value: Option<f64>) -> String {
     value
         .map(|value| format!("{value:.2}"))
         .unwrap_or_else(|| "null".to_owned())
+}
+
+fn optional_i64_log_value(value: Option<i64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unavailable".to_owned())
+}
+
+fn optional_u128_log_value(value: Option<u128>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unavailable".to_owned())
 }
 
 fn to_checkpoint_error(error: impl fmt::Display) -> IndexerRunnerError {

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -103,11 +103,11 @@ fn test_datalens_log_query_retries_retryable_rate_limit_before_success() {
             .expect("client");
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
 
-    let rows = client
+    let result = client
         .query_logs(plans[0].input.clone())
         .expect("query retries and succeeds");
 
-    assert_eq!(rows, serde_json::json!([{ "block_number": 100 }]));
+    assert_eq!(result.rows, serde_json::json!([{ "block_number": 100 }]));
     let requests = server.join();
     assert_eq!(requests.len(), 2);
     assert!(
@@ -130,11 +130,11 @@ fn test_datalens_log_query_retries_provider_timeout_before_success() {
             .expect("client");
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
 
-    let rows = client
+    let result = client
         .query_logs(plans[0].input.clone())
         .expect("query retries and succeeds");
 
-    assert_eq!(rows, serde_json::json!([{ "block_number": 101 }]));
+    assert_eq!(result.rows, serde_json::json!([{ "block_number": 101 }]));
     let requests = server.join();
     assert_eq!(requests.len(), 2);
 }
@@ -153,11 +153,11 @@ fn test_datalens_log_query_retries_transport_failure_before_success() {
             .expect("client");
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
 
-    let rows = client
+    let result = client
         .query_logs(plans[0].input.clone())
         .expect("query retries and succeeds");
 
-    assert_eq!(rows, serde_json::json!([{ "block_number": 102 }]));
+    assert_eq!(result.rows, serde_json::json!([{ "block_number": 102 }]));
     let requests = server.join();
     assert_eq!(requests.len(), 2);
 }

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -4,8 +4,8 @@ use datalens_sdk::native::{QueryInput, QueryRangeKindInput, SelectorKindInput};
 use degov_datalens_indexer::{
     ChainFamily, ChainIdentityConfig, DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan,
     DaoLogSource, DatalensConfig, DatalensError, DatalensFinality, DatalensLogQueryReader,
-    DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig, SecretString, fetch_dao_log_pages,
-    plan_dao_log_queries,
+    DatalensLogQueryResult, DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig,
+    SecretString, fetch_dao_log_pages, plan_dao_log_queries,
 };
 
 #[test]
@@ -225,8 +225,10 @@ impl MockLogReader {
 }
 
 impl DatalensLogQueryReader for MockLogReader {
-    fn query_logs(&mut self, input: QueryInput) -> Result<serde_json::Value, DatalensError> {
+    fn query_logs(&mut self, input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
         self.calls.push(input);
-        self.results.remove(0)
+        self.results
+            .remove(0)
+            .map(DatalensLogQueryResult::rows_only)
     }
 }

--- a/apps/indexer/tests/datalens_warmup_effectiveness.rs
+++ b/apps/indexer/tests/datalens_warmup_effectiveness.rs
@@ -1,0 +1,195 @@
+use std::time::Duration;
+
+use datalens_sdk::native::QueryInput;
+use degov_datalens_indexer::{
+    ChainFamily, ChainIdentityConfig, DaoContractAddresses, DatalensConfig, DatalensError,
+    DatalensFinality, DatalensLogQueryCacheOutcome, DatalensLogQueryCacheSummary,
+    DatalensLogQueryReader, DatalensLogQueryResult, DatalensWarmupEffectivenessAggregation,
+    DatalensWarmupEffectivenessLogFields, DatasetKeyConfig, GovernanceTokenStandard,
+    IndexerCheckpointIdentity, QueryLimitConfig, SecretString, fetch_dao_log_pages,
+    plan_dao_log_queries,
+};
+use serde_json::json;
+
+#[test]
+fn test_query_cache_summary_extracts_full_partial_and_miss_outcomes() {
+    let full_hit = DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+        "hit_ranges": [{ "kind": "block", "start": 10, "end": 12 }],
+        "missing_ranges": [],
+        "durable_hit_ranges": [{ "kind": "block", "start": 10, "end": 12 }],
+        "hot_hit_ranges": [],
+        "provider_fill_ranges": []
+    }));
+    let partial_hit = DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+        "hit_ranges": [{ "kind": "block", "start": 10, "end": 10 }],
+        "missing_ranges": [{ "kind": "block", "start": 11, "end": 12 }],
+        "durable_hit_ranges": [{ "kind": "block", "start": 10, "end": 10 }],
+        "hot_hit_ranges": [],
+        "provider_fill_ranges": [{ "kind": "block", "start": 11, "end": 12 }]
+    }));
+    let miss = DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+        "hit_ranges": [],
+        "missing_ranges": [{ "kind": "block", "start": 10, "end": 12 }],
+        "durable_hit_ranges": [],
+        "hot_hit_ranges": [],
+        "provider_fill_ranges": [{ "kind": "block", "start": 10, "end": 12 }]
+    }));
+
+    assert_eq!(full_hit.outcome, DatalensLogQueryCacheOutcome::FullHit);
+    assert_eq!(full_hit.provider_fill_range_count, Some(0));
+    assert_eq!(
+        partial_hit.outcome,
+        DatalensLogQueryCacheOutcome::PartialHit
+    );
+    assert_eq!(partial_hit.provider_fill_range_count, Some(1));
+    assert_eq!(miss.outcome, DatalensLogQueryCacheOutcome::Miss);
+    assert_eq!(miss.provider_fill_range_count, Some(1));
+}
+
+#[test]
+fn test_query_cache_summary_marks_missing_fields_unavailable() {
+    let summary = DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({}));
+
+    assert_eq!(summary.outcome, DatalensLogQueryCacheOutcome::Unavailable);
+    assert_eq!(summary.hit_range_count, None);
+    assert_eq!(summary.missing_range_count, None);
+    assert_eq!(summary.provider_fill_range_count, None);
+}
+
+#[test]
+fn test_warmup_effectiveness_aggregation_builds_operator_log_fields() {
+    let mut aggregation = DatalensWarmupEffectivenessAggregation::new();
+    aggregation.record_query(
+        DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+            "hit_ranges": [{ "kind": "block", "start": 100, "end": 109 }],
+            "missing_ranges": [],
+            "provider_fill_ranges": []
+        })),
+        Duration::from_millis(20),
+    );
+    aggregation.record_query(
+        DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+            "hit_ranges": [{ "kind": "block", "start": 110, "end": 114 }],
+            "missing_ranges": [{ "kind": "block", "start": 115, "end": 119 }],
+            "provider_fill_ranges": [{ "kind": "block", "start": 115, "end": 119 }]
+        })),
+        Duration::from_millis(100),
+    );
+    aggregation.record_query(
+        DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({})),
+        Duration::from_millis(60),
+    );
+    aggregation.record_provider_limit();
+
+    let fields = DatalensWarmupEffectivenessLogFields::from_aggregation(
+        &identity(),
+        "selector-abc",
+        Some(100),
+        Some(119),
+        &aggregation,
+    );
+
+    assert_eq!(fields.dao_code, "demo-dao");
+    assert_eq!(fields.chain_id, 1);
+    assert_eq!(fields.contract_set_id, "demo-contracts");
+    assert_eq!(fields.selector_fingerprint, "selector-abc");
+    assert_eq!(fields.query_watermark, Some(119));
+    assert_eq!(fields.current_checkpoint, Some(100));
+    assert_eq!(fields.warmup_task_id, "unavailable");
+    assert_eq!(fields.warmup_cursor, "unavailable");
+    assert_eq!(fields.warmup_lead_blocks, "unavailable");
+    assert_eq!(fields.full_hit_count, 1);
+    assert_eq!(fields.partial_hit_count, 1);
+    assert_eq!(fields.miss_count, 0);
+    assert_eq!(fields.unavailable_count, 1);
+    assert_eq!(fields.provider_fill_range_count, 1);
+    assert_eq!(fields.provider_limit_count, 1);
+    assert_eq!(fields.query_duration_min_ms, Some(20));
+    assert_eq!(fields.query_duration_avg_ms, Some(60));
+    assert_eq!(fields.query_duration_max_ms, Some(100));
+}
+
+#[test]
+fn test_fetch_dao_log_pages_preserves_cache_summary() {
+    let config = config();
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
+    let mut reader = MockLogReader::new(vec![Ok(DatalensLogQueryResult {
+        rows: json!([]),
+        cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+            "hit_ranges": [],
+            "missing_ranges": [{ "kind": "block", "start": 100, "end": 100 }],
+            "provider_fill_ranges": [{ "kind": "block", "start": 100, "end": 100 }]
+        })),
+    })]);
+
+    let pages = fetch_dao_log_pages(&mut reader, &plans).expect("pages");
+
+    assert_eq!(pages.len(), 1);
+    assert_eq!(pages[0].cache.outcome, DatalensLogQueryCacheOutcome::Miss);
+    assert_eq!(pages[0].cache.provider_fill_range_count, Some(1));
+}
+
+fn identity() -> IndexerCheckpointIdentity {
+    IndexerCheckpointIdentity {
+        dao_code: "demo-dao".to_owned(),
+        chain_id: 1,
+        contract_set_id: "demo-contracts".to_owned(),
+        stream_id: "governance-events".to_owned(),
+        data_source_version: "v1".to_owned(),
+    }
+}
+
+fn config() -> DatalensConfig {
+    DatalensConfig {
+        endpoint: "https://datalens.ringdao.com".to_owned(),
+        application: "degov-live".to_owned(),
+        bearer_token: SecretString::new("redacted"),
+        timeout: Duration::from_secs(60),
+        finality: DatalensFinality::DurableOnly,
+        chain: ChainIdentityConfig {
+            family: ChainFamily::Evm,
+            configured_name: "ethereum".to_owned(),
+            network_id: Some(1),
+        },
+        dataset: DatasetKeyConfig {
+            family: "evm".to_owned(),
+            name: "logs".to_owned(),
+        },
+        query_limits: QueryLimitConfig {
+            block_range_limit: 1_000,
+        },
+        warmup: Default::default(),
+        dao_contracts: None,
+        chains: Vec::new(),
+    }
+}
+
+fn addresses() -> DaoContractAddresses {
+    DaoContractAddresses {
+        governor: "0x1111111111111111111111111111111111111111".to_owned(),
+        governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+        governor_token_standard: GovernanceTokenStandard::Erc20,
+        timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+    }
+}
+
+struct MockLogReader {
+    calls: Vec<QueryInput>,
+    results: Vec<Result<DatalensLogQueryResult, DatalensError>>,
+}
+
+impl MockLogReader {
+    fn new(results: Vec<Result<DatalensLogQueryResult, DatalensError>>) -> Self {
+        Self {
+            calls: Vec::new(),
+            results,
+        }
+    }
+}
+
+impl DatalensLogQueryReader for MockLogReader {
+    fn query_logs(&mut self, input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
+        self.calls.push(input);
+        self.results.remove(0)
+    }
+}

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -6,8 +6,8 @@ use datalens_sdk::native::QueryInput;
 use degov_datalens_indexer::{
     BatchReadPlanConfig, ChainContracts, ChainFamily, ChainIdentityConfig, DaoContractAddresses,
     DaoEventDecodeError, DaoLogSource, DatalensConfig, DatalensError, DatalensFinality,
-    DatalensLogQueryReader, DatasetKeyConfig, DecodedDaoEvent, DecodedGovernorEvent,
-    DecodedTokenEvent, GovernanceTokenStandard, InMemoryIndexerRunnerStore,
+    DatalensLogQueryReader, DatalensLogQueryResult, DatasetKeyConfig, DecodedDaoEvent,
+    DecodedGovernorEvent, DecodedTokenEvent, GovernanceTokenStandard, InMemoryIndexerRunnerStore,
     IndexerCheckpointIdentity, IndexerEventDecoder, IndexerRunner, IndexerRunnerContexts,
     IndexerRunnerOptions, NormalizedEvmLog, QueryLimitConfig, SecretString, TokenProjectionContext,
     VoteCastEvent, VoteProjectionContext, page_rows,
@@ -460,17 +460,17 @@ struct ScriptedDatalensReader {
 }
 
 impl DatalensLogQueryReader for ScriptedDatalensReader {
-    fn query_logs(&mut self, _input: QueryInput) -> Result<Value, DatalensError> {
-        Ok(Value::Array(
+    fn query_logs(&mut self, _input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
+        Ok(DatalensLogQueryResult::rows_only(Value::Array(
             self.rows.pop_front().expect("scripted query response"),
-        ))
+        )))
     }
 }
 
 struct FailingDatalensReader;
 
 impl DatalensLogQueryReader for FailingDatalensReader {
-    fn query_logs(&mut self, _input: QueryInput) -> Result<Value, DatalensError> {
+    fn query_logs(&mut self, _input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
         Err(DatalensError::Query(
             r#"datalens HTTP error 429: {"error":{"kind":"rate_limited","message":"rate limited"}}"#
                 .to_owned(),
@@ -493,7 +493,7 @@ impl ProviderLimitDatalensReader {
 }
 
 impl DatalensLogQueryReader for ProviderLimitDatalensReader {
-    fn query_logs(&mut self, input: QueryInput) -> Result<Value, DatalensError> {
+    fn query_logs(&mut self, input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
         let range = (input.range.start, input.range.end);
         self.observed_ranges
             .lock()
@@ -507,7 +507,7 @@ impl DatalensLogQueryReader for ProviderLimitDatalensReader {
             ));
         }
 
-        Ok(Value::Array(Vec::new()))
+        Ok(DatalensLogQueryResult::rows_only(Value::Array(Vec::new())))
     }
 }
 

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -6,7 +6,7 @@ use datalens_sdk::native::QueryInput;
 use degov_datalens_indexer::{
     BatchReadPlanConfig, ChainContracts, ChainFamily, ChainIdentityConfig, ChainReadMethod,
     DaoContractAddresses, DaoEventDecoder, DatalensConfig, DatalensError, DatalensFinality,
-    DatalensLogQueryReader, DatasetKeyConfig, GovernanceTokenStandard,
+    DatalensLogQueryReader, DatalensLogQueryResult, DatasetKeyConfig, GovernanceTokenStandard,
     InMemoryProposalProjectionRepository, InMemoryTimelockProjectionRepository,
     InMemoryTokenProjectionRepository, InMemoryVoteProjectionRepository, IndexerCheckpoint,
     IndexerCheckpointIdentity, IndexerProjectionBatch, IndexerRunner, IndexerRunnerContexts,
@@ -287,10 +287,10 @@ struct ScriptedReader {
 }
 
 impl DatalensLogQueryReader for ScriptedReader {
-    fn query_logs(&mut self, _input: QueryInput) -> Result<Value, DatalensError> {
-        Ok(Value::Array(
+    fn query_logs(&mut self, _input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
+        Ok(DatalensLogQueryResult::rows_only(Value::Array(
             self.rows.pop_front().expect("scripted query response"),
-        ))
+        )))
     }
 }
 


### PR DESCRIPTION
## Summary
- capture Datalens native query cache metadata and preserve unavailable fields explicitly
- aggregate follow_query warmup effectiveness per indexer chunk with hit/partial/miss/unavailable, provider fill, provider limit, checkpoint/watermark, selector fingerprint, and query duration fields
- add focused tests for cache extraction, aggregation/log fields, and query metadata propagation

## Tests
- cargo fmt --check
- cargo test -p degov-datalens-indexer --test datalens_warmup_effectiveness --test datalens_warmup --test datalens_planner --test indexer_runner --test native_runner_integration --test datalens_client
- cargo test -p degov-datalens-indexer (blocked by missing DEGOV_INDEXER_TEST_DATABASE_URL in checkpoint_repository tests)

## Notes
- warmup task cursor and lead blocks remain logged as unavailable because the current warmup submit API does not expose them
- no finality was added to warmup submit
- no onchain refresh scheduling or adaptive chunk/concurrency policy changes