### PR TITLE
Add provisional Datalens worker boundary

### DIFF
--- a/apps/indexer/src/config/mod.rs
+++ b/apps/indexer/src/config/mod.rs
@@ -78,6 +78,37 @@ impl FromStr for DatalensFinality {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
+pub enum DatalensProvisionalFinality {
+    SafeToLatest,
+    LatestOnly,
+}
+
+impl DatalensProvisionalFinality {
+    pub fn as_datalens_value(self) -> &'static str {
+        match self {
+            Self::SafeToLatest => "safe_to_latest",
+            Self::LatestOnly => "latest_only",
+        }
+    }
+}
+
+impl FromStr for DatalensProvisionalFinality {
+    type Err = ConfigError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "safe_to_latest" => Ok(Self::SafeToLatest),
+            "latest_only" => Ok(Self::LatestOnly),
+            value => Err(ConfigError::InvalidField {
+                field: "DEGOV_PROVISIONAL_FINALITY".to_owned(),
+                reason: format!("expected safe_to_latest or latest_only, got {value}"),
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ChainFamily {
     Evm,
 }

--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -7,10 +7,14 @@ use std::{
 use datalens_sdk::{
     ApiErrorKind, DatalensClient, Error as DatalensSdkError, RetryConfig,
     native::{ChainHeadFinalityInput, QueryInput},
+    safety::{CacheSegment, DataFinality, extract_cache_segments},
 };
 use log::{info, warn};
 
-use crate::{DatalensConfig, DatalensError, DatalensLogQueryReader};
+use crate::{
+    DatalensConfig, DatalensError, DatalensLogQueryReader, DatalensProvisionalCacheSegment,
+    DatalensProvisionalLogQueryReader, DatalensProvisionalLogQueryResult,
+};
 
 pub trait DatalensNativeReader {
     fn service_readiness(&self) -> Result<ServiceReadiness, DatalensError>;
@@ -340,6 +344,45 @@ impl DatalensNativeClient {
             }
         }
     }
+
+    fn query_provisional_with_transient_fallback(
+        &self,
+        input: QueryInput,
+    ) -> Result<DatalensProvisionalLogQueryResult, DatalensSdkError> {
+        let started_at = Instant::now();
+        let mut attempt = 1;
+        loop {
+            match self.client.native().query_provisional(input.clone()) {
+                Ok(response) => {
+                    let segments = extract_cache_segments(&response)
+                        .into_iter()
+                        .filter_map(provisional_cache_segment)
+                        .collect();
+                    return Ok(DatalensProvisionalLogQueryResult {
+                        rows: response.rows,
+                        segments,
+                    });
+                }
+                Err(error) => {
+                    let Some(delay) =
+                        fallback_retry_delay(&self.retry_config, &error, attempt, started_at)
+                    else {
+                        return Err(error);
+                    };
+                    warn!(
+                        "Datalens provisional query transient fallback retry scheduled attempt={} max_attempts={} delay_ms={} error_class={} error={}",
+                        attempt + 1,
+                        self.retry_config.max_attempts,
+                        delay.as_millis(),
+                        classify_datalens_query_error(&error.to_string()).as_str(),
+                        error
+                    );
+                    std::thread::sleep(delay);
+                    attempt += 1;
+                }
+            }
+        }
+    }
 }
 
 fn fallback_retry_delay(
@@ -436,6 +479,43 @@ impl DatalensLogQueryReader for DatalensNativeClient {
     }
 }
 
+impl DatalensProvisionalLogQueryReader for DatalensNativeClient {
+    fn query_provisional_logs(
+        &mut self,
+        input: QueryInput,
+    ) -> Result<DatalensProvisionalLogQueryResult, DatalensError> {
+        let _permit = self
+            .query_gate
+            .as_ref()
+            .map(|gate| {
+                let permit = gate.acquire(&self.query_key)?;
+                info!(
+                    "Datalens process-local provisional query concurrency permit acquired chain_family={} chain_name={} chain_network_id={} wait_ms={} process_in_flight={} chain_in_flight={}",
+                    self.query_key.family,
+                    self.query_key.configured_name,
+                    self.query_key.log_network_id(),
+                    permit.wait_duration.as_millis(),
+                    permit.global_in_flight,
+                    permit.chain_in_flight
+                );
+                Ok::<_, DatalensError>(permit)
+            })
+            .transpose()?;
+
+        self.query_provisional_with_transient_fallback(input)
+            .map_err(|error| {
+                let error_message = error.to_string();
+                warn!(
+                    "Datalens provisional query failed error_class={} max_attempts={} error={}",
+                    classify_datalens_query_error(&error_message).as_str(),
+                    self.retry_config.max_attempts,
+                    error_message
+                );
+                DatalensError::Query(error_message)
+            })
+    }
+}
+
 impl DatalensDurableHeadReader for DatalensNativeClient {
     fn durable_head_height(&mut self, config: &DatalensConfig) -> Result<i64, DatalensError> {
         let response = self
@@ -453,6 +533,38 @@ impl DatalensDurableHeadReader for DatalensNativeClient {
                 response.height
             ))
         })
+    }
+}
+
+fn provisional_cache_segment(segment: CacheSegment) -> Option<DatalensProvisionalCacheSegment> {
+    let range = segment.range?;
+    let anchor = segment.anchor;
+    Some(DatalensProvisionalCacheSegment {
+        source: segment.source.unwrap_or_else(|| "unknown".to_owned()),
+        finality: data_finality_value(segment.finality).to_owned(),
+        range_start_block: i64::try_from(range.start).ok()?,
+        range_end_block: i64::try_from(range.end).ok()?,
+        anchor_block_number: anchor
+            .as_ref()
+            .and_then(|anchor| i64::try_from(anchor.height).ok()),
+        anchor_block_hash: anchor.as_ref().and_then(|anchor| anchor.block_hash.clone()),
+        anchor_parent_hash: anchor
+            .as_ref()
+            .and_then(|anchor| anchor.parent_hash.clone()),
+        anchor_block_timestamp: anchor
+            .as_ref()
+            .and_then(|anchor| anchor.timestamp)
+            .and_then(|timestamp| i64::try_from(timestamp).ok()),
+    })
+}
+
+fn data_finality_value(finality: DataFinality) -> &'static str {
+    match finality {
+        DataFinality::Finalized => "finalized",
+        DataFinality::Safe => "safe",
+        DataFinality::Latest => "latest",
+        DataFinality::Provisional => "provisional",
+        DataFinality::Unknown => "unknown",
     }
 }
 

--- a/apps/indexer/src/datalens/mod.rs
+++ b/apps/indexer/src/datalens/mod.rs
@@ -16,7 +16,9 @@ pub use effectiveness::{
 };
 pub use planner::{
     DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan, DaoLogSource, DatalensLogPage,
-    DatalensLogQueryReader, fetch_dao_log_pages, plan_dao_log_queries,
+    DatalensLogQueryReader, DatalensProvisionalCacheSegment, DatalensProvisionalLogPage,
+    DatalensProvisionalLogQueryReader, DatalensProvisionalLogQueryResult, fetch_dao_log_pages,
+    fetch_provisional_dao_log_pages, plan_dao_log_queries,
 };
 pub use warmup::{
     DatalensWarmupConfig, DatalensWarmupEnsureOutcome, DatalensWarmupEnsurer, DatalensWarmupKind,

--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -8,7 +8,7 @@ use datalens_sdk::native::{
 
 use crate::{
     DatalensConfig, DatalensError, DatalensLogQueryCacheSummary, DatalensLogQueryResult,
-    GovernanceTokenStandard,
+    DatalensProvisionalFinality, GovernanceTokenStandard,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -50,6 +50,48 @@ pub struct DatalensLogPage {
 
 pub trait DatalensLogQueryReader {
     fn query_logs(&mut self, input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError>;
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DatalensProvisionalLogPage {
+    pub plan: DaoLogQueryPlan,
+    pub rows: serde_json::Value,
+    pub segments: Vec<DatalensProvisionalCacheSegment>,
+    pub query_duration: Duration,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensProvisionalCacheSegment {
+    pub source: String,
+    pub finality: String,
+    pub range_start_block: i64,
+    pub range_end_block: i64,
+    pub anchor_block_number: Option<i64>,
+    pub anchor_block_hash: Option<String>,
+    pub anchor_parent_hash: Option<String>,
+    pub anchor_block_timestamp: Option<i64>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DatalensProvisionalLogQueryResult {
+    pub rows: serde_json::Value,
+    pub segments: Vec<DatalensProvisionalCacheSegment>,
+}
+
+impl DatalensProvisionalLogQueryResult {
+    pub fn rows_only(rows: serde_json::Value) -> Self {
+        Self {
+            rows,
+            segments: Vec::new(),
+        }
+    }
+}
+
+pub trait DatalensProvisionalLogQueryReader {
+    fn query_provisional_logs(
+        &mut self,
+        input: QueryInput,
+    ) -> Result<DatalensProvisionalLogQueryResult, DatalensError>;
 }
 
 pub fn plan_dao_log_queries(
@@ -108,6 +150,28 @@ pub fn fetch_dao_log_pages(
             plan: plan.clone(),
             rows: result.rows,
             cache: result.cache,
+            query_duration: query_started_at.elapsed(),
+        });
+    }
+
+    Ok(pages)
+}
+
+pub fn fetch_provisional_dao_log_pages(
+    reader: &mut impl DatalensProvisionalLogQueryReader,
+    plans: &[DaoLogQueryPlan],
+    finality: DatalensProvisionalFinality,
+) -> Result<Vec<DatalensProvisionalLogPage>, DatalensError> {
+    let mut pages = Vec::new();
+    for plan in plans {
+        let mut input = plan.input.clone();
+        input.finality = Some(finality.as_datalens_value().to_owned());
+        let query_started_at = Instant::now();
+        let result = reader.query_provisional_logs(input)?;
+        pages.push(DatalensProvisionalLogPage {
+            plan: plan.clone(),
+            rows: result.rows,
+            segments: result.segments,
             query_duration: query_started_at.elapsed(),
         });
     }

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod graphql;
 pub mod onchain;
 pub mod projection;
+pub mod provisional;
 pub mod runner;
 pub mod runtime;
 pub mod runtime_config;
@@ -21,7 +22,9 @@ pub use crate::chain::tool::{
 };
 pub use crate::datalens::planner::{
     DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan, DaoLogSource, DatalensLogPage,
-    DatalensLogQueryReader, fetch_dao_log_pages, plan_dao_log_queries,
+    DatalensLogQueryReader, DatalensProvisionalCacheSegment, DatalensProvisionalLogPage,
+    DatalensProvisionalLogQueryReader, DatalensProvisionalLogQueryResult, fetch_dao_log_pages,
+    fetch_provisional_dao_log_pages, plan_dao_log_queries,
 };
 pub use crate::datalens::warmup::{
     DatalensWarmupConfig, DatalensWarmupEnsureOutcome, DatalensWarmupEnsurer, DatalensWarmupKind,
@@ -91,6 +94,7 @@ pub use crate::projection::vote::{
 };
 pub use crate::store::postgres::{
     PostgresIndexerRunnerStore, PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
+    PostgresProvisionalSegmentStore,
 };
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
@@ -98,8 +102,8 @@ pub use checkpoint::{
 };
 pub use config::{
     ChainFamily, ChainIdentityConfig, DatalensChainConfig, DatalensConfig,
-    DatalensContractSetConfig, DatalensFinality, DatalensRuntimeContractSet, DatasetKeyConfig,
-    QueryLimitConfig, SecretString,
+    DatalensContractSetConfig, DatalensFinality, DatalensProvisionalFinality,
+    DatalensRuntimeContractSet, DatasetKeyConfig, QueryLimitConfig, SecretString,
 };
 pub use datalens::{
     DatalensDurableHeadReader, DatalensNativeClient, DatalensNativeReader, ServiceReadiness,
@@ -107,6 +111,10 @@ pub use datalens::{
 };
 pub use error::{CheckpointError, ConfigError, DatalensError, IndexerError};
 pub use graphql::IndexerGraphqlSchema;
+pub use provisional::{
+    DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite, ProvisionalWorker,
+    ProvisionalWorkerError, ProvisionalWorkerOptions, ProvisionalWorkerReport,
+};
 pub use runner::{
     AdaptiveChunkFeedback, AdaptiveChunkSizer, AdaptiveChunkSizerConfig,
     AdaptiveChunkSizingDecision, AdaptiveChunkSizingReason, DaoEventDecoder,
@@ -119,6 +127,6 @@ pub use runtime_config::{
     AdaptiveChunkSizerRuntimeConfig, ContractSetConcurrencyLimit, GraphqlRuntimeConfig,
     IndexerContractSetMode, IndexerContractSetRuntimeConfig, IndexerRuntimeConfig,
     IndexerTargetHeight, OnchainRefreshRpcChainConfig, OnchainRefreshRuntimeConfig,
-    datalens_retry_config, onchain_refresh_worker_enabled, parse_bool_env_value,
-    parse_i64_env_value, required_env,
+    ProvisionalRuntimeConfig, datalens_retry_config, onchain_refresh_worker_enabled,
+    parse_bool_env_value, parse_i64_env_value, required_env,
 };

--- a/apps/indexer/src/provisional.rs
+++ b/apps/indexer/src/provisional.rs
@@ -1,0 +1,153 @@
+use std::fmt;
+
+use crate::{
+    DaoContractAddresses, DatalensConfig, DatalensError, DatalensProvisionalCacheSegment,
+    DatalensProvisionalFinality, DatalensProvisionalLogQueryReader, datalens_selector_fingerprint,
+    fetch_provisional_dao_log_pages, plan_dao_log_queries,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalWorkerOptions {
+    pub datalens_config: DatalensConfig,
+    pub addresses: DaoContractAddresses,
+    pub dao_code: String,
+    pub contract_set_id: String,
+    pub chain_id: i32,
+    pub chain_name: String,
+    pub finality: DatalensProvisionalFinality,
+    pub from_block: i64,
+    pub to_block: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensProvisionalSegmentWrite {
+    pub id: String,
+    pub dao_code: Option<String>,
+    pub contract_set_id: String,
+    pub chain_id: Option<i32>,
+    pub chain_name: Option<String>,
+    pub dataset_key: String,
+    pub selector: String,
+    pub selector_fingerprint: Option<String>,
+    pub range_start_block: i64,
+    pub range_end_block: i64,
+    pub segment_finality: String,
+    pub source: String,
+    pub anchor_block_number: Option<i64>,
+    pub anchor_block_hash: Option<String>,
+    pub anchor_parent_hash: Option<String>,
+    pub anchor_block_timestamp: Option<i64>,
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalWorkerReport {
+    pub segments_written: usize,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProvisionalWorkerError {
+    #[error("provisional Datalens query error: {0}")]
+    Datalens(#[from] DatalensError),
+
+    #[error("provisional segment store error: {0}")]
+    Store(String),
+}
+
+pub trait DatalensProvisionalSegmentStore {
+    type Error: fmt::Display;
+
+    fn write_provisional_segments(
+        &mut self,
+        segments: &[DatalensProvisionalSegmentWrite],
+    ) -> Result<(), Self::Error>;
+}
+
+pub struct ProvisionalWorker<'a, R, S> {
+    options: ProvisionalWorkerOptions,
+    reader: &'a mut R,
+    store: &'a mut S,
+}
+
+impl<'a, R, S> ProvisionalWorker<'a, R, S>
+where
+    R: DatalensProvisionalLogQueryReader,
+    S: DatalensProvisionalSegmentStore,
+{
+    pub fn new(options: ProvisionalWorkerOptions, reader: &'a mut R, store: &'a mut S) -> Self {
+        Self {
+            options,
+            reader,
+            store,
+        }
+    }
+
+    pub fn run_once(&mut self) -> Result<ProvisionalWorkerReport, ProvisionalWorkerError> {
+        let plans = plan_dao_log_queries(
+            &self.options.datalens_config,
+            &self.options.addresses,
+            self.options.from_block,
+            self.options.to_block,
+        )?;
+        let pages = fetch_provisional_dao_log_pages(self.reader, &plans, self.options.finality)?;
+        let mut writes = Vec::new();
+
+        for page in pages {
+            let selector = serde_json::to_string(&page.plan.input.selector)
+                .unwrap_or_else(|_| "unavailable".to_owned());
+            let selector_fingerprint = datalens_selector_fingerprint(&page.plan.input.selector);
+            for segment in page.segments {
+                writes.push(self.segment_write(segment, &selector, &selector_fingerprint));
+            }
+        }
+
+        self.store
+            .write_provisional_segments(&writes)
+            .map_err(|error| ProvisionalWorkerError::Store(error.to_string()))?;
+
+        Ok(ProvisionalWorkerReport {
+            segments_written: writes.len(),
+        })
+    }
+
+    fn segment_write(
+        &self,
+        segment: DatalensProvisionalCacheSegment,
+        selector: &str,
+        selector_fingerprint: &str,
+    ) -> DatalensProvisionalSegmentWrite {
+        let dataset_key = self.options.datalens_config.dataset.key();
+        let id = format!(
+            "{}:{}:{}:{}:{}:{}:{}:{}:{}",
+            self.options.dao_code,
+            self.options.chain_name,
+            self.options.contract_set_id,
+            dataset_key,
+            selector_fingerprint,
+            segment.range_start_block,
+            segment.range_end_block,
+            segment.finality,
+            segment.source
+        );
+
+        DatalensProvisionalSegmentWrite {
+            id,
+            dao_code: Some(self.options.dao_code.clone()),
+            contract_set_id: self.options.contract_set_id.clone(),
+            chain_id: Some(self.options.chain_id),
+            chain_name: Some(self.options.chain_name.clone()),
+            dataset_key,
+            selector: selector.to_owned(),
+            selector_fingerprint: Some(selector_fingerprint.to_owned()),
+            range_start_block: segment.range_start_block,
+            range_end_block: segment.range_end_block,
+            segment_finality: segment.finality,
+            source: segment.source,
+            anchor_block_number: segment.anchor_block_number,
+            anchor_block_hash: segment.anchor_block_hash,
+            anchor_parent_hash: segment.anchor_parent_hash,
+            anchor_block_timestamp: segment.anchor_block_timestamp,
+            error: None,
+        }
+    }
+}

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -583,8 +583,8 @@ mod tests {
     };
 
     use crate::{
-        ChainFamily, ChainIdentityConfig, DatalensFinality, DatasetKeyConfig, QueryLimitConfig,
-        SecretString,
+        ChainFamily, ChainIdentityConfig, DatalensFinality, DatalensProvisionalFinality,
+        DatasetKeyConfig, ProvisionalRuntimeConfig, QueryLimitConfig, SecretString,
     };
 
     use super::*;
@@ -608,6 +608,10 @@ mod tests {
             progress_refresh_lag_blocks: 100,
             adaptive_chunk_sizer: Default::default(),
             onchain_refresh_tick: Default::default(),
+            provisional: ProvisionalRuntimeConfig {
+                enabled: false,
+                finality: DatalensProvisionalFinality::SafeToLatest,
+            },
         };
         let config = DatalensConfig {
             endpoint: "http://127.0.0.1:1".to_owned(),

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -7,10 +7,10 @@ use serde::Deserialize;
 
 use crate::{
     AdaptiveChunkSizerConfig, BatchReadPlanConfig, ChainContracts, ChainReadMethod, DatalensConfig,
-    DatalensQueryConcurrencyConfig, DatalensRuntimeContractSet, IndexerCheckpointIdentity,
-    IndexerRunnerContexts, IndexerRunnerOptions, OnchainRefreshTickConfig,
-    OnchainRefreshWorkerConfig, ProposalProjectionContext, SecretString, TimelockProjectionContext,
-    TokenProjectionContext, VoteProjectionContext,
+    DatalensProvisionalFinality, DatalensQueryConcurrencyConfig, DatalensRuntimeContractSet,
+    IndexerCheckpointIdentity, IndexerRunnerContexts, IndexerRunnerOptions,
+    OnchainRefreshTickConfig, OnchainRefreshWorkerConfig, ProposalProjectionContext, SecretString,
+    TimelockProjectionContext, TokenProjectionContext, VoteProjectionContext,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -18,6 +18,25 @@ pub struct GraphqlRuntimeConfig {
     pub bind_address: SocketAddr,
     pub public_endpoint: Option<String>,
     pub paths: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalRuntimeConfig {
+    pub enabled: bool,
+    pub finality: DatalensProvisionalFinality,
+}
+
+impl ProvisionalRuntimeConfig {
+    pub fn from_env() -> Result<Self> {
+        let enabled = optional_env_bool("DEGOV_PROVISIONAL_WORKER_ENABLED")?.unwrap_or(false);
+        let finality = optional_env("DEGOV_PROVISIONAL_FINALITY")?
+            .as_deref()
+            .map(str::parse)
+            .transpose()?
+            .unwrap_or(DatalensProvisionalFinality::SafeToLatest);
+
+        Ok(Self { enabled, finality })
+    }
 }
 
 impl GraphqlRuntimeConfig {

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -150,6 +150,7 @@ pub struct IndexerRuntimeConfig {
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
+    pub provisional: ProvisionalRuntimeConfig,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -338,6 +339,7 @@ impl IndexerRuntimeConfig {
             .unwrap_or(100),
             adaptive_chunk_sizer: load_adaptive_chunk_sizer_runtime_config()?,
             onchain_refresh_tick: load_onchain_refresh_tick_config()?,
+            provisional: ProvisionalRuntimeConfig::from_env()?,
             poll_interval,
             run_once,
             max_chunks_per_run: optional_env_u64("DEGOV_INDEXER_MAX_CHUNKS_PER_RUN")?,

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -7,7 +7,8 @@ use std::{
 use sqlx::{PgPool, Postgres, Row, Transaction};
 
 use crate::{
-    CheckpointRepository, ContributorVoteSignalWrite, DataMetricWrite, DecodedTimelockEvent,
+    CheckpointRepository, ContributorVoteSignalWrite, DataMetricWrite,
+    DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite, DecodedTimelockEvent,
     DelegateChangedWrite, DelegateRollingWrite, DelegateVotesChangedWrite, GovernanceTokenStandard,
     IndexerCheckpoint, IndexerCheckpointIdentity, IndexerProjectionBatch, IndexerRunnerStore,
     IndexerRunnerTransaction, PowerReconcileCandidate, ProposalActionWrite, ProposalCreatedWrite,
@@ -210,3 +211,4 @@ include!("data_metric.rs");
 include!("token.rs");
 include!("onchain_refresh.rs");
 include!("timelock.rs");
+include!("provisional.rs");

--- a/apps/indexer/src/store/postgres/provisional.rs
+++ b/apps/indexer/src/store/postgres/provisional.rs
@@ -39,8 +39,36 @@ async fn upsert_provisional_segment(
     transaction: &mut Transaction<'_, Postgres>,
     segment: &DatalensProvisionalSegmentWrite,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
-    sqlx::query(
-        "INSERT INTO degov_provisional_segment (
+    sqlx::query(UPSERT_PROVISIONAL_SEGMENT_SQL)
+        .bind(&segment.id)
+        .bind(&segment.dao_code)
+        .bind(&segment.contract_set_id)
+        .bind(segment.chain_id)
+        .bind(&segment.chain_name)
+        .bind(&segment.dataset_key)
+        .bind(&segment.selector)
+        .bind(&segment.selector_fingerprint)
+        .bind(segment.range_start_block)
+        .bind(segment.range_end_block)
+        .bind(&segment.segment_finality)
+        .bind(&segment.source)
+        .bind(if segment.error.is_some() {
+            "error"
+        } else {
+            "available"
+        })
+        .bind(segment.anchor_block_number)
+        .bind(&segment.anchor_block_hash)
+        .bind(&segment.anchor_parent_hash)
+        .bind(segment.anchor_block_timestamp)
+        .bind(&segment.error)
+        .execute(&mut **transaction)
+        .await?;
+
+    Ok(())
+}
+
+const UPSERT_PROVISIONAL_SEGMENT_SQL: &str = "INSERT INTO degov_provisional_segment (
              id, dao_code, contract_set_id, chain_id, chain_name, dataset_key, selector,
              selector_fingerprint, range_start_block, range_end_block, segment_finality,
              source, status, anchor_block_number, anchor_block_hash, anchor_parent_hash,
@@ -52,10 +80,7 @@ async fn upsert_provisional_segment(
              $12, $13, $14::NUMERIC(78, 0), $15, $16,
              $17::NUMERIC(78, 0), $18
          )
-         ON CONFLICT (
-             chain_id, chain_name, contract_set_id, dao_code, dataset_key, selector,
-             range_start_block, range_end_block, segment_finality, source
-         )
+         ON CONFLICT ON CONSTRAINT degov_provisional_segment_scope_unique
          DO UPDATE SET
              id = EXCLUDED.id,
              selector_fingerprint = EXCLUDED.selector_fingerprint,
@@ -65,32 +90,17 @@ async fn upsert_provisional_segment(
              anchor_parent_hash = EXCLUDED.anchor_parent_hash,
              anchor_block_timestamp = EXCLUDED.anchor_block_timestamp,
              error = EXCLUDED.error,
-             updated_at = now()",
-    )
-    .bind(&segment.id)
-    .bind(&segment.dao_code)
-    .bind(&segment.contract_set_id)
-    .bind(segment.chain_id)
-    .bind(&segment.chain_name)
-    .bind(&segment.dataset_key)
-    .bind(&segment.selector)
-    .bind(&segment.selector_fingerprint)
-    .bind(segment.range_start_block)
-    .bind(segment.range_end_block)
-    .bind(&segment.segment_finality)
-    .bind(&segment.source)
-    .bind(if segment.error.is_some() {
-        "error"
-    } else {
-        "available"
-    })
-    .bind(segment.anchor_block_number)
-    .bind(&segment.anchor_block_hash)
-    .bind(&segment.anchor_parent_hash)
-    .bind(segment.anchor_block_timestamp)
-    .bind(&segment.error)
-    .execute(&mut **transaction)
-    .await?;
+             updated_at = now()";
 
-    Ok(())
+#[cfg(test)]
+mod provisional_segment_sql_tests {
+    use super::*;
+
+    #[test]
+    fn test_provisional_segment_upsert_targets_scope_constraint() {
+        assert!(
+            UPSERT_PROVISIONAL_SEGMENT_SQL
+                .contains("ON CONFLICT ON CONSTRAINT degov_provisional_segment_scope_unique")
+        );
+    }
 }

--- a/apps/indexer/src/store/postgres/provisional.rs
+++ b/apps/indexer/src/store/postgres/provisional.rs
@@ -1,0 +1,96 @@
+#[derive(Clone)]
+pub struct PostgresProvisionalSegmentStore {
+    pool: PgPool,
+}
+
+impl PostgresProvisionalSegmentStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn write_provisional_segments(
+        &self,
+        segments: &[DatalensProvisionalSegmentWrite],
+    ) -> Result<(), PostgresIndexerRunnerStoreError> {
+        let mut transaction = self.pool.begin().await?;
+        for segment in segments {
+            upsert_provisional_segment(&mut transaction, segment).await?;
+        }
+        transaction.commit().await?;
+
+        Ok(())
+    }
+}
+
+impl DatalensProvisionalSegmentStore for PostgresProvisionalSegmentStore {
+    type Error = PostgresIndexerRunnerStoreError;
+
+    fn write_provisional_segments(
+        &mut self,
+        segments: &[DatalensProvisionalSegmentWrite],
+    ) -> Result<(), Self::Error> {
+        block_on_runtime(PostgresProvisionalSegmentStore::write_provisional_segments(
+            self, segments,
+        ))
+    }
+}
+
+async fn upsert_provisional_segment(
+    transaction: &mut Transaction<'_, Postgres>,
+    segment: &DatalensProvisionalSegmentWrite,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    sqlx::query(
+        "INSERT INTO degov_provisional_segment (
+             id, dao_code, contract_set_id, chain_id, chain_name, dataset_key, selector,
+             selector_fingerprint, range_start_block, range_end_block, segment_finality,
+             source, status, anchor_block_number, anchor_block_hash, anchor_parent_hash,
+             anchor_block_timestamp, error
+         )
+         VALUES (
+             $1, $2, $3, $4, $5, $6, $7,
+             $8, $9::NUMERIC(78, 0), $10::NUMERIC(78, 0), $11,
+             $12, $13, $14::NUMERIC(78, 0), $15, $16,
+             $17::NUMERIC(78, 0), $18
+         )
+         ON CONFLICT (
+             chain_id, chain_name, contract_set_id, dao_code, dataset_key, selector,
+             range_start_block, range_end_block, segment_finality, source
+         )
+         DO UPDATE SET
+             id = EXCLUDED.id,
+             selector_fingerprint = EXCLUDED.selector_fingerprint,
+             status = EXCLUDED.status,
+             anchor_block_number = EXCLUDED.anchor_block_number,
+             anchor_block_hash = EXCLUDED.anchor_block_hash,
+             anchor_parent_hash = EXCLUDED.anchor_parent_hash,
+             anchor_block_timestamp = EXCLUDED.anchor_block_timestamp,
+             error = EXCLUDED.error,
+             updated_at = now()",
+    )
+    .bind(&segment.id)
+    .bind(&segment.dao_code)
+    .bind(&segment.contract_set_id)
+    .bind(segment.chain_id)
+    .bind(&segment.chain_name)
+    .bind(&segment.dataset_key)
+    .bind(&segment.selector)
+    .bind(&segment.selector_fingerprint)
+    .bind(segment.range_start_block)
+    .bind(segment.range_end_block)
+    .bind(&segment.segment_finality)
+    .bind(&segment.source)
+    .bind(if segment.error.is_some() {
+        "error"
+    } else {
+        "available"
+    })
+    .bind(segment.anchor_block_number)
+    .bind(&segment.anchor_block_hash)
+    .bind(&segment.anchor_parent_hash)
+    .bind(segment.anchor_block_timestamp)
+    .bind(&segment.error)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(())
+}

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -89,12 +89,19 @@ fn test_indexer_runtime_config_defaults_to_latest_target_height() {
         [
             ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
             ("DEGOV_INDEXER_START_BLOCK", Some("10")),
-            ("DEGOV_INDEXER_TARGET_HEIGHT", None),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", None::<&str>),
+            ("DEGOV_PROVISIONAL_WORKER_ENABLED", None::<&str>),
+            ("DEGOV_PROVISIONAL_FINALITY", None::<&str>),
         ],
         || {
             let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
 
             assert_eq!(config.target_height, IndexerTargetHeight::Latest);
+            assert!(!config.provisional.enabled);
+            assert_eq!(
+                config.provisional.finality,
+                DatalensProvisionalFinality::SafeToLatest
+            );
         },
     );
 }
@@ -127,6 +134,28 @@ fn test_provisional_runtime_config_rejects_final_finality() {
                 .expect_err("durable finality is invalid for provisional worker");
 
             assert!(error.to_string().contains("DEGOV_PROVISIONAL_FINALITY"));
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_accepts_provisional_worker_enablement() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_START_BLOCK", Some("10")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("latest")),
+            ("DEGOV_PROVISIONAL_WORKER_ENABLED", Some("true")),
+            ("DEGOV_PROVISIONAL_FINALITY", Some("latest_only")),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert!(config.provisional.enabled);
+            assert_eq!(
+                config.provisional.finality,
+                DatalensProvisionalFinality::LatestOnly
+            );
         },
     );
 }
@@ -480,6 +509,10 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        provisional: ProvisionalRuntimeConfig {
+            enabled: false,
+            finality: DatalensProvisionalFinality::SafeToLatest,
+        },
     };
     let selected = config
         .configured_contract_sets(Some("lisk-dao"))
@@ -556,6 +589,10 @@ fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        provisional: ProvisionalRuntimeConfig {
+            enabled: false,
+            finality: DatalensProvisionalFinality::SafeToLatest,
+        },
     };
     let selected = config
         .configured_contract_sets(Some("lisk-dao"))
@@ -592,6 +629,10 @@ fn test_indexer_runtime_latest_target_height_does_not_skip_all_mode_contract_set
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        provisional: ProvisionalRuntimeConfig {
+            enabled: false,
+            finality: DatalensProvisionalFinality::SafeToLatest,
+        },
     };
 
     assert!(!runtime.should_skip_contract_set_start_after_target(568752));

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -1,10 +1,11 @@
 use std::time::Duration;
 
 use degov_datalens_indexer::{
-    ContractSetConcurrencyLimit, DatalensConfig, DatalensQueryConcurrencyConfig,
-    GraphqlRuntimeConfig, IndexerContractSetMode, IndexerRuntimeConfig, IndexerTargetHeight,
-    OnchainRefreshTickConfig, datalens_retry_config, onchain_refresh_worker_enabled,
-    parse_bool_env_value, parse_i64_env_value,
+    ContractSetConcurrencyLimit, DatalensConfig, DatalensProvisionalFinality,
+    DatalensQueryConcurrencyConfig, GraphqlRuntimeConfig, IndexerContractSetMode,
+    IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshTickConfig, ProvisionalRuntimeConfig,
+    datalens_retry_config, onchain_refresh_worker_enabled, parse_bool_env_value,
+    parse_i64_env_value,
 };
 
 #[test]
@@ -94,6 +95,38 @@ fn test_indexer_runtime_config_defaults_to_latest_target_height() {
             let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
 
             assert_eq!(config.target_height, IndexerTargetHeight::Latest);
+        },
+    );
+}
+
+#[test]
+fn test_provisional_runtime_config_defaults_to_disabled_safe_to_latest() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_PROVISIONAL_WORKER_ENABLED", None::<&str>),
+            ("DEGOV_PROVISIONAL_FINALITY", None::<&str>),
+        ],
+        || {
+            let config = ProvisionalRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert!(!config.enabled);
+            assert_eq!(config.finality, DatalensProvisionalFinality::SafeToLatest);
+        },
+    );
+}
+
+#[test]
+fn test_provisional_runtime_config_rejects_final_finality() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_PROVISIONAL_WORKER_ENABLED", Some("true")),
+            ("DEGOV_PROVISIONAL_FINALITY", Some("durable_only")),
+        ],
+        || {
+            let error = ProvisionalRuntimeConfig::from_env()
+                .expect_err("durable finality is invalid for provisional worker");
+
+            assert!(error.to_string().contains("DEGOV_PROVISIONAL_FINALITY"));
         },
     );
 }

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -9,10 +9,11 @@ use datalens_sdk::RetryConfig;
 use degov_datalens_indexer::{
     ChainFamily, ChainIdentityConfig, DaoContractAddresses, DatalensConfig,
     DatalensDurableHeadReader, DatalensError, DatalensFinality, DatalensLogQueryReader,
-    DatalensNativeClient, DatalensNativeReader, DatalensQueryConcurrencyConfig,
-    DatalensQueryConcurrencyGate, DatalensQueryConcurrencyKey, DatalensQueryErrorClass,
-    DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig, SecretString, ServiceReadiness,
-    classify_datalens_query_error, plan_dao_log_queries, verify_datalens_service,
+    DatalensNativeClient, DatalensNativeReader, DatalensProvisionalLogQueryReader,
+    DatalensQueryConcurrencyConfig, DatalensQueryConcurrencyGate, DatalensQueryConcurrencyKey,
+    DatalensQueryErrorClass, DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig,
+    SecretString, ServiceReadiness, classify_datalens_query_error, plan_dao_log_queries,
+    verify_datalens_service,
 };
 use std::sync::mpsc;
 
@@ -276,6 +277,37 @@ fn test_datalens_log_query_does_not_retry_non_retryable_quota_error() {
     assert_eq!(requests.len(), 1);
 }
 
+#[test]
+fn test_datalens_provisional_log_query_uses_query_provisional_with_safe_to_latest_finality() {
+    let server = FakeQueryServer::start(vec![query_success_response_with_segment(
+        serde_json::json!([]),
+        "hot",
+        "latest",
+    )]);
+    let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("client");
+    let mut input = plan_dao_log_queries(&config, &addresses(), 100, 105)
+        .expect("query plan builds")
+        .remove(0)
+        .input;
+    input.finality = Some("safe_to_latest".to_owned());
+
+    let result = client
+        .query_provisional_logs(input)
+        .expect("provisional query succeeds");
+
+    assert_eq!(result.segments.len(), 1);
+    assert_eq!(result.segments[0].source, "hot");
+    assert_eq!(result.segments[0].finality, "latest");
+    assert_eq!(result.segments[0].range_start_block, 100);
+    assert_eq!(result.segments[0].range_end_block, 105);
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].contains(r#""finality":"safe_to_latest""#));
+}
+
 struct FakeHeadServer {
     endpoint: String,
     handle: thread::JoinHandle<String>,
@@ -380,6 +412,44 @@ fn query_success_response(rows: serde_json::Value) -> String {
             "end": 100
         },
         "cache": {},
+        "rows": rows
+    });
+    http_response(200, body)
+}
+
+fn query_success_response_with_segment(
+    rows: serde_json::Value,
+    source: &str,
+    finality: &str,
+) -> String {
+    let body = serde_json::json!({
+        "chain": {
+            "configured_name": "ethereum"
+        },
+        "dataset_key": "evm.logs",
+        "range": {
+            "kind": "block",
+            "start": 100,
+            "end": 105
+        },
+        "cache": {
+            "segments": [{
+                "range": {
+                    "kind": "block",
+                    "start": 100,
+                    "end": 105
+                },
+                "source": source,
+                "finality": finality,
+                "anchor": {
+                    "range_kind": "block",
+                    "height": 105,
+                    "block_hash": "0xabc",
+                    "parent_hash": "0xdef",
+                    "timestamp": 1700000000
+                }
+            }]
+        },
         "rows": rows
     });
     http_response(200, body)

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -4,8 +4,9 @@ use datalens_sdk::native::{QueryInput, QueryRangeKindInput, SelectorKindInput};
 use degov_datalens_indexer::{
     ChainFamily, ChainIdentityConfig, DaoContractAddresses, DaoLogAddressSource, DaoLogQueryPlan,
     DaoLogSource, DatalensConfig, DatalensError, DatalensFinality, DatalensLogQueryReader,
-    DatalensLogQueryResult, DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig,
-    SecretString, fetch_dao_log_pages, plan_dao_log_queries,
+    DatalensLogQueryResult, DatalensProvisionalFinality, DatalensProvisionalLogQueryReader,
+    DatalensProvisionalLogQueryResult, DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig,
+    SecretString, fetch_dao_log_pages, fetch_provisional_dao_log_pages, plan_dao_log_queries,
 };
 
 #[test]
@@ -93,6 +94,36 @@ fn test_plan_dao_log_queries_uses_durable_only_finality_for_final_indexing() {
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
 
     assert_eq!(plans[0].input.finality.as_deref(), Some("durable_only"));
+}
+
+#[test]
+fn test_fetch_provisional_dao_log_pages_uses_explicit_safe_to_latest_finality() {
+    let config = config(1_000, DatalensFinality::DurableOnly);
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
+    let mut reader = MockProvisionalLogReader::new(vec![Ok(serde_json::json!([]))]);
+
+    let pages = fetch_provisional_dao_log_pages(
+        &mut reader,
+        &plans[..1],
+        DatalensProvisionalFinality::SafeToLatest,
+    )
+    .expect("pages");
+
+    assert_eq!(pages.len(), 1);
+    assert_eq!(reader.calls.len(), 1);
+    assert_eq!(reader.calls[0].finality.as_deref(), Some("safe_to_latest"));
+}
+
+#[test]
+fn test_fetch_dao_log_pages_keeps_final_path_on_safe_query_api() {
+    let config = config(1_000, DatalensFinality::DurableOnly);
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
+    let mut reader = MockLogReader::new(vec![Ok(serde_json::json!([]))]);
+
+    fetch_dao_log_pages(&mut reader, &plans[..1]).expect("pages");
+
+    assert_eq!(reader.calls.len(), 1);
+    assert_eq!(reader.calls[0].finality.as_deref(), Some("durable_only"));
 }
 
 #[test]
@@ -230,5 +261,31 @@ impl DatalensLogQueryReader for MockLogReader {
         self.results
             .remove(0)
             .map(DatalensLogQueryResult::rows_only)
+    }
+}
+
+struct MockProvisionalLogReader {
+    calls: Vec<QueryInput>,
+    results: Vec<Result<serde_json::Value, DatalensError>>,
+}
+
+impl MockProvisionalLogReader {
+    fn new(results: Vec<Result<serde_json::Value, DatalensError>>) -> Self {
+        Self {
+            calls: Vec::new(),
+            results,
+        }
+    }
+}
+
+impl DatalensProvisionalLogQueryReader for MockProvisionalLogReader {
+    fn query_provisional_logs(
+        &mut self,
+        input: QueryInput,
+    ) -> Result<DatalensProvisionalLogQueryResult, DatalensError> {
+        self.calls.push(input);
+        self.results
+            .remove(0)
+            .map(DatalensProvisionalLogQueryResult::rows_only)
     }
 }

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -1,0 +1,311 @@
+use std::{
+    env,
+    error::Error,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use datalens_sdk::native::QueryInput;
+use degov_datalens_indexer::{
+    ChainFamily, ChainIdentityConfig, DaoContractAddresses, DatalensConfig, DatalensError,
+    DatalensFinality, DatalensProvisionalCacheSegment, DatalensProvisionalFinality,
+    DatalensProvisionalLogQueryReader, DatalensProvisionalLogQueryResult,
+    DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite, DatasetKeyConfig,
+    GovernanceTokenStandard, PostgresProvisionalSegmentStore, ProvisionalWorker,
+    ProvisionalWorkerOptions, QueryLimitConfig, SecretString, runtime::apply_migrations,
+};
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use tokio::sync::{Mutex, MutexGuard};
+
+static SCHEMA_COUNTER: AtomicU64 = AtomicU64::new(0);
+static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+#[test]
+fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
+    let config = datalens_config();
+    let mut reader = MockProvisionalReader::new(vec![Ok(DatalensProvisionalLogQueryResult {
+        rows: serde_json::json!([]),
+        segments: vec![cache_segment("provider", "latest", 100, 105)],
+    })]);
+    let mut store = RecordingProvisionalStore::default();
+    let mut worker = ProvisionalWorker::new(options(&config), &mut reader, &mut store);
+
+    let report = worker.run_once().expect("worker runs once");
+
+    assert_eq!(report.segments_written, 1);
+    assert_eq!(reader.calls.len(), 1);
+    assert_eq!(reader.calls[0].finality.as_deref(), Some("safe_to_latest"));
+    assert_eq!(store.writes.len(), 1);
+    assert_eq!(store.writes[0].segment_finality, "latest");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_provisional_segment_upsert_is_idempotent_and_does_not_advance_checkpoint()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    insert_checkpoint(&database.pool).await?;
+    let store = PostgresProvisionalSegmentStore::new(database.pool.clone());
+    let write = segment_write("provider", "latest", 100, 105);
+
+    store
+        .write_provisional_segments(&[write.clone()])
+        .await
+        .expect("first write succeeds");
+    store
+        .write_provisional_segments(&[write])
+        .await
+        .expect("retry write succeeds");
+
+    assert_eq!(
+        table_count(&database.pool, "degov_provisional_segment").await?,
+        1
+    );
+    assert_checkpoint(&database.pool).await?;
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct RecordingProvisionalStore {
+    writes: Vec<DatalensProvisionalSegmentWrite>,
+}
+
+impl DatalensProvisionalSegmentStore for RecordingProvisionalStore {
+    type Error = String;
+
+    fn write_provisional_segments(
+        &mut self,
+        segments: &[DatalensProvisionalSegmentWrite],
+    ) -> Result<(), Self::Error> {
+        self.writes.extend_from_slice(segments);
+        Ok(())
+    }
+}
+
+struct MockProvisionalReader {
+    calls: Vec<QueryInput>,
+    results: Vec<Result<DatalensProvisionalLogQueryResult, DatalensError>>,
+}
+
+impl MockProvisionalReader {
+    fn new(results: Vec<Result<DatalensProvisionalLogQueryResult, DatalensError>>) -> Self {
+        Self {
+            calls: Vec::new(),
+            results,
+        }
+    }
+}
+
+impl DatalensProvisionalLogQueryReader for MockProvisionalReader {
+    fn query_provisional_logs(
+        &mut self,
+        input: QueryInput,
+    ) -> Result<DatalensProvisionalLogQueryResult, DatalensError> {
+        self.calls.push(input);
+        self.results.remove(0)
+    }
+}
+
+fn cache_segment(
+    source: &str,
+    finality: &str,
+    range_start: i64,
+    range_end: i64,
+) -> DatalensProvisionalCacheSegment {
+    DatalensProvisionalCacheSegment {
+        source: source.to_owned(),
+        finality: finality.to_owned(),
+        range_start_block: range_start,
+        range_end_block: range_end,
+        anchor_block_number: Some(range_end),
+        anchor_block_hash: Some("0xabc".to_owned()),
+        anchor_parent_hash: Some("0xdef".to_owned()),
+        anchor_block_timestamp: Some(1_700_000_000),
+    }
+}
+
+fn segment_write(
+    source: &str,
+    finality: &str,
+    range_start: i64,
+    range_end: i64,
+) -> DatalensProvisionalSegmentWrite {
+    DatalensProvisionalSegmentWrite {
+        id: "demo-dao:ethereum:demo-set:evm.logs:selector:100:105:safe_to_latest:provider"
+            .to_owned(),
+        dao_code: Some("demo-dao".to_owned()),
+        contract_set_id: "demo-set".to_owned(),
+        chain_id: Some(1),
+        chain_name: Some("ethereum".to_owned()),
+        dataset_key: "evm.logs".to_owned(),
+        selector: "selector".to_owned(),
+        selector_fingerprint: Some("selector-fingerprint".to_owned()),
+        range_start_block: range_start,
+        range_end_block: range_end,
+        segment_finality: finality.to_owned(),
+        source: source.to_owned(),
+        anchor_block_number: Some(range_end),
+        anchor_block_hash: Some("0xabc".to_owned()),
+        anchor_parent_hash: Some("0xdef".to_owned()),
+        anchor_block_timestamp: Some(1_700_000_000),
+        error: None,
+    }
+}
+
+fn options(config: &DatalensConfig) -> ProvisionalWorkerOptions {
+    ProvisionalWorkerOptions {
+        datalens_config: config.clone(),
+        addresses: addresses(),
+        dao_code: "demo-dao".to_owned(),
+        contract_set_id: "demo-set".to_owned(),
+        chain_id: 1,
+        chain_name: "ethereum".to_owned(),
+        finality: DatalensProvisionalFinality::SafeToLatest,
+        from_block: 100,
+        to_block: 105,
+    }
+}
+
+fn datalens_config() -> DatalensConfig {
+    DatalensConfig {
+        endpoint: "https://datalens.ringdao.com".to_owned(),
+        application: "degov-test".to_owned(),
+        bearer_token: SecretString::new("redacted"),
+        timeout: Duration::from_secs(60),
+        finality: DatalensFinality::DurableOnly,
+        chain: ChainIdentityConfig {
+            family: ChainFamily::Evm,
+            configured_name: "ethereum".to_owned(),
+            network_id: Some(1),
+        },
+        dataset: DatasetKeyConfig {
+            family: "evm".to_owned(),
+            name: "logs".to_owned(),
+        },
+        query_limits: QueryLimitConfig {
+            block_range_limit: 1_000,
+        },
+        warmup: Default::default(),
+        dao_contracts: None,
+        chains: Vec::new(),
+    }
+}
+
+fn addresses() -> DaoContractAddresses {
+    DaoContractAddresses {
+        governor: "0x1111111111111111111111111111111111111111".to_owned(),
+        governor_token: "0x2222222222222222222222222222222222222222".to_owned(),
+        governor_token_standard: GovernanceTokenStandard::Erc20,
+        timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+    }
+}
+
+struct TestDatabase {
+    _guard: MutexGuard<'static, ()>,
+    pool: PgPool,
+    schema: String,
+}
+
+impl TestDatabase {
+    async fn connect() -> Result<Self, Box<dyn Error>> {
+        let guard = DATABASE_TEST_LOCK.lock().await;
+        let database_url = env::var("DEGOV_INDEXER_TEST_DATABASE_URL")
+            .map_err(|_| "DEGOV_INDEXER_TEST_DATABASE_URL is required")?;
+        let schema = unique_schema_name();
+
+        let setup_pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await?;
+        sqlx::query("DROP SCHEMA IF EXISTS squid_processor CASCADE")
+            .execute(&setup_pool)
+            .await?;
+        sqlx::query(&format!(r#"CREATE SCHEMA "{schema}""#))
+            .execute(&setup_pool)
+            .await?;
+        setup_pool.close().await;
+
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url_with_search_path(&database_url, &schema))
+            .await?;
+
+        Ok(Self {
+            _guard: guard,
+            pool,
+            schema,
+        })
+    }
+
+    async fn cleanup(&self) -> Result<(), sqlx::Error> {
+        sqlx::query("DROP SCHEMA IF EXISTS squid_processor CASCADE")
+            .execute(&self.pool)
+            .await?;
+        sqlx::query(&format!(
+            r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+            self.schema
+        ))
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+fn unique_schema_name() -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_millis();
+    let counter = SCHEMA_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+    format!("degov_test_provisional_worker_{millis}_{counter}")
+}
+
+fn database_url_with_search_path(database_url: &str, schema: &str) -> String {
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    format!("{database_url}{separator}options=-csearch_path%3D{schema}")
+}
+
+async fn insert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO degov_indexer_checkpoint (
+             dao_code, chain_id, contract_set_id, stream_id, data_source_version,
+             next_block, processed_height, target_height
+         )
+         VALUES ('demo-dao', 1, 'demo-set', 'datalens-native', 'datalens-v1', 11, 10, 10)",
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn assert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT next_block, processed_height, target_height
+         FROM degov_indexer_checkpoint
+         WHERE dao_code = 'demo-dao'
+           AND chain_id = 1
+           AND contract_set_id = 'demo-set'
+           AND stream_id = 'datalens-native'
+           AND data_source_version = 'datalens-v1'",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<i64, _>("next_block"), 11);
+    assert_eq!(row.get::<Option<i64>, _>("processed_height"), Some(10));
+    assert_eq!(row.get::<Option<i64>, _>("target_height"), Some(10));
+
+    Ok(())
+}
+
+async fn table_count(pool: &PgPool, table: &str) -> Result<i64, sqlx::Error> {
+    sqlx::query_scalar(&format!("SELECT count(*)::BIGINT FROM {table}"))
+        .fetch_one(pool)
+        .await
+}

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -286,7 +286,10 @@ async fn insert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
 
 async fn assert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
     let row = sqlx::query(
-        "SELECT next_block, processed_height, target_height
+        "SELECT
+           next_block::BIGINT AS next_block,
+           processed_height::BIGINT AS processed_height,
+           target_height::BIGINT AS target_height
          FROM degov_indexer_checkpoint
          WHERE dao_code = 'demo-dao'
            AND chain_id = 1


### PR DESCRIPTION
## Summary

- add an explicit provisional runtime config flag, defaulting the worker off with `safe_to_latest` finality
- add a separate Datalens provisional query path that uses SDK `query_provisional` and extracts cache segment metadata
- add a provisional worker/store boundary plus idempotent Postgres upsert for `degov_provisional_segment`
- add tests for final/provisional query separation, provisional config, segment write safety, and checkpoint non-advancement coverage

## Validation

- `cargo test -p degov-datalens-indexer --tests --no-run`
- `cargo test -p degov-datalens-indexer --test datalens_client test_datalens_provisional_log_query_uses_query_provisional_with_safe_to_latest_finality`
- `cargo test -p degov-datalens-indexer --test datalens_planner test_fetch`
- `cargo test -p degov-datalens-indexer --test cli_runtime_config test_provisional_runtime_config`
- `cargo test -p degov-datalens-indexer --test provisional_worker test_provisional_worker_writes_segments_without_final_checkpoint_boundary`

`DEGOV_INDEXER_TEST_DATABASE_URL` was not set locally, so the Postgres execution half of `tests/provisional_worker.rs` was compile-checked but not run.