### PR TITLE
Implement provisional overlay cleanup

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -95,8 +95,8 @@ pub use crate::projection::vote::{
 };
 pub use crate::store::postgres::{
     PostgresIndexerRunnerStore, PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
-    PostgresProvisionalPowerOverlayStore, PostgresProvisionalProposalOverlayStore,
-    PostgresProvisionalSegmentStore,
+    PostgresProvisionalCleanupStore, PostgresProvisionalPowerOverlayStore,
+    PostgresProvisionalProposalOverlayStore, PostgresProvisionalSegmentStore,
 };
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
@@ -114,12 +114,14 @@ pub use datalens::{
 pub use error::{CheckpointError, ConfigError, DatalensError, IndexerError};
 pub use graphql::IndexerGraphqlSchema;
 pub use provisional::{
-    DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite,
-    ProvisionalContributorPowerOverlayWrite, ProvisionalDelegatePowerOverlayRelation,
-    ProvisionalDelegatePowerOverlayWrite, ProvisionalPowerOverlayScope,
-    ProvisionalPowerOverlayStore, ProvisionalProposalOverlayStore, ProvisionalProposalOverlayWrite,
+    DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite, ProvisionalCleanupReport,
+    ProvisionalCleanupStore, ProvisionalContributorPowerOverlayWrite,
+    ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
+    ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ProvisionalProposalOverlayStore,
+    ProvisionalProposalOverlayWrite, ProvisionalRollbackReport, ProvisionalRollbackScope,
+    ProvisionalSegmentCleanupCandidate, ProvisionalSegmentCleanupDecision,
     ProvisionalTimelockOperationOverlayWrite, ProvisionalWorker, ProvisionalWorkerError,
-    ProvisionalWorkerOptions, ProvisionalWorkerReport,
+    ProvisionalWorkerOptions, ProvisionalWorkerReport, plan_provisional_segment_cleanup,
 };
 pub use runner::{
     AdaptiveChunkFeedback, AdaptiveChunkSizer, AdaptiveChunkSizerConfig,

--- a/apps/indexer/src/provisional.rs
+++ b/apps/indexer/src/provisional.rs
@@ -1,9 +1,13 @@
 use std::fmt;
 
+use datalens_sdk::safety::{
+    BlockAnchor, DataFinality, DataRange, PromotionDecision, plan_promotion,
+};
+
 use crate::{
     DaoContractAddresses, DatalensConfig, DatalensError, DatalensProvisionalCacheSegment,
-    DatalensProvisionalFinality, DatalensProvisionalLogQueryReader, datalens_selector_fingerprint,
-    fetch_provisional_dao_log_pages, plan_dao_log_queries,
+    DatalensProvisionalFinality, DatalensProvisionalLogQueryReader, IndexerCheckpointIdentity,
+    datalens_selector_fingerprint, fetch_provisional_dao_log_pages, plan_dao_log_queries,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -196,6 +200,47 @@ pub struct ProvisionalWorkerReport {
     pub segments_written: usize,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalRollbackScope {
+    pub dao_code: String,
+    pub contract_set_id: String,
+    pub chain_id: i32,
+    pub source: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProvisionalCleanupReport {
+    pub segments_marked_finalized: usize,
+    pub contributor_overlays_marked_finalized: usize,
+    pub delegate_overlays_marked_finalized: usize,
+    pub proposal_overlays_marked_finalized: usize,
+    pub timelock_overlays_marked_finalized: usize,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProvisionalRollbackReport {
+    pub segments_marked_invalid: usize,
+    pub contributor_overlays_marked_invalid: usize,
+    pub delegate_overlays_marked_invalid: usize,
+    pub proposal_overlays_marked_invalid: usize,
+    pub timelock_overlays_marked_invalid: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvisionalSegmentCleanupCandidate {
+    pub range_start_block: i64,
+    pub range_end_block: i64,
+    pub segment_finality: String,
+    pub anchor_block_number: Option<i64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProvisionalSegmentCleanupDecision {
+    Finalize,
+    Keep,
+    Invalid,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ProvisionalWorkerError {
     #[error("provisional Datalens query error: {0}")]
@@ -237,6 +282,81 @@ pub trait ProvisionalProposalOverlayStore {
         proposals: &[ProvisionalProposalOverlayWrite],
         timelocks: &[ProvisionalTimelockOperationOverlayWrite],
     ) -> Result<(), Self::Error>;
+}
+
+pub trait ProvisionalCleanupStore {
+    type Error: fmt::Display;
+
+    fn cleanup_finalized_provisional_overlays(
+        &mut self,
+        identity: &IndexerCheckpointIdentity,
+        source: Option<&str>,
+    ) -> Result<ProvisionalCleanupReport, Self::Error>;
+
+    fn rollback_provisional_overlays(
+        &mut self,
+        scope: &ProvisionalRollbackScope,
+        reason: &str,
+    ) -> Result<ProvisionalRollbackReport, Self::Error>;
+}
+
+pub fn plan_provisional_segment_cleanup(
+    finalized_height: i64,
+    candidate: &ProvisionalSegmentCleanupCandidate,
+) -> ProvisionalSegmentCleanupDecision {
+    if finalized_height < 0
+        || candidate.range_start_block < 0
+        || candidate.range_end_block < candidate.range_start_block
+    {
+        return ProvisionalSegmentCleanupDecision::Invalid;
+    }
+
+    let Ok(finalized_height) = u64::try_from(finalized_height) else {
+        return ProvisionalSegmentCleanupDecision::Invalid;
+    };
+    let Ok(range_start) = u64::try_from(candidate.range_start_block) else {
+        return ProvisionalSegmentCleanupDecision::Invalid;
+    };
+    let Ok(range_end) = u64::try_from(candidate.range_end_block) else {
+        return ProvisionalSegmentCleanupDecision::Invalid;
+    };
+    let anchor_height = candidate
+        .anchor_block_number
+        .and_then(|height| u64::try_from(height).ok())
+        .unwrap_or(range_end);
+    let durable_head = BlockAnchor {
+        range_kind: "block".to_owned(),
+        height: finalized_height,
+        block_hash: None,
+        parent_hash: None,
+        timestamp: None,
+        finality: DataFinality::Safe,
+    };
+    let provisional_range = DataRange::new("block", range_start, range_end);
+    let provisional_anchor = BlockAnchor {
+        range_kind: "block".to_owned(),
+        height: anchor_height,
+        block_hash: None,
+        parent_hash: None,
+        timestamp: None,
+        finality: DataFinality::from(candidate.segment_finality.as_str()),
+    };
+
+    match plan_promotion(
+        Some(&durable_head),
+        Some(&provisional_range),
+        Some(&provisional_anchor),
+    )
+    .decision
+    {
+        PromotionDecision::Promote { .. } => ProvisionalSegmentCleanupDecision::Finalize,
+        PromotionDecision::Rollback { .. } => ProvisionalSegmentCleanupDecision::Invalid,
+        PromotionDecision::KeepProvisional { .. } => ProvisionalSegmentCleanupDecision::Keep,
+        PromotionDecision::Recheck { .. } if finalized_height >= range_end => {
+            ProvisionalSegmentCleanupDecision::Finalize
+        }
+        PromotionDecision::Recheck { .. } => ProvisionalSegmentCleanupDecision::Keep,
+    }
 }
 
 pub struct ProvisionalWorker<'a, R, S> {

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -13,7 +13,8 @@ use crate::{
     IndexerRuntimeConfig, IndexerTargetHeight, MultiChainToolOnchainRefreshReader,
     OnchainRefreshRuntimeConfig, OnchainRefreshTickReport, OnchainRefreshTickRunner,
     OnchainRefreshTickScheduler, OnchainRefreshWorker, OnchainRefreshWorkerError,
-    PostgresIndexerRunnerStore, datalens_retry_config, ensure_datalens_warmup_task, required_env,
+    PostgresIndexerRunnerStore, PostgresProvisionalCleanupStore, datalens_retry_config,
+    ensure_datalens_warmup_task, required_env,
 };
 
 use super::{datalens::verify_datalens, migrate::apply_migrations};
@@ -155,7 +156,7 @@ async fn run_configured_contract_set_pass(
         contract_runtime.clone(),
         contract_set.config.clone(),
         contract_set.addresses.clone(),
-        pool,
+        pool.clone(),
         datalens_query_gate,
     )
     .await
@@ -170,6 +171,7 @@ async fn run_configured_contract_set_pass(
             );
         }
     };
+    cleanup_finalized_provisional_overlays(&contract_runtime, &contract_set, pool.clone()).await?;
 
     log::info!(
         "Datalens indexer run pass completed dao_code={} chain_id={} contract_set_id={} chunks_processed={} processed_height={:?} target_height={} synced_percentage={} onchain_refresh_allowed={}",
@@ -182,6 +184,58 @@ async fn run_configured_contract_set_pass(
         report.last_progress.synced_percentage,
         report.last_progress.onchain_refresh_allowed
     );
+
+    Ok(())
+}
+
+async fn cleanup_finalized_provisional_overlays(
+    runtime: &IndexerContractSetRuntimeConfig,
+    contract_set: &DatalensRuntimeContractSet,
+    pool: sqlx::PgPool,
+) -> Result<()> {
+    let identity = crate::IndexerCheckpointIdentity {
+        dao_code: runtime.dao_code.clone(),
+        chain_id: contract_set.contract.chain_id,
+        contract_set_id: runtime.checkpoint_contract_set_id.clone(),
+        stream_id: runtime.checkpoint_stream_id.clone(),
+        data_source_version: runtime.data_source_version.clone(),
+    };
+    let store = PostgresProvisionalCleanupStore::new(pool);
+    let report = match store
+        .cleanup_finalized_provisional_overlays(&identity, None)
+        .await
+    {
+        Ok(report) => report,
+        Err(error) => {
+            log::warn!(
+                "Datalens indexer provisional cleanup failed after final pass dao_code={} chain_id={} contract_set_id={} error={}",
+                identity.dao_code,
+                identity.chain_id,
+                identity.contract_set_id,
+                error
+            );
+            return Ok(());
+        }
+    };
+
+    if report.segments_marked_finalized > 0
+        || report.contributor_overlays_marked_finalized > 0
+        || report.delegate_overlays_marked_finalized > 0
+        || report.proposal_overlays_marked_finalized > 0
+        || report.timelock_overlays_marked_finalized > 0
+    {
+        log::info!(
+            "Datalens indexer provisional cleanup completed dao_code={} chain_id={} contract_set_id={} segments_marked_finalized={} contributor_overlays_marked_finalized={} delegate_overlays_marked_finalized={} proposal_overlays_marked_finalized={} timelock_overlays_marked_finalized={}",
+            identity.dao_code,
+            identity.chain_id,
+            identity.contract_set_id,
+            report.segments_marked_finalized,
+            report.contributor_overlays_marked_finalized,
+            report.delegate_overlays_marked_finalized,
+            report.proposal_overlays_marked_finalized,
+            report.timelock_overlays_marked_finalized
+        );
+    }
 
     Ok(())
 }

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -14,15 +14,18 @@ use crate::{
     IndexerRunnerTransaction, PowerReconcileCandidate, ProposalActionWrite, ProposalCreatedWrite,
     ProposalDeadlineExtensionWrite, ProposalExtendedWrite, ProposalIdWrite,
     ProposalProjectionBatch, ProposalQueuedWrite, ProposalStateEpochWrite, ProposalVoteTotalWrite,
-    ProposalWrite, ProvisionalContributorPowerOverlayWrite,
-    ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
-    ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ProvisionalProposalOverlayStore,
-    ProvisionalProposalOverlayWrite, ProvisionalTimelockOperationOverlayWrite, TimelockCallWrite,
+    ProposalWrite, ProvisionalCleanupReport, ProvisionalCleanupStore,
+    ProvisionalContributorPowerOverlayWrite, ProvisionalDelegatePowerOverlayRelation,
+    ProvisionalDelegatePowerOverlayWrite, ProvisionalPowerOverlayScope,
+    ProvisionalPowerOverlayStore, ProvisionalProposalOverlayStore, ProvisionalProposalOverlayWrite,
+    ProvisionalRollbackReport, ProvisionalRollbackScope, ProvisionalSegmentCleanupCandidate,
+    ProvisionalSegmentCleanupDecision, ProvisionalTimelockOperationOverlayWrite, TimelockCallWrite,
     TimelockMinDelayChangeWrite, TimelockOperationHintWrite, TimelockOperationWrite,
     TimelockProjectionBatch, TimelockProjectionContext, TimelockProjectionEvent,
     TimelockProposalActionLink, TimelockProposalLinkContext, TimelockRoleEventWrite,
     TokenEventCommon, TokenProjectionBatch, TokenProjectionOperation, TokenTransferWrite,
     VoteCastGroupWrite, VoteCastWithParamsWrite, VoteCastWrite, VoteProjectionBatch,
+    plan_provisional_segment_cleanup,
 };
 
 #[derive(Clone)]

--- a/apps/indexer/src/store/postgres/provisional.rs
+++ b/apps/indexer/src/store/postgres/provisional.rs
@@ -32,7 +32,6 @@ impl PostgresProvisionalCleanupStore {
                 "degov_provisional_contributor_power_overlay",
                 identity,
                 source,
-                finalized_height,
                 &segment_ids,
             )
             .await?,
@@ -41,7 +40,6 @@ impl PostgresProvisionalCleanupStore {
                 "degov_provisional_delegate_power_overlay",
                 identity,
                 source,
-                finalized_height,
                 &segment_ids,
             )
             .await?,
@@ -50,7 +48,6 @@ impl PostgresProvisionalCleanupStore {
                 "degov_provisional_proposal_overlay",
                 identity,
                 source,
-                finalized_height,
                 &segment_ids,
             )
             .await?,
@@ -59,7 +56,6 @@ impl PostgresProvisionalCleanupStore {
                 "degov_provisional_timelock_operation_overlay",
                 identity,
                 source,
-                finalized_height,
                 &segment_ids,
             )
             .await?,
@@ -387,9 +383,12 @@ async fn mark_finalized_overlay_table(
     table: &str,
     identity: &IndexerCheckpointIdentity,
     source: Option<&str>,
-    finalized_height: i64,
     segment_ids: &[String],
 ) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    if segment_ids.is_empty() {
+        return Ok(0);
+    }
+
     let result = sqlx::query(&format!(
         "UPDATE {table}
          SET status = 'finalized',
@@ -399,19 +398,12 @@ async fn mark_finalized_overlay_table(
            AND chain_id IS NOT DISTINCT FROM $2
            AND contract_set_id = $3
            AND ($4::TEXT IS NULL OR source = $4)
-           AND (
-             (
-               anchor_block_number IS NOT NULL
-               AND anchor_block_number <= $5::NUMERIC(78, 0)
-             )
-             OR segment_id = ANY($6::TEXT[])
-           )"
+           AND segment_id = ANY($5::TEXT[])"
     ))
     .bind(&identity.dao_code)
     .bind(identity.chain_id)
     .bind(&identity.contract_set_id)
     .bind(source)
-    .bind(finalized_height)
     .bind(segment_ids)
     .execute(&mut **transaction)
     .await?;

--- a/apps/indexer/src/store/postgres/provisional.rs
+++ b/apps/indexer/src/store/postgres/provisional.rs
@@ -1,4 +1,145 @@
 #[derive(Clone)]
+pub struct PostgresProvisionalCleanupStore {
+    pool: PgPool,
+}
+
+impl PostgresProvisionalCleanupStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn cleanup_finalized_provisional_overlays(
+        &self,
+        identity: &IndexerCheckpointIdentity,
+        source: Option<&str>,
+    ) -> Result<ProvisionalCleanupReport, PostgresIndexerRunnerStoreError> {
+        let mut transaction = self.pool.begin().await?;
+        let Some(finalized_height) =
+            read_finalized_checkpoint_height(&mut transaction, identity).await?
+        else {
+            transaction.commit().await?;
+            return Ok(ProvisionalCleanupReport::default());
+        };
+        let segment_ids =
+            finalized_provisional_segment_ids(&mut transaction, identity, source, finalized_height)
+                .await?;
+
+        let report = ProvisionalCleanupReport {
+            segments_marked_finalized: mark_segments_finalized(&mut transaction, &segment_ids)
+                .await?,
+            contributor_overlays_marked_finalized: mark_finalized_overlay_table(
+                &mut transaction,
+                "degov_provisional_contributor_power_overlay",
+                identity,
+                source,
+                finalized_height,
+                &segment_ids,
+            )
+            .await?,
+            delegate_overlays_marked_finalized: mark_finalized_overlay_table(
+                &mut transaction,
+                "degov_provisional_delegate_power_overlay",
+                identity,
+                source,
+                finalized_height,
+                &segment_ids,
+            )
+            .await?,
+            proposal_overlays_marked_finalized: mark_finalized_overlay_table(
+                &mut transaction,
+                "degov_provisional_proposal_overlay",
+                identity,
+                source,
+                finalized_height,
+                &segment_ids,
+            )
+            .await?,
+            timelock_overlays_marked_finalized: mark_finalized_overlay_table(
+                &mut transaction,
+                "degov_provisional_timelock_operation_overlay",
+                identity,
+                source,
+                finalized_height,
+                &segment_ids,
+            )
+            .await?,
+        };
+        transaction.commit().await?;
+
+        Ok(report)
+    }
+
+    pub async fn rollback_provisional_overlays(
+        &self,
+        scope: &ProvisionalRollbackScope,
+        reason: &str,
+    ) -> Result<ProvisionalRollbackReport, PostgresIndexerRunnerStoreError> {
+        let mut transaction = self.pool.begin().await?;
+        let report = ProvisionalRollbackReport {
+            segments_marked_invalid: mark_available_segments_invalid(
+                &mut transaction,
+                scope,
+                reason,
+            )
+            .await?,
+            contributor_overlays_marked_invalid: mark_available_overlay_table_invalid(
+                &mut transaction,
+                "degov_provisional_contributor_power_overlay",
+                scope,
+            )
+            .await?,
+            delegate_overlays_marked_invalid: mark_available_overlay_table_invalid(
+                &mut transaction,
+                "degov_provisional_delegate_power_overlay",
+                scope,
+            )
+            .await?,
+            proposal_overlays_marked_invalid: mark_available_overlay_table_invalid(
+                &mut transaction,
+                "degov_provisional_proposal_overlay",
+                scope,
+            )
+            .await?,
+            timelock_overlays_marked_invalid: mark_available_overlay_table_invalid(
+                &mut transaction,
+                "degov_provisional_timelock_operation_overlay",
+                scope,
+            )
+            .await?,
+        };
+        transaction.commit().await?;
+
+        Ok(report)
+    }
+}
+
+impl ProvisionalCleanupStore for PostgresProvisionalCleanupStore {
+    type Error = PostgresIndexerRunnerStoreError;
+
+    fn cleanup_finalized_provisional_overlays(
+        &mut self,
+        identity: &IndexerCheckpointIdentity,
+        source: Option<&str>,
+    ) -> Result<ProvisionalCleanupReport, Self::Error> {
+        block_on_runtime(
+            PostgresProvisionalCleanupStore::cleanup_finalized_provisional_overlays(
+                self, identity, source,
+            ),
+        )
+    }
+
+    fn rollback_provisional_overlays(
+        &mut self,
+        scope: &ProvisionalRollbackScope,
+        reason: &str,
+    ) -> Result<ProvisionalRollbackReport, Self::Error> {
+        block_on_runtime(PostgresProvisionalCleanupStore::rollback_provisional_overlays(
+            self, scope, reason,
+        ))
+    }
+}
+
+#[derive(Clone)]
 pub struct PostgresProvisionalSegmentStore {
     pool: PgPool,
 }
@@ -142,6 +283,192 @@ impl ProvisionalProposalOverlayStore for PostgresProvisionalProposalOverlayStore
             self, proposals, timelocks,
         ))
     }
+}
+
+async fn read_finalized_checkpoint_height(
+    transaction: &mut Transaction<'_, Postgres>,
+    identity: &IndexerCheckpointIdentity,
+) -> Result<Option<i64>, PostgresIndexerRunnerStoreError> {
+    let row = sqlx::query(
+        "SELECT processed_height::BIGINT AS processed_height
+         FROM degov_indexer_checkpoint
+         WHERE dao_code = $1
+           AND chain_id = $2
+           AND contract_set_id = $3
+           AND stream_id = $4
+           AND data_source_version = $5",
+    )
+    .bind(&identity.dao_code)
+    .bind(identity.chain_id)
+    .bind(&identity.contract_set_id)
+    .bind(&identity.stream_id)
+    .bind(&identity.data_source_version)
+    .fetch_optional(&mut **transaction)
+    .await?;
+
+    Ok(row
+        .map(|row| row.try_get::<Option<i64>, _>("processed_height"))
+        .transpose()?
+        .flatten())
+}
+
+async fn finalized_provisional_segment_ids(
+    transaction: &mut Transaction<'_, Postgres>,
+    identity: &IndexerCheckpointIdentity,
+    source: Option<&str>,
+    finalized_height: i64,
+) -> Result<Vec<String>, PostgresIndexerRunnerStoreError> {
+    let rows = sqlx::query(
+        "SELECT
+             id,
+             range_start_block::BIGINT AS range_start_block,
+             range_end_block::BIGINT AS range_end_block,
+             segment_finality,
+             anchor_block_number::BIGINT AS anchor_block_number
+         FROM degov_provisional_segment
+         WHERE status = 'available'
+           AND dao_code = $1
+           AND chain_id IS NOT DISTINCT FROM $2
+           AND contract_set_id = $3
+           AND ($4::TEXT IS NULL OR source = $4)
+           AND range_end_block <= $5::NUMERIC(78, 0)
+           AND COALESCE(anchor_block_number, range_end_block) <= $5::NUMERIC(78, 0)",
+    )
+    .bind(&identity.dao_code)
+    .bind(identity.chain_id)
+    .bind(&identity.contract_set_id)
+    .bind(source)
+    .bind(finalized_height)
+    .fetch_all(&mut **transaction)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let candidate = ProvisionalSegmentCleanupCandidate {
+                range_start_block: row.get("range_start_block"),
+                range_end_block: row.get("range_end_block"),
+                segment_finality: row.get("segment_finality"),
+                anchor_block_number: row.get("anchor_block_number"),
+            };
+            match plan_provisional_segment_cleanup(finalized_height, &candidate) {
+                ProvisionalSegmentCleanupDecision::Finalize => Some(row.get("id")),
+                ProvisionalSegmentCleanupDecision::Keep
+                | ProvisionalSegmentCleanupDecision::Invalid => None,
+            }
+        })
+        .collect())
+}
+
+async fn mark_segments_finalized(
+    transaction: &mut Transaction<'_, Postgres>,
+    segment_ids: &[String],
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    if segment_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let result = sqlx::query(
+        "UPDATE degov_provisional_segment
+         SET status = 'finalized',
+             updated_at = now()
+         WHERE status = 'available'
+           AND id = ANY($1::TEXT[])",
+    )
+    .bind(segment_ids)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(result.rows_affected() as usize)
+}
+
+async fn mark_finalized_overlay_table(
+    transaction: &mut Transaction<'_, Postgres>,
+    table: &str,
+    identity: &IndexerCheckpointIdentity,
+    source: Option<&str>,
+    finalized_height: i64,
+    segment_ids: &[String],
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    let result = sqlx::query(&format!(
+        "UPDATE {table}
+         SET status = 'finalized',
+             updated_at = now()
+         WHERE status = 'available'
+           AND dao_code = $1
+           AND chain_id IS NOT DISTINCT FROM $2
+           AND contract_set_id = $3
+           AND ($4::TEXT IS NULL OR source = $4)
+           AND (
+             (
+               anchor_block_number IS NOT NULL
+               AND anchor_block_number <= $5::NUMERIC(78, 0)
+             )
+             OR segment_id = ANY($6::TEXT[])
+           )"
+    ))
+    .bind(&identity.dao_code)
+    .bind(identity.chain_id)
+    .bind(&identity.contract_set_id)
+    .bind(source)
+    .bind(finalized_height)
+    .bind(segment_ids)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(result.rows_affected() as usize)
+}
+
+async fn mark_available_segments_invalid(
+    transaction: &mut Transaction<'_, Postgres>,
+    scope: &ProvisionalRollbackScope,
+    reason: &str,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    let result = sqlx::query(
+        "UPDATE degov_provisional_segment
+         SET status = 'invalid',
+             error = $5,
+             updated_at = now()
+         WHERE status = 'available'
+           AND dao_code = $1
+           AND chain_id IS NOT DISTINCT FROM $2
+           AND contract_set_id = $3
+           AND ($4::TEXT IS NULL OR source = $4)",
+    )
+    .bind(&scope.dao_code)
+    .bind(scope.chain_id)
+    .bind(&scope.contract_set_id)
+    .bind(scope.source.as_deref())
+    .bind(reason)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(result.rows_affected() as usize)
+}
+
+async fn mark_available_overlay_table_invalid(
+    transaction: &mut Transaction<'_, Postgres>,
+    table: &str,
+    scope: &ProvisionalRollbackScope,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    let result = sqlx::query(&format!(
+        "UPDATE {table}
+         SET status = 'invalid',
+             updated_at = now()
+         WHERE status = 'available'
+           AND dao_code = $1
+           AND chain_id IS NOT DISTINCT FROM $2
+           AND contract_set_id = $3
+           AND ($4::TEXT IS NULL OR source = $4)"
+    ))
+    .bind(&scope.dao_code)
+    .bind(scope.chain_id)
+    .bind(&scope.contract_set_id)
+    .bind(scope.source.as_deref())
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(result.rows_affected() as usize)
 }
 
 async fn upsert_provisional_segment(

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -253,6 +253,60 @@ async fn test_postgres_cleanup_after_finalized_checkpoint_hides_all_overlay_type
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_cleanup_keeps_live_onchain_overlays_without_segment_id()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    insert_checkpoint_at(&database.pool, 110).await?;
+    insert_available_live_onchain_overlay_rows(&database.pool, "demo-dao", "demo-set", 1).await?;
+    let cleanup_store = PostgresProvisionalCleanupStore::new(database.pool.clone());
+
+    let report = cleanup_store
+        .cleanup_finalized_provisional_overlays(
+            &checkpoint_identity("demo-dao", "demo-set", 1),
+            None,
+        )
+        .await
+        .expect("cleanup succeeds");
+
+    assert_eq!(report.segments_marked_finalized, 0);
+    assert_eq!(report.contributor_overlays_marked_finalized, 0);
+    assert_eq!(report.delegate_overlays_marked_finalized, 0);
+    assert_eq!(report.proposal_overlays_marked_finalized, 0);
+    assert_eq!(report.timelock_overlays_marked_finalized, 0);
+    assert_eq!(
+        active_provisional_count(
+            &database.pool,
+            "degov_provisional_contributor_power_overlay"
+        )
+        .await?,
+        1
+    );
+    assert_eq!(
+        active_provisional_count(&database.pool, "degov_provisional_delegate_power_overlay")
+            .await?,
+        1
+    );
+    assert_eq!(
+        active_provisional_count(&database.pool, "degov_provisional_proposal_overlay").await?,
+        1
+    );
+    assert_eq!(
+        active_provisional_count(
+            &database.pool,
+            "degov_provisional_timelock_operation_overlay"
+        )
+        .await?,
+        1
+    );
+    assert_checkpoint_at(&database.pool, 110).await?;
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_rollback_invalidates_provisional_overlays_without_mutating_final_rows()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -290,6 +344,48 @@ async fn test_postgres_rollback_invalidates_provisional_overlays_without_mutatin
         "invalid"
     );
     assert_final_rows(&database.pool).await?;
+    assert_checkpoint_at(&database.pool, 10).await?;
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_rollback_invalidates_live_onchain_overlays_without_segment_id()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    insert_checkpoint_at(&database.pool, 10).await?;
+    insert_available_live_onchain_overlay_rows(&database.pool, "demo-dao", "demo-set", 1).await?;
+    let cleanup_store = PostgresProvisionalCleanupStore::new(database.pool.clone());
+
+    let report = cleanup_store
+        .rollback_provisional_overlays(
+            &ProvisionalRollbackScope {
+                dao_code: "demo-dao".to_owned(),
+                contract_set_id: "demo-set".to_owned(),
+                chain_id: 1,
+                source: Some("live-onchain".to_owned()),
+            },
+            "test invalidation",
+        )
+        .await
+        .expect("rollback succeeds");
+
+    assert_eq!(report.segments_marked_invalid, 0);
+    assert_eq!(report.contributor_overlays_marked_invalid, 1);
+    assert_eq!(report.delegate_overlays_marked_invalid, 1);
+    assert_eq!(report.proposal_overlays_marked_invalid, 1);
+    assert_eq!(report.timelock_overlays_marked_invalid, 1);
+    assert_eq!(
+        active_provisional_count(
+            &database.pool,
+            "degov_provisional_contributor_power_overlay"
+        )
+        .await?,
+        0
+    );
     assert_checkpoint_at(&database.pool, 10).await?;
     database.cleanup().await?;
 
@@ -869,6 +965,65 @@ async fn insert_available_provisional_rows(
         chain_id,
     );
     timelock.segment_id = Some(segment_id);
+
+    power_store
+        .write_power_overlays(&[contributor], &[delegate])
+        .await?;
+    proposal_store
+        .write_proposal_overlays(&[proposal], &[timelock])
+        .await?;
+
+    Ok(())
+}
+
+async fn insert_available_live_onchain_overlay_rows(
+    pool: &PgPool,
+    dao_code: &str,
+    contract_set_id: &str,
+    chain_id: i32,
+) -> Result<(), Box<dyn Error>> {
+    let power_store = PostgresProvisionalPowerOverlayStore::new(pool.clone());
+    let proposal_store = PostgresProvisionalProposalOverlayStore::new(pool.clone());
+    let mut contributor = contributor_power_write("0xliveabc", "29");
+    set_overlay_scope(
+        &mut contributor.id,
+        &mut contributor.dao_code,
+        &mut contributor.contract_set_id,
+        &mut contributor.chain_id,
+        dao_code,
+        contract_set_id,
+        chain_id,
+    );
+    let mut delegate = delegate_power_write("0xliveabc", "0xlivedef", "29");
+    set_overlay_scope(
+        &mut delegate.id,
+        &mut delegate.dao_code,
+        &mut delegate.contract_set_id,
+        &mut delegate.chain_id,
+        dao_code,
+        contract_set_id,
+        chain_id,
+    );
+    let mut proposal = proposal_overlay_write("84", "Queued");
+    set_overlay_scope(
+        &mut proposal.id,
+        &mut proposal.dao_code,
+        &mut proposal.contract_set_id,
+        &mut proposal.chain_id,
+        dao_code,
+        contract_set_id,
+        chain_id,
+    );
+    let mut timelock = timelock_overlay_write("84", "0xliveoperation", "Ready");
+    set_overlay_scope(
+        &mut timelock.id,
+        &mut timelock.dao_code,
+        &mut timelock.contract_set_id,
+        &mut timelock.chain_id,
+        dao_code,
+        contract_set_id,
+        chain_id,
+    );
 
     power_store
         .write_power_overlays(&[contributor], &[delegate])

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -11,11 +11,14 @@ use degov_datalens_indexer::{
     DatalensFinality, DatalensProvisionalCacheSegment, DatalensProvisionalFinality,
     DatalensProvisionalLogQueryReader, DatalensProvisionalLogQueryResult,
     DatalensProvisionalSegmentStore, DatalensProvisionalSegmentWrite, DatasetKeyConfig,
-    GovernanceTokenStandard, PostgresProvisionalPowerOverlayStore,
-    PostgresProvisionalProposalOverlayStore, PostgresProvisionalSegmentStore,
-    ProvisionalContributorPowerOverlayWrite, ProvisionalDelegatePowerOverlayWrite,
-    ProvisionalProposalOverlayWrite, ProvisionalTimelockOperationOverlayWrite, ProvisionalWorker,
-    ProvisionalWorkerOptions, QueryLimitConfig, SecretString, runtime::apply_migrations,
+    GovernanceTokenStandard, IndexerCheckpointIdentity, PostgresProvisionalCleanupStore,
+    PostgresProvisionalPowerOverlayStore, PostgresProvisionalProposalOverlayStore,
+    PostgresProvisionalSegmentStore, ProvisionalContributorPowerOverlayWrite,
+    ProvisionalDelegatePowerOverlayWrite, ProvisionalProposalOverlayWrite,
+    ProvisionalRollbackScope, ProvisionalSegmentCleanupCandidate,
+    ProvisionalSegmentCleanupDecision, ProvisionalTimelockOperationOverlayWrite, ProvisionalWorker,
+    ProvisionalWorkerOptions, QueryLimitConfig, SecretString, plan_provisional_segment_cleanup,
+    runtime::apply_migrations,
 };
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
@@ -40,6 +43,36 @@ fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
     assert_eq!(reader.calls[0].finality.as_deref(), Some("safe_to_latest"));
     assert_eq!(store.writes.len(), 1);
     assert_eq!(store.writes[0].segment_finality, "latest");
+}
+
+#[test]
+fn test_provisional_cleanup_planner_finalizes_latest_segment_after_safe_checkpoint_covers_range() {
+    let decision = plan_provisional_segment_cleanup(
+        110,
+        &ProvisionalSegmentCleanupCandidate {
+            range_start_block: 100,
+            range_end_block: 105,
+            segment_finality: "latest".to_owned(),
+            anchor_block_number: Some(105),
+        },
+    );
+
+    assert_eq!(decision, ProvisionalSegmentCleanupDecision::Finalize);
+}
+
+#[test]
+fn test_provisional_cleanup_planner_keeps_segment_until_safe_checkpoint_covers_range() {
+    let decision = plan_provisional_segment_cleanup(
+        102,
+        &ProvisionalSegmentCleanupCandidate {
+            range_start_block: 100,
+            range_end_block: 105,
+            segment_finality: "latest".to_owned(),
+            anchor_block_number: Some(105),
+        },
+    );
+
+    assert_eq!(decision, ProvisionalSegmentCleanupDecision::Keep);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -154,6 +187,190 @@ async fn test_postgres_live_proposal_timelock_overlay_upsert_is_idempotent_and_w
     );
     assert_eq!(table_count(&database.pool, "timelock_operation").await?, 0);
     assert_checkpoint(&database.pool).await?;
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_cleanup_after_finalized_checkpoint_hides_all_overlay_types_without_mutating_final_rows()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    insert_checkpoint_at(&database.pool, 110).await?;
+    insert_final_rows(&database.pool).await?;
+    insert_available_provisional_rows(&database.pool, "demo-dao", "demo-set", 1).await?;
+    let cleanup_store = PostgresProvisionalCleanupStore::new(database.pool.clone());
+
+    let report = cleanup_store
+        .cleanup_finalized_provisional_overlays(
+            &checkpoint_identity("demo-dao", "demo-set", 1),
+            None,
+        )
+        .await
+        .expect("cleanup succeeds");
+
+    assert_eq!(report.segments_marked_finalized, 1);
+    assert_eq!(report.contributor_overlays_marked_finalized, 1);
+    assert_eq!(report.delegate_overlays_marked_finalized, 1);
+    assert_eq!(report.proposal_overlays_marked_finalized, 1);
+    assert_eq!(report.timelock_overlays_marked_finalized, 1);
+    assert_eq!(
+        active_provisional_count(&database.pool, "degov_provisional_segment").await?,
+        0
+    );
+    assert_eq!(
+        active_provisional_count(
+            &database.pool,
+            "degov_provisional_contributor_power_overlay"
+        )
+        .await?,
+        0
+    );
+    assert_eq!(
+        active_provisional_count(&database.pool, "degov_provisional_delegate_power_overlay")
+            .await?,
+        0
+    );
+    assert_eq!(
+        active_provisional_count(&database.pool, "degov_provisional_proposal_overlay").await?,
+        0
+    );
+    assert_eq!(
+        active_provisional_count(
+            &database.pool,
+            "degov_provisional_timelock_operation_overlay"
+        )
+        .await?,
+        0
+    );
+    assert_final_rows(&database.pool).await?;
+    assert_checkpoint_at(&database.pool, 110).await?;
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_rollback_invalidates_provisional_overlays_without_mutating_final_rows()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    insert_checkpoint_at(&database.pool, 10).await?;
+    insert_final_rows(&database.pool).await?;
+    insert_available_provisional_rows(&database.pool, "demo-dao", "demo-set", 1).await?;
+    let cleanup_store = PostgresProvisionalCleanupStore::new(database.pool.clone());
+
+    let report = cleanup_store
+        .rollback_provisional_overlays(
+            &ProvisionalRollbackScope {
+                dao_code: "demo-dao".to_owned(),
+                contract_set_id: "demo-set".to_owned(),
+                chain_id: 1,
+                source: None,
+            },
+            "test invalidation",
+        )
+        .await
+        .expect("rollback succeeds");
+
+    assert_eq!(report.segments_marked_invalid, 1);
+    assert_eq!(report.contributor_overlays_marked_invalid, 1);
+    assert_eq!(report.delegate_overlays_marked_invalid, 1);
+    assert_eq!(report.proposal_overlays_marked_invalid, 1);
+    assert_eq!(report.timelock_overlays_marked_invalid, 1);
+    assert_eq!(
+        active_provisional_count(&database.pool, "degov_provisional_segment").await?,
+        0
+    );
+    assert_eq!(
+        provisional_status(&database.pool, "degov_provisional_segment").await?,
+        "invalid"
+    );
+    assert_final_rows(&database.pool).await?;
+    assert_checkpoint_at(&database.pool, 10).await?;
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_cleanup_scopes_by_contract_set_chain_and_dao() -> Result<(), Box<dyn Error>>
+{
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    insert_checkpoint_at(&database.pool, 110).await?;
+    insert_checkpoint_for(&database.pool, "other-dao", "other-set", 2, 110).await?;
+    insert_available_provisional_rows(&database.pool, "demo-dao", "demo-set", 1).await?;
+    insert_available_provisional_rows(&database.pool, "other-dao", "other-set", 2).await?;
+    let cleanup_store = PostgresProvisionalCleanupStore::new(database.pool.clone());
+
+    cleanup_store
+        .cleanup_finalized_provisional_overlays(
+            &checkpoint_identity("demo-dao", "demo-set", 1),
+            None,
+        )
+        .await
+        .expect("cleanup succeeds");
+
+    assert_eq!(
+        active_provisional_count_for(&database.pool, "degov_provisional_segment", "demo-dao", 1)
+            .await?,
+        0
+    );
+    assert_eq!(
+        active_provisional_count_for(&database.pool, "degov_provisional_segment", "other-dao", 2)
+            .await?,
+        1
+    );
+    assert_eq!(
+        active_provisional_count_for(
+            &database.pool,
+            "degov_provisional_proposal_overlay",
+            "other-dao",
+            2
+        )
+        .await?,
+        1
+    );
+    assert_checkpoint_at(&database.pool, 110).await?;
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_cleanup_is_idempotent() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    insert_checkpoint_at(&database.pool, 110).await?;
+    insert_available_provisional_rows(&database.pool, "demo-dao", "demo-set", 1).await?;
+    let cleanup_store = PostgresProvisionalCleanupStore::new(database.pool.clone());
+    let identity = checkpoint_identity("demo-dao", "demo-set", 1);
+
+    cleanup_store
+        .cleanup_finalized_provisional_overlays(&identity, None)
+        .await
+        .expect("first cleanup succeeds");
+    let retry_report = cleanup_store
+        .cleanup_finalized_provisional_overlays(&identity, None)
+        .await
+        .expect("retry cleanup succeeds");
+
+    assert_eq!(retry_report.segments_marked_finalized, 0);
+    assert_eq!(retry_report.contributor_overlays_marked_finalized, 0);
+    assert_eq!(retry_report.delegate_overlays_marked_finalized, 0);
+    assert_eq!(retry_report.proposal_overlays_marked_finalized, 0);
+    assert_eq!(retry_report.timelock_overlays_marked_finalized, 0);
+    assert_eq!(
+        active_provisional_count(&database.pool, "degov_provisional_segment").await?,
+        0
+    );
+    assert_checkpoint_at(&database.pool, 110).await?;
     database.cleanup().await?;
 
     Ok(())
@@ -502,13 +719,32 @@ fn database_url_with_search_path(database_url: &str, schema: &str) -> String {
 }
 
 async fn insert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
+    insert_checkpoint_at(pool, 10).await
+}
+
+async fn insert_checkpoint_at(pool: &PgPool, processed_height: i64) -> Result<(), sqlx::Error> {
+    insert_checkpoint_for(pool, "demo-dao", "demo-set", 1, processed_height).await
+}
+
+async fn insert_checkpoint_for(
+    pool: &PgPool,
+    dao_code: &str,
+    contract_set_id: &str,
+    chain_id: i32,
+    processed_height: i64,
+) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO degov_indexer_checkpoint (
              dao_code, chain_id, contract_set_id, stream_id, data_source_version,
              next_block, processed_height, target_height
          )
-         VALUES ('demo-dao', 1, 'demo-set', 'datalens-native', 'datalens-v1', 11, 10, 10)",
+         VALUES ($1, $2, $3, 'datalens-native', 'datalens-v1',
+                 ($4 + 1)::NUMERIC(78, 0), $4::NUMERIC(78, 0), $4::NUMERIC(78, 0))",
     )
+    .bind(dao_code)
+    .bind(chain_id)
+    .bind(contract_set_id)
+    .bind(processed_height)
     .execute(pool)
     .await?;
 
@@ -516,6 +752,10 @@ async fn insert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
 }
 
 async fn assert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
+    assert_checkpoint_at(pool, 10).await
+}
+
+async fn assert_checkpoint_at(pool: &PgPool, processed_height: i64) -> Result<(), sqlx::Error> {
     let row = sqlx::query(
         "SELECT
            next_block::BIGINT AS next_block,
@@ -531,11 +771,243 @@ async fn assert_checkpoint(pool: &PgPool) -> Result<(), sqlx::Error> {
     .fetch_one(pool)
     .await?;
 
-    assert_eq!(row.get::<i64, _>("next_block"), 11);
-    assert_eq!(row.get::<Option<i64>, _>("processed_height"), Some(10));
-    assert_eq!(row.get::<Option<i64>, _>("target_height"), Some(10));
+    assert_eq!(row.get::<i64, _>("next_block"), processed_height + 1);
+    assert_eq!(
+        row.get::<Option<i64>, _>("processed_height"),
+        Some(processed_height)
+    );
+    assert_eq!(
+        row.get::<Option<i64>, _>("target_height"),
+        Some(processed_height)
+    );
 
     Ok(())
+}
+
+fn checkpoint_identity(
+    dao_code: &str,
+    contract_set_id: &str,
+    chain_id: i32,
+) -> IndexerCheckpointIdentity {
+    IndexerCheckpointIdentity {
+        dao_code: dao_code.to_owned(),
+        chain_id,
+        contract_set_id: contract_set_id.to_owned(),
+        stream_id: "datalens-native".to_owned(),
+        data_source_version: "datalens-v1".to_owned(),
+    }
+}
+
+async fn insert_available_provisional_rows(
+    pool: &PgPool,
+    dao_code: &str,
+    contract_set_id: &str,
+    chain_id: i32,
+) -> Result<(), Box<dyn Error>> {
+    let segment_id = format!("{dao_code}:{contract_set_id}:{chain_id}:segment");
+    sqlx::query(
+        "INSERT INTO degov_provisional_segment (
+             id, dao_code, contract_set_id, chain_id, chain_name, dataset_key, selector,
+             range_start_block, range_end_block, segment_finality, source, status,
+             anchor_block_number, anchor_block_timestamp
+         )
+         VALUES (
+             $1, $2, $3, $4, 'ethereum', 'evm.logs', 'selector',
+             100, 105, 'latest', 'provider', 'available', 105, 1700000000
+         )",
+    )
+    .bind(&segment_id)
+    .bind(dao_code)
+    .bind(contract_set_id)
+    .bind(chain_id)
+    .execute(pool)
+    .await?;
+
+    let power_store = PostgresProvisionalPowerOverlayStore::new(pool.clone());
+    let proposal_store = PostgresProvisionalProposalOverlayStore::new(pool.clone());
+    let mut contributor = contributor_power_write("0xabc", "19");
+    set_overlay_scope(
+        &mut contributor.id,
+        &mut contributor.dao_code,
+        &mut contributor.contract_set_id,
+        &mut contributor.chain_id,
+        dao_code,
+        contract_set_id,
+        chain_id,
+    );
+    contributor.segment_id = Some(segment_id.clone());
+    let mut delegate = delegate_power_write("0xabc", "0xdef", "19");
+    set_overlay_scope(
+        &mut delegate.id,
+        &mut delegate.dao_code,
+        &mut delegate.contract_set_id,
+        &mut delegate.chain_id,
+        dao_code,
+        contract_set_id,
+        chain_id,
+    );
+    delegate.segment_id = Some(segment_id.clone());
+    let mut proposal = proposal_overlay_write("42", "Queued");
+    set_overlay_scope(
+        &mut proposal.id,
+        &mut proposal.dao_code,
+        &mut proposal.contract_set_id,
+        &mut proposal.chain_id,
+        dao_code,
+        contract_set_id,
+        chain_id,
+    );
+    proposal.segment_id = Some(segment_id.clone());
+    let mut timelock = timelock_overlay_write("42", "0xoperation", "Ready");
+    set_overlay_scope(
+        &mut timelock.id,
+        &mut timelock.dao_code,
+        &mut timelock.contract_set_id,
+        &mut timelock.chain_id,
+        dao_code,
+        contract_set_id,
+        chain_id,
+    );
+    timelock.segment_id = Some(segment_id);
+
+    power_store
+        .write_power_overlays(&[contributor], &[delegate])
+        .await?;
+    proposal_store
+        .write_proposal_overlays(&[proposal], &[timelock])
+        .await?;
+
+    Ok(())
+}
+
+fn set_overlay_scope(
+    id: &mut String,
+    dao_code: &mut Option<String>,
+    contract_set_id: &mut String,
+    chain_id: &mut Option<i32>,
+    new_dao_code: &str,
+    new_contract_set_id: &str,
+    new_chain_id: i32,
+) {
+    *id = id
+        .replace("demo-dao", new_dao_code)
+        .replace("demo-set", new_contract_set_id)
+        .replace(":1:", &format!(":{new_chain_id}:"));
+    *dao_code = Some(new_dao_code.to_owned());
+    *contract_set_id = new_contract_set_id.to_owned();
+    *chain_id = Some(new_chain_id);
+}
+
+async fn insert_final_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO contributor (
+             id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+             block_number, block_timestamp, transaction_hash, power, delegates_count_all,
+             delegates_count_effective
+         )
+         VALUES (
+             '0xabc', 'demo-set', 1, 'demo-dao', '0xgovernor', '0xtoken',
+             10, 1700000010, '0xfinalcontributor', 5, 0, 0
+         )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO delegate (
+             id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+             from_delegate, to_delegate, block_number, block_timestamp, transaction_hash,
+             is_current, power
+         )
+         VALUES (
+             'delegate-final', 'demo-set', 1, 'demo-dao', '0xgovernor', '0xtoken',
+             '0xabc', '0xdef', 10, 1700000010, '0xfinaldelegate', TRUE, 5
+         )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO proposal (
+             id, contract_set_id, chain_id, dao_code, governor_address, contract_address,
+             proposal_id, proposer, targets, values, signatures, calldatas, vote_start,
+             vote_end, description, block_number, block_timestamp, transaction_hash, title,
+             vote_start_timestamp, vote_end_timestamp, clock_mode, quorum, decimals
+         )
+         VALUES (
+             'proposal-final', 'demo-set', 1, 'demo-dao', '0xgovernor', '0xgovernor',
+             '42', '0xproposer', ARRAY['0xtarget'], ARRAY['0'], ARRAY['transfer(address,uint256)'],
+             ARRAY['0x'], 1000, 2000, 'Final proposal body', 10, 1700000010,
+             '0xfinalproposal', 'Final proposal title', 1700001000, 1700002000,
+             'mode=blocknumber&from=default', 40, 18
+         )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO timelock_operation (
+             id, contract_set_id, chain_id, dao_code, governor_address, timelock_address,
+             proposal_ref, proposal_id, operation_id, timelock_type, state
+         )
+         VALUES (
+             'timelock-final', 'demo-set', 1, 'demo-dao', '0xgovernor', '0xtimelock',
+             'proposal-final', '42', '0xoperation', 'single', 'Pending'
+         )",
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn assert_final_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
+    assert_eq!(table_count(pool, "contributor").await?, 1);
+    assert_eq!(table_count(pool, "delegate").await?, 1);
+    assert_eq!(table_count(pool, "proposal").await?, 1);
+    assert_eq!(table_count(pool, "timelock_operation").await?, 1);
+
+    let contributor_power: i64 =
+        sqlx::query_scalar("SELECT power::BIGINT FROM contributor WHERE id = '0xabc'")
+            .fetch_one(pool)
+            .await?;
+    let proposal_title: String =
+        sqlx::query_scalar("SELECT title FROM proposal WHERE id = 'proposal-final'")
+            .fetch_one(pool)
+            .await?;
+    assert_eq!(contributor_power, 5);
+    assert_eq!(proposal_title, "Final proposal title");
+
+    Ok(())
+}
+
+async fn active_provisional_count(pool: &PgPool, table: &str) -> Result<i64, sqlx::Error> {
+    sqlx::query_scalar(&format!(
+        "SELECT count(*)::BIGINT FROM {table} WHERE status = 'available'"
+    ))
+    .fetch_one(pool)
+    .await
+}
+
+async fn active_provisional_count_for(
+    pool: &PgPool,
+    table: &str,
+    dao_code: &str,
+    chain_id: i32,
+) -> Result<i64, sqlx::Error> {
+    sqlx::query_scalar(&format!(
+        "SELECT count(*)::BIGINT FROM {table}
+         WHERE status = 'available'
+           AND dao_code = $1
+           AND chain_id = $2"
+    ))
+    .bind(dao_code)
+    .bind(chain_id)
+    .fetch_one(pool)
+    .await
+}
+
+async fn provisional_status(pool: &PgPool, table: &str) -> Result<String, sqlx::Error> {
+    sqlx::query_scalar(&format!("SELECT status FROM {table} LIMIT 1"))
+        .fetch_one(pool)
+        .await
 }
 
 async fn table_count(pool: &PgPool, table: &str) -> Result<i64, sqlx::Error> {


### PR DESCRIPTION
## Summary

- Add a provisional cleanup planner around Datalens SDK safety decisions for finalized checkpoint coverage.
- Add a Postgres cleanup store that marks covered provisional segments and contributor/delegate/proposal/timelock overlays as `finalized`, so GraphQL no longer reads them as `available`.
- Add a rollback path that marks scoped provisional segments and overlays as `invalid` without mutating final business tables or checkpoints.
- Run cleanup after successful safe/final indexer passes, logging cleanup failures without changing final indexing/checkpoint behavior.

## Correctness notes

- Final business tables are not promoted from provisional rows in this change.
- Final checkpoints are read as the cleanup boundary and are not advanced or rewritten by cleanup/rollback.
- Cleanup scopes by `dao_code`, `chain_id`, `contract_set_id`, and optional `source`.
- GraphQL fallback relies on the existing `status = 'available'` overlay filters.

## Tests

- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/postgres cargo test -p degov-datalens-indexer --test provisional_worker`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/postgres cargo test -p degov-datalens-indexer --test graphql_service`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/postgres cargo test -p degov-datalens-indexer --test migration_schema`
- `cargo test -p degov-datalens-indexer --lib`
- `cargo test -p degov-datalens-indexer --no-run`
- `git diff --check`