### PR TITLE
Batch onchain refresh task upserts

### DIFF
--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -4,7 +4,7 @@ use std::{
     future::Future,
 };
 
-use sqlx::{PgPool, Postgres, Row, Transaction};
+use sqlx::{PgPool, Postgres, QueryBuilder, Row, Transaction};
 
 use crate::{
     CheckpointRepository, ContributorVoteSignalWrite, DataMetricWrite,
@@ -200,9 +200,7 @@ async fn write_projection_batch(
         refresh_vote_data_metric(transaction, &vote.contributor_vote_signals).await?;
     }
     if let Some(token) = &batch.token {
-        for candidate in &token.reconcile_plan.candidates {
-            upsert_onchain_refresh_task(transaction, candidate).await?;
-        }
+        upsert_onchain_refresh_tasks(transaction, &token.reconcile_plan.candidates).await?;
     }
     if let Some(batch) = &batch.timelock {
         write_timelock_batch(transaction, batch).await?;

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -1,12 +1,21 @@
 // Onchain refresh task persistence.
+const MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS: usize = 1_000;
+
 async fn upsert_onchain_refresh_tasks(
     transaction: &mut Transaction<'_, Postgres>,
     rows: &[PowerReconcileCandidate],
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
-    if rows.is_empty() {
-        return Ok(());
+    for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
+        upsert_onchain_refresh_task_chunk(transaction, chunk).await?;
     }
 
+    Ok(())
+}
+
+async fn upsert_onchain_refresh_task_chunk(
+    transaction: &mut Transaction<'_, Postgres>,
+    rows: &[PowerReconcileCandidate],
+) -> Result<(), PostgresIndexerRunnerStoreError> {
     let mut query = QueryBuilder::<Postgres>::new(
         "INSERT INTO onchain_refresh_task (
             id, contract_set_id, chain_id, dao_code, governor_address, token_address, account, refresh_balance,
@@ -121,7 +130,7 @@ async fn upsert_onchain_refresh_tasks(
     query
         .build()
         .execute(&mut **transaction)
-    .await?;
+        .await?;
 
     Ok(())
 }

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -1,36 +1,70 @@
 // Onchain refresh task persistence.
-async fn upsert_onchain_refresh_task(
+async fn upsert_onchain_refresh_tasks(
     transaction: &mut Transaction<'_, Postgres>,
-    row: &PowerReconcileCandidate,
+    rows: &[PowerReconcileCandidate],
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
-    let status = &row.status;
-    let task_id = format!(
-        "{}:{}:{}:{}:{}:{}",
-        status.contract_set_id,
-        status.dao_code,
-        status.chain_id,
-        status.governor,
-        status.governor_token,
-        status.account
-    );
-    let reason = if status.reason.is_empty() {
-        "token-activity".to_owned()
-    } else {
-        status.reason.clone()
-    };
+    if rows.is_empty() {
+        return Ok(());
+    }
 
-    sqlx::query(
+    let mut query = QueryBuilder::<Postgres>::new(
         "INSERT INTO onchain_refresh_task (
             id, contract_set_id, chain_id, dao_code, governor_address, token_address, account, refresh_balance,
             refresh_power, reason, first_seen_block_number, last_seen_block_number,
             last_seen_block_timestamp, last_seen_transaction_hash, status, attempts,
             next_run_at, pending_after_lock, created_at, updated_at
          )
-         VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::NUMERIC(78, 0), $12::NUMERIC(78, 0),
-            $13::NUMERIC(78, 0), $14, 'pending', 0, 0::NUMERIC(78, 0), false,
-            $12::NUMERIC(78, 0), $12::NUMERIC(78, 0)
-         )
+         ",
+    );
+    query.push_values(rows, |mut values, row| {
+        let status = &row.status;
+        let task_id = format!(
+            "{}:{}:{}:{}:{}:{}",
+            status.contract_set_id,
+            status.dao_code,
+            status.chain_id,
+            status.governor,
+            status.governor_token,
+            status.account
+        );
+        let reason = if status.reason.is_empty() {
+            "token-activity".to_owned()
+        } else {
+            status.reason.clone()
+        };
+        let first_seen_block_number = u64_to_string(status.first_seen_activity_block);
+        let last_seen_block_number = u64_to_string(status.last_seen_activity_block);
+        let last_seen_block_timestamp = status.last_seen_block_timestamp_ms.map(u64_to_string);
+
+        values
+            .push_bind(task_id)
+            .push_bind(&status.contract_set_id)
+            .push_bind(status.chain_id)
+            .push_bind(&status.dao_code)
+            .push_bind(&status.governor)
+            .push_bind(&status.governor_token)
+            .push_bind(&status.account)
+            .push_bind(status.refresh_balance)
+            .push_bind(status.refresh_power)
+            .push_bind(reason)
+            .push_bind(first_seen_block_number)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(last_seen_block_number.clone())
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(last_seen_block_timestamp)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&status.last_seen_transaction_hash)
+            .push("'pending'")
+            .push("0")
+            .push("0::NUMERIC(78, 0)")
+            .push("false")
+            .push_bind(last_seen_block_number.clone())
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(last_seen_block_number)
+            .push_unseparated("::NUMERIC(78, 0)");
+    });
+    query.push(
+        "
          ON CONFLICT ON CONSTRAINT onchain_refresh_task_account_unique DO UPDATE
          SET refresh_balance = onchain_refresh_task.refresh_balance OR EXCLUDED.refresh_balance,
              refresh_power = onchain_refresh_task.refresh_power OR EXCLUDED.refresh_power,
@@ -83,22 +117,10 @@ async fn upsert_onchain_refresh_task(
                ELSE NULL
              END,
              updated_at = EXCLUDED.updated_at",
-    )
-    .bind(task_id)
-    .bind(&status.contract_set_id)
-    .bind(status.chain_id)
-    .bind(&status.dao_code)
-    .bind(&status.governor)
-    .bind(&status.governor_token)
-    .bind(&status.account)
-    .bind(status.refresh_balance)
-    .bind(status.refresh_power)
-    .bind(reason)
-    .bind(u64_to_string(status.first_seen_activity_block))
-    .bind(u64_to_string(status.last_seen_activity_block))
-    .bind(status.last_seen_block_timestamp_ms.map(u64_to_string))
-    .bind(&status.last_seen_transaction_hash)
-    .execute(&mut **transaction)
+    );
+    query
+        .build()
+        .execute(&mut **transaction)
     .await?;
 
     Ok(())

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -872,6 +872,80 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
+-> Result<(), Box<dyn Error>> {
+    const DENSE_CANDIDATE_COUNT: usize = 1_001;
+
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let token_batch = project_token_events(
+        &token_projection_context(),
+        (0..DENSE_CANDIDATE_COUNT)
+            .map(|index| TokenProjectionEvent {
+                log: normalized_token_log(
+                    &format!("0000000030-dense-votes-{index}"),
+                    30 + index as u64,
+                    0,
+                    1,
+                ),
+                event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                    delegate: indexed_account(index),
+                    previous_votes: "0".to_owned(),
+                    new_votes: "1".to_owned(),
+                }),
+            })
+            .collect(),
+    )
+    .map_err(|error| format!("dense token projection failed: {error:?}"))?;
+    assert_eq!(
+        token_batch.reconcile_plan.candidates.len(),
+        DENSE_CANDIDATE_COUNT
+    );
+
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(token_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let task_count: i64 = sqlx::query_scalar(
+        "SELECT count(*)::BIGINT
+         FROM onchain_refresh_task
+         WHERE contract_set_id = $1",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(task_count, DENSE_CANDIDATE_COUNT as i64);
+
+    for index in [0, DENSE_CANDIDATE_COUNT - 1] {
+        let account = indexed_account(index);
+        let row = sqlx::query(
+            "SELECT id, reason, status, last_seen_block_number::TEXT AS last_seen_block_number
+             FROM onchain_refresh_task
+             WHERE contract_set_id = $1 AND account = $2",
+        )
+        .bind(CONTRACT_SET_ID)
+        .bind(&account)
+        .fetch_one(&database.pool)
+        .await?;
+        assert_eq!(row.get::<String, _>("id"), refresh_task_id(&account));
+        assert_eq!(row.get::<String, _>("reason"), "delegate-votes-changed");
+        assert_eq!(row.get::<String, _>("status"), "pending");
+        assert_eq!(
+            row.get::<String, _>("last_seen_block_number"),
+            (30 + index as u64).to_string()
+        );
+    }
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_projection_state_scopes_repeated_identifiers_by_contract_set_and_chain()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -2008,6 +2082,10 @@ async fn seed_refresh_task_for_account(
 
 fn refresh_task_id(account: &str) -> String {
     format!("{CONTRACT_SET_ID}:demo-dao:1:{GOVERNOR}:{TOKEN}:{account}")
+}
+
+fn indexed_account(index: usize) -> String {
+    format!("0x{:040x}", 0x1000usize + index)
 }
 
 fn normalized_token_log(

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -709,6 +709,169 @@ async fn test_postgres_token_same_batch_mapping_mutations_remain_ordered()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    seed_refresh_task_for_account(
+        &database.pool,
+        DELEGATOR,
+        "failed",
+        3,
+        50,
+        Some("stale error"),
+        false,
+    )
+    .await?;
+    seed_refresh_task_for_account(
+        &database.pool,
+        SECOND_DELEGATE,
+        "processing",
+        5,
+        999,
+        Some("rpc still running"),
+        false,
+    )
+    .await?;
+
+    let mut token_batch = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000020-transfer", 20, 0, 1),
+                event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                    from: DELEGATOR.to_owned(),
+                    to: RECEIVER.to_owned(),
+                    value: "40".to_owned(),
+                    standard: GovernanceTokenStandard::Erc20,
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000022-delegator-votes", 22, 0, 2),
+                event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                    delegate: DELEGATOR.to_owned(),
+                    previous_votes: "0".to_owned(),
+                    new_votes: "100".to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000025-processing-votes", 25, 0, 3),
+                event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                    delegate: SECOND_DELEGATE.to_owned(),
+                    previous_votes: "0".to_owned(),
+                    new_votes: "80".to_owned(),
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("token projection failed: {error:?}"))?;
+    token_batch
+        .reconcile_plan
+        .candidates
+        .iter_mut()
+        .find(|candidate| candidate.account == RECEIVER)
+        .expect("receiver candidate")
+        .status
+        .reason
+        .clear();
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(token_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let rows = sqlx::query(
+        "SELECT id, account, refresh_balance, refresh_power, reason, status, attempts,
+                next_run_at::TEXT AS next_run_at, first_seen_block_number::TEXT AS first_seen_block_number,
+                last_seen_block_number::TEXT AS last_seen_block_number,
+                last_seen_block_timestamp::TEXT AS last_seen_block_timestamp,
+                last_seen_transaction_hash, processed_at::TEXT AS processed_at, error,
+                pending_after_lock, pending_after_lock_block_number::TEXT AS pending_after_lock_block_number,
+                pending_after_lock_block_timestamp::TEXT AS pending_after_lock_block_timestamp,
+                pending_after_lock_transaction_hash
+         FROM onchain_refresh_task
+         ORDER BY account ASC",
+    )
+    .fetch_all(&database.pool)
+    .await?;
+    assert_eq!(rows.len(), 3);
+
+    let pending = rows
+        .iter()
+        .find(|row| row.get::<String, _>("account") == DELEGATOR)
+        .expect("pending conflict row");
+    assert!(!pending.get::<bool, _>("refresh_balance"));
+    assert!(pending.get::<bool, _>("refresh_power"));
+    assert_eq!(
+        pending.get::<String, _>("reason"),
+        "delegate-votes-changed+transfer"
+    );
+    assert_eq!(pending.get::<String, _>("status"), "pending");
+    assert_eq!(pending.get::<i32, _>("attempts"), 0);
+    assert_eq!(pending.get::<String, _>("next_run_at"), "0");
+    assert_eq!(pending.get::<String, _>("first_seen_block_number"), "10");
+    assert_eq!(pending.get::<String, _>("last_seen_block_number"), "22");
+    assert_eq!(
+        pending.get::<String, _>("last_seen_block_timestamp"),
+        "1700000022000"
+    );
+    assert_eq!(
+        pending.get::<String, _>("last_seen_transaction_hash"),
+        "0xtx220"
+    );
+    assert_eq!(pending.get::<Option<String>, _>("processed_at"), None);
+    assert_eq!(pending.get::<Option<String>, _>("error"), None);
+    assert!(!pending.get::<bool, _>("pending_after_lock"));
+    assert_eq!(
+        pending.get::<Option<String>, _>("pending_after_lock_block_number"),
+        None
+    );
+
+    let inserted = rows
+        .iter()
+        .find(|row| row.get::<String, _>("account") == RECEIVER)
+        .expect("inserted row");
+    assert_eq!(inserted.get::<String, _>("id"), refresh_task_id(RECEIVER));
+    assert_eq!(inserted.get::<String, _>("reason"), "token-activity");
+    assert_eq!(inserted.get::<String, _>("first_seen_block_number"), "20");
+    assert_eq!(inserted.get::<String, _>("last_seen_block_number"), "20");
+    assert_eq!(inserted.get::<String, _>("status"), "pending");
+
+    let processing = rows
+        .iter()
+        .find(|row| row.get::<String, _>("account") == SECOND_DELEGATE)
+        .expect("processing conflict row");
+    assert_eq!(processing.get::<String, _>("status"), "processing");
+    assert_eq!(processing.get::<i32, _>("attempts"), 5);
+    assert_eq!(processing.get::<String, _>("next_run_at"), "999");
+    assert_eq!(
+        processing.get::<Option<String>, _>("error"),
+        Some("rpc still running".to_owned())
+    );
+    assert_eq!(processing.get::<String, _>("first_seen_block_number"), "10");
+    assert_eq!(processing.get::<String, _>("last_seen_block_number"), "25");
+    assert!(processing.get::<bool, _>("pending_after_lock"));
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_block_number"),
+        Some("25".to_owned())
+    );
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_block_timestamp"),
+        Some("1700000025000".to_owned())
+    );
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_transaction_hash"),
+        Some("0xtx250".to_owned())
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_projection_state_scopes_repeated_identifiers_by_contract_set_and_chain()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -1802,6 +1965,49 @@ async fn seed_empty_global_metric(pool: &PgPool) -> Result<(), sqlx::Error> {
     .await?;
 
     Ok(())
+}
+
+async fn seed_refresh_task_for_account(
+    pool: &PgPool,
+    account: &str,
+    status: &str,
+    attempts: i32,
+    next_run_at: u64,
+    error: Option<&str>,
+    pending_after_lock: bool,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO onchain_refresh_task (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address, account,
+            refresh_balance, refresh_power, reason, first_seen_block_number,
+            last_seen_block_number, last_seen_block_timestamp, last_seen_transaction_hash,
+            status, attempts, next_run_at, pending_after_lock, created_at, updated_at, error
+         )
+         VALUES (
+            $1, $2, 1, 'demo-dao', $3, $4, $5, false, true, 'seeded',
+            10::NUMERIC(78, 0), 12::NUMERIC(78, 0), 1700000012000::NUMERIC(78, 0),
+            '0xseed', $6, $7, $8::NUMERIC(78, 0), $9, 10::NUMERIC(78, 0),
+            12::NUMERIC(78, 0), $10
+         )",
+    )
+    .bind(refresh_task_id(account))
+    .bind(CONTRACT_SET_ID)
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .bind(account)
+    .bind(status)
+    .bind(attempts)
+    .bind(next_run_at.to_string())
+    .bind(pending_after_lock)
+    .bind(error)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+fn refresh_task_id(account: &str) -> String {
+    format!("{CONTRACT_SET_ID}:demo-dao:1:{GOVERNOR}:{TOKEN}:{account}")
 }
 
 fn normalized_token_log(


### PR DESCRIPTION
## Summary
- Batch token reconcile candidate persistence into one `onchain_refresh_task` bulk upsert per projection batch.
- Preserve the existing task id, empty-reason fallback, insert values, and conflict update behavior for pending, failed, and processing tasks.
- Add a Postgres runtime regression test covering multi-candidate inserts, conflict updates, processing lock preservation, pending-after-lock fields, and fallback reason handling.

## Validation
- `cargo fmt -p degov-datalens-indexer`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@localhost:7432/indexer cargo test -p degov-datalens-indexer --locked --test postgres_runtime_run --test onchain_refresh_worker`