### PR TITLE
fix(indexer): restore ENS GraphQL parity

### DIFF
--- a/.local/run-indexer-and-graphql.sh
+++ b/.local/run-indexer-and-graphql.sh
@@ -2,24 +2,53 @@
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
-set -a
-source .env
-set +a
-export DEGOV_INDEXER_DATABASE_URL="postgresql://postgres:password@localhost:7432/degov_datalens_main_latest"
-export DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS="0.0.0.0:8005"
-export DEGOV_INDEXER_GRAPHQL_ENDPOINT="http://eu2.ncp.kahub.in:8005/graphql"
-export DEGOV_INDEXER_GRAPHQL_PATH="/graphql"
-export DEGOV_INDEXER_CONFIG_FILE="apps/indexer/indexer.yml"
-export DEGOV_INDEXER_CONTRACT_SET_MODE="all"
-export DEGOV_INDEXER_CONTRACT_SET_MAX_CONCURRENCY="unlimited"
-export DEGOV_INDEXER_TARGET_HEIGHT="latest"
-export DEGOV_INDEXER_RUN_ONCE="false"
-export DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED="true"
-export DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED="true"
-export RUST_LOG="info"
+if [[ -f .env ]]; then
+  set -a
+  source .env
+  set +a
+fi
+
+: "${DEGOV_DB_HOST:=localhost}"
+: "${DEGOV_DB_PORT:=7432}"
+: "${DEGOV_DB_NAME:=degov_datalens_main_latest}"
+: "${DEGOV_DB_USER:=postgres}"
+if [[ -z "${DEGOV_INDEXER_DATABASE_URL:-}" ]]; then
+  if [[ -n "${DEGOV_DB_PASSWORD:-}" ]]; then
+    export DEGOV_INDEXER_DATABASE_URL="postgresql://${DEGOV_DB_USER}:${DEGOV_DB_PASSWORD}@${DEGOV_DB_HOST}:${DEGOV_DB_PORT}/${DEGOV_DB_NAME}"
+  else
+    export DEGOV_INDEXER_DATABASE_URL="postgresql://${DEGOV_DB_USER}@${DEGOV_DB_HOST}:${DEGOV_DB_PORT}/${DEGOV_DB_NAME}"
+  fi
+fi
+
+: "${DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS:=0.0.0.0:8005}"
+: "${DEGOV_INDEXER_GRAPHQL_PATH:=/graphql}"
+: "${DEGOV_INDEXER_GRAPHQL_ENDPOINT:=http://127.0.0.1:8005${DEGOV_INDEXER_GRAPHQL_PATH}}"
+: "${DEGOV_INDEXER_CONFIG_FILE:=apps/indexer/indexer.yml}"
+: "${DEGOV_INDEXER_CONTRACT_SET_MODE:=all}"
+: "${DEGOV_INDEXER_CONTRACT_SET_MAX_CONCURRENCY:=unlimited}"
+: "${DEGOV_INDEXER_TARGET_HEIGHT:=latest}"
+: "${DEGOV_INDEXER_RUN_ONCE:=false}"
+: "${DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED:=true}"
+: "${DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED:=true}"
+: "${RUST_LOG:=info}"
+export DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS
+export DEGOV_INDEXER_GRAPHQL_ENDPOINT
+export DEGOV_INDEXER_GRAPHQL_PATH
+export DEGOV_INDEXER_CONFIG_FILE
+export DEGOV_INDEXER_CONTRACT_SET_MODE
+export DEGOV_INDEXER_CONTRACT_SET_MAX_CONCURRENCY
+export DEGOV_INDEXER_TARGET_HEIGHT
+export DEGOV_INDEXER_RUN_ONCE
+export DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED
+export DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED
+export RUST_LOG
 LOG_DIR="$REPO_ROOT/.local/logs"
 mkdir -p "$LOG_DIR"
-echo "combined runner starting at $(date -u +%Y-%m-%dT%H:%M:%SZ) commit=$(git rev-parse --short HEAD) db=${DEGOV_INDEXER_DATABASE_URL} bind=${DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS}" >> "$LOG_DIR/indexer-combined-main.log"
+DB_LOG_URL="$DEGOV_INDEXER_DATABASE_URL"
+if [[ "$DB_LOG_URL" =~ ^([^:]+://[^:/@]+):[^@]+@(.*)$ ]]; then
+  DB_LOG_URL="${BASH_REMATCH[1]}:****@${BASH_REMATCH[2]}"
+fi
+echo "combined runner starting at $(date -u +%Y-%m-%dT%H:%M:%SZ) commit=$(git rev-parse --short HEAD) db=${DB_LOG_URL} bind=${DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS}" >> "$LOG_DIR/indexer-combined-main.log"
 cleanup() {
   set +e
   echo "combined runner stopping at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$LOG_DIR/indexer-combined-main.log"

--- a/.local/run-indexer-and-graphql.sh
+++ b/.local/run-indexer-and-graphql.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+set -a
+source .env
+set +a
+export DEGOV_INDEXER_DATABASE_URL="postgresql://postgres:password@localhost:7432/degov_datalens_main_latest"
+export DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS="0.0.0.0:8005"
+export DEGOV_INDEXER_GRAPHQL_ENDPOINT="http://eu2.ncp.kahub.in:8005/graphql"
+export DEGOV_INDEXER_GRAPHQL_PATH="/graphql"
+export DEGOV_INDEXER_CONFIG_FILE="apps/indexer/indexer.yml"
+export DEGOV_INDEXER_CONTRACT_SET_MODE="all"
+export DEGOV_INDEXER_CONTRACT_SET_MAX_CONCURRENCY="unlimited"
+export DEGOV_INDEXER_TARGET_HEIGHT="latest"
+export DEGOV_INDEXER_RUN_ONCE="false"
+export DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED="true"
+export DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED="true"
+export RUST_LOG="info"
+LOG_DIR="$REPO_ROOT/.local/logs"
+mkdir -p "$LOG_DIR"
+echo "combined runner starting at $(date -u +%Y-%m-%dT%H:%M:%SZ) commit=$(git rev-parse --short HEAD) db=${DEGOV_INDEXER_DATABASE_URL} bind=${DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS}" >> "$LOG_DIR/indexer-combined-main.log"
+cleanup() {
+  set +e
+  echo "combined runner stopping at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$LOG_DIR/indexer-combined-main.log"
+  [[ -n "${GRAPHQL_PID:-}" ]] && kill "$GRAPHQL_PID" 2>/dev/null || true
+  [[ -n "${INDEXER_PID:-}" ]] && kill "$INDEXER_PID" 2>/dev/null || true
+  wait "$GRAPHQL_PID" 2>/dev/null || true
+  wait "$INDEXER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+cargo run -p degov-datalens-indexer --locked -- graphql >> "$LOG_DIR/indexer-graphql-main.log" 2>&1 &
+GRAPHQL_PID=$!
+echo "graphql pid=$GRAPHQL_PID" >> "$LOG_DIR/indexer-combined-main.log"
+sleep 3
+cargo run -p degov-datalens-indexer --locked -- run >> "$LOG_DIR/indexer-sync-main.log" 2>&1 &
+INDEXER_PID=$!
+echo "indexer pid=$INDEXER_PID" >> "$LOG_DIR/indexer-combined-main.log"
+wait -n "$GRAPHQL_PID" "$INDEXER_PID"
+status=$?
+echo "combined runner child exited at $(date -u +%Y-%m-%dT%H:%M:%SZ) status=$status graphql_pid=$GRAPHQL_PID indexer_pid=$INDEXER_PID" >> "$LOG_DIR/indexer-combined-main.log"
+exit "$status"

--- a/apps/indexer/src/chain/tool.rs
+++ b/apps/indexer/src/chain/tool.rs
@@ -43,6 +43,7 @@ pub enum BlockReadMode {
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ChainReadMethod {
+    BlockTimestamp,
     CountingMode,
     ClockMode,
     Decimals,
@@ -470,6 +471,26 @@ impl ChainReadPlanBuilder {
         );
     }
 
+    pub fn add_optional_block_timestamp_read(&mut self, block_number: &str) {
+        let Ok(block_number_value) = block_number.parse::<u64>() else {
+            return;
+        };
+        self.add_read(
+            ChainReadDraft {
+                contract_address: self.contracts.governor.clone(),
+                method: ChainReadMethod::BlockTimestamp,
+                args: vec![block_number.to_owned()],
+                block_mode: BlockReadMode::AtBlock(block_number_value),
+                account: None,
+                proposal_id: None,
+                operation_id: None,
+                reason: ChainReadReason::OptionalEnrichment,
+                activity_block: None,
+            },
+            ReadRequirement::Optional,
+        );
+    }
+
     pub fn build(self) -> ChainReadPlan {
         let reads = self
             .reads
@@ -639,6 +660,9 @@ fn build_multicall_groups(
 
     let mut grouped = BTreeMap::<(i32, String, BlockReadMode), Vec<usize>>::new();
     for (index, read) in reads.iter().enumerate() {
+        if read.key.method == ChainReadMethod::BlockTimestamp {
+            continue;
+        }
         grouped
             .entry((
                 read.key.chain_id,

--- a/apps/indexer/src/graphql/filters.rs
+++ b/apps/indexer/src/graphql/filters.rs
@@ -35,13 +35,7 @@ pub(super) fn push_proposal_filters<'a>(
 ) {
     push_scope_filters(query, has_condition, &where_.scope, table_alias);
     if let Some(proposal_id) = &where_.proposal_id_eq {
-        push_column_eq(
-            query,
-            has_condition,
-            table_alias,
-            "proposal_id",
-            proposal_id,
-        );
+        push_proposal_id_eq(query, has_condition, table_alias, proposal_id);
     }
     if let Some(proposer) = &where_.proposer_eq {
         push_column_eq(query, has_condition, table_alias, "proposer", proposer);
@@ -112,7 +106,7 @@ pub(super) fn push_event_where<'a>(
         if let Some(where_) = where_ {
             push_scope_filters(query, &mut has_condition, where_.scope(), "");
             if let Some(proposal_id) = where_.proposal_id_eq() {
-                push_column_eq(query, &mut has_condition, "", "proposal_id", proposal_id);
+                push_proposal_id_eq(query, &mut has_condition, "", proposal_id);
             }
         }
         if !has_condition {
@@ -482,6 +476,36 @@ pub(super) fn push_numeric_column_eq<'a>(
     push_and(query, has_condition);
     push_qualified_column(query, table_alias, column);
     query.push(" = ").push_bind(value).push("::numeric");
+}
+
+fn push_proposal_id_eq<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    table_alias: &str,
+    proposal_id: &'a str,
+) {
+    let values = proposal_id_compat_values(proposal_id);
+    if values.len() == 1 {
+        push_column_eq(
+            query,
+            has_condition,
+            table_alias,
+            "proposal_id",
+            proposal_id,
+        );
+        return;
+    }
+
+    push_and(query, has_condition);
+    query.push("(");
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            query.push(" OR ");
+        }
+        push_qualified_column(query, table_alias, "proposal_id");
+        query.push(" = ").push_bind(value.clone());
+    }
+    query.push(")");
 }
 
 pub(super) fn push_qualified_column(

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -42,15 +42,19 @@ pub(super) async fn query_proposals(
         SELECT id, contract_set_id, chain_id, dao_code, governor_address, proposal_id, proposer,
           targets, values, signatures, calldatas, vote_start::text AS vote_start,
           vote_end::text AS vote_end, description, block_number::text AS block_number,
-          block_timestamp::text AS block_timestamp, transaction_hash, metrics_votes_count,
+          (CASE WHEN block_timestamp < 1000000000000 THEN block_timestamp * 1000 ELSE block_timestamp END)::text AS block_timestamp,
+          transaction_hash, metrics_votes_count,
           metrics_votes_with_params_count, metrics_votes_without_params_count,
           metrics_votes_weight_for_sum::text AS metrics_votes_weight_for_sum,
           metrics_votes_weight_against_sum::text AS metrics_votes_weight_against_sum,
           metrics_votes_weight_abstain_sum::text AS metrics_votes_weight_abstain_sum,
-          title, vote_start_timestamp::text AS vote_start_timestamp,
-          vote_end_timestamp::text AS vote_end_timestamp, block_interval, clock_mode,
+          title,
+          (CASE WHEN vote_start_timestamp < 1000000000000 THEN vote_start_timestamp * 1000 ELSE vote_start_timestamp END)::text AS vote_start_timestamp,
+          (CASE WHEN vote_end_timestamp < 1000000000000 THEN vote_end_timestamp * 1000 ELSE vote_end_timestamp END)::text AS vote_end_timestamp,
+          block_interval, clock_mode,
           proposal_deadline::text AS proposal_deadline, proposal_eta::text AS proposal_eta,
-          queue_ready_at::text AS queue_ready_at, queue_expires_at::text AS queue_expires_at,
+          (CASE WHEN queue_ready_at IS NULL THEN NULL WHEN queue_ready_at < 1000000000000 THEN queue_ready_at * 1000 ELSE queue_ready_at END)::text AS queue_ready_at,
+          (CASE WHEN queue_expires_at IS NULL THEN NULL WHEN queue_expires_at < 1000000000000 THEN queue_expires_at * 1000 ELSE queue_expires_at END)::text AS queue_expires_at,
           quorum::text AS quorum, decimals::text AS decimals, timelock_address,
           timelock_grace_period::text AS timelock_grace_period
         FROM (
@@ -206,7 +210,8 @@ where
     let mut query = QueryBuilder::<Postgres>::new(format!(
         r#"
         SELECT id, proposal_id, block_number::text AS block_number,
-          block_timestamp::text AS block_timestamp, transaction_hash
+          (CASE WHEN block_timestamp < 1000000000000 THEN block_timestamp * 1000 ELSE block_timestamp END)::text AS block_timestamp,
+          transaction_hash
         FROM {table}
         "#
     ));
@@ -266,8 +271,10 @@ pub(super) async fn query_contributors(
     let mut query = QueryBuilder::<Postgres>::new(
         r#"
         SELECT id, chain_id, dao_code, governor_address, block_number::text AS block_number,
-          block_timestamp::text AS block_timestamp, transaction_hash,
-          last_vote_timestamp::text AS last_vote_timestamp, power::text AS power,
+          (CASE WHEN block_timestamp < 1000000000000 THEN block_timestamp * 1000 ELSE block_timestamp END)::text AS block_timestamp,
+          transaction_hash,
+          (CASE WHEN last_vote_timestamp IS NULL THEN NULL WHEN last_vote_timestamp < 1000000000000 THEN last_vote_timestamp * 1000 ELSE last_vote_timestamp END)::text AS last_vote_timestamp,
+          power::text AS power,
           balance::text AS balance, delegates_count_all
         FROM (
           SELECT contributor.id, contributor.contract_set_id, contributor.chain_id,
@@ -310,7 +317,8 @@ pub(super) async fn query_delegates(
     let mut query = QueryBuilder::<Postgres>::new(
         r#"
         SELECT id, chain_id, dao_code, governor_address, from_delegate, to_delegate,
-          block_number::text AS block_number, block_timestamp::text AS block_timestamp,
+          block_number::text AS block_number,
+          (CASE WHEN block_timestamp < 1000000000000 THEN block_timestamp * 1000 ELSE block_timestamp END)::text AS block_timestamp,
           transaction_hash, is_current, power::text AS power
         FROM (
           SELECT delegate.id, delegate.contract_set_id, delegate.chain_id,
@@ -353,7 +361,8 @@ pub(super) async fn query_delegate_mappings(
     let mut query = QueryBuilder::<Postgres>::new(
         r#"
         SELECT id, chain_id, dao_code, governor_address, "from", "to", power::text AS power,
-          block_number::text AS block_number, block_timestamp::text AS block_timestamp,
+          block_number::text AS block_number,
+          (CASE WHEN block_timestamp < 1000000000000 THEN block_timestamp * 1000 ELSE block_timestamp END)::text AS block_timestamp,
           transaction_hash
         FROM delegate_mapping
         "#,

--- a/apps/indexer/src/graphql/schema.rs
+++ b/apps/indexer/src/graphql/schema.rs
@@ -85,7 +85,8 @@ impl QueryRoot {
         let mut query = QueryBuilder::<Postgres>::new(
             r#"
             SELECT id, proposal_id, eta_seconds::text AS eta_seconds,
-              block_number::text AS block_number, block_timestamp::text AS block_timestamp,
+              block_number::text AS block_number,
+              (CASE WHEN block_timestamp < 1000000000000 THEN block_timestamp * 1000 ELSE block_timestamp END)::text AS block_timestamp,
               transaction_hash
             FROM proposal_queued
             "#,
@@ -244,6 +245,10 @@ impl QueryRoot {
 
 #[ComplexObject(rename_fields = "camelCase")]
 impl Proposal {
+    async fn proposal_id(&self) -> String {
+        graphql_proposal_id(&self.proposal_id)
+    }
+
     async fn voters(
         &self,
         ctx: &Context<'_>,
@@ -256,7 +261,8 @@ impl Proposal {
         let mut query = QueryBuilder::<Postgres>::new(
             r#"
             SELECT id, type, params, voter, support, weight::text AS weight, reason,
-              block_number::text AS block_number, block_timestamp::text AS block_timestamp,
+              block_number::text AS block_number,
+              (CASE WHEN block_timestamp < 1000000000000 THEN block_timestamp * 1000 ELSE block_timestamp END)::text AS block_timestamp,
               transaction_hash
             FROM vote_cast_group
             "#,

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -1,4 +1,4 @@
-use async_graphql::{Enum, InputObject, SimpleObject};
+use async_graphql::{ComplexObject, Enum, InputObject, SimpleObject};
 use sqlx::FromRow;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -42,6 +42,7 @@ pub struct Proposal {
     pub(super) chain_id: Option<i32>,
     pub(super) dao_code: Option<String>,
     pub(super) governor_address: Option<String>,
+    #[graphql(skip)]
     pub(super) proposal_id: String,
     pub(super) proposer: String,
     pub(super) targets: Vec<String>,
@@ -91,9 +92,10 @@ pub struct VoteCastGroup {
 }
 
 #[derive(Clone, Debug, FromRow, SimpleObject)]
-#[graphql(rename_fields = "camelCase")]
+#[graphql(rename_fields = "camelCase", complex)]
 pub struct ProposalCanceled {
     pub(super) id: String,
+    #[graphql(skip)]
     pub(super) proposal_id: String,
     pub(super) block_number: String,
     pub(super) block_timestamp: String,
@@ -101,9 +103,10 @@ pub struct ProposalCanceled {
 }
 
 #[derive(Clone, Debug, FromRow, SimpleObject)]
-#[graphql(rename_fields = "camelCase")]
+#[graphql(rename_fields = "camelCase", complex)]
 pub struct ProposalExecuted {
     pub(super) id: String,
+    #[graphql(skip)]
     pub(super) proposal_id: String,
     pub(super) block_number: String,
     pub(super) block_timestamp: String,
@@ -111,9 +114,10 @@ pub struct ProposalExecuted {
 }
 
 #[derive(Clone, Debug, FromRow, SimpleObject)]
-#[graphql(rename_fields = "camelCase")]
+#[graphql(rename_fields = "camelCase", complex)]
 pub struct ProposalQueued {
     pub(super) id: String,
+    #[graphql(skip)]
     pub(super) proposal_id: String,
     pub(super) eta_seconds: String,
     pub(super) block_number: String,
@@ -208,6 +212,141 @@ pub struct IndexerStatus {
 #[graphql(rename_fields = "camelCase")]
 pub struct Connection {
     pub(super) total_count: i64,
+}
+
+#[ComplexObject(rename_fields = "camelCase")]
+impl ProposalCanceled {
+    async fn proposal_id(&self) -> String {
+        graphql_proposal_id(&self.proposal_id)
+    }
+}
+
+#[ComplexObject(rename_fields = "camelCase")]
+impl ProposalExecuted {
+    async fn proposal_id(&self) -> String {
+        graphql_proposal_id(&self.proposal_id)
+    }
+}
+
+#[ComplexObject(rename_fields = "camelCase")]
+impl ProposalQueued {
+    async fn proposal_id(&self) -> String {
+        graphql_proposal_id(&self.proposal_id)
+    }
+}
+
+pub(super) fn proposal_id_compat_values(value: &str) -> Vec<String> {
+    let mut values = vec![value.to_owned()];
+    if let Some(hex) = decimal_to_hex(value) {
+        push_unique(&mut values, hex);
+    }
+    if let Some(decimal) = hex_to_decimal(value) {
+        push_unique(&mut values, decimal);
+    }
+    values
+}
+
+pub(super) fn graphql_proposal_id(value: &str) -> String {
+    decimal_to_hex(value)
+        .unwrap_or_else(|| normalize_hex(value).unwrap_or_else(|| value.to_owned()))
+}
+
+fn normalize_hex(value: &str) -> Option<String> {
+    let hex = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))?;
+    if hex.is_empty() || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    let hex = hex.to_ascii_lowercase();
+    let trimmed = hex.trim_start_matches('0');
+    Some(format!(
+        "0x{}",
+        if trimmed.is_empty() { "0" } else { trimmed }
+    ))
+}
+
+fn decimal_to_hex(value: &str) -> Option<String> {
+    let mut digits = value.as_bytes().to_vec();
+    if digits.is_empty() || !digits.iter().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    while digits.len() > 1 && digits.first() == Some(&b'0') {
+        digits.remove(0);
+    }
+
+    let mut hex = Vec::new();
+    while !(digits.len() == 1 && digits[0] == b'0') {
+        let mut quotient = Vec::new();
+        let mut remainder = 0u8;
+        for digit in digits {
+            let value = remainder as u16 * 10 + (digit - b'0') as u16;
+            let next = (value / 16) as u8;
+            remainder = (value % 16) as u8;
+            if !quotient.is_empty() || next != 0 {
+                quotient.push(next + b'0');
+            }
+        }
+        hex.push(char::from_digit(remainder as u32, 16)?);
+        digits = if quotient.is_empty() {
+            vec![b'0']
+        } else {
+            quotient
+        };
+    }
+
+    hex.reverse();
+    Some(format!("0x{}", hex.into_iter().collect::<String>()))
+}
+
+fn hex_to_decimal(value: &str) -> Option<String> {
+    let hex = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))?;
+    if hex.is_empty() || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+
+    let mut digits = vec![0u8];
+    for nibble in hex.bytes().map(hex_nibble) {
+        let nibble = nibble?;
+        let mut carry = nibble;
+        for digit in digits.iter_mut().rev() {
+            let value = (*digit as u16) * 16 + carry as u16;
+            *digit = (value % 10) as u8;
+            carry = (value / 10) as u8;
+        }
+        while carry > 0 {
+            digits.insert(0, carry % 10);
+            carry /= 10;
+        }
+    }
+
+    let decimal = digits
+        .into_iter()
+        .skip_while(|digit| *digit == 0)
+        .map(|digit| (digit + b'0') as char)
+        .collect::<String>();
+    Some(if decimal.is_empty() {
+        "0".to_owned()
+    } else {
+        decimal
+    })
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
 }
 
 #[derive(Clone, Debug, Default, InputObject)]

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -237,6 +237,9 @@ impl ProposalQueued {
 
 pub(super) fn proposal_id_compat_values(value: &str) -> Vec<String> {
     let mut values = vec![value.to_owned()];
+    if let Some(decimal) = normalize_decimal(value) {
+        push_unique(&mut values, decimal);
+    }
     if let Some(hex) = decimal_to_hex(value) {
         push_unique(&mut values, hex);
     }
@@ -267,13 +270,11 @@ fn normalize_hex(value: &str) -> Option<String> {
 }
 
 fn decimal_to_hex(value: &str) -> Option<String> {
-    let mut digits = value.as_bytes().to_vec();
-    if digits.is_empty() || !digits.iter().all(|byte| byte.is_ascii_digit()) {
-        return None;
+    let decimal = normalize_decimal(value)?;
+    if decimal == "0" {
+        return Some("0x0".to_owned());
     }
-    while digits.len() > 1 && digits.first() == Some(&b'0') {
-        digits.remove(0);
-    }
+    let mut digits = decimal.into_bytes();
 
     let mut hex = Vec::new();
     while !(digits.len() == 1 && digits[0] == b'0') {
@@ -297,6 +298,18 @@ fn decimal_to_hex(value: &str) -> Option<String> {
 
     hex.reverse();
     Some(format!("0x{}", hex.into_iter().collect::<String>()))
+}
+
+fn normalize_decimal(value: &str) -> Option<String> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let trimmed = value.trim_start_matches('0');
+    Some(if trimmed.is_empty() {
+        "0".to_owned()
+    } else {
+        trimmed.to_owned()
+    })
 }
 
 fn hex_to_decimal(value: &str) -> Option<String> {
@@ -565,4 +578,21 @@ pub enum DelegateMappingOrderByInput {
     PowerDesc,
     #[graphql(name = "blockNumber_DESC")]
     BlockNumberDesc,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{graphql_proposal_id, proposal_id_compat_values};
+
+    #[test]
+    fn test_graphql_proposal_id_formats_zero_decimal_as_hex() {
+        assert_eq!(graphql_proposal_id("0"), "0x0");
+        assert_eq!(graphql_proposal_id("000"), "0x0");
+    }
+
+    #[test]
+    fn test_proposal_id_compat_values_include_canonical_zero_forms() {
+        assert_eq!(proposal_id_compat_values("000"), vec!["000", "0", "0x0"]);
+        assert_eq!(proposal_id_compat_values("0x0"), vec!["0x0", "0"]);
+    }
 }

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -1137,6 +1137,11 @@ impl EvmRpcChainTool {
                 .execute_timelock_operation_state(read_index, read)
                 .map(|result| (result, false));
         }
+        if read.key.method == ChainReadMethod::BlockTimestamp {
+            return self
+                .execute_block_timestamp(read_index, read)
+                .map(|result| (result, false));
+        }
 
         if let Some(value) = self.cache.get(&read.key) {
             return Ok((
@@ -1162,6 +1167,30 @@ impl EvmRpcChainTool {
             },
             false,
         ))
+    }
+
+    fn execute_block_timestamp(
+        &self,
+        read_index: usize,
+        read: &crate::ChainReadRequest,
+    ) -> Result<ChainReadResult, String> {
+        let block_number = read
+            .key
+            .args
+            .first()
+            .ok_or_else(|| "missing block number argument for BlockTimestamp".to_owned())?;
+        let timestamp_seconds = self.eth_get_block_timestamp(block_number)?;
+
+        Ok(ChainReadResult {
+            read_index,
+            key: read.key.clone(),
+            value: ChainReadValue::Integer(
+                timestamp_seconds
+                    .checked_mul(1_000)
+                    .ok_or_else(|| "block timestamp overflow".to_owned())?
+                    .to_string(),
+            ),
+        })
     }
 
     fn execute_timelock_operation_state(
@@ -1272,6 +1301,64 @@ impl EvmRpcChainTool {
         })
         .join()
         .map_err(|_| "RPC eth_call worker thread panicked".to_owned())?
+    }
+
+    fn eth_get_block_timestamp(&self, block_number: &str) -> Result<u128, String> {
+        let block_number = block_number
+            .parse::<u64>()
+            .map_err(|error| format!("parse block number {block_number}: {error}"))?;
+        let client = self.client.clone();
+        let rpc_url = self.rpc_url.clone();
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_getBlockByNumber",
+            "params": [
+                format!("0x{block_number:x}"),
+                false,
+            ],
+        });
+        thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| error.to_string())?;
+            runtime.block_on(async move {
+                let response = client
+                    .post(&rpc_url)
+                    .json(&body)
+                    .send()
+                    .await
+                    .map_err(|error| error.to_string())?;
+
+                if !response.status().is_success() {
+                    return Err(format!(
+                        "RPC eth_getBlockByNumber failed with HTTP {}",
+                        response.status()
+                    ));
+                }
+
+                let payload = response
+                    .json::<JsonRpcBlockResponse>()
+                    .await
+                    .map_err(|error| error.to_string())?;
+                if let Some(error) = payload.error {
+                    return Err(error.message);
+                }
+
+                let block = payload
+                    .result
+                    .ok_or_else(|| "RPC eth_getBlockByNumber returned no result".to_owned())?;
+                let timestamp = block
+                    .timestamp
+                    .strip_prefix("0x")
+                    .ok_or_else(|| "block timestamp must be hex".to_owned())?;
+                u128::from_str_radix(timestamp, 16)
+                    .map_err(|error| format!("parse block timestamp: {error}"))
+            })
+        })
+        .join()
+        .map_err(|_| "RPC eth_getBlockByNumber worker thread panicked".to_owned())?
     }
 }
 
@@ -1662,6 +1749,9 @@ fn format_failures(failures: &PartialChainReadFailureReport) -> String {
 
 fn encode_call_data(method: ChainReadMethod, args: &[String]) -> Result<String, String> {
     let (signature, tokens) = match method {
+        ChainReadMethod::BlockTimestamp => {
+            return Err("BlockTimestamp uses eth_getBlockByNumber".to_owned());
+        }
         ChainReadMethod::CountingMode => ("COUNTING_MODE()", vec![]),
         ChainReadMethod::ClockMode => ("CLOCK_MODE()", vec![]),
         ChainReadMethod::Decimals => ("decimals()", vec![]),
@@ -1867,6 +1957,17 @@ fn decode_hex_result(value: &str) -> Result<Vec<u8>, String> {
 struct JsonRpcResponse {
     result: Option<String>,
     error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcBlockResponse {
+    result: Option<JsonRpcBlock>,
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcBlock {
+    timestamp: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -41,6 +41,18 @@ pub struct ProposalProjectionBatch {
 
 impl ProposalProjectionBatch {
     pub fn apply_chain_read_execution_report(&mut self, report: &ChainReadExecutionReport) {
+        let block_timestamps = report
+            .results
+            .iter()
+            .filter_map(|result| {
+                if result.key.method != ChainReadMethod::BlockTimestamp {
+                    return None;
+                }
+                let block_number = result.key.args.first()?;
+                let timestamp = chain_read_scalar(&result.value)?;
+                Some(((result.key.chain_id, block_number.clone()), timestamp))
+            })
+            .collect::<BTreeMap<_, _>>();
         let proposal_indexes = self
             .proposals
             .iter()
@@ -69,27 +81,14 @@ impl ProposalProjectionBatch {
 
         for result in results {
             if result.key.method == ChainReadMethod::BlockTimestamp {
-                let Some(block_number) = result.key.args.first() else {
-                    continue;
-                };
-                let Some(timestamp) = chain_read_scalar(&result.value) else {
-                    continue;
-                };
-                for proposal in &mut self.proposals {
-                    if &proposal.vote_start == block_number {
-                        proposal.vote_start_timestamp = timestamp.clone();
-                    }
-                    if &proposal.vote_end == block_number {
-                        proposal.vote_end_timestamp = timestamp.clone();
-                    }
-                }
                 continue;
             }
             if result.key.method == ChainReadMethod::ClockMode {
                 if let Some(value) = chain_read_clock_mode(&result.value) {
                     for proposal in &mut self.proposals {
                         proposal.clock_mode = value.clone();
-                        proposal.block_interval = block_interval(&proposal.clock_mode);
+                        proposal.block_interval =
+                            block_interval(proposal.chain_id, &proposal.clock_mode);
                         proposal.vote_start_timestamp =
                             timepoint_timestamp_for_proposal(proposal, &proposal.vote_start);
                         proposal.vote_end_timestamp =
@@ -148,6 +147,23 @@ impl ProposalProjectionBatch {
                 }
                 _ => {}
             }
+        }
+        apply_block_timestamps(&mut self.proposals, &block_timestamps);
+    }
+}
+
+fn apply_block_timestamps(
+    proposals: &mut [ProposalWrite],
+    block_timestamps: &BTreeMap<(i32, String), String>,
+) {
+    for proposal in proposals {
+        let start_key = (proposal.chain_id, proposal.vote_start.clone());
+        if let Some(timestamp) = block_timestamps.get(&start_key) {
+            proposal.vote_start_timestamp = timestamp.clone();
+        }
+        let end_key = (proposal.chain_id, proposal.vote_end.clone());
+        if let Some(timestamp) = block_timestamps.get(&end_key) {
+            proposal.vote_end_timestamp = timestamp.clone();
         }
     }
 }
@@ -849,7 +865,7 @@ fn proposal_write(
 ) -> ProposalWrite {
     let metadata = derive_proposal_metadata(&event.description);
     let clock_mode = infer_clock_mode(&event.vote_start, &event.vote_end);
-    let block_interval = block_interval(&clock_mode);
+    let block_interval = block_interval(common.chain_id, &clock_mode);
 
     ProposalWrite {
         contract_set_id: common.contract_set_id.clone(),
@@ -1011,6 +1027,7 @@ fn deadline_extension_write(
 fn lifecycle_stub(common: &ProposalEventCommon, proposal_ref: &str, state: &str) -> ProposalWrite {
     let metadata = derive_proposal_metadata("");
     let clock_mode = "blocknumber".to_owned();
+    let block_interval = block_interval(common.chain_id, &clock_mode);
 
     ProposalWrite {
         contract_set_id: common.contract_set_id.clone(),
@@ -1044,7 +1061,7 @@ fn lifecycle_stub(common: &ProposalEventCommon, proposal_ref: &str, state: &str)
         proposal_eta: None,
         queue_ready_at: None,
         queue_expires_at: None,
-        block_interval: Some("12".to_owned()),
+        block_interval,
         clock_mode,
         quorum: "0".to_owned(),
         decimals: "0".to_owned(),
@@ -1383,8 +1400,10 @@ fn estimate_blocknumber_timestamp(
     (estimated >= 0).then(|| estimated.to_string())
 }
 
-fn block_interval(clock_mode: &str) -> Option<String> {
-    (clock_mode == "blocknumber").then(|| "12".to_owned())
+fn block_interval(chain_id: i32, clock_mode: &str) -> Option<String> {
+    const ETHEREUM_MAINNET_CHAIN_ID: i32 = 1;
+
+    (chain_id == ETHEREUM_MAINNET_CHAIN_ID && clock_mode == "blocknumber").then(|| "12".to_owned())
 }
 
 fn timepoint_timestamp_for_proposal(proposal: &ProposalWrite, timepoint: &str) -> String {

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -68,14 +68,32 @@ impl ProposalProjectionBatch {
         });
 
         for result in results {
+            if result.key.method == ChainReadMethod::BlockTimestamp {
+                let Some(block_number) = result.key.args.first() else {
+                    continue;
+                };
+                let Some(timestamp) = chain_read_scalar(&result.value) else {
+                    continue;
+                };
+                for proposal in &mut self.proposals {
+                    if &proposal.vote_start == block_number {
+                        proposal.vote_start_timestamp = timestamp.clone();
+                    }
+                    if &proposal.vote_end == block_number {
+                        proposal.vote_end_timestamp = timestamp.clone();
+                    }
+                }
+                continue;
+            }
             if result.key.method == ChainReadMethod::ClockMode {
                 if let Some(value) = chain_read_clock_mode(&result.value) {
                     for proposal in &mut self.proposals {
                         proposal.clock_mode = value.clone();
+                        proposal.block_interval = block_interval(&proposal.clock_mode);
                         proposal.vote_start_timestamp =
-                            timepoint_timestamp(&proposal.vote_start, &proposal.clock_mode);
+                            timepoint_timestamp_for_proposal(proposal, &proposal.vote_start);
                         proposal.vote_end_timestamp =
-                            timepoint_timestamp(&proposal.vote_end, &proposal.clock_mode);
+                            timepoint_timestamp_for_proposal(proposal, &proposal.vote_end);
                     }
                 }
                 continue;
@@ -240,9 +258,11 @@ pub struct ProposalWrite {
     pub proposal_eta: Option<String>,
     pub queue_ready_at: Option<String>,
     pub queue_expires_at: Option<String>,
+    pub block_interval: Option<String>,
     pub clock_mode: String,
     pub quorum: String,
     pub decimals: String,
+    pub timelock_address: Option<String>,
     pub queued_block_number: Option<String>,
     pub queued_block_timestamp: Option<String>,
     pub queued_transaction_hash: Option<String>,
@@ -491,7 +511,7 @@ pub fn project_proposal_events(
                 let metric = proposal_data_metric(&input.log.id, &common);
                 data_metrics.insert(metric.id.clone(), metric);
 
-                let proposal = proposal_write(common.clone(), event);
+                let proposal = proposal_write(common.clone(), event, &context.contracts.timelock);
                 proposal_refs.insert(proposal_lookup_key(&common), proposal.id.clone());
                 for action in proposal_action_writes(&common, &proposal, event) {
                     proposal_actions.insert(action.id.clone(), action);
@@ -530,6 +550,10 @@ pub fn project_proposal_events(
                     vec![event.vote_start.clone()],
                     crate::BlockReadMode::Safe,
                 );
+                if proposal.clock_mode == "blocknumber" {
+                    builder.add_optional_block_timestamp_read(&event.vote_start);
+                    builder.add_optional_block_timestamp_read(&event.vote_end);
+                }
                 if context.token_standard == GovernanceTokenStandard::Erc20 {
                     builder.add_optional_enrichment_read(
                         context.contracts.governor_token.clone(),
@@ -818,9 +842,14 @@ fn proposal_data_metric(log_id: &str, common: &ProposalEventCommon) -> DataMetri
     }
 }
 
-fn proposal_write(common: ProposalEventCommon, event: &ProposalCreatedEvent) -> ProposalWrite {
+fn proposal_write(
+    common: ProposalEventCommon,
+    event: &ProposalCreatedEvent,
+    timelock_address: &str,
+) -> ProposalWrite {
     let metadata = derive_proposal_metadata(&event.description);
     let clock_mode = infer_clock_mode(&event.vote_start, &event.vote_end);
+    let block_interval = block_interval(&clock_mode);
 
     ProposalWrite {
         contract_set_id: common.contract_set_id.clone(),
@@ -843,8 +872,20 @@ fn proposal_write(common: ProposalEventCommon, event: &ProposalCreatedEvent) -> 
         calldatas: event.calldatas.clone(),
         vote_start: event.vote_start.clone(),
         vote_end: event.vote_end.clone(),
-        vote_start_timestamp: timepoint_timestamp(&event.vote_start, &clock_mode),
-        vote_end_timestamp: timepoint_timestamp(&event.vote_end, &clock_mode),
+        vote_start_timestamp: timepoint_timestamp(
+            &event.vote_start,
+            &clock_mode,
+            common.block_number.as_str(),
+            common.block_timestamp.as_deref(),
+            block_interval.as_deref(),
+        ),
+        vote_end_timestamp: timepoint_timestamp(
+            &event.vote_end,
+            &clock_mode,
+            common.block_number.as_str(),
+            common.block_timestamp.as_deref(),
+            block_interval.as_deref(),
+        ),
         description: metadata.description,
         title: metadata.title,
         description_body: metadata.description_body,
@@ -858,9 +899,11 @@ fn proposal_write(common: ProposalEventCommon, event: &ProposalCreatedEvent) -> 
         proposal_eta: Some("0".to_owned()),
         queue_ready_at: None,
         queue_expires_at: None,
+        block_interval,
         clock_mode,
         quorum: "0".to_owned(),
         decimals: "0".to_owned(),
+        timelock_address: Some(normalize_identifier(timelock_address)),
         queued_block_number: None,
         queued_block_timestamp: None,
         queued_transaction_hash: None,
@@ -1001,9 +1044,11 @@ fn lifecycle_stub(common: &ProposalEventCommon, proposal_ref: &str, state: &str)
         proposal_eta: None,
         queue_ready_at: None,
         queue_expires_at: None,
+        block_interval: Some("12".to_owned()),
         clock_mode,
         quorum: "0".to_owned(),
         decimals: "0".to_owned(),
+        timelock_address: None,
         queued_block_number: None,
         queued_block_timestamp: None,
         queued_transaction_hash: None,
@@ -1026,6 +1071,7 @@ impl ProposalWrite {
             merged.proposal_eta = self.proposal_eta.clone().or(merged.proposal_eta);
             merged.queue_ready_at = self.queue_ready_at.clone().or(merged.queue_ready_at);
             merged.queue_expires_at = self.queue_expires_at.clone().or(merged.queue_expires_at);
+            merged.block_interval = self.block_interval.clone().or(merged.block_interval);
             if merged.clock_mode == "blocknumber" && self.clock_mode != "blocknumber" {
                 merged.clock_mode = self.clock_mode.clone();
             }
@@ -1035,6 +1081,7 @@ impl ProposalWrite {
             if merged.decimals == "0" {
                 merged.decimals = self.decimals.clone();
             }
+            merged.timelock_address = self.timelock_address.clone().or(merged.timelock_address);
             merged.queued_block_number = self
                 .queued_block_number
                 .clone()
@@ -1088,6 +1135,7 @@ impl ProposalWrite {
                 .queue_expires_at
                 .clone()
                 .or(self.queue_expires_at.clone());
+            self.block_interval = next.block_interval.clone().or(self.block_interval.clone());
             if self.clock_mode == "blocknumber" && next.clock_mode != "blocknumber" {
                 self.clock_mode = next.clock_mode.clone();
             }
@@ -1097,6 +1145,10 @@ impl ProposalWrite {
             if self.decimals == "0" {
                 self.decimals = next.decimals.clone();
             }
+            self.timelock_address = next
+                .timelock_address
+                .clone()
+                .or(self.timelock_address.clone());
             self.queued_block_number = next
                 .queued_block_number
                 .clone()
@@ -1296,12 +1348,53 @@ fn is_unix_seconds_timepoint(value: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn timepoint_timestamp(timepoint: &str, clock_mode: &str) -> String {
+fn timepoint_timestamp(
+    timepoint: &str,
+    clock_mode: &str,
+    anchor_block_number: &str,
+    anchor_block_timestamp: Option<&str>,
+    block_interval: Option<&str>,
+) -> String {
     if clock_mode == "timestamp" {
-        seconds_to_millis(timepoint).unwrap_or_else(|| timepoint.to_owned())
-    } else {
-        timepoint.to_owned()
+        return seconds_to_millis(timepoint).unwrap_or_else(|| timepoint.to_owned());
     }
+
+    estimate_blocknumber_timestamp(
+        timepoint,
+        anchor_block_number,
+        anchor_block_timestamp,
+        block_interval,
+    )
+    .unwrap_or_else(|| timepoint.to_owned())
+}
+
+fn estimate_blocknumber_timestamp(
+    timepoint: &str,
+    anchor_block_number: &str,
+    anchor_block_timestamp: Option<&str>,
+    block_interval: Option<&str>,
+) -> Option<String> {
+    let target = timepoint.parse::<i128>().ok()?;
+    let anchor = anchor_block_number.parse::<i128>().ok()?;
+    let timestamp = anchor_block_timestamp?.parse::<i128>().ok()?;
+    let interval_ms = block_interval?.parse::<i128>().ok()? * 1_000;
+    let estimated = timestamp.checked_add(target.checked_sub(anchor)?.checked_mul(interval_ms)?)?;
+
+    (estimated >= 0).then(|| estimated.to_string())
+}
+
+fn block_interval(clock_mode: &str) -> Option<String> {
+    (clock_mode == "blocknumber").then(|| "12".to_owned())
+}
+
+fn timepoint_timestamp_for_proposal(proposal: &ProposalWrite, timepoint: &str) -> String {
+    timepoint_timestamp(
+        timepoint,
+        &proposal.clock_mode,
+        &proposal.block_number,
+        proposal.block_timestamp.as_deref(),
+        proposal.block_interval.as_deref(),
+    )
 }
 
 fn seconds_to_millis(seconds: &str) -> Option<String> {

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -222,16 +222,16 @@ async fn upsert_proposal(
             transaction_index, proposal_id, proposer, targets, values, signatures, calldatas,
             vote_start, vote_end, description, block_number, block_timestamp, transaction_hash,
             title, vote_start_timestamp, vote_end_timestamp, description_hash, proposal_snapshot,
-            proposal_deadline, proposal_eta, queue_ready_at, queue_expires_at, clock_mode, quorum,
-            decimals
+            proposal_deadline, proposal_eta, queue_ready_at, queue_expires_at, block_interval,
+            clock_mode, quorum, decimals, timelock_address
          )
          VALUES (
             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
             $15::NUMERIC(78, 0), $16::NUMERIC(78, 0), $17, $18::NUMERIC(78, 0),
             $19::NUMERIC(78, 0), $20, $21, $22::NUMERIC(78, 0), $23::NUMERIC(78, 0),
             $24, $25::NUMERIC(78, 0), $26::NUMERIC(78, 0), $27::NUMERIC(78, 0),
-            $28::NUMERIC(78, 0), $29::NUMERIC(78, 0), $30, $31::NUMERIC(78, 0),
-            $32::NUMERIC(78, 0)
+            $28::NUMERIC(78, 0), $29::NUMERIC(78, 0), $30, $31, $32::NUMERIC(78, 0),
+            $33::NUMERIC(78, 0), $34
          )
          ON CONFLICT (id) DO UPDATE
          SET proposer = CASE WHEN EXCLUDED.proposer = '' THEN proposal.proposer ELSE EXCLUDED.proposer END,
@@ -249,9 +249,11 @@ async fn upsert_proposal(
              proposal_eta = COALESCE(EXCLUDED.proposal_eta, proposal.proposal_eta),
              queue_ready_at = COALESCE(EXCLUDED.queue_ready_at, proposal.queue_ready_at),
              queue_expires_at = COALESCE(EXCLUDED.queue_expires_at, proposal.queue_expires_at),
+             block_interval = COALESCE(EXCLUDED.block_interval, proposal.block_interval),
              clock_mode = EXCLUDED.clock_mode,
              quorum = EXCLUDED.quorum,
-             decimals = EXCLUDED.decimals",
+             decimals = EXCLUDED.decimals,
+             timelock_address = COALESCE(EXCLUDED.timelock_address, proposal.timelock_address)",
     )
     .bind(&row.id)
     .bind(&row.contract_set_id)
@@ -288,9 +290,11 @@ async fn upsert_proposal(
     .bind(row.proposal_eta.as_deref())
     .bind(row.queue_ready_at.as_deref())
     .bind(row.queue_expires_at.as_deref())
+    .bind(row.block_interval.as_deref())
     .bind(&row.clock_mode)
     .bind(&row.quorum)
     .bind(&row.decimals)
+    .bind(row.timelock_address.as_deref())
     .execute(&mut **transaction)
     .await?;
 

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -114,6 +114,12 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
                 title
                 proposer
                 blockTimestamp
+                voteStartTimestamp
+                voteEndTimestamp
+                blockInterval
+                quorum
+                decimals
+                timelockAddress
                 chainId
                 daoCode
                 governorAddress
@@ -190,14 +196,30 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
     );
 
     let data = response.data.into_json()?;
-    assert_eq!(data["proposals"][0]["proposalId"], "101");
-    assert_eq!(data["proposals"][0]["blockTimestamp"], "1700000100");
+    assert_eq!(data["proposals"][0]["proposalId"], "0x65");
+    assert_eq!(data["proposals"][0]["blockTimestamp"], "1700000100000");
+    assert_eq!(data["proposals"][0]["voteStartTimestamp"], "1700001000000");
+    assert_eq!(data["proposals"][0]["voteEndTimestamp"], "1700002000000");
+    assert_eq!(data["proposals"][0]["blockInterval"], "12");
+    assert_eq!(data["proposals"][0]["quorum"], "40");
+    assert_eq!(data["proposals"][0]["decimals"], "18");
+    assert_eq!(data["proposals"][0]["timelockAddress"], "0xtimelock");
     assert_eq!(data["proposals"][0]["metricsVotesWeightForSum"], "100");
     // PR #768 changes proposal id/FK semantics; keep this nested voter assertion
     // in the revalidation set after that branch lands.
     assert_eq!(data["proposals"][0]["voters"][0]["voter"], "0xvoter1");
     assert_eq!(data["proposals"][0]["voters"][0]["weight"], "100");
+    assert_eq!(
+        data["proposals"][0]["voters"][0]["blockTimestamp"],
+        "1700000110000"
+    );
     assert_eq!(data["proposalQueueds"][0]["etaSeconds"], "1700000200");
+    assert_eq!(data["proposalCanceleds"][0]["proposalId"], "0x65");
+    assert_eq!(
+        data["proposalCanceleds"][0]["blockTimestamp"],
+        "1700000130000"
+    );
+    assert_eq!(data["proposalExecuteds"][0]["proposalId"], "0x65");
     assert_eq!(data["dataMetrics"][0]["powerSum"], "150");
     assert_eq!(data["dataMetricsConnection"]["totalCount"], 1);
     assert_eq!(data["contributors"][0]["id"], "0xvoter1");
@@ -235,9 +257,9 @@ async fn test_graphql_schema_accepts_current_web_event_where_type_names()
                 "#,
             )
             .variables(async_graphql::Variables::from_json(json!({
-                "canceledWhere": { "proposalId_eq": "101" },
-                "executedWhere": { "proposalId_eq": "101" },
-                "queuedWhere": { "proposalId_eq": "101" }
+                "canceledWhere": { "proposalId_eq": "0x65" },
+                "executedWhere": { "proposalId_eq": "0x65" },
+                "queuedWhere": { "proposalId_eq": "0x65" }
             }))),
         )
         .await;
@@ -249,8 +271,8 @@ async fn test_graphql_schema_accepts_current_web_event_where_type_names()
     );
 
     let data = response.data.into_json()?;
-    assert_eq!(data["proposalCanceleds"][0]["proposalId"], "101");
-    assert_eq!(data["proposalExecuteds"][0]["proposalId"], "101");
+    assert_eq!(data["proposalCanceleds"][0]["proposalId"], "0x65");
+    assert_eq!(data["proposalExecuteds"][0]["proposalId"], "0x65");
     assert_eq!(data["proposalQueueds"][0]["etaSeconds"], "1700000200");
 
     database.cleanup().await?;
@@ -622,18 +644,18 @@ async fn test_graphql_proposal_fields_prefer_provisional_overlay_and_fallback_to
     );
 
     let data = response.data.into_json()?;
-    assert_eq!(data["proposals"][0]["proposalId"], "101");
+    assert_eq!(data["proposals"][0]["proposalId"], "0x65");
     assert_eq!(data["proposals"][0]["title"], "Live launch title");
     assert_eq!(
         data["proposals"][0]["description"],
         "Live launch description"
     );
     assert_eq!(data["proposals"][0]["proposalEta"], "1700000300");
-    assert_eq!(data["proposals"][0]["queueReadyAt"], "1700000300");
-    assert_eq!(data["proposals"][0]["queueExpiresAt"], "1700000900");
+    assert_eq!(data["proposals"][0]["queueReadyAt"], "1700000300000");
+    assert_eq!(data["proposals"][0]["queueExpiresAt"], "1700000900000");
     assert_eq!(data["proposals"][0]["timelockAddress"], "0xtimelock");
     assert_eq!(data["proposals"][0]["timelockGracePeriod"], "600");
-    assert_eq!(data["proposals"][1]["proposalId"], "102");
+    assert_eq!(data["proposals"][1]["proposalId"], "0x66");
     assert_eq!(data["proposals"][1]["title"], "Unrelated");
     assert_eq!(data["liveDetail"][0]["proposalEta"], "1700000300");
     assert_eq!(data["fallbackDetail"][0]["title"], "Unrelated");
@@ -1091,19 +1113,22 @@ async fn seed_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
           description, block_number, block_timestamp, transaction_hash,
           metrics_votes_count, metrics_votes_with_params_count, metrics_votes_without_params_count,
           metrics_votes_weight_for_sum, metrics_votes_weight_against_sum, metrics_votes_weight_abstain_sum,
-          title, vote_start_timestamp, vote_end_timestamp, clock_mode, quorum, decimals
+          title, vote_start_timestamp, vote_end_timestamp, block_interval, timelock_address,
+          clock_mode, quorum, decimals
         ) VALUES
         (
           'proposal:1135:0xgovernor:101', $1, 1135, 'lisk-dao', '0xgovernor', '0xgovernor', 1, 0,
           '101', '0xproposer', ARRAY['0xtarget'], ARRAY['0'], ARRAY['transfer(address,uint256)'], ARRAY['0x'],
           1000, 2000, 'Launch treasury program', 800, 1700000100, '0xproposal',
-          2, 1, 1, 100, 25, 0, 'Launch treasury program', 1700001000, 1700002000, 'mode=blocknumber&from=default', 40, 18
+          2, 1, 1, 100, 25, 0, 'Launch treasury program', 1700001000, 1700002000,
+          '12', '0xtimelock', 'mode=blocknumber&from=default', 40, 18
         ),
         (
           'proposal:1135:0xgovernor:102', $1, 1135, 'lisk-dao', '0xgovernor', '0xgovernor', 2, 0,
           '102', '0xother', ARRAY[]::TEXT[], ARRAY[]::TEXT[], ARRAY[]::TEXT[], ARRAY[]::TEXT[],
           1000, 2000, 'Unrelated', 801, 1700000200, '0xproposal2',
-          0, 0, 0, 0, 0, 0, 'Unrelated', 1700001000, 1700002000, 'mode=blocknumber&from=default', 40, 18
+          0, 0, 0, 0, 0, 0, 'Unrelated', 1700001000, 1700002000,
+          '12', '0xtimelock', 'mode=blocknumber&from=default', 40, 18
         )
         "#,
     )

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -1575,7 +1575,7 @@ async fn assert_proposal_projection_parity_state(pool: &PgPool) -> Result<(), sq
                 vote_start_timestamp::TEXT AS vote_start_timestamp,
                 vote_end_timestamp::TEXT AS vote_end_timestamp,
                 proposal_eta::TEXT AS proposal_eta, clock_mode, quorum::TEXT AS quorum,
-                decimals::TEXT AS decimals, metrics_votes_count,
+                decimals::TEXT AS decimals, block_interval, timelock_address, metrics_votes_count,
                 metrics_votes_weight_for_sum::TEXT AS metrics_votes_weight_for_sum
          FROM proposal",
     )
@@ -1589,12 +1589,26 @@ async fn assert_proposal_projection_parity_state(pool: &PgPool) -> Result<(), sq
         proposal.get::<String, _>("block_timestamp"),
         "1700000002000"
     );
-    assert_eq!(proposal.get::<String, _>("vote_start_timestamp"), "100");
-    assert_eq!(proposal.get::<String, _>("vote_end_timestamp"), "200");
+    assert_eq!(
+        proposal.get::<String, _>("vote_start_timestamp"),
+        "1700001178000"
+    );
+    assert_eq!(
+        proposal.get::<String, _>("vote_end_timestamp"),
+        "1700002378000"
+    );
     assert_eq!(proposal.get::<String, _>("proposal_eta"), "1234");
     assert_eq!(proposal.get::<String, _>("clock_mode"), "blocknumber");
     assert_eq!(proposal.get::<String, _>("quorum"), "9000");
     assert_eq!(proposal.get::<String, _>("decimals"), "18");
+    assert_eq!(
+        proposal.get::<Option<String>, _>("block_interval"),
+        Some("12".to_owned())
+    );
+    assert_eq!(
+        proposal.get::<Option<String>, _>("timelock_address"),
+        Some(TIMELOCK.to_owned())
+    );
     assert_eq!(
         proposal.get::<Option<i32>, _>("metrics_votes_count"),
         Some(1)

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -289,6 +289,11 @@ fn test_project_proposal_created_estimates_blocknumber_vote_timestamps_from_prop
     let report = ChainReadExecutionReport {
         results: vec![
             read_result(
+                ChainReadMethod::ClockMode,
+                "",
+                ChainReadValue::String("mode=blocknumber&from=default".to_owned()),
+            ),
+            read_result(
                 ChainReadMethod::BlockTimestamp,
                 "22339716",
                 ChainReadValue::Integer("1745507999000".to_owned()),
@@ -313,6 +318,43 @@ fn test_project_proposal_created_estimates_blocknumber_vote_timestamps_from_prop
         proposal.timelock_address.as_deref(),
         Some("0x2222222222222222222222222222222222222222")
     );
+}
+
+#[test]
+fn test_project_proposal_created_omits_block_interval_for_non_ethereum_blocknumber() {
+    let mut event_log = production_log(
+        "0022339715-afd3c-000054",
+        22_339_715,
+        0,
+        84,
+        1_745_507_987_000,
+    );
+    event_log.chain_id = 8453;
+    let batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: event_log,
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "42".to_owned(),
+                proposer: "0x1d5460f896521ad685ea4c3f2c679ec0b6806359".to_owned(),
+                targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "22339716".to_owned(),
+                vote_end: "22385534".to_owned(),
+                description: "Base blocknumber proposal".to_owned(),
+            }),
+        }],
+    )
+    .expect("projection succeeds");
+
+    let proposal = &batch.proposals[0];
+    assert_eq!(proposal.chain_id, 8453);
+    assert_eq!(proposal.clock_mode, "blocknumber");
+    assert_eq!(proposal.block_interval, None);
+    assert_eq!(proposal.vote_start_timestamp, "22339716");
+    assert_eq!(proposal.vote_end_timestamp, "22385534");
 }
 
 #[test]
@@ -388,6 +430,28 @@ fn test_project_proposal_lifecycle_events_builds_metadata_and_state_epochs() {
 
     assert_eq!(batch.chain_read_plan.metrics.requested_reads, 12);
     assert_eq!(batch.chain_read_plan.reads.len(), 6);
+}
+
+#[test]
+fn test_project_proposal_lifecycle_stub_omits_block_interval_for_non_ethereum_chain() {
+    let mut event_log = log(13, 0, 1);
+    event_log.chain_id = 8453;
+    let batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: event_log,
+            event: DecodedGovernorEvent::ProposalQueued(ProposalQueuedEvent {
+                proposal_id: "42".to_owned(),
+                eta_seconds: "1700000400".to_owned(),
+            }),
+        }],
+    )
+    .expect("projection succeeds");
+
+    let proposal = &batch.proposals[0];
+    assert_eq!(proposal.chain_id, 8453);
+    assert_eq!(proposal.clock_mode, "blocknumber");
+    assert_eq!(proposal.block_interval, None);
 }
 
 #[test]

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -120,6 +120,8 @@ fn test_project_proposal_created_builds_aggregate_actions_and_chain_reads() {
         methods,
         vec![
             ChainReadMethod::Decimals,
+            ChainReadMethod::BlockTimestamp,
+            ChainReadMethod::BlockTimestamp,
             ChainReadMethod::ClockMode,
             ChainReadMethod::ProposalSnapshot,
             ChainReadMethod::ProposalDeadline,
@@ -254,6 +256,63 @@ fn test_project_proposal_created_uses_raw_log_id_and_timestamp_clock_enrichment(
         Some("1722633201000")
     );
     assert_eq!(active.end_block_timestamp.as_deref(), Some("1723238001000"));
+}
+
+#[test]
+fn test_project_proposal_created_estimates_blocknumber_vote_timestamps_from_proposal_block() {
+    let mut batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: production_log(
+                "0022339715-afd3c-000054",
+                22_339_715,
+                0,
+                84,
+                1_745_507_987_000,
+            ),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id:
+                    "7402631996988205717047317892914463120232263405485409023912445691668825031406"
+                        .to_owned(),
+                proposer: "0x1d5460f896521ad685ea4c3f2c679ec0b6806359".to_owned(),
+                targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "22339716".to_owned(),
+                vote_end: "22385534".to_owned(),
+                description: "ENS blocknumber proposal".to_owned(),
+            }),
+        }],
+    )
+    .expect("projection succeeds");
+    let report = ChainReadExecutionReport {
+        results: vec![
+            read_result(
+                ChainReadMethod::BlockTimestamp,
+                "22339716",
+                ChainReadValue::Integer("1745507999000".to_owned()),
+            ),
+            read_result(
+                ChainReadMethod::BlockTimestamp,
+                "22385534",
+                ChainReadValue::Integer("1746060503000".to_owned()),
+            ),
+        ],
+        ..ChainReadExecutionReport::default()
+    };
+
+    batch.apply_chain_read_execution_report(&report);
+
+    let proposal = &batch.proposals[0];
+    assert_eq!(proposal.clock_mode, "blocknumber");
+    assert_eq!(proposal.vote_start_timestamp, "1745507999000");
+    assert_eq!(proposal.vote_end_timestamp, "1746060503000");
+    assert_eq!(proposal.block_interval.as_deref(), Some("12"));
+    assert_eq!(
+        proposal.timelock_address.as_deref(),
+        Some("0x2222222222222222222222222222222222222222")
+    );
 }
 
 #[test]

--- a/apps/indexer/tests/support/fixtures/known-dao-ranges/expected/projected-outputs.json
+++ b/apps/indexer/tests/support/fixtures/known-dao-ranges/expected/projected-outputs.json
@@ -2,7 +2,7 @@
   "proposal": {
     "chain_read_metrics": {
       "deduped_reads": 9,
-      "requested_reads": 15
+      "requested_reads": 17
     },
     "event_order": [
       "evm:1:10000:0x00000000000000000000000000000000000000000000000000000000000f4240:0:0",


### PR DESCRIPTION
## Summary

Fixes the first ENS indexer parity issues from HBX-397:

- HBX-398: enable the local all-mode runner path to process onchain refresh tasks by setting `DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED=true`.
- HBX-399: populate proposal blocknumber timestamps from block timestamp reads and persist static proposal metadata (`blockInterval`, `timelockAddress`, `quorum`, `decimals`).
- HBX-404: restore old GraphQL compatibility by emitting proposal IDs as hex and timestamp fields as milliseconds.

## Details

- Adds an optional `BlockTimestamp` chain read backed by `eth_getBlockByNumber` so blocknumber-clock proposals can store real `voteStartTimestamp` / `voteEndTimestamp` values instead of raw block numbers.
- Persists proposal `block_interval` and `timelock_address` alongside existing quorum/decimals enrichment.
- Normalizes GraphQL timestamp outputs to milliseconds for proposal, event, vote, contributor, delegate, and delegateMapping timestamp fields while preserving `proposalEta`/`etaSeconds` as seconds.
- Keeps GraphQL proposal ID filters compatible with both decimal and hex inputs while returning hex IDs to clients.

## Validation

- `cargo fmt --all`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@localhost:7432/postgres cargo test -p degov-datalens-indexer --tests`

All tests passed locally against the existing local Postgres container on port 7432.
