### PR TITLE
feat(indexer): add Datalens query concurrency limits

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -1,4 +1,8 @@
-use std::time::Instant;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Condvar, Mutex},
+    time::{Duration, Instant},
+};
 
 use datalens_sdk::{
     ApiErrorKind, DatalensClient, Error as DatalensSdkError, RetryConfig,
@@ -28,6 +32,198 @@ pub struct DatalensNativeClient {
     application: String,
     bearer_token: crate::SecretString,
     http: reqwest::blocking::Client,
+    query_gate: Option<DatalensQueryConcurrencyGate>,
+    query_key: DatalensQueryConcurrencyKey,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DatalensQueryConcurrencyConfig {
+    pub global_max_in_flight: Option<usize>,
+    pub per_chain_max_in_flight: Option<usize>,
+}
+
+impl DatalensQueryConcurrencyConfig {
+    pub fn is_limited(self) -> bool {
+        self.global_max_in_flight.is_some() || self.per_chain_max_in_flight.is_some()
+    }
+
+    pub fn validate(self) -> Result<Self, DatalensError> {
+        if self.global_max_in_flight.is_some_and(|limit| limit == 0) {
+            return Err(DatalensError::Query(
+                "Datalens global query concurrency limit must be greater than zero".to_owned(),
+            ));
+        }
+        if self.per_chain_max_in_flight.is_some_and(|limit| limit == 0) {
+            return Err(DatalensError::Query(
+                "Datalens per-chain query concurrency limit must be greater than zero".to_owned(),
+            ));
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DatalensQueryConcurrencyKey {
+    pub family: String,
+    pub configured_name: String,
+    pub network_id: Option<i32>,
+}
+
+impl DatalensQueryConcurrencyKey {
+    pub fn from_config(config: &DatalensConfig) -> Self {
+        Self {
+            family: config.chain.family.as_datalens_value().to_owned(),
+            configured_name: config.chain.configured_name.clone(),
+            network_id: config.chain.network_id,
+        }
+    }
+
+    fn log_network_id(&self) -> String {
+        self.network_id
+            .map(|network_id| network_id.to_string())
+            .unwrap_or_else(|| "none".to_owned())
+    }
+}
+
+#[derive(Clone)]
+pub struct DatalensQueryConcurrencyGate {
+    inner: Arc<DatalensQueryConcurrencyGateInner>,
+}
+
+struct DatalensQueryConcurrencyGateInner {
+    config: DatalensQueryConcurrencyConfig,
+    state: Mutex<DatalensQueryConcurrencyGateState>,
+    available: Condvar,
+}
+
+#[derive(Default)]
+struct DatalensQueryConcurrencyGateState {
+    global_in_flight: usize,
+    per_chain_in_flight: HashMap<DatalensQueryConcurrencyKey, usize>,
+}
+
+pub struct DatalensQueryConcurrencyPermit {
+    gate: DatalensQueryConcurrencyGate,
+    key: DatalensQueryConcurrencyKey,
+    pub wait_duration: Duration,
+    pub global_in_flight: usize,
+    pub chain_in_flight: usize,
+}
+
+impl DatalensQueryConcurrencyGate {
+    pub fn new(config: DatalensQueryConcurrencyConfig) -> Result<Self, DatalensError> {
+        let config = config.validate()?;
+        Ok(Self {
+            inner: Arc::new(DatalensQueryConcurrencyGateInner {
+                config,
+                state: Mutex::new(DatalensQueryConcurrencyGateState::default()),
+                available: Condvar::new(),
+            }),
+        })
+    }
+
+    pub fn acquire(
+        &self,
+        key: &DatalensQueryConcurrencyKey,
+    ) -> Result<DatalensQueryConcurrencyPermit, DatalensError> {
+        let started_at = Instant::now();
+        let mut state = self.inner.state.lock().map_err(|_| {
+            DatalensError::Query("Datalens query concurrency gate lock poisoned".to_owned())
+        })?;
+
+        while self
+            .inner
+            .config
+            .global_max_in_flight
+            .is_some_and(|limit| state.global_in_flight >= limit)
+            || self
+                .inner
+                .config
+                .per_chain_max_in_flight
+                .is_some_and(|limit| {
+                    state
+                        .per_chain_in_flight
+                        .get(key)
+                        .copied()
+                        .unwrap_or_default()
+                        >= limit
+                })
+        {
+            state = self.inner.available.wait(state).map_err(|_| {
+                DatalensError::Query("Datalens query concurrency gate lock poisoned".to_owned())
+            })?;
+        }
+
+        state.global_in_flight += 1;
+        let chain_in_flight = {
+            let chain_in_flight = state.per_chain_in_flight.entry(key.clone()).or_default();
+            *chain_in_flight += 1;
+            *chain_in_flight
+        };
+        let global_in_flight = state.global_in_flight;
+
+        Ok(DatalensQueryConcurrencyPermit {
+            gate: self.clone(),
+            key: key.clone(),
+            wait_duration: started_at.elapsed(),
+            global_in_flight,
+            chain_in_flight,
+        })
+    }
+}
+
+impl Drop for DatalensQueryConcurrencyPermit {
+    fn drop(&mut self) {
+        if let Ok(mut state) = self.gate.inner.state.lock() {
+            state.global_in_flight = state.global_in_flight.saturating_sub(1);
+            if let Some(chain_in_flight) = state.per_chain_in_flight.get_mut(&self.key) {
+                *chain_in_flight = chain_in_flight.saturating_sub(1);
+                if *chain_in_flight == 0 {
+                    state.per_chain_in_flight.remove(&self.key);
+                }
+            }
+        }
+        self.gate.inner.available.notify_all();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DatalensQueryErrorClass {
+    ProviderLimit,
+    Transient,
+    Other,
+}
+
+impl DatalensQueryErrorClass {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ProviderLimit => "provider_limit",
+            Self::Transient => "transient",
+            Self::Other => "other",
+        }
+    }
+}
+
+pub fn classify_datalens_query_error(error: &str) -> DatalensQueryErrorClass {
+    let normalized = error.to_ascii_lowercase();
+    if normalized.contains("provider_limit") || normalized.contains("narrow your filter") {
+        return DatalensQueryErrorClass::ProviderLimit;
+    }
+    if normalized.contains("provider_timeout")
+        || normalized.contains("timeout")
+        || normalized.contains("request_rate_limit")
+        || normalized.contains("rate_limit")
+        || normalized.contains("transport")
+        || normalized.contains("provider_failure")
+        || normalized.contains("unavailable_head")
+        || normalized.contains("storage_read_failure")
+        || normalized.contains("storage_write_failure")
+        || normalized.contains("manifest_update_failure")
+        || normalized.contains("internal")
+    {
+        return DatalensQueryErrorClass::Transient;
+    }
+    DatalensQueryErrorClass::Other
 }
 
 impl DatalensNativeClient {
@@ -46,6 +242,8 @@ impl DatalensNativeClient {
                 .user_agent(crate::config::DEGOV_DATALENS_USER_AGENT)
                 .build()
                 .map_err(|error| DatalensError::SdkConfig(error.to_string()))?,
+            query_gate: None,
+            query_key: DatalensQueryConcurrencyKey::from_config(config),
         })
     }
 
@@ -78,7 +276,14 @@ impl DatalensNativeClient {
                 .user_agent(crate::config::DEGOV_DATALENS_USER_AGENT)
                 .build()
                 .map_err(|error| DatalensError::SdkConfig(error.to_string()))?,
+            query_gate: None,
+            query_key: DatalensQueryConcurrencyKey::from_config(config),
         })
+    }
+
+    pub fn with_query_concurrency_gate(mut self, gate: DatalensQueryConcurrencyGate) -> Self {
+        self.query_gate = Some(gate);
+        self
     }
 
     pub(crate) fn service_base_endpoint(&self) -> &str {
@@ -120,10 +325,11 @@ impl DatalensNativeClient {
                         return Err(error);
                     };
                     warn!(
-                        "Datalens query transient fallback retry scheduled attempt={} max_attempts={} delay_ms={} error={}",
+                        "Datalens query transient fallback retry scheduled attempt={} max_attempts={} delay_ms={} error_class={} error={}",
                         attempt + 1,
                         self.retry_config.max_attempts,
                         delay.as_millis(),
+                        classify_datalens_query_error(&error.to_string()).as_str(),
                         error
                     );
                     std::thread::sleep(delay);
@@ -197,8 +403,34 @@ impl DatalensLogQueryReader for DatalensNativeClient {
         &mut self,
         input: QueryInput,
     ) -> Result<crate::DatalensLogQueryResult, DatalensError> {
-        self.query_with_transient_fallback(input)
-            .map_err(|error| DatalensError::Query(error.to_string()))
+        let _permit = self
+            .query_gate
+            .as_ref()
+            .map(|gate| {
+                let permit = gate.acquire(&self.query_key)?;
+                info!(
+                    "Datalens query concurrency permit acquired chain_family={} chain_name={} chain_network_id={} wait_ms={} global_in_flight={} chain_in_flight={}",
+                    self.query_key.family,
+                    self.query_key.configured_name,
+                    self.query_key.log_network_id(),
+                    permit.wait_duration.as_millis(),
+                    permit.global_in_flight,
+                    permit.chain_in_flight
+                );
+                Ok::<_, DatalensError>(permit)
+            })
+            .transpose()?;
+
+        self.query_with_transient_fallback(input).map_err(|error| {
+            let error_message = error.to_string();
+            warn!(
+                "Datalens query failed error_class={} max_attempts={} error={}",
+                classify_datalens_query_error(&error_message).as_str(),
+                self.retry_config.max_attempts,
+                error_message
+            );
+            DatalensError::Query(error_message)
+        })
     }
 }
 

--- a/apps/indexer/src/datalens/mod.rs
+++ b/apps/indexer/src/datalens/mod.rs
@@ -4,7 +4,9 @@ pub mod planner;
 pub mod warmup;
 
 pub use client::{
-    DatalensDurableHeadReader, DatalensNativeClient, DatalensNativeReader, ServiceReadiness,
+    DatalensDurableHeadReader, DatalensNativeClient, DatalensNativeReader,
+    DatalensQueryConcurrencyConfig, DatalensQueryConcurrencyGate, DatalensQueryConcurrencyKey,
+    DatalensQueryErrorClass, ServiceReadiness, classify_datalens_query_error,
     verify_datalens_service,
 };
 pub use effectiveness::{

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -29,7 +29,9 @@ pub use crate::datalens::warmup::{
 };
 pub use crate::datalens::{
     DatalensLogQueryCacheOutcome, DatalensLogQueryCacheSummary, DatalensLogQueryResult,
-    DatalensWarmupEffectivenessAggregation, DatalensWarmupEffectivenessLogFields,
+    DatalensQueryConcurrencyConfig, DatalensQueryConcurrencyGate, DatalensQueryConcurrencyKey,
+    DatalensQueryErrorClass, DatalensWarmupEffectivenessAggregation,
+    DatalensWarmupEffectivenessLogFields, classify_datalens_query_error,
     datalens_selector_fingerprint,
 };
 pub use crate::decode::dao_event::{

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -8,18 +8,20 @@ use thiserror::Error;
 use crate::{
     CheckpointBlockRange, CheckpointError, DaoContractAddresses, DaoEventDecodeError, DaoLogSource,
     DatalensConfig, DatalensError, DatalensLogPage, DatalensLogQueryReader,
-    DatalensWarmupEffectivenessAggregation, DatalensWarmupEffectivenessLogFields, DecodedDaoEvent,
-    GovernanceTokenStandard, InMemoryProposalProjectionRepository,
-    InMemoryTimelockProjectionRepository, InMemoryTokenProjectionRepository,
-    InMemoryVoteProjectionRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
-    NormalizedEvmLog, ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionEvent,
-    ProposalProjectionRepository, TimelockProjectionBatch, TimelockProjectionContext,
-    TimelockProjectionEvent, TimelockProjectionRepository, TimelockProposalLinkContext,
-    TokenProjectionBatch, TokenProjectionContext, TokenProjectionEvent, TokenProjectionRepository,
-    VoteProjectionBatch, VoteProjectionContext, VoteProjectionEvent, VoteProjectionRepository,
-    datalens_selector_fingerprint, decode_dao_log, fetch_dao_log_pages, normalize_evm_log_rows,
-    plan_dao_log_queries, plan_next_checkpoint_range, project_proposal_events,
-    project_timelock_events_with_proposal_links, project_token_events, project_vote_events,
+    DatalensQueryErrorClass, DatalensWarmupEffectivenessAggregation,
+    DatalensWarmupEffectivenessLogFields, DecodedDaoEvent, GovernanceTokenStandard,
+    InMemoryProposalProjectionRepository, InMemoryTimelockProjectionRepository,
+    InMemoryTokenProjectionRepository, InMemoryVoteProjectionRepository, IndexerCheckpoint,
+    IndexerCheckpointIdentity, NormalizedEvmLog, ProposalProjectionBatch,
+    ProposalProjectionContext, ProposalProjectionEvent, ProposalProjectionRepository,
+    TimelockProjectionBatch, TimelockProjectionContext, TimelockProjectionEvent,
+    TimelockProjectionRepository, TimelockProposalLinkContext, TokenProjectionBatch,
+    TokenProjectionContext, TokenProjectionEvent, TokenProjectionRepository, VoteProjectionBatch,
+    VoteProjectionContext, VoteProjectionEvent, VoteProjectionRepository,
+    classify_datalens_query_error, datalens_selector_fingerprint, decode_dao_log,
+    fetch_dao_log_pages, normalize_evm_log_rows, plan_dao_log_queries, plan_next_checkpoint_range,
+    project_proposal_events, project_timelock_events_with_proposal_links, project_token_events,
+    project_vote_events,
 };
 
 use crate::OnchainRefreshTickReport;
@@ -1199,9 +1201,8 @@ fn is_provider_limit_error(error: &IndexerRunnerError) -> bool {
         IndexerRunnerError::Datalens(DatalensError::Query(message)) => message,
         _ => return false,
     };
-    let normalized = message.to_ascii_lowercase();
 
-    normalized.contains("provider_limit") || normalized.contains("narrow your filter")
+    classify_datalens_query_error(message) == DatalensQueryErrorClass::ProviderLimit
 }
 
 #[derive(Clone, Debug, Eq, Error, PartialEq)]

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -7,12 +7,13 @@ use tokio::{runtime::Handle, task, time::sleep};
 
 use crate::{
     DaoContractAddresses, DaoEventDecoder, DatalensConfig, DatalensDurableHeadReader,
-    DatalensNativeClient, DatalensWarmupEnsureOutcome, EvmRpcChainTool,
-    IndexerContractSetRuntimeConfig, IndexerOnchainRefreshTick, IndexerRunner, IndexerRunnerReport,
-    IndexerRuntimeConfig, IndexerTargetHeight, MultiChainToolOnchainRefreshReader,
-    OnchainRefreshRuntimeConfig, OnchainRefreshTickReport, OnchainRefreshTickRunner,
-    OnchainRefreshTickScheduler, OnchainRefreshWorker, OnchainRefreshWorkerError,
-    PostgresIndexerRunnerStore, datalens_retry_config, ensure_datalens_warmup_task, required_env,
+    DatalensNativeClient, DatalensQueryConcurrencyGate, DatalensWarmupEnsureOutcome,
+    EvmRpcChainTool, IndexerContractSetRuntimeConfig, IndexerOnchainRefreshTick, IndexerRunner,
+    IndexerRunnerReport, IndexerRuntimeConfig, IndexerTargetHeight,
+    MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig, OnchainRefreshTickReport,
+    OnchainRefreshTickRunner, OnchainRefreshTickScheduler, OnchainRefreshWorker,
+    OnchainRefreshWorkerError, PostgresIndexerRunnerStore, datalens_retry_config,
+    ensure_datalens_warmup_task, required_env,
 };
 
 use super::{datalens::verify_datalens, migrate::apply_migrations};
@@ -39,6 +40,14 @@ pub async fn run_indexer() -> Result<()> {
         .context("connect to DeGov indexer Postgres")?;
     apply_migrations(&pool).await?;
     ensure_warmup_on_startup(&runtime, &config).await?;
+    let datalens_query_gate = if runtime.datalens_query_concurrency.is_limited() {
+        Some(
+            DatalensQueryConcurrencyGate::new(runtime.datalens_query_concurrency)
+                .context("create Datalens query concurrency gate")?,
+        )
+    } else {
+        None
+    };
 
     loop {
         let contract_sets = runtime
@@ -76,6 +85,7 @@ pub async fn run_indexer() -> Result<()> {
                 contract_set.config.clone(),
                 contract_set.addresses.clone(),
                 pool.clone(),
+                datalens_query_gate.clone(),
             )
             .await?;
 
@@ -159,6 +169,7 @@ async fn run_contract_set_pass(
     config: DatalensConfig,
     contracts: DaoContractAddresses,
     pool: sqlx::PgPool,
+    datalens_query_gate: Option<DatalensQueryConcurrencyGate>,
 ) -> Result<IndexerRunnerReport> {
     log::info!(
         "Datalens indexer contract set pass is ready dao_code={} dao_chain={} chain_id={:?} contract_set_id={} governor={} token={} timelock={} start_block={} target_height={}",
@@ -176,11 +187,14 @@ async fn run_contract_set_pass(
     let onchain_refresh_tick = build_onchain_refresh_tick(&runtime, pool.clone())?;
 
     task::spawn_blocking(move || -> Result<_> {
-        let client = DatalensNativeClient::from_config_with_retry_config(
+        let mut client = DatalensNativeClient::from_config_with_retry_config(
             &config,
             datalens_retry_config(runtime.query_max_attempts),
         )
         .context("create Datalens client")?;
+        if let Some(gate) = datalens_query_gate {
+            client = client.with_query_concurrency_gate(gate);
+        }
         let store = PostgresIndexerRunnerStore::new(pool);
         let mut runner = IndexerRunner::new(
             runtime.options(&config, &contracts)?,
@@ -340,6 +354,7 @@ mod tests {
             checkpoint_stream_id: "datalens-native".to_owned(),
             data_source_version: "datalens-v1".to_owned(),
             query_max_attempts: 1,
+            datalens_query_concurrency: Default::default(),
             progress_refresh_lag_blocks: 100,
             adaptive_chunk_sizer: Default::default(),
             onchain_refresh_tick: Default::default(),

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -7,10 +7,10 @@ use serde::Deserialize;
 
 use crate::{
     AdaptiveChunkSizerConfig, BatchReadPlanConfig, ChainContracts, ChainReadMethod, DatalensConfig,
-    DatalensRuntimeContractSet, IndexerCheckpointIdentity, IndexerRunnerContexts,
-    IndexerRunnerOptions, OnchainRefreshTickConfig, OnchainRefreshWorkerConfig,
-    ProposalProjectionContext, SecretString, TimelockProjectionContext, TokenProjectionContext,
-    VoteProjectionContext,
+    DatalensQueryConcurrencyConfig, DatalensRuntimeContractSet, IndexerCheckpointIdentity,
+    IndexerRunnerContexts, IndexerRunnerOptions, OnchainRefreshTickConfig,
+    OnchainRefreshWorkerConfig, ProposalProjectionContext, SecretString, TimelockProjectionContext,
+    TokenProjectionContext, VoteProjectionContext,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -125,6 +125,7 @@ pub struct IndexerRuntimeConfig {
     pub checkpoint_stream_id: String,
     pub data_source_version: String,
     pub query_max_attempts: u32,
+    pub datalens_query_concurrency: DatalensQueryConcurrencyConfig,
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
@@ -195,6 +196,7 @@ pub struct IndexerContractSetRuntimeConfig {
     pub checkpoint_stream_id: String,
     pub data_source_version: String,
     pub query_max_attempts: u32,
+    pub datalens_query_concurrency: DatalensQueryConcurrencyConfig,
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub max_chunks_per_run: Option<u64>,
@@ -271,6 +273,7 @@ impl IndexerRuntimeConfig {
             data_source_version: optional_env("DEGOV_INDEXER_DATA_SOURCE_VERSION")?
                 .unwrap_or_else(|| "datalens-v1".to_owned()),
             query_max_attempts,
+            datalens_query_concurrency: load_datalens_query_concurrency_config()?,
             progress_refresh_lag_blocks: optional_env_i64(
                 "DEGOV_INDEXER_PROGRESS_REFRESH_LAG_BLOCKS",
             )?
@@ -337,6 +340,7 @@ impl IndexerRuntimeConfig {
             checkpoint_stream_id: self.checkpoint_stream_id.clone(),
             data_source_version: self.data_source_version.clone(),
             query_max_attempts: self.query_max_attempts,
+            datalens_query_concurrency: self.datalens_query_concurrency,
             progress_refresh_lag_blocks: self.progress_refresh_lag_blocks,
             adaptive_chunk_sizer: self.adaptive_chunk_sizer,
             max_chunks_per_run: self.max_chunks_per_run,
@@ -625,6 +629,30 @@ fn load_onchain_refresh_tick_config() -> Result<OnchainRefreshTickConfig> {
     }
     if config.min_blocks_between_ticks < 0 {
         bail!("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MIN_BLOCKS must be zero or greater");
+    }
+
+    Ok(config)
+}
+
+fn load_datalens_query_concurrency_config() -> Result<DatalensQueryConcurrencyConfig> {
+    let config = DatalensQueryConcurrencyConfig {
+        global_max_in_flight: optional_env_usize("DEGOV_INDEXER_DATALENS_QUERY_MAX_IN_FLIGHT")?,
+        per_chain_max_in_flight: optional_env_usize(
+            "DEGOV_INDEXER_DATALENS_QUERY_PER_CHAIN_MAX_IN_FLIGHT",
+        )?,
+    };
+
+    if config
+        .global_max_in_flight
+        .is_some_and(|max_in_flight| max_in_flight == 0)
+    {
+        bail!("DEGOV_INDEXER_DATALENS_QUERY_MAX_IN_FLIGHT must be greater than zero");
+    }
+    if config
+        .per_chain_max_in_flight
+        .is_some_and(|max_in_flight| max_in_flight == 0)
+    {
+        bail!("DEGOV_INDEXER_DATALENS_QUERY_PER_CHAIN_MAX_IN_FLIGHT must be greater than zero");
     }
 
     Ok(config)

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use degov_datalens_indexer::{
-    DatalensConfig, GraphqlRuntimeConfig, IndexerContractSetMode, IndexerRuntimeConfig,
-    IndexerTargetHeight, OnchainRefreshTickConfig, datalens_retry_config,
+    DatalensConfig, DatalensQueryConcurrencyConfig, GraphqlRuntimeConfig, IndexerContractSetMode,
+    IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshTickConfig, datalens_retry_config,
     onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value,
 };
 
@@ -125,6 +125,75 @@ fn test_indexer_runtime_config_keeps_numeric_target_height_for_debug_runs() {
             let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
 
             assert_eq!(config.target_height, IndexerTargetHeight::Fixed(123));
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_defaults_datalens_query_concurrency_to_unbounded() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_DATALENS_QUERY_MAX_IN_FLIGHT", None),
+            ("DEGOV_INDEXER_DATALENS_QUERY_PER_CHAIN_MAX_IN_FLIGHT", None),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(
+                config.datalens_query_concurrency,
+                DatalensQueryConcurrencyConfig::default()
+            );
+            assert!(!config.datalens_query_concurrency.is_limited());
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_accepts_datalens_query_concurrency_overrides() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_DATALENS_QUERY_MAX_IN_FLIGHT", Some("4")),
+            (
+                "DEGOV_INDEXER_DATALENS_QUERY_PER_CHAIN_MAX_IN_FLIGHT",
+                Some("2"),
+            ),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(
+                config.datalens_query_concurrency,
+                DatalensQueryConcurrencyConfig {
+                    global_max_in_flight: Some(4),
+                    per_chain_max_in_flight: Some(2),
+                }
+            );
+            assert!(config.datalens_query_concurrency.is_limited());
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_rejects_zero_datalens_query_concurrency() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_DATALENS_QUERY_MAX_IN_FLIGHT", Some("0")),
+            ("DEGOV_INDEXER_DATALENS_QUERY_PER_CHAIN_MAX_IN_FLIGHT", None),
+        ],
+        || {
+            let error = IndexerRuntimeConfig::from_env().expect_err("zero global limit is invalid");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("DEGOV_INDEXER_DATALENS_QUERY_MAX_IN_FLIGHT")
+            );
         },
     );
 }
@@ -261,6 +330,7 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
         checkpoint_stream_id: "datalens-native".to_owned(),
         data_source_version: "datalens-v1".to_owned(),
         query_max_attempts: 3,
+        datalens_query_concurrency: Default::default(),
         progress_refresh_lag_blocks: 100,
         adaptive_chunk_sizer: Default::default(),
         poll_interval: Duration::from_secs(10),
@@ -334,6 +404,7 @@ fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
         checkpoint_stream_id: "datalens-native".to_owned(),
         data_source_version: "datalens-v1".to_owned(),
         query_max_attempts: 3,
+        datalens_query_concurrency: Default::default(),
         progress_refresh_lag_blocks: 100,
         adaptive_chunk_sizer: Default::default(),
         poll_interval: Duration::from_secs(10),
@@ -367,6 +438,7 @@ fn test_indexer_runtime_latest_target_height_does_not_skip_all_mode_contract_set
         checkpoint_stream_id: "datalens-native".to_owned(),
         data_source_version: "datalens-v1".to_owned(),
         query_max_attempts: 3,
+        datalens_query_concurrency: Default::default(),
         progress_refresh_lag_blocks: 100,
         adaptive_chunk_sizer: Default::default(),
         poll_interval: Duration::from_secs(10),

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -9,10 +9,12 @@ use datalens_sdk::RetryConfig;
 use degov_datalens_indexer::{
     ChainFamily, ChainIdentityConfig, DaoContractAddresses, DatalensConfig,
     DatalensDurableHeadReader, DatalensError, DatalensFinality, DatalensLogQueryReader,
-    DatalensNativeClient, DatalensNativeReader, DatasetKeyConfig, GovernanceTokenStandard,
-    QueryLimitConfig, SecretString, ServiceReadiness, plan_dao_log_queries,
-    verify_datalens_service,
+    DatalensNativeClient, DatalensNativeReader, DatalensQueryConcurrencyConfig,
+    DatalensQueryConcurrencyGate, DatalensQueryConcurrencyKey, DatalensQueryErrorClass,
+    DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig, SecretString, ServiceReadiness,
+    classify_datalens_query_error, plan_dao_log_queries, verify_datalens_service,
 };
+use std::sync::mpsc;
 
 struct MockDatalensReader {
     readiness: Result<ServiceReadiness, DatalensError>,
@@ -51,6 +53,96 @@ fn test_verify_datalens_service_rejects_mocked_unready_client() {
     let error = verify_datalens_service(&reader).expect_err("unready");
 
     assert!(error.to_string().contains("readiness was not confirmed"));
+}
+
+#[test]
+fn test_datalens_query_gate_blocks_when_global_limit_is_full() {
+    let gate = DatalensQueryConcurrencyGate::new(DatalensQueryConcurrencyConfig {
+        global_max_in_flight: Some(1),
+        per_chain_max_in_flight: None,
+    })
+    .expect("gate");
+    let first_key = query_key("evm", "ethereum", Some(1));
+    let second_key = query_key("evm", "lisk", Some(1135));
+    let first = gate.acquire(&first_key).expect("first permit");
+    let (sender, receiver) = mpsc::channel();
+    let thread_gate = gate.clone();
+
+    let handle = thread::spawn(move || {
+        let permit = thread_gate.acquire(&second_key).expect("second permit");
+        sender
+            .send(permit.wait_duration > Duration::ZERO)
+            .expect("send wait result");
+    });
+
+    assert!(receiver.recv_timeout(Duration::from_millis(50)).is_err());
+    drop(first);
+    assert!(
+        receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("unblocked")
+    );
+    handle.join().expect("thread joins");
+}
+
+#[test]
+fn test_datalens_query_gate_limits_same_chain_but_allows_other_chain() {
+    let gate = DatalensQueryConcurrencyGate::new(DatalensQueryConcurrencyConfig {
+        global_max_in_flight: Some(2),
+        per_chain_max_in_flight: Some(1),
+    })
+    .expect("gate");
+    let ethereum = query_key("evm", "ethereum", Some(1));
+    let same_ethereum = query_key("evm", "ethereum", Some(1));
+    let lisk = query_key("evm", "lisk", Some(1135));
+    let first = gate.acquire(&ethereum).expect("first permit");
+    let (same_sender, same_receiver) = mpsc::channel();
+    let same_gate = gate.clone();
+    let same_handle = thread::spawn(move || {
+        let _permit = same_gate
+            .acquire(&same_ethereum)
+            .expect("same-chain permit");
+        same_sender.send(()).expect("send same-chain result");
+    });
+
+    assert!(
+        same_receiver
+            .recv_timeout(Duration::from_millis(50))
+            .is_err()
+    );
+    let other = gate.acquire(&lisk).expect("other-chain permit");
+    drop(other);
+    drop(first);
+    same_receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("same chain unblocked");
+    same_handle.join().expect("thread joins");
+}
+
+#[test]
+fn test_datalens_query_concurrency_key_uses_full_chain_identity() {
+    let ethereum = query_key("evm", "ethereum", Some(1));
+    let ethereum_alias = query_key("evm", "ethereum-mainnet", Some(1));
+    let textual = query_key("evm", "ethereum", None);
+
+    assert_ne!(ethereum, ethereum_alias);
+    assert_ne!(ethereum, textual);
+}
+
+#[test]
+fn test_classify_datalens_query_error_separates_provider_limit_from_timeout() {
+    assert_eq!(
+        classify_datalens_query_error("provider_limit: narrow your filter"),
+        DatalensQueryErrorClass::ProviderLimit
+    );
+    assert_eq!(
+        classify_datalens_query_error("provider_timeout: upstream RPC timed out"),
+        DatalensQueryErrorClass::Transient
+    );
+    assert_eq!(
+        classify_datalens_query_error("request_rate_limit"),
+        DatalensQueryErrorClass::Transient
+    );
 }
 
 #[test]
@@ -374,6 +466,18 @@ fn retry_config_with_attempts(max_attempts: u32) -> RetryConfig {
         max_elapsed: None,
         jitter: false,
         jitter_factor: 0.0,
+    }
+}
+
+fn query_key(
+    family: &'static str,
+    configured_name: &'static str,
+    network_id: Option<i32>,
+) -> DatalensQueryConcurrencyKey {
+    DatalensQueryConcurrencyKey {
+        family: family.to_owned(),
+        configured_name: configured_name.to_owned(),
+        network_id,
     }
 }
 


### PR DESCRIPTION
## Summary
- add optional global and per-chain Datalens query concurrency limits with unbounded defaults
- gate blocking native Datalens log queries by configured chain identity (family/configured_name/network_id)
- classify provider_limit separately from transient query errors and keep adaptive provider-limit shrinking on that classifier

## Validation
- cargo fmt --all -- --check
- cargo test -p degov-datalens-indexer --test datalens_client
- cargo test -p degov-datalens-indexer --test datalens_planner
- cargo test -p degov-datalens-indexer --test cli_runtime_config
- cargo test -p degov-datalens-indexer --test indexer_runner

## Notes
- Full `cargo test -p degov-datalens-indexer` reaches database-backed `checkpoint_repository` tests and is blocked without `DEGOV_INDEXER_TEST_DATABASE_URL`.
