### PR TITLE
Implement live power overlay for indexer

### DIFF
--- a/apps/indexer/src/chain/tool.rs
+++ b/apps/indexer/src/chain/tool.rs
@@ -314,12 +314,45 @@ impl ChainReadPlanBuilder {
         reason: ChainReadReason,
         method: ChainReadMethod,
     ) {
+        self.add_account_power_refresh_with_method_and_block_mode(
+            account,
+            activity_block,
+            reason,
+            method,
+            BlockReadMode::Safe,
+        );
+    }
+
+    pub fn add_account_latest_power_refresh_with_method(
+        &mut self,
+        account: &str,
+        activity_block: u64,
+        reason: ChainReadReason,
+        method: ChainReadMethod,
+    ) {
+        self.add_account_power_refresh_with_method_and_block_mode(
+            account,
+            activity_block,
+            reason,
+            method,
+            BlockReadMode::Latest,
+        );
+    }
+
+    fn add_account_power_refresh_with_method_and_block_mode(
+        &mut self,
+        account: &str,
+        activity_block: u64,
+        reason: ChainReadReason,
+        method: ChainReadMethod,
+        block_mode: BlockReadMode,
+    ) {
         let account = normalize_identifier(account);
         self.add_required_read(ChainReadDraft {
             contract_address: self.contracts.governor_token.clone(),
             method,
             args: vec![account.clone()],
-            block_mode: BlockReadMode::Safe,
+            block_mode,
             account: Some(account),
             proposal_id: None,
             operation_id: None,

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -213,7 +213,27 @@ pub(super) async fn query_contributors(
           block_timestamp::text AS block_timestamp, transaction_hash,
           last_vote_timestamp::text AS last_vote_timestamp, power::text AS power,
           balance::text AS balance, delegates_count_all
-        FROM contributor
+        FROM (
+          SELECT contributor.id, contributor.contract_set_id, contributor.chain_id,
+            contributor.dao_code, contributor.governor_address, contributor.block_number,
+            contributor.block_timestamp, contributor.transaction_hash,
+            contributor.last_vote_timestamp,
+            COALESCE(contributor_power_overlay.power, contributor.power) AS power,
+            contributor.balance, contributor.delegates_count_all
+          FROM contributor
+          LEFT JOIN degov_provisional_contributor_power_overlay contributor_power_overlay
+            ON contributor_power_overlay.contract_set_id = contributor.contract_set_id
+           AND contributor_power_overlay.chain_id IS NOT DISTINCT FROM contributor.chain_id
+           AND contributor_power_overlay.dao_code IS NOT DISTINCT FROM contributor.dao_code
+           AND contributor_power_overlay.governor_address IS NOT DISTINCT FROM contributor.governor_address
+           AND (
+             contributor_power_overlay.token_address IS NOT DISTINCT FROM contributor.token_address
+             OR contributor.token_address IS NULL
+           )
+           AND contributor_power_overlay.account = contributor.id
+           AND contributor_power_overlay.source = 'live-onchain'
+           AND contributor_power_overlay.status = 'available'
+        ) contributor
         "#,
     );
     push_contributor_where(&mut query, implicit_scope, where_);
@@ -236,7 +256,27 @@ pub(super) async fn query_delegates(
         SELECT id, chain_id, dao_code, governor_address, from_delegate, to_delegate,
           block_number::text AS block_number, block_timestamp::text AS block_timestamp,
           transaction_hash, is_current, power::text AS power
-        FROM delegate
+        FROM (
+          SELECT delegate.id, delegate.contract_set_id, delegate.chain_id,
+            delegate.dao_code, delegate.governor_address, delegate.from_delegate,
+            delegate.to_delegate, delegate.block_number, delegate.block_timestamp,
+            delegate.transaction_hash, delegate.is_current,
+            COALESCE(delegate_power_overlay.power, delegate.power) AS power
+          FROM delegate
+          LEFT JOIN degov_provisional_delegate_power_overlay delegate_power_overlay
+            ON delegate_power_overlay.contract_set_id = delegate.contract_set_id
+           AND delegate_power_overlay.chain_id IS NOT DISTINCT FROM delegate.chain_id
+           AND delegate_power_overlay.dao_code IS NOT DISTINCT FROM delegate.dao_code
+           AND delegate_power_overlay.governor_address IS NOT DISTINCT FROM delegate.governor_address
+           AND (
+             delegate_power_overlay.token_address IS NOT DISTINCT FROM delegate.token_address
+             OR delegate.token_address IS NULL
+           )
+           AND delegate_power_overlay.delegator = delegate.from_delegate
+           AND delegate_power_overlay.delegate = delegate.to_delegate
+           AND delegate_power_overlay.source = 'live-onchain'
+           AND delegate_power_overlay.status = 'available'
+        ) delegate
         "#,
     );
     push_delegate_where(&mut query, implicit_scope, where_);
@@ -274,8 +314,30 @@ pub(super) async fn count_contributors(
     implicit_scope: &GraphqlScope,
     where_: Option<&ContributorWhereInput>,
 ) -> GraphqlResult<i64> {
-    let mut query =
-        QueryBuilder::<Postgres>::new("SELECT COUNT(*)::int8 AS total FROM contributor");
+    let mut query = QueryBuilder::<Postgres>::new(
+        r#"
+        SELECT COUNT(*)::int8 AS total
+        FROM (
+          SELECT contributor.id, contributor.contract_set_id, contributor.chain_id,
+            contributor.dao_code, contributor.governor_address,
+            COALESCE(contributor_power_overlay.power, contributor.power) AS power,
+            contributor.last_vote_timestamp, contributor.delegates_count_all
+          FROM contributor
+          LEFT JOIN degov_provisional_contributor_power_overlay contributor_power_overlay
+            ON contributor_power_overlay.contract_set_id = contributor.contract_set_id
+           AND contributor_power_overlay.chain_id IS NOT DISTINCT FROM contributor.chain_id
+           AND contributor_power_overlay.dao_code IS NOT DISTINCT FROM contributor.dao_code
+           AND contributor_power_overlay.governor_address IS NOT DISTINCT FROM contributor.governor_address
+           AND (
+             contributor_power_overlay.token_address IS NOT DISTINCT FROM contributor.token_address
+             OR contributor.token_address IS NULL
+           )
+           AND contributor_power_overlay.account = contributor.id
+           AND contributor_power_overlay.source = 'live-onchain'
+           AND contributor_power_overlay.status = 'available'
+        ) contributor
+        "#,
+    );
     push_contributor_where(&mut query, implicit_scope, where_);
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)
@@ -286,7 +348,31 @@ pub(super) async fn count_delegates(
     implicit_scope: &GraphqlScope,
     where_: Option<&DelegateWhereInput>,
 ) -> GraphqlResult<i64> {
-    let mut query = QueryBuilder::<Postgres>::new("SELECT COUNT(*)::int8 AS total FROM delegate");
+    let mut query = QueryBuilder::<Postgres>::new(
+        r#"
+        SELECT COUNT(*)::int8 AS total
+        FROM (
+          SELECT delegate.id, delegate.contract_set_id, delegate.chain_id,
+            delegate.dao_code, delegate.governor_address, delegate.from_delegate,
+            delegate.to_delegate, delegate.is_current,
+            COALESCE(delegate_power_overlay.power, delegate.power) AS power
+          FROM delegate
+          LEFT JOIN degov_provisional_delegate_power_overlay delegate_power_overlay
+            ON delegate_power_overlay.contract_set_id = delegate.contract_set_id
+           AND delegate_power_overlay.chain_id IS NOT DISTINCT FROM delegate.chain_id
+           AND delegate_power_overlay.dao_code IS NOT DISTINCT FROM delegate.dao_code
+           AND delegate_power_overlay.governor_address IS NOT DISTINCT FROM delegate.governor_address
+           AND (
+             delegate_power_overlay.token_address IS NOT DISTINCT FROM delegate.token_address
+             OR delegate.token_address IS NULL
+           )
+           AND delegate_power_overlay.delegator = delegate.from_delegate
+           AND delegate_power_overlay.delegate = delegate.to_delegate
+           AND delegate_power_overlay.source = 'live-onchain'
+           AND delegate_power_overlay.status = 'available'
+        ) delegate
+        "#,
+    );
     push_delegate_where(&mut query, implicit_scope, where_);
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -49,12 +49,13 @@ pub use crate::decode::evm_log::{
     EvmLogNormalizationError, NormalizedEvmLog, normalize_evm_log_rows,
 };
 pub use crate::onchain::refresh::{
-    ChainToolOnchainRefreshReader, EvmRpcChainTool, MultiChainToolOnchainRefreshReader,
-    OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError,
-    OnchainRefreshRunReport, OnchainRefreshTask, OnchainRefreshTickClock, OnchainRefreshTickConfig,
-    OnchainRefreshTickReport, OnchainRefreshTickRunner, OnchainRefreshTickScheduler,
-    OnchainRefreshTickSkipReason, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
-    OnchainRefreshWorkerError, SystemOnchainRefreshTickClock,
+    ChainToolOnchainRefreshReader, EvmRpcChainTool, LivePowerOverlayReader,
+    LivePowerOverlayRefreshError, MultiChainToolOnchainRefreshReader, OnchainRefreshReadValue,
+    OnchainRefreshReader, OnchainRefreshReaderError, OnchainRefreshRunReport, OnchainRefreshTask,
+    OnchainRefreshTickClock, OnchainRefreshTickConfig, OnchainRefreshTickReport,
+    OnchainRefreshTickRunner, OnchainRefreshTickScheduler, OnchainRefreshTickSkipReason,
+    OnchainRefreshWorker, OnchainRefreshWorkerConfig, OnchainRefreshWorkerError,
+    SystemOnchainRefreshTickClock, refresh_live_power_overlays,
 };
 pub use crate::projection::data_metric::DataMetricWrite;
 pub use crate::projection::power_reconcile::{
@@ -94,7 +95,7 @@ pub use crate::projection::vote::{
 };
 pub use crate::store::postgres::{
     PostgresIndexerRunnerStore, PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
-    PostgresProvisionalSegmentStore,
+    PostgresProvisionalPowerOverlayStore, PostgresProvisionalSegmentStore,
 };
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
@@ -112,8 +113,11 @@ pub use datalens::{
 pub use error::{CheckpointError, ConfigError, DatalensError, IndexerError};
 pub use graphql::IndexerGraphqlSchema;
 pub use provisional::{
-    DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite, ProvisionalWorker,
-    ProvisionalWorkerError, ProvisionalWorkerOptions, ProvisionalWorkerReport,
+    DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite,
+    ProvisionalContributorPowerOverlayWrite, ProvisionalDelegatePowerOverlayRelation,
+    ProvisionalDelegatePowerOverlayWrite, ProvisionalPowerOverlayScope,
+    ProvisionalPowerOverlayStore, ProvisionalWorker, ProvisionalWorkerError,
+    ProvisionalWorkerOptions, ProvisionalWorkerReport,
 };
 pub use runner::{
     AdaptiveChunkFeedback, AdaptiveChunkSizer, AdaptiveChunkSizerConfig,

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -13,7 +13,10 @@ use thiserror::Error;
 use crate::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadExecutionReport, ChainReadFailure,
     ChainReadFailureKind, ChainReadMethod, ChainReadMetrics, ChainReadPlan, ChainReadPlanBuilder,
-    ChainReadResult, ChainReadValue, ChainTool, PartialChainReadFailureReport, ReadRequirement,
+    ChainReadResult, ChainReadValue, ChainTool, PartialChainReadFailureReport,
+    ProvisionalContributorPowerOverlayWrite, ProvisionalDelegatePowerOverlayRelation,
+    ProvisionalDelegatePowerOverlayWrite, ProvisionalPowerOverlayScope,
+    ProvisionalPowerOverlayStore, ReadRequirement,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -312,6 +315,14 @@ pub enum OnchainRefreshWorkerError {
         task_id: String,
         field: &'static str,
     },
+}
+
+#[derive(Debug, Error)]
+pub enum LivePowerOverlayRefreshError {
+    #[error("live power overlay reader error: {0}")]
+    Reader(#[from] OnchainRefreshReaderError),
+    #[error("live power overlay store error: {0}")]
+    Store(String),
 }
 
 #[derive(Clone)]
@@ -804,6 +815,152 @@ where
 }
 
 #[derive(Clone)]
+pub struct LivePowerOverlayReader<T> {
+    chain_tool: T,
+    read_plan_config: BatchReadPlanConfig,
+    current_power_method: ChainReadMethod,
+}
+
+impl<T> LivePowerOverlayReader<T> {
+    pub fn new(
+        chain_tool: T,
+        read_plan_config: BatchReadPlanConfig,
+        current_power_method: ChainReadMethod,
+    ) -> Self {
+        Self {
+            chain_tool,
+            read_plan_config: read_plan_config.validated(),
+            current_power_method,
+        }
+    }
+}
+
+impl<T> LivePowerOverlayReader<T>
+where
+    T: ChainTool + Clone + Send + Sync + 'static,
+{
+    pub fn read_power_overlays(
+        &self,
+        tasks: &[OnchainRefreshTask],
+    ) -> Result<Vec<ProvisionalContributorPowerOverlayWrite>, OnchainRefreshReaderError> {
+        let mut groups = BTreeMap::<(i32, String, String), Vec<&OnchainRefreshTask>>::new();
+        for task in tasks.iter().filter(|task| task.refresh_power) {
+            groups
+                .entry((
+                    task.chain_id,
+                    task.governor_address.clone(),
+                    task.token_address.clone(),
+                ))
+                .or_default()
+                .push(task);
+        }
+
+        let mut writes = Vec::new();
+        for ((chain_id, governor_address, token_address), group_tasks) in groups {
+            let mut builder = ChainReadPlanBuilder::new(
+                chain_id,
+                ChainContracts {
+                    governor: governor_address.clone(),
+                    governor_token: token_address.clone(),
+                    timelock: String::new(),
+                },
+                self.read_plan_config,
+            );
+            let mut tasks_by_account = BTreeMap::<String, &OnchainRefreshTask>::new();
+            for task in group_tasks {
+                tasks_by_account
+                    .entry(normalize_identifier(&task.account))
+                    .or_insert(task);
+            }
+            for task in tasks_by_account.values() {
+                builder.add_account_latest_power_refresh_with_method(
+                    &task.account,
+                    parse_u64(&task.last_seen_block_number)?,
+                    crate::ChainReadReason::TokenActivityPowerRefresh,
+                    self.current_power_method,
+                );
+            }
+
+            let plan = builder.build();
+            let report = self
+                .chain_tool
+                .execute_read_plan(&plan)
+                .map_err(|failures| OnchainRefreshReaderError::new(format_failures(&failures)))?;
+
+            for result in report.results {
+                let Some(account) = result.key.args.first() else {
+                    continue;
+                };
+                let value = match result.value {
+                    ChainReadValue::Integer(value) => value,
+                    other => {
+                        return Err(OnchainRefreshReaderError::new(format!(
+                            "expected integer chain read for {:?}, got {:?}",
+                            result.key.method, other
+                        )));
+                    }
+                };
+                let Some(task) = tasks_by_account.get(account) else {
+                    continue;
+                };
+                writes.push(ProvisionalContributorPowerOverlayWrite {
+                    id: provisional_contributor_power_overlay_id(task),
+                    segment_id: None,
+                    dao_code: task.dao_code.clone(),
+                    contract_set_id: task.contract_set_id.clone(),
+                    chain_id: Some(task.chain_id),
+                    chain_name: None,
+                    governor_address: Some(normalize_identifier(&governor_address)),
+                    token_address: Some(normalize_identifier(&token_address)),
+                    account: normalize_identifier(&task.account),
+                    power: value,
+                    balance: None,
+                    delegates_count_all: 0,
+                    delegates_count_effective: 0,
+                    last_vote_block_number: None,
+                    last_vote_timestamp: None,
+                    source: "live-onchain".to_owned(),
+                    status: "available".to_owned(),
+                    anchor_block_number: Some(task.last_seen_block_number.clone()),
+                    anchor_block_hash: None,
+                    anchor_parent_hash: None,
+                    anchor_block_timestamp: Some(task.last_seen_block_timestamp.clone()),
+                });
+            }
+        }
+
+        Ok(writes)
+    }
+}
+
+pub fn refresh_live_power_overlays<T, S>(
+    reader: &LivePowerOverlayReader<T>,
+    store: &mut S,
+    tasks: &[OnchainRefreshTask],
+) -> Result<usize, LivePowerOverlayRefreshError>
+where
+    T: ChainTool + Clone + Send + Sync + 'static,
+    S: ProvisionalPowerOverlayStore,
+{
+    let contributors = reader.read_power_overlays(tasks)?;
+    let scopes = tasks
+        .iter()
+        .filter(|task| task.refresh_power)
+        .map(provisional_power_overlay_scope)
+        .collect::<Vec<_>>();
+    let relations = store
+        .current_delegate_power_overlay_relations(&scopes)
+        .map_err(|error| LivePowerOverlayRefreshError::Store(error.to_string()))?;
+    let delegates = provisional_delegate_power_overlay_writes(&contributors, &relations);
+    let writes = contributors.len() + delegates.len();
+    store
+        .write_power_overlays(&contributors, &delegates)
+        .map_err(|error| LivePowerOverlayRefreshError::Store(error.to_string()))?;
+
+    Ok(writes)
+}
+
+#[derive(Clone)]
 pub struct EvmRpcChainTool {
     rpc_url: String,
     client: reqwest::blocking::Client,
@@ -1188,6 +1345,101 @@ fn onchain_refresh_checkpoint_scope(task: &OnchainRefreshTask) -> String {
 
 fn contributor_ref(task: &OnchainRefreshTask) -> String {
     normalize_identifier(&task.account)
+}
+
+fn provisional_contributor_power_overlay_id(task: &OnchainRefreshTask) -> String {
+    format!(
+        "{}:{}:{}:{}:{}:{}:live-onchain",
+        task.contract_set_id,
+        task.chain_id,
+        task.dao_code.as_deref().unwrap_or_default(),
+        normalize_identifier(&task.governor_address),
+        normalize_identifier(&task.token_address),
+        normalize_identifier(&task.account),
+    )
+}
+
+fn provisional_power_overlay_scope(task: &OnchainRefreshTask) -> ProvisionalPowerOverlayScope {
+    ProvisionalPowerOverlayScope {
+        contract_set_id: task.contract_set_id.clone(),
+        chain_id: task.chain_id,
+        dao_code: task.dao_code.clone(),
+        governor_address: normalize_identifier(&task.governor_address),
+        token_address: normalize_identifier(&task.token_address),
+        account: normalize_identifier(&task.account),
+    }
+}
+
+fn provisional_delegate_power_overlay_writes(
+    contributors: &[ProvisionalContributorPowerOverlayWrite],
+    relations: &[ProvisionalDelegatePowerOverlayRelation],
+) -> Vec<ProvisionalDelegatePowerOverlayWrite> {
+    let contributors_by_scope = contributors
+        .iter()
+        .map(|contributor| {
+            (
+                (
+                    contributor.contract_set_id.clone(),
+                    contributor.chain_id,
+                    contributor.dao_code.clone(),
+                    contributor.governor_address.clone(),
+                    contributor.token_address.clone(),
+                    contributor.account.clone(),
+                ),
+                contributor,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    relations
+        .iter()
+        .filter_map(|relation| {
+            let contributor = contributors_by_scope.get(&(
+                relation.contract_set_id.clone(),
+                relation.chain_id,
+                relation.dao_code.clone(),
+                relation.governor_address.clone(),
+                relation.token_address.clone(),
+                relation.delegator.clone(),
+            ))?;
+
+            Some(ProvisionalDelegatePowerOverlayWrite {
+                id: provisional_delegate_power_overlay_id(relation),
+                segment_id: contributor.segment_id.clone(),
+                dao_code: relation.dao_code.clone(),
+                contract_set_id: relation.contract_set_id.clone(),
+                chain_id: relation.chain_id,
+                chain_name: relation.chain_name.clone(),
+                governor_address: relation.governor_address.clone(),
+                token_address: relation.token_address.clone(),
+                delegator: relation.delegator.clone(),
+                delegate: relation.delegate.clone(),
+                power: contributor.power.clone(),
+                is_current: relation.is_current,
+                source: contributor.source.clone(),
+                status: contributor.status.clone(),
+                anchor_block_number: contributor.anchor_block_number.clone(),
+                anchor_block_hash: contributor.anchor_block_hash.clone(),
+                anchor_parent_hash: contributor.anchor_parent_hash.clone(),
+                anchor_block_timestamp: contributor.anchor_block_timestamp.clone(),
+            })
+        })
+        .collect()
+}
+
+fn provisional_delegate_power_overlay_id(
+    relation: &ProvisionalDelegatePowerOverlayRelation,
+) -> String {
+    format!(
+        "{}:{}:{}:{}:{}:{}:{}:live-onchain",
+        relation.contract_set_id,
+        relation.chain_id.unwrap_or_default(),
+        relation.dao_code.as_deref().unwrap_or_default(),
+        relation.governor_address.as_deref().unwrap_or_default(),
+        relation.token_address.as_deref().unwrap_or_default(),
+        relation.delegator,
+        relation.delegate,
+    )
 }
 
 fn current_power_checkpoint_source(method: ChainReadMethod) -> &'static str {

--- a/apps/indexer/src/provisional.rs
+++ b/apps/indexer/src/provisional.rs
@@ -41,6 +41,76 @@ pub struct DatalensProvisionalSegmentWrite {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalContributorPowerOverlayWrite {
+    pub id: String,
+    pub segment_id: Option<String>,
+    pub dao_code: Option<String>,
+    pub contract_set_id: String,
+    pub chain_id: Option<i32>,
+    pub chain_name: Option<String>,
+    pub governor_address: Option<String>,
+    pub token_address: Option<String>,
+    pub account: String,
+    pub power: String,
+    pub balance: Option<String>,
+    pub delegates_count_all: i32,
+    pub delegates_count_effective: i32,
+    pub last_vote_block_number: Option<String>,
+    pub last_vote_timestamp: Option<String>,
+    pub source: String,
+    pub status: String,
+    pub anchor_block_number: Option<String>,
+    pub anchor_block_hash: Option<String>,
+    pub anchor_parent_hash: Option<String>,
+    pub anchor_block_timestamp: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalDelegatePowerOverlayWrite {
+    pub id: String,
+    pub segment_id: Option<String>,
+    pub dao_code: Option<String>,
+    pub contract_set_id: String,
+    pub chain_id: Option<i32>,
+    pub chain_name: Option<String>,
+    pub governor_address: Option<String>,
+    pub token_address: Option<String>,
+    pub delegator: String,
+    pub delegate: String,
+    pub power: String,
+    pub is_current: bool,
+    pub source: String,
+    pub status: String,
+    pub anchor_block_number: Option<String>,
+    pub anchor_block_hash: Option<String>,
+    pub anchor_parent_hash: Option<String>,
+    pub anchor_block_timestamp: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalPowerOverlayScope {
+    pub contract_set_id: String,
+    pub chain_id: i32,
+    pub dao_code: Option<String>,
+    pub governor_address: String,
+    pub token_address: String,
+    pub account: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalDelegatePowerOverlayRelation {
+    pub contract_set_id: String,
+    pub chain_id: Option<i32>,
+    pub chain_name: Option<String>,
+    pub dao_code: Option<String>,
+    pub governor_address: Option<String>,
+    pub token_address: Option<String>,
+    pub delegator: String,
+    pub delegate: String,
+    pub is_current: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProvisionalWorkerReport {
     pub segments_written: usize,
 }
@@ -60,6 +130,21 @@ pub trait DatalensProvisionalSegmentStore {
     fn write_provisional_segments(
         &mut self,
         segments: &[DatalensProvisionalSegmentWrite],
+    ) -> Result<(), Self::Error>;
+}
+
+pub trait ProvisionalPowerOverlayStore {
+    type Error: fmt::Display;
+
+    fn current_delegate_power_overlay_relations(
+        &mut self,
+        scopes: &[ProvisionalPowerOverlayScope],
+    ) -> Result<Vec<ProvisionalDelegatePowerOverlayRelation>, Self::Error>;
+
+    fn write_power_overlays(
+        &mut self,
+        contributors: &[ProvisionalContributorPowerOverlayWrite],
+        delegates: &[ProvisionalDelegatePowerOverlayWrite],
     ) -> Result<(), Self::Error>;
 }
 

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -14,12 +14,14 @@ use crate::{
     IndexerRunnerTransaction, PowerReconcileCandidate, ProposalActionWrite, ProposalCreatedWrite,
     ProposalDeadlineExtensionWrite, ProposalExtendedWrite, ProposalIdWrite,
     ProposalProjectionBatch, ProposalQueuedWrite, ProposalStateEpochWrite, ProposalVoteTotalWrite,
-    ProposalWrite, TimelockCallWrite, TimelockMinDelayChangeWrite, TimelockOperationHintWrite,
-    TimelockOperationWrite, TimelockProjectionBatch, TimelockProjectionContext,
-    TimelockProjectionEvent, TimelockProposalActionLink, TimelockProposalLinkContext,
-    TimelockRoleEventWrite, TokenEventCommon, TokenProjectionBatch, TokenProjectionOperation,
-    TokenTransferWrite, VoteCastGroupWrite, VoteCastWithParamsWrite, VoteCastWrite,
-    VoteProjectionBatch,
+    ProposalWrite, ProvisionalContributorPowerOverlayWrite,
+    ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
+    ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, TimelockCallWrite,
+    TimelockMinDelayChangeWrite, TimelockOperationHintWrite, TimelockOperationWrite,
+    TimelockProjectionBatch, TimelockProjectionContext, TimelockProjectionEvent,
+    TimelockProposalActionLink, TimelockProposalLinkContext, TimelockRoleEventWrite,
+    TokenEventCommon, TokenProjectionBatch, TokenProjectionOperation, TokenTransferWrite,
+    VoteCastGroupWrite, VoteCastWithParamsWrite, VoteCastWrite, VoteProjectionBatch,
 };
 
 #[derive(Clone)]

--- a/apps/indexer/src/store/postgres/provisional.rs
+++ b/apps/indexer/src/store/postgres/provisional.rs
@@ -35,6 +35,73 @@ impl DatalensProvisionalSegmentStore for PostgresProvisionalSegmentStore {
     }
 }
 
+#[derive(Clone)]
+pub struct PostgresProvisionalPowerOverlayStore {
+    pool: PgPool,
+}
+
+impl PostgresProvisionalPowerOverlayStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn write_power_overlays(
+        &self,
+        contributors: &[ProvisionalContributorPowerOverlayWrite],
+        delegates: &[ProvisionalDelegatePowerOverlayWrite],
+    ) -> Result<(), PostgresIndexerRunnerStoreError> {
+        let mut transaction = self.pool.begin().await?;
+        for contributor in contributors {
+            upsert_provisional_contributor_power_overlay(&mut transaction, contributor).await?;
+        }
+        for delegate in delegates {
+            upsert_provisional_delegate_power_overlay(&mut transaction, delegate).await?;
+        }
+        transaction.commit().await?;
+
+        Ok(())
+    }
+
+    pub async fn current_delegate_power_overlay_relations(
+        &self,
+        scopes: &[ProvisionalPowerOverlayScope],
+    ) -> Result<Vec<ProvisionalDelegatePowerOverlayRelation>, PostgresIndexerRunnerStoreError> {
+        let mut relations = Vec::new();
+        for scope in scopes {
+            relations.extend(read_current_delegate_power_overlay_relations(&self.pool, scope).await?);
+        }
+
+        Ok(relations)
+    }
+}
+
+impl ProvisionalPowerOverlayStore for PostgresProvisionalPowerOverlayStore {
+    type Error = PostgresIndexerRunnerStoreError;
+
+    fn current_delegate_power_overlay_relations(
+        &mut self,
+        scopes: &[ProvisionalPowerOverlayScope],
+    ) -> Result<Vec<ProvisionalDelegatePowerOverlayRelation>, Self::Error> {
+        block_on_runtime(
+            PostgresProvisionalPowerOverlayStore::current_delegate_power_overlay_relations(
+                self, scopes,
+            ),
+        )
+    }
+
+    fn write_power_overlays(
+        &mut self,
+        contributors: &[ProvisionalContributorPowerOverlayWrite],
+        delegates: &[ProvisionalDelegatePowerOverlayWrite],
+    ) -> Result<(), Self::Error> {
+        block_on_runtime(PostgresProvisionalPowerOverlayStore::write_power_overlays(
+            self,
+            contributors,
+            delegates,
+        ))
+    }
+}
+
 async fn upsert_provisional_segment(
     transaction: &mut Transaction<'_, Postgres>,
     segment: &DatalensProvisionalSegmentWrite,
@@ -92,6 +159,167 @@ const UPSERT_PROVISIONAL_SEGMENT_SQL: &str = "INSERT INTO degov_provisional_segm
              error = EXCLUDED.error,
              updated_at = now()";
 
+async fn read_current_delegate_power_overlay_relations(
+    pool: &PgPool,
+    scope: &ProvisionalPowerOverlayScope,
+) -> Result<Vec<ProvisionalDelegatePowerOverlayRelation>, PostgresIndexerRunnerStoreError> {
+    let rows = sqlx::query(
+        "SELECT
+             contract_set_id, chain_id, dao_code, governor_address, token_address,
+             from_delegate, to_delegate, is_current
+         FROM delegate
+         WHERE contract_set_id = $1
+           AND chain_id = $2
+           AND dao_code IS NOT DISTINCT FROM $3
+           AND governor_address = $4
+           AND (token_address IS NOT DISTINCT FROM $5 OR token_address IS NULL)
+           AND from_delegate = $6
+           AND is_current = TRUE",
+    )
+    .bind(&scope.contract_set_id)
+    .bind(scope.chain_id)
+    .bind(&scope.dao_code)
+    .bind(&scope.governor_address)
+    .bind(&scope.token_address)
+    .bind(&scope.account)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ProvisionalDelegatePowerOverlayRelation {
+            contract_set_id: row.get("contract_set_id"),
+            chain_id: row.get("chain_id"),
+            chain_name: None,
+            dao_code: row.get("dao_code"),
+            governor_address: row.get("governor_address"),
+            token_address: row
+                .get::<Option<String>, _>("token_address")
+                .or_else(|| Some(scope.token_address.clone())),
+            delegator: row.get("from_delegate"),
+            delegate: row.get("to_delegate"),
+            is_current: row.get("is_current"),
+        })
+        .collect())
+}
+
+async fn upsert_provisional_contributor_power_overlay(
+    transaction: &mut Transaction<'_, Postgres>,
+    contributor: &ProvisionalContributorPowerOverlayWrite,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    sqlx::query(UPSERT_PROVISIONAL_CONTRIBUTOR_POWER_OVERLAY_SQL)
+        .bind(&contributor.id)
+        .bind(&contributor.segment_id)
+        .bind(&contributor.contract_set_id)
+        .bind(contributor.chain_id)
+        .bind(&contributor.chain_name)
+        .bind(&contributor.dao_code)
+        .bind(&contributor.governor_address)
+        .bind(&contributor.token_address)
+        .bind(&contributor.account)
+        .bind(&contributor.power)
+        .bind(&contributor.balance)
+        .bind(contributor.delegates_count_all)
+        .bind(contributor.delegates_count_effective)
+        .bind(&contributor.last_vote_block_number)
+        .bind(&contributor.last_vote_timestamp)
+        .bind(&contributor.source)
+        .bind(&contributor.status)
+        .bind(&contributor.anchor_block_number)
+        .bind(&contributor.anchor_block_hash)
+        .bind(&contributor.anchor_parent_hash)
+        .bind(&contributor.anchor_block_timestamp)
+        .execute(&mut **transaction)
+        .await?;
+
+    Ok(())
+}
+
+async fn upsert_provisional_delegate_power_overlay(
+    transaction: &mut Transaction<'_, Postgres>,
+    delegate: &ProvisionalDelegatePowerOverlayWrite,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    sqlx::query(UPSERT_PROVISIONAL_DELEGATE_POWER_OVERLAY_SQL)
+        .bind(&delegate.id)
+        .bind(&delegate.segment_id)
+        .bind(&delegate.contract_set_id)
+        .bind(delegate.chain_id)
+        .bind(&delegate.chain_name)
+        .bind(&delegate.dao_code)
+        .bind(&delegate.governor_address)
+        .bind(&delegate.token_address)
+        .bind(&delegate.delegator)
+        .bind(&delegate.delegate)
+        .bind(&delegate.power)
+        .bind(delegate.is_current)
+        .bind(&delegate.source)
+        .bind(&delegate.status)
+        .bind(&delegate.anchor_block_number)
+        .bind(&delegate.anchor_block_hash)
+        .bind(&delegate.anchor_parent_hash)
+        .bind(&delegate.anchor_block_timestamp)
+        .execute(&mut **transaction)
+        .await?;
+
+    Ok(())
+}
+
+const UPSERT_PROVISIONAL_CONTRIBUTOR_POWER_OVERLAY_SQL: &str =
+    "INSERT INTO degov_provisional_contributor_power_overlay (
+             id, segment_id, contract_set_id, chain_id, chain_name, dao_code, governor_address,
+             token_address, account, power, balance, delegates_count_all,
+             delegates_count_effective, last_vote_block_number, last_vote_timestamp, source,
+             status, anchor_block_number, anchor_block_hash, anchor_parent_hash,
+             anchor_block_timestamp
+         )
+         VALUES (
+             $1, $2, $3, $4, $5, $6, $7,
+             $8, $9, $10::NUMERIC(78, 0), $11::NUMERIC(78, 0), $12,
+             $13, $14::NUMERIC(78, 0), $15::NUMERIC(78, 0), $16,
+             $17, $18::NUMERIC(78, 0), $19, $20,
+             $21::NUMERIC(78, 0)
+         )
+         ON CONFLICT ON CONSTRAINT degov_provisional_contributor_power_overlay_scope_unique
+         DO UPDATE SET
+             id = EXCLUDED.id,
+             segment_id = EXCLUDED.segment_id,
+             power = EXCLUDED.power,
+             balance = EXCLUDED.balance,
+             delegates_count_all = EXCLUDED.delegates_count_all,
+             delegates_count_effective = EXCLUDED.delegates_count_effective,
+             last_vote_block_number = EXCLUDED.last_vote_block_number,
+             last_vote_timestamp = EXCLUDED.last_vote_timestamp,
+             status = EXCLUDED.status,
+             anchor_block_number = EXCLUDED.anchor_block_number,
+             anchor_block_hash = EXCLUDED.anchor_block_hash,
+             anchor_parent_hash = EXCLUDED.anchor_parent_hash,
+             anchor_block_timestamp = EXCLUDED.anchor_block_timestamp,
+             updated_at = now()";
+
+const UPSERT_PROVISIONAL_DELEGATE_POWER_OVERLAY_SQL: &str =
+    "INSERT INTO degov_provisional_delegate_power_overlay (
+             id, segment_id, contract_set_id, chain_id, chain_name, dao_code, governor_address,
+             token_address, delegator, delegate, power, is_current, source, status,
+             anchor_block_number, anchor_block_hash, anchor_parent_hash, anchor_block_timestamp
+         )
+         VALUES (
+             $1, $2, $3, $4, $5, $6, $7,
+             $8, $9, $10, $11::NUMERIC(78, 0), $12, $13, $14,
+             $15::NUMERIC(78, 0), $16, $17, $18::NUMERIC(78, 0)
+         )
+         ON CONFLICT ON CONSTRAINT degov_provisional_delegate_power_overlay_scope_unique
+         DO UPDATE SET
+             id = EXCLUDED.id,
+             segment_id = EXCLUDED.segment_id,
+             power = EXCLUDED.power,
+             is_current = EXCLUDED.is_current,
+             status = EXCLUDED.status,
+             anchor_block_number = EXCLUDED.anchor_block_number,
+             anchor_block_hash = EXCLUDED.anchor_block_hash,
+             anchor_parent_hash = EXCLUDED.anchor_parent_hash,
+             anchor_block_timestamp = EXCLUDED.anchor_block_timestamp,
+             updated_at = now()";
+
 #[cfg(test)]
 mod provisional_segment_sql_tests {
     use super::*;
@@ -101,6 +329,20 @@ mod provisional_segment_sql_tests {
         assert!(
             UPSERT_PROVISIONAL_SEGMENT_SQL
                 .contains("ON CONFLICT ON CONSTRAINT degov_provisional_segment_scope_unique")
+        );
+    }
+
+    #[test]
+    fn test_provisional_power_overlay_upserts_target_scope_constraints() {
+        assert!(
+            UPSERT_PROVISIONAL_CONTRIBUTOR_POWER_OVERLAY_SQL.contains(
+                "ON CONFLICT ON CONSTRAINT degov_provisional_contributor_power_overlay_scope_unique"
+            )
+        );
+        assert!(
+            UPSERT_PROVISIONAL_DELEGATE_POWER_OVERLAY_SQL.contains(
+                "ON CONFLICT ON CONSTRAINT degov_provisional_delegate_power_overlay_scope_unique"
+            )
         );
     }
 }

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -540,6 +540,47 @@ async fn test_graphql_schema_serves_indexer_accuracy_audit_queries() -> Result<(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_power_fields_prefer_provisional_overlay_and_fallback_to_final()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_power_overlay_rows(&database.pool).await?;
+    let schema = graphql::build_schema(database.pool.clone());
+
+    let request = Request::new(
+        r#"
+            query LivePowerOverlay {
+              contributors(where: { id_in: ["0xvoter1", "0xvoter2"] }, orderBy: [id_ASC]) {
+                id
+                power
+              }
+              delegates(where: { toDelegate_eq: "0xdelegate" }) {
+                id
+                power
+              }
+            }
+            "#,
+    );
+    let response = schema.execute(request).await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+
+    let data = serde_json::to_value(response.data)?;
+    assert_eq!(data["contributors"][0]["id"], "0xvoter1");
+    assert_eq!(data["contributors"][0]["power"], "999");
+    assert_eq!(data["contributors"][1]["id"], "0xvoter2");
+    assert_eq!(data["contributors"][1]["power"], "25");
+    assert_eq!(data["delegates"][0]["power"], "888");
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_schema_applies_implicit_scope_to_queries_and_connections()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -1215,6 +1256,42 @@ async fn seed_other_scope_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
         "#,
     )
     .bind(OTHER_CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn seed_power_overlay_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO degov_provisional_contributor_power_overlay (
+          id, contract_set_id, chain_id, chain_name, dao_code, governor_address, token_address,
+          account, power, delegates_count_all, delegates_count_effective, source, status,
+          anchor_block_number, anchor_block_timestamp
+        ) VALUES (
+          'overlay:contributor:0xvoter1', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor', '0xtoken',
+          '0xvoter1', 999, 1, 1, 'live-onchain', 'available', 900, 1700000200
+        )
+        "#,
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO degov_provisional_delegate_power_overlay (
+          id, contract_set_id, chain_id, chain_name, dao_code, governor_address, token_address,
+          delegator, delegate, power, is_current, source, status, anchor_block_number,
+          anchor_block_timestamp
+        ) VALUES (
+          'overlay:delegate:0xdelegator:0xdelegate', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor', '0xtoken',
+          '0xdelegator', '0xdelegate', 888, TRUE, 'live-onchain', 'available', 900,
+          1700000200
+        )
+        "#,
+    )
+    .bind(CONTRACT_SET_ID)
     .execute(pool)
     .await?;
 

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -12,11 +12,15 @@ use std::{
 use degov_datalens_indexer::{
     BatchReadPlanConfig, BlockReadMode, ChainReadExecutionReport, ChainReadMethod,
     ChainReadMetrics, ChainReadPlan, ChainReadResult, ChainReadValue, ChainTool,
-    MultiChainToolOnchainRefreshReader, OnchainRefreshReadValue, OnchainRefreshReader,
-    OnchainRefreshReaderError, OnchainRefreshRunReport, OnchainRefreshTask,
+    LivePowerOverlayReader, MultiChainToolOnchainRefreshReader, OnchainRefreshReadValue,
+    OnchainRefreshReader, OnchainRefreshReaderError, OnchainRefreshRunReport, OnchainRefreshTask,
     OnchainRefreshTickClock, OnchainRefreshTickConfig, OnchainRefreshTickRunner,
     OnchainRefreshTickScheduler, OnchainRefreshTickSkipReason, OnchainRefreshWorker,
-    OnchainRefreshWorkerConfig, PartialChainReadFailureReport, runtime::apply_migrations,
+    OnchainRefreshWorkerConfig, PartialChainReadFailureReport,
+    PostgresProvisionalPowerOverlayStore, ProvisionalContributorPowerOverlayWrite,
+    ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
+    ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, refresh_live_power_overlays,
+    runtime::apply_migrations,
 };
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
@@ -687,6 +691,123 @@ fn test_multi_chain_reader_routes_tasks_to_matching_chain_tool() {
     }
 }
 
+#[test]
+fn test_live_power_overlay_reader_uses_latest_block_mode_and_dedupes_accounts() {
+    let chain_tool = StaticValueChainTool::new("19");
+    let reader = LivePowerOverlayReader::new(
+        chain_tool.clone(),
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+    let account = "0xabc0000000000000000000000000000000000000";
+
+    let writes = reader
+        .read_power_overlays(&[
+            task_for_chain("task-one", 46, account),
+            task_for_chain("task-two", 46, account),
+        ])
+        .expect("reads live overlays");
+
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].account, account);
+    assert_eq!(writes[0].power, "19");
+    assert_eq!(writes[0].source, "live-onchain");
+    assert_eq!(writes[0].status, "available");
+    assert_eq!(writes[0].segment_id, None);
+
+    let plans = chain_tool.captured_plans();
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].reads.len(), 1);
+    assert_eq!(plans[0].reads[0].key.block_mode, BlockReadMode::Latest);
+}
+
+#[test]
+fn test_refresh_live_power_overlays_writes_provisional_store_only() {
+    let chain_tool = StaticValueChainTool::new("23");
+    let reader = LivePowerOverlayReader::new(
+        chain_tool,
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+    let mut store =
+        RecordingPowerOverlayStore::with_relations([ProvisionalDelegatePowerOverlayRelation {
+            contract_set_id: "scope-46".to_owned(),
+            chain_id: Some(46),
+            chain_name: None,
+            dao_code: Some("dao-46".to_owned()),
+            governor_address: Some(GOVERNOR.to_owned()),
+            token_address: Some(TOKEN.to_owned()),
+            delegator: "0xabc0000000000000000000000000000000000000".to_owned(),
+            delegate: "0xdef0000000000000000000000000000000000000".to_owned(),
+            is_current: true,
+        }]);
+
+    let written = refresh_live_power_overlays(
+        &reader,
+        &mut store,
+        &[task_for_chain(
+            "task-one",
+            46,
+            "0xabc0000000000000000000000000000000000000",
+        )],
+    )
+    .expect("refresh writes overlay");
+
+    assert_eq!(written, 2);
+    assert_eq!(store.contributors.len(), 1);
+    assert_eq!(store.contributors[0].power, "23");
+    assert_eq!(store.delegates.len(), 1);
+    assert_eq!(store.delegates[0].delegator, store.contributors[0].account);
+    assert_eq!(
+        store.delegates[0].delegate,
+        "0xdef0000000000000000000000000000000000000"
+    );
+    assert_eq!(store.delegates[0].power, "23");
+    assert_eq!(store.delegates[0].source, "live-onchain");
+    assert_eq!(store.delegates[0].status, "available");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_refresh_live_power_overlays_writes_delegate_overlay_from_current_final_delegate()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_final_delegate(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "7").await?;
+    let reader = LivePowerOverlayReader::new(
+        StaticValueChainTool::new("23"),
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+    let mut store = PostgresProvisionalPowerOverlayStore::new(database.pool.clone());
+
+    let written = refresh_live_power_overlays(
+        &reader,
+        &mut store,
+        &[task_for_chain("task-one", 46, ACCOUNT_ONE)],
+    )
+    .expect("refresh writes overlay");
+
+    assert_eq!(written, 2);
+    assert_table_count(
+        &database.pool,
+        "degov_provisional_contributor_power_overlay",
+        1,
+    )
+    .await?;
+    assert_table_count(
+        &database.pool,
+        "degov_provisional_delegate_power_overlay",
+        1,
+    )
+    .await?;
+    assert_delegate_overlay(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "23").await?;
+    assert_table_count(&database.pool, "delegate", 1).await?;
+    assert_table_count(&database.pool, "vote_power_checkpoint", 0).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_fails_only_missing_rpc_chain_group()
 -> Result<(), Box<dyn Error>> {
@@ -802,6 +923,61 @@ struct StaticValueChainTool {
     plans: Arc<StdMutex<Vec<ChainReadPlan>>>,
 }
 
+#[derive(Default)]
+struct RecordingPowerOverlayStore {
+    relations: Vec<ProvisionalDelegatePowerOverlayRelation>,
+    contributors: Vec<ProvisionalContributorPowerOverlayWrite>,
+    delegates: Vec<ProvisionalDelegatePowerOverlayWrite>,
+}
+
+impl RecordingPowerOverlayStore {
+    fn with_relations<const N: usize>(
+        relations: [ProvisionalDelegatePowerOverlayRelation; N],
+    ) -> Self {
+        Self {
+            relations: Vec::from(relations),
+            contributors: Vec::new(),
+            delegates: Vec::new(),
+        }
+    }
+}
+
+impl ProvisionalPowerOverlayStore for RecordingPowerOverlayStore {
+    type Error = String;
+
+    fn current_delegate_power_overlay_relations(
+        &mut self,
+        scopes: &[ProvisionalPowerOverlayScope],
+    ) -> Result<Vec<ProvisionalDelegatePowerOverlayRelation>, Self::Error> {
+        Ok(self
+            .relations
+            .iter()
+            .filter(|relation| {
+                scopes.iter().any(|scope| {
+                    relation.contract_set_id == scope.contract_set_id
+                        && relation.chain_id == Some(scope.chain_id)
+                        && relation.dao_code == scope.dao_code
+                        && relation.governor_address.as_deref()
+                            == Some(scope.governor_address.as_str())
+                        && relation.token_address.as_deref() == Some(scope.token_address.as_str())
+                        && relation.delegator == scope.account
+                })
+            })
+            .cloned()
+            .collect())
+    }
+
+    fn write_power_overlays(
+        &mut self,
+        contributors: &[ProvisionalContributorPowerOverlayWrite],
+        delegates: &[ProvisionalDelegatePowerOverlayWrite],
+    ) -> Result<(), Self::Error> {
+        self.contributors.extend_from_slice(contributors);
+        self.delegates.extend_from_slice(delegates);
+        Ok(())
+    }
+}
+
 impl StaticValueChainTool {
     fn new(value: &str) -> Self {
         Self {
@@ -904,6 +1080,36 @@ async fn seed_contributor_with_scope(
     .bind(token)
     .bind(power)
     .bind(balance)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn seed_final_delegate(
+    pool: &PgPool,
+    delegator: &str,
+    delegate: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO delegate (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            from_delegate, to_delegate, block_number, block_timestamp, transaction_hash,
+            is_current, power
+         )
+         VALUES (
+            $1, 'scope-46', 46, 'dao-46', $2, $3, $4, $5,
+            12::NUMERIC(78, 0), 12000::NUMERIC(78, 0), '0xdelegate', TRUE,
+            $6::NUMERIC(78, 0)
+         )",
+    )
+    .bind(format!("{delegator}_{delegate}"))
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .bind(delegator)
+    .bind(delegate)
+    .bind(power)
     .execute(pool)
     .await?;
 
@@ -1268,6 +1474,44 @@ async fn assert_table_count(pool: &PgPool, table: &str, expected: i64) -> Result
         .get(0);
 
     assert_eq!(count, expected);
+
+    Ok(())
+}
+
+async fn assert_delegate_overlay(
+    pool: &PgPool,
+    delegator: &str,
+    delegate: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT delegator, delegate, power::TEXT AS power, source, status,
+                segment_id, anchor_block_number::TEXT AS anchor_block_number,
+                anchor_block_timestamp::TEXT AS anchor_block_timestamp
+         FROM degov_provisional_delegate_power_overlay
+         WHERE contract_set_id = 'scope-46'
+           AND delegator = $1
+           AND delegate = $2",
+    )
+    .bind(delegator)
+    .bind(delegate)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("delegator"), delegator);
+    assert_eq!(row.get::<String, _>("delegate"), delegate);
+    assert_eq!(row.get::<String, _>("power"), power);
+    assert_eq!(row.get::<String, _>("source"), "live-onchain");
+    assert_eq!(row.get::<String, _>("status"), "available");
+    assert_eq!(row.get::<Option<String>, _>("segment_id"), None);
+    assert_eq!(
+        row.get::<Option<String>, _>("anchor_block_number"),
+        Some("12".to_owned())
+    );
+    assert_eq!(
+        row.get::<Option<String>, _>("anchor_block_timestamp"),
+        Some("12000".to_owned())
+    );
 
     Ok(())
 }

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -11,8 +11,10 @@ use degov_datalens_indexer::{
     DatalensFinality, DatalensProvisionalCacheSegment, DatalensProvisionalFinality,
     DatalensProvisionalLogQueryReader, DatalensProvisionalLogQueryResult,
     DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite, DatasetKeyConfig,
-    GovernanceTokenStandard, PostgresProvisionalSegmentStore, ProvisionalWorker,
-    ProvisionalWorkerOptions, QueryLimitConfig, SecretString, runtime::apply_migrations,
+    GovernanceTokenStandard, PostgresProvisionalPowerOverlayStore, PostgresProvisionalSegmentStore,
+    ProvisionalContributorPowerOverlayWrite, ProvisionalDelegatePowerOverlayWrite,
+    ProvisionalWorker, ProvisionalWorkerOptions, QueryLimitConfig, SecretString,
+    runtime::apply_migrations,
 };
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
@@ -61,6 +63,50 @@ async fn test_postgres_provisional_segment_upsert_is_idempotent_and_does_not_adv
     assert_eq!(
         table_count(&database.pool, "degov_provisional_segment").await?,
         1
+    );
+    assert_checkpoint(&database.pool).await?;
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_live_power_overlay_upsert_is_idempotent_and_writes_no_final_tables()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    insert_checkpoint(&database.pool).await?;
+    let store = PostgresProvisionalPowerOverlayStore::new(database.pool.clone());
+    let contributor = contributor_power_write("0xabc", "19");
+    let delegate = delegate_power_write("0xabc", "0xdef", "19");
+
+    store
+        .write_power_overlays(&[contributor.clone()], &[delegate.clone()])
+        .await
+        .expect("first write succeeds");
+    store
+        .write_power_overlays(&[contributor], &[delegate])
+        .await
+        .expect("retry write succeeds");
+
+    assert_eq!(
+        table_count(
+            &database.pool,
+            "degov_provisional_contributor_power_overlay"
+        )
+        .await?,
+        1
+    );
+    assert_eq!(
+        table_count(&database.pool, "degov_provisional_delegate_power_overlay").await?,
+        1
+    );
+    assert_eq!(table_count(&database.pool, "contributor").await?, 0);
+    assert_eq!(table_count(&database.pool, "delegate").await?, 0);
+    assert_eq!(
+        table_count(&database.pool, "vote_power_checkpoint").await?,
+        0
     );
     assert_checkpoint(&database.pool).await?;
     database.cleanup().await?;
@@ -152,6 +198,59 @@ fn segment_write(
         anchor_parent_hash: Some("0xdef".to_owned()),
         anchor_block_timestamp: Some(1_700_000_000),
         error: None,
+    }
+}
+
+fn contributor_power_write(account: &str, power: &str) -> ProvisionalContributorPowerOverlayWrite {
+    ProvisionalContributorPowerOverlayWrite {
+        id: format!("demo-set:1:demo-dao:0xgovernor:0xtoken:{account}:live-onchain"),
+        segment_id: None,
+        dao_code: Some("demo-dao".to_owned()),
+        contract_set_id: "demo-set".to_owned(),
+        chain_id: Some(1),
+        chain_name: Some("ethereum".to_owned()),
+        governor_address: Some("0xgovernor".to_owned()),
+        token_address: Some("0xtoken".to_owned()),
+        account: account.to_owned(),
+        power: power.to_owned(),
+        balance: None,
+        delegates_count_all: 0,
+        delegates_count_effective: 0,
+        last_vote_block_number: None,
+        last_vote_timestamp: None,
+        source: "live-onchain".to_owned(),
+        status: "available".to_owned(),
+        anchor_block_number: Some("105".to_owned()),
+        anchor_block_hash: None,
+        anchor_parent_hash: None,
+        anchor_block_timestamp: Some("1700000000".to_owned()),
+    }
+}
+
+fn delegate_power_write(
+    delegator: &str,
+    delegate: &str,
+    power: &str,
+) -> ProvisionalDelegatePowerOverlayWrite {
+    ProvisionalDelegatePowerOverlayWrite {
+        id: format!("demo-set:1:demo-dao:0xgovernor:0xtoken:{delegator}:{delegate}:live-onchain"),
+        segment_id: None,
+        dao_code: Some("demo-dao".to_owned()),
+        contract_set_id: "demo-set".to_owned(),
+        chain_id: Some(1),
+        chain_name: Some("ethereum".to_owned()),
+        governor_address: Some("0xgovernor".to_owned()),
+        token_address: Some("0xtoken".to_owned()),
+        delegator: delegator.to_owned(),
+        delegate: delegate.to_owned(),
+        power: power.to_owned(),
+        is_current: true,
+        source: "live-onchain".to_owned(),
+        status: "available".to_owned(),
+        anchor_block_number: Some("105".to_owned()),
+        anchor_block_hash: None,
+        anchor_parent_hash: None,
+        anchor_block_timestamp: Some("1700000000".to_owned()),
     }
 }
 


### PR DESCRIPTION
## Summary
- add a live onchain power overlay read path using latest block reads and per-window account deduping
- add provisional contributor/delegate power overlay write structs and Postgres idempotent upserts
- update GraphQL contributor/delegate power queries and counts to prefer available live overlay rows with final rows as fallback

## Validation
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:6543/postgres cargo test --locked
- node ./scripts/check-rust-conventions.mjs

## Notes
- live overlay writes do not touch final contributor/delegate/checkpoint tables
- segment_id is nullable for this path because segment linkage is not available here yet
- proposal/timelock overlay is intentionally out of scope for HBX-359