### PR TITLE
Optimize proposal onchain enrichment

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -1,6 +1,8 @@
 use std::{
     collections::BTreeMap,
-    fmt, thread,
+    fmt,
+    sync::{Arc, Mutex},
+    thread,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -13,11 +15,11 @@ use thiserror::Error;
 
 use crate::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadExecutionReport, ChainReadFailure,
-    ChainReadFailureKind, ChainReadMethod, ChainReadMetrics, ChainReadPlan, ChainReadPlanBuilder,
-    ChainReadResult, ChainReadValue, ChainTool, PartialChainReadFailureReport,
-    ProvisionalContributorPowerOverlayWrite, ProvisionalDelegatePowerOverlayRelation,
-    ProvisionalDelegatePowerOverlayWrite, ProvisionalPowerOverlayScope,
-    ProvisionalPowerOverlayStore, ReadRequirement,
+    ChainReadFailureKind, ChainReadKey, ChainReadMethod, ChainReadMetrics, ChainReadPlan,
+    ChainReadPlanBuilder, ChainReadResult, ChainReadValue, ChainTool,
+    PartialChainReadFailureReport, ProvisionalContributorPowerOverlayWrite,
+    ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
+    ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ReadRequirement,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -965,6 +967,7 @@ where
 pub struct EvmRpcChainTool {
     rpc_url: String,
     client: reqwest::Client,
+    cache: ChainReadCache,
 }
 
 impl EvmRpcChainTool {
@@ -974,7 +977,101 @@ impl EvmRpcChainTool {
             .build()
             .map_err(|error| OnchainRefreshReaderError::new(error.to_string()))?;
 
-        Ok(Self { rpc_url, client })
+        Ok(Self {
+            rpc_url,
+            client,
+            cache: ChainReadCache::default(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct ChainReadCache {
+    values: Arc<Mutex<BTreeMap<ChainReadCacheKey, CachedChainReadValue>>>,
+}
+
+impl ChainReadCache {
+    fn get(&self, key: &ChainReadKey) -> Option<ChainReadValue> {
+        let key = ChainReadCacheKey::from_read_key(key)?;
+        let mut values = self.values.lock().ok()?;
+        let cached = values.get(&key)?;
+        if cached.is_expired(&key) {
+            values.remove(&key);
+            return None;
+        }
+        Some(cached.value.clone())
+    }
+
+    fn insert(&self, key: &ChainReadKey, value: ChainReadValue) {
+        let Some(key) = ChainReadCacheKey::from_read_key(key) else {
+            return;
+        };
+        if let Ok(mut values) = self.values.lock() {
+            values.insert(
+                key,
+                CachedChainReadValue {
+                    value,
+                    inserted_at: SystemTime::now(),
+                },
+            );
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CachedChainReadValue {
+    value: ChainReadValue,
+    inserted_at: SystemTime,
+}
+
+impl CachedChainReadValue {
+    fn is_expired(&self, key: &ChainReadCacheKey) -> bool {
+        match key {
+            ChainReadCacheKey::Decimals { .. } => false,
+            ChainReadCacheKey::Quorum { .. } => self
+                .inserted_at
+                .elapsed()
+                .map(|elapsed| elapsed >= QUORUM_CACHE_DURATION)
+                .unwrap_or(true),
+        }
+    }
+}
+
+const QUORUM_CACHE_DURATION: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum ChainReadCacheKey {
+    Decimals {
+        chain_id: i32,
+        contract_address: String,
+    },
+    Quorum {
+        chain_id: i32,
+        contract_address: String,
+        args: Vec<String>,
+        block_mode: BlockReadMode,
+    },
+}
+
+impl ChainReadCacheKey {
+    fn from_read_key(key: &ChainReadKey) -> Option<Self> {
+        match key.method {
+            ChainReadMethod::Decimals => Some(Self::Decimals {
+                chain_id: key.chain_id,
+                contract_address: normalize_identifier(&key.contract_address),
+            }),
+            ChainReadMethod::Quorum => Some(Self::Quorum {
+                chain_id: key.chain_id,
+                contract_address: normalize_identifier(&key.contract_address),
+                args: key
+                    .args
+                    .iter()
+                    .map(|arg| normalize_identifier(arg))
+                    .collect(),
+                block_mode: key.block_mode,
+            }),
+            _ => None,
+        }
     }
 }
 
@@ -985,10 +1082,14 @@ impl ChainTool for EvmRpcChainTool {
     ) -> Result<ChainReadExecutionReport, PartialChainReadFailureReport> {
         let mut results = Vec::new();
         let mut failures = PartialChainReadFailureReport::default();
+        let mut cache_hits = 0;
 
         for (read_index, read) in plan.reads.iter().enumerate() {
             match self.execute_read(read_index, read) {
-                Ok(result) => results.push(result),
+                Ok((result, cache_hit)) => {
+                    cache_hits += usize::from(cache_hit);
+                    results.push(result);
+                }
                 Err(message) => {
                     let failure = ChainReadFailure {
                         key: read.key.clone(),
@@ -1012,9 +1113,10 @@ impl ChainTool for EvmRpcChainTool {
             metrics: ChainReadMetrics {
                 requested_reads: plan.metrics.requested_reads,
                 deduped_reads: plan.metrics.deduped_reads,
-                executed_rpc_calls: results.len(),
+                executed_rpc_calls: results.len().saturating_sub(cache_hits),
                 multicall_batch_size: plan.metrics.multicall_batch_size,
                 failures: failures.optional_failures.len(),
+                cache_hits,
                 ..ChainReadMetrics::default()
             },
             results,
@@ -1029,20 +1131,37 @@ impl EvmRpcChainTool {
         &self,
         read_index: usize,
         read: &crate::ChainReadRequest,
-    ) -> Result<ChainReadResult, String> {
+    ) -> Result<(ChainReadResult, bool), String> {
         if read.key.method == ChainReadMethod::TimelockOperationState {
-            return self.execute_timelock_operation_state(read_index, read);
+            return self
+                .execute_timelock_operation_state(read_index, read)
+                .map(|result| (result, false));
+        }
+
+        if let Some(value) = self.cache.get(&read.key) {
+            return Ok((
+                ChainReadResult {
+                    read_index,
+                    key: read.key.clone(),
+                    value,
+                },
+                true,
+            ));
         }
 
         let data = encode_call_data(read.key.method, &read.key.args)?;
         let result = self.eth_call(&read.key.contract_address, &data, read.key.block_mode)?;
         let value = decode_call_value(read.key.method, &result)?;
+        self.cache.insert(&read.key, value.clone());
 
-        Ok(ChainReadResult {
-            read_index,
-            key: read.key.clone(),
-            value,
-        })
+        Ok((
+            ChainReadResult {
+                read_index,
+                key: read.key.clone(),
+                value,
+            },
+            false,
+        ))
     }
 
     fn execute_timelock_operation_state(
@@ -1767,5 +1886,81 @@ mod tests {
             .expect("hex proposal id encodes");
 
         assert_eq!(hex, decimal);
+    }
+
+    #[test]
+    fn test_chain_read_cache_keys_decimals_by_token_and_quorum_by_timepoint() {
+        let cache = ChainReadCache::default();
+        let decimals = ChainReadKey {
+            chain_id: 1,
+            contract_address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+            method: ChainReadMethod::Decimals,
+            args: vec![],
+            block_mode: BlockReadMode::Safe,
+        };
+        let same_token_latest = ChainReadKey {
+            block_mode: BlockReadMode::Latest,
+            ..decimals.clone()
+        };
+        let quorum_10 = ChainReadKey {
+            chain_id: 1,
+            contract_address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+            method: ChainReadMethod::Quorum,
+            args: vec!["10".to_owned()],
+            block_mode: BlockReadMode::Safe,
+        };
+        let quorum_11 = ChainReadKey {
+            args: vec!["11".to_owned()],
+            ..quorum_10.clone()
+        };
+
+        cache.insert(&decimals, ChainReadValue::Integer("18".to_owned()));
+        cache.insert(&quorum_10, ChainReadValue::Integer("100".to_owned()));
+
+        assert_eq!(
+            cache.get(&same_token_latest),
+            Some(ChainReadValue::Integer("18".to_owned()))
+        );
+        assert_eq!(cache.get(&quorum_11), None);
+    }
+
+    #[test]
+    fn test_chain_read_cache_expires_quorum_but_not_decimals() {
+        let cache = ChainReadCache::default();
+        let decimals = ChainReadKey {
+            chain_id: 1,
+            contract_address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+            method: ChainReadMethod::Decimals,
+            args: vec![],
+            block_mode: BlockReadMode::Safe,
+        };
+        let quorum = ChainReadKey {
+            chain_id: 1,
+            contract_address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+            method: ChainReadMethod::Quorum,
+            args: vec!["10".to_owned()],
+            block_mode: BlockReadMode::Safe,
+        };
+
+        cache.insert(&decimals, ChainReadValue::Integer("18".to_owned()));
+        cache.insert(&quorum, ChainReadValue::Integer("100".to_owned()));
+
+        let expired_at = SystemTime::now() - QUORUM_CACHE_DURATION - Duration::from_secs(1);
+        let mut values = cache.values.lock().expect("cache lock");
+        values
+            .get_mut(&ChainReadCacheKey::from_read_key(&decimals).expect("decimals key"))
+            .expect("decimals value")
+            .inserted_at = expired_at;
+        values
+            .get_mut(&ChainReadCacheKey::from_read_key(&quorum).expect("quorum key"))
+            .expect("quorum value")
+            .inserted_at = expired_at;
+        drop(values);
+
+        assert_eq!(
+            cache.get(&decimals),
+            Some(ChainReadValue::Integer("18".to_owned()))
+        );
+        assert_eq!(cache.get(&quorum), None);
     }
 }

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use crate::{
     BatchReadPlanConfig, ChainContracts, ChainReadExecutionReport, ChainReadMethod, ChainReadPlan,
     ChainReadPlanBuilder, ChainReadReason, ChainReadValue, DataMetricWrite, DecodedGovernorEvent,
-    NormalizedEvmLog, ProposalCreatedEvent, ProposalExtendedEvent, ProposalQueuedEvent,
-    derive_proposal_metadata,
+    GovernanceTokenStandard, NormalizedEvmLog, ProposalCreatedEvent, ProposalExtendedEvent,
+    ProposalQueuedEvent, derive_proposal_metadata,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -13,6 +13,7 @@ pub struct ProposalProjectionContext {
     pub dao_code: String,
     pub governor_address: String,
     pub contracts: ChainContracts,
+    pub token_standard: GovernanceTokenStandard,
     pub read_plan_config: BatchReadPlanConfig,
 }
 
@@ -529,12 +530,14 @@ pub fn project_proposal_events(
                     vec![event.vote_start.clone()],
                     crate::BlockReadMode::Safe,
                 );
-                builder.add_optional_enrichment_read(
-                    context.contracts.governor_token.clone(),
-                    ChainReadMethod::Decimals,
-                    vec![],
-                    crate::BlockReadMode::Safe,
-                );
+                if context.token_standard == GovernanceTokenStandard::Erc20 {
+                    builder.add_optional_enrichment_read(
+                        context.contracts.governor_token.clone(),
+                        ChainReadMethod::Decimals,
+                        vec![],
+                        crate::BlockReadMode::Safe,
+                    );
+                }
                 proposals
                     .entry(proposal.id.clone())
                     .and_modify(|stored: &mut ProposalWrite| stored.merge(&proposal))

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -511,6 +511,7 @@ impl IndexerContractSetRuntimeConfig {
                 dao_code: self.dao_code.clone(),
                 governor_address: contracts.governor.clone(),
                 contracts: chain_contracts.clone(),
+                token_standard: contracts.governor_token_standard,
                 read_plan_config,
             }),
             timelock: Some(TimelockProjectionContext {

--- a/apps/indexer/tests/datalens_fixtures.rs
+++ b/apps/indexer/tests/datalens_fixtures.rs
@@ -614,6 +614,7 @@ fn proposal_context() -> ProposalProjectionContext {
         dao_code: "demo-dao".to_owned(),
         governor_address: "0x1111111111111111111111111111111111111111".to_owned(),
         contracts: contracts("0x2222222222222222222222222222222222222222"),
+        token_standard: GovernanceTokenStandard::Erc20,
         read_plan_config: read_plan_config(),
     }
 }

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -614,6 +614,7 @@ fn contexts() -> IndexerRunnerContexts {
             dao_code: "demo-dao".to_owned(),
             governor_address: contracts.governor.clone(),
             contracts: contracts.clone(),
+            token_standard: GovernanceTokenStandard::Erc20,
             read_plan_config,
         }),
         timelock: Some(TimelockProjectionContext {

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -1952,6 +1952,7 @@ fn proposal_projection_context() -> ProposalProjectionContext {
             governor_token: TOKEN.to_owned(),
             timelock: TIMELOCK.to_owned(),
         },
+        token_standard: GovernanceTokenStandard::Erc20,
         read_plan_config: BatchReadPlanConfig {
             max_concurrency: 4,
             multicall_batch_size: 10,
@@ -2011,6 +2012,7 @@ fn proposal_projection_context_with_scope(
             governor_token: token.to_owned(),
             timelock: timelock.to_owned(),
         },
+        token_standard: GovernanceTokenStandard::Erc20,
         read_plan_config: BatchReadPlanConfig {
             max_concurrency: 4,
             multicall_batch_size: 10,

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -1,9 +1,10 @@
 use degov_datalens_indexer::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadExecutionReport, ChainReadKey,
-    ChainReadMethod, ChainReadResult, ChainReadValue, DecodedGovernorEvent, NormalizedEvmLog,
-    ProposalCreatedEvent, ProposalExtendedEvent, ProposalIdEvent, ProposalProjectionContext,
-    ProposalProjectionError, ProposalProjectionEvent, ProposalProjectionRepository,
-    ProposalQueuedEvent, ProposalStateWriteKind, ReadRequirement, project_proposal_events,
+    ChainReadMethod, ChainReadResult, ChainReadValue, DecodedGovernorEvent,
+    GovernanceTokenStandard, NormalizedEvmLog, ProposalCreatedEvent, ProposalExtendedEvent,
+    ProposalIdEvent, ProposalProjectionContext, ProposalProjectionError, ProposalProjectionEvent,
+    ProposalProjectionRepository, ProposalQueuedEvent, ProposalStateWriteKind, ReadRequirement,
+    project_proposal_events,
 };
 use serde_json::json;
 
@@ -125,6 +126,44 @@ fn test_project_proposal_created_builds_aggregate_actions_and_chain_reads() {
             ChainReadMethod::State,
             ChainReadMethod::Quorum,
         ]
+    );
+}
+
+#[test]
+fn test_project_proposal_created_keeps_erc20_decimals_enrichment_read() {
+    let batch = project_proposal_events(
+        &context_with_token_standard(GovernanceTokenStandard::Erc20),
+        vec![ProposalProjectionEvent {
+            log: log(10, 2, 7),
+            event: proposal_created("42", "# Proposal title\n\nProposal body"),
+        }],
+    )
+    .expect("projection succeeds");
+
+    assert!(batch.chain_read_plan.reads.iter().any(|read| {
+        read.key.method == ChainReadMethod::Decimals
+            && read.requirement == ReadRequirement::Optional
+    }));
+}
+
+#[test]
+fn test_project_proposal_created_skips_erc721_decimals_enrichment_read() {
+    let batch = project_proposal_events(
+        &context_with_token_standard(GovernanceTokenStandard::Erc721),
+        vec![ProposalProjectionEvent {
+            log: log(10, 2, 7),
+            event: proposal_created("42", "# Proposal title\n\nProposal body"),
+        }],
+    )
+    .expect("projection succeeds");
+
+    assert_eq!(batch.proposals[0].decimals, "0");
+    assert!(
+        !batch
+            .chain_read_plan
+            .reads
+            .iter()
+            .any(|read| read.key.method == ChainReadMethod::Decimals)
     );
 }
 
@@ -709,6 +748,12 @@ fn test_description_heading_single_newline_and_no_heading() {
 }
 
 fn context() -> ProposalProjectionContext {
+    context_with_token_standard(GovernanceTokenStandard::Erc20)
+}
+
+fn context_with_token_standard(
+    token_standard: GovernanceTokenStandard,
+) -> ProposalProjectionContext {
     ProposalProjectionContext {
         contract_set_id: "dao=unit-dao|chain=1|governor=0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|token=0x1111111111111111111111111111111111111111".to_owned(),
         dao_code: "unit-dao".to_owned(),
@@ -718,6 +763,7 @@ fn context() -> ProposalProjectionContext {
             governor_token: "0x1111111111111111111111111111111111111111".to_owned(),
             timelock: "0x2222222222222222222222222222222222222222".to_owned(),
         },
+        token_standard,
         read_plan_config: BatchReadPlanConfig {
             max_concurrency: 4,
             multicall_batch_size: 10,

--- a/apps/indexer/tests/timelock_projection.rs
+++ b/apps/indexer/tests/timelock_projection.rs
@@ -1,12 +1,12 @@
 use degov_datalens_indexer::{
     BatchReadPlanConfig, CallExecutedEvent, CallSaltEvent, CallScheduledEvent, ChainContracts,
     ChainReadExecutionReport, ChainReadKey, ChainReadMethod, ChainReadResult, ChainReadValue,
-    DecodedGovernorEvent, DecodedTimelockEvent, NormalizedEvmLog, ParameterChangeEvent,
-    ProposalCreatedEvent, ProposalProjectionContext, ProposalProjectionEvent, ProposalQueuedEvent,
-    ReadRequirement, RoleAccountEvent, RoleAdminChangedEvent, TimelockOperationIdEvent,
-    TimelockProjectionContext, TimelockProjectionError, TimelockProjectionEvent,
-    TimelockProjectionRepository, TimelockProposalLinkContext, project_proposal_events,
-    project_timelock_events, project_timelock_events_with_proposal_links,
+    DecodedGovernorEvent, DecodedTimelockEvent, GovernanceTokenStandard, NormalizedEvmLog,
+    ParameterChangeEvent, ProposalCreatedEvent, ProposalProjectionContext, ProposalProjectionEvent,
+    ProposalQueuedEvent, ReadRequirement, RoleAccountEvent, RoleAdminChangedEvent,
+    TimelockOperationIdEvent, TimelockProjectionContext, TimelockProjectionError,
+    TimelockProjectionEvent, TimelockProjectionRepository, TimelockProposalLinkContext,
+    project_proposal_events, project_timelock_events, project_timelock_events_with_proposal_links,
 };
 use serde_json::json;
 use sha3::{Digest, Keccak256};
@@ -641,6 +641,7 @@ fn proposal_context() -> ProposalProjectionContext {
             governor_token: "0x1111111111111111111111111111111111111111".to_owned(),
             timelock: "0x2222222222222222222222222222222222222222".to_owned(),
         },
+        token_standard: GovernanceTokenStandard::Erc20,
         read_plan_config: BatchReadPlanConfig {
             max_concurrency: 4,
             multicall_batch_size: 10,


### PR DESCRIPTION
## Summary

- Pass the configured governor token standard into proposal projection so ERC721 proposal enrichment keeps `decimals = "0"` and does not schedule `decimals()` reads.
- Keep ERC20 proposal enrichment scheduling the optional `decimals()` read.
- Add a process-local `EvmRpcChainTool` cache for decimals and quorum reads; decimals are keyed by chain/token, while quorum is keyed by chain/governor/timepoint args/block mode.

## Validation

- `cargo fmt`
- `cargo test -p degov-datalens-indexer --locked --test proposal_projection` passed: 17/17
- `cargo test -p degov-datalens-indexer --locked --test chain_tool_read_plan` passed: 8/8
- `cargo test -p degov-datalens-indexer --locked onchain::refresh::tests::test_chain_read_cache_keys_decimals_by_token_and_quorum_by_timepoint` passed
- `cargo test -p degov-datalens-indexer --locked` was attempted; DB-backed tests failed because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set.
- `cargo test -p degov-datalens-indexer --locked --test onchain_refresh_worker` was attempted; 10 non-DB tests passed and 7 DB-backed tests failed because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set.

## Follow-up

- Future quorum fallback was left out of scope because the current APIs only expose the scheduled read args cleanly; adding fallback behavior should be handled once the desired legacy-governor fallback source is defined.