### PR TITLE
fix(indexer): restore proposal title compatibility

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -71,7 +71,10 @@ pub use crate::projection::proposal::{
     ProposalRepositoryWriteError, ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite,
     project_proposal_events,
 };
-pub use crate::projection::proposal_metadata::{ProposalTextMetadata, derive_proposal_metadata};
+pub use crate::projection::proposal_metadata::{
+    ProposalTextMetadata, ProposalTitleExtractor, derive_proposal_metadata,
+    derive_proposal_metadata_with_title_extractor,
+};
 pub use crate::projection::timelock::{
     InMemoryTimelockProjectionRepository, TIMELOCK_POSTGRES_ADAPTER_GAP, TimelockCallWrite,
     TimelockEventCommon, TimelockMinDelayChangeWrite, TimelockOperationHintWrite,

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -72,8 +72,8 @@ pub use crate::projection::proposal::{
     project_proposal_events,
 };
 pub use crate::projection::proposal_metadata::{
-    ProposalTextMetadata, ProposalTitleExtractor, derive_proposal_metadata,
-    derive_proposal_metadata_with_title_extractor,
+    ProposalTextMetadata, ProposalTitleExtractionError, ProposalTitleExtractor,
+    derive_proposal_metadata, derive_proposal_metadata_with_title_extractor,
 };
 pub use crate::projection::timelock::{
     InMemoryTimelockProjectionRepository, TIMELOCK_POSTGRES_ADAPTER_GAP, TimelockCallWrite,

--- a/apps/indexer/src/projection/proposal_metadata.rs
+++ b/apps/indexer/src/projection/proposal_metadata.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use serde::Deserialize;
 use serde_json::json;
 use sha3::{Digest, Keccak256};
@@ -8,20 +7,39 @@ const OPENROUTER_CHAT_COMPLETIONS_URL: &str = "https://openrouter.ai/api/v1/chat
 const OPENROUTER_DEFAULT_MODEL: &str = "google/gemini-2.5-flash-preview";
 
 pub trait ProposalTitleExtractor {
-    fn extract_title(&self, description: &str) -> anyhow::Result<Option<String>>;
+    fn extract_title(
+        &self,
+        description: &str,
+    ) -> Result<Option<String>, ProposalTitleExtractionError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProposalTitleExtractionError {
+    #[error("send OpenRouter title extraction request")]
+    SendRequest(#[source] reqwest::Error),
+    #[error("OpenRouter title extraction response status")]
+    ResponseStatus(#[source] reqwest::Error),
+    #[error("decode OpenRouter title extraction response")]
+    DecodeResponse(#[source] reqwest::Error),
+    #[error("decode OpenRouter title JSON content: {content}")]
+    DecodeTitleJson {
+        content: String,
+        #[source]
+        source: serde_json::Error,
+    },
 }
 
 pub struct OpenRouterProposalTitleExtractor {
-    api_key: Option<String>,
+    api_key: String,
     model: String,
     http: reqwest::blocking::Client,
 }
 
 impl OpenRouterProposalTitleExtractor {
-    pub fn from_env() -> Self {
+    pub fn from_env() -> Option<Self> {
         let api_key = std::env::var("OPENROUTER_API_KEY")
             .ok()
-            .filter(|value| !value.trim().is_empty());
+            .filter(|value| !value.trim().is_empty())?;
         let model = std::env::var("OPENROUTER_DEFAULT_MODEL")
             .ok()
             .filter(|value| !value.trim().is_empty())
@@ -34,27 +52,25 @@ impl OpenRouterProposalTitleExtractor {
                 reqwest::blocking::Client::new()
             });
 
-        Self {
+        Some(Self {
             api_key,
             model,
             http,
-        }
+        })
     }
 }
 
 impl ProposalTitleExtractor for OpenRouterProposalTitleExtractor {
-    fn extract_title(&self, description: &str) -> anyhow::Result<Option<String>> {
-        let Some(api_key) = &self.api_key else {
-            log::warn!("textplus.ai disabled: missing OPENROUTER_API_KEY");
-            return Ok(None);
-        };
-
+    fn extract_title(
+        &self,
+        description: &str,
+    ) -> Result<Option<String>, ProposalTitleExtractionError> {
         let response = self
             .http
             .post(OPENROUTER_CHAT_COMPLETIONS_URL)
-            .bearer_auth(api_key)
+            .bearer_auth(&self.api_key)
             .json(&json!({
-                "model": self.model,
+                "model": &self.model,
                 "messages": [
                     {
                         "role": "system",
@@ -70,11 +86,11 @@ impl ProposalTitleExtractor for OpenRouterProposalTitleExtractor {
                 }
             }))
             .send()
-            .context("send OpenRouter title extraction request")?
+            .map_err(ProposalTitleExtractionError::SendRequest)?
             .error_for_status()
-            .context("OpenRouter title extraction response status")?
+            .map_err(ProposalTitleExtractionError::ResponseStatus)?
             .json::<OpenRouterChatCompletionResponse>()
-            .context("decode OpenRouter title extraction response")?;
+            .map_err(ProposalTitleExtractionError::DecodeResponse)?;
 
         let Some(content) = response
             .choices
@@ -84,8 +100,12 @@ impl ProposalTitleExtractor for OpenRouterProposalTitleExtractor {
         else {
             return Ok(None);
         };
-        let parsed = serde_json::from_str::<OpenRouterTitleObject>(content)
-            .with_context(|| format!("decode OpenRouter title JSON content: {content}"))?;
+        let parsed = serde_json::from_str::<OpenRouterTitleObject>(content).map_err(|source| {
+            ProposalTitleExtractionError::DecodeTitleJson {
+                content: content.to_owned(),
+                source,
+            }
+        })?;
         let title = parsed.title.trim();
 
         if title.is_empty() {
@@ -127,10 +147,11 @@ pub struct ProposalTextMetadata {
 }
 
 pub fn derive_proposal_metadata(description: &str) -> ProposalTextMetadata {
-    derive_proposal_metadata_with_title_extractor(
-        description,
-        &OpenRouterProposalTitleExtractor::from_env(),
-    )
+    if let Some(title_extractor) = OpenRouterProposalTitleExtractor::from_env() {
+        derive_proposal_metadata_with_title_extractor(description, &title_extractor)
+    } else {
+        derive_proposal_metadata_without_title_extractor(description)
+    }
 }
 
 pub fn derive_proposal_metadata_with_title_extractor(
@@ -138,7 +159,26 @@ pub fn derive_proposal_metadata_with_title_extractor(
     title_extractor: &dyn ProposalTitleExtractor,
 ) -> ProposalTextMetadata {
     let (title, description_body) = extract_title_and_body(description);
-    let title = extract_ai_title(title_extractor, description).unwrap_or(title);
+    let title = if description.trim().is_empty() || title.trim().is_empty() {
+        title
+    } else {
+        extract_ai_title(title_extractor, description).unwrap_or(title)
+    };
+    let (description_body, discussion, signature_content) =
+        extract_description_tags(&description_body);
+
+    ProposalTextMetadata {
+        description: description.to_owned(),
+        title,
+        description_body,
+        description_hash: description_hash(description),
+        discussion,
+        signature_content,
+    }
+}
+
+fn derive_proposal_metadata_without_title_extractor(description: &str) -> ProposalTextMetadata {
+    let (title, description_body) = extract_title_and_body(description);
     let (description_body, discussion, signature_content) =
         extract_description_tags(&description_body);
 
@@ -231,7 +271,7 @@ fn clean_fullback_line(line: &str) -> String {
 fn strip_heading_prefix(line: &str) -> Option<&str> {
     let trimmed = line.trim_start();
     let rest = trimmed.trim_start_matches('#');
-    if rest == trimmed || !rest.starts_with(char::is_whitespace) {
+    if rest == trimmed || !starts_with_whitespace(rest) {
         return None;
     }
 
@@ -241,7 +281,7 @@ fn strip_heading_prefix(line: &str) -> Option<&str> {
 fn strip_line_prefix(line: &str, marker: char) -> Option<&str> {
     let trimmed = line.trim_start();
     let rest = trimmed.strip_prefix(marker)?;
-    if !rest.starts_with(char::is_whitespace) {
+    if !starts_with_whitespace(rest) {
         return None;
     }
 
@@ -254,11 +294,14 @@ fn strip_blockquote_prefix(line: &str) -> &str {
         return line;
     };
 
-    if let Some(rest) = rest.strip_prefix(char::is_whitespace) {
-        rest
-    } else {
-        rest
-    }
+    rest.trim_start()
+}
+
+fn starts_with_whitespace(value: &str) -> bool {
+    value
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_whitespace())
 }
 
 fn is_horizontal_rule(line: &str) -> bool {

--- a/apps/indexer/src/projection/proposal_metadata.rs
+++ b/apps/indexer/src/projection/proposal_metadata.rs
@@ -1,4 +1,120 @@
+use anyhow::Context;
+use serde::Deserialize;
+use serde_json::json;
 use sha3::{Digest, Keccak256};
+use std::time::Duration;
+
+const OPENROUTER_CHAT_COMPLETIONS_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
+const OPENROUTER_DEFAULT_MODEL: &str = "google/gemini-2.5-flash-preview";
+
+pub trait ProposalTitleExtractor {
+    fn extract_title(&self, description: &str) -> anyhow::Result<Option<String>>;
+}
+
+pub struct OpenRouterProposalTitleExtractor {
+    api_key: Option<String>,
+    model: String,
+    http: reqwest::blocking::Client,
+}
+
+impl OpenRouterProposalTitleExtractor {
+    pub fn from_env() -> Self {
+        let api_key = std::env::var("OPENROUTER_API_KEY")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+        let model = std::env::var("OPENROUTER_DEFAULT_MODEL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| OPENROUTER_DEFAULT_MODEL.to_owned());
+        let http = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(20))
+            .build()
+            .unwrap_or_else(|error| {
+                log::warn!("openrouter client build failed; using default client: {error}");
+                reqwest::blocking::Client::new()
+            });
+
+        Self {
+            api_key,
+            model,
+            http,
+        }
+    }
+}
+
+impl ProposalTitleExtractor for OpenRouterProposalTitleExtractor {
+    fn extract_title(&self, description: &str) -> anyhow::Result<Option<String>> {
+        let Some(api_key) = &self.api_key else {
+            log::warn!("textplus.ai disabled: missing OPENROUTER_API_KEY");
+            return Ok(None);
+        };
+
+        let response = self
+            .http
+            .post(OPENROUTER_CHAT_COMPLETIONS_URL)
+            .bearer_auth(api_key)
+            .json(&json!({
+                "model": self.model,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are an experienced Content Strategist and master Copywriter. Return a single raw JSON object with a string field named title."
+                    },
+                    {
+                        "role": "user",
+                        "content": format!("{description}\n---\nExtract a title from the content above, following these rules in order:\n\n1. Priority 1: Extract the first H1 heading from the content.\n2. Priority 2: If no H1 heading exists, use the first line of the content, provided it effectively summarizes the main topic.\n3. Priority 3: If both methods fail, generate a concise title by summarizing the content.")
+                    }
+                ],
+                "response_format": {
+                    "type": "json_object"
+                }
+            }))
+            .send()
+            .context("send OpenRouter title extraction request")?
+            .error_for_status()
+            .context("OpenRouter title extraction response status")?
+            .json::<OpenRouterChatCompletionResponse>()
+            .context("decode OpenRouter title extraction response")?;
+
+        let Some(content) = response
+            .choices
+            .first()
+            .map(|choice| choice.message.content.trim())
+            .filter(|content| !content.is_empty())
+        else {
+            return Ok(None);
+        };
+        let parsed = serde_json::from_str::<OpenRouterTitleObject>(content)
+            .with_context(|| format!("decode OpenRouter title JSON content: {content}"))?;
+        let title = parsed.title.trim();
+
+        if title.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(title.to_owned()))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct OpenRouterChatCompletionResponse {
+    choices: Vec<OpenRouterChatCompletionChoice>,
+}
+
+#[derive(Deserialize)]
+struct OpenRouterChatCompletionChoice {
+    message: OpenRouterChatCompletionMessage,
+}
+
+#[derive(Deserialize)]
+struct OpenRouterChatCompletionMessage {
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct OpenRouterTitleObject {
+    title: String,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProposalTextMetadata {
@@ -11,7 +127,18 @@ pub struct ProposalTextMetadata {
 }
 
 pub fn derive_proposal_metadata(description: &str) -> ProposalTextMetadata {
+    derive_proposal_metadata_with_title_extractor(
+        description,
+        &OpenRouterProposalTitleExtractor::from_env(),
+    )
+}
+
+pub fn derive_proposal_metadata_with_title_extractor(
+    description: &str,
+    title_extractor: &dyn ProposalTitleExtractor,
+) -> ProposalTextMetadata {
     let (title, description_body) = extract_title_and_body(description);
+    let title = extract_ai_title(title_extractor, description).unwrap_or(title);
     let (description_body, discussion, signature_content) =
         extract_description_tags(&description_body);
 
@@ -25,48 +152,180 @@ pub fn derive_proposal_metadata(description: &str) -> ProposalTextMetadata {
     }
 }
 
+fn extract_ai_title(
+    title_extractor: &dyn ProposalTitleExtractor,
+    description: &str,
+) -> Option<String> {
+    match title_extractor.extract_title(description) {
+        Ok(Some(title)) if !title.trim().is_empty() => Some(title.trim().to_owned()),
+        Ok(_) => None,
+        Err(error) => {
+            log::warn!("textplus.title generation failed; falling back to local: {error}");
+            None
+        }
+    }
+}
+
 fn extract_title_and_body(description: &str) -> (String, String) {
     let trimmed = description.trim();
-    if let Some(rest) = trimmed.strip_prefix("# ") {
-        let mut parts = rest.splitn(2, '\n');
-        let raw_title = parts.next().unwrap_or_default();
-        let title = normalize_heading_title(raw_title);
-        let body = parts.next().unwrap_or_default().trim().to_owned();
-        return (title, body);
-    }
-
-    fallback_title_and_body(trimmed)
-}
-
-fn normalize_heading_title(value: &str) -> String {
-    let clean_title = strip_html_tags(value).trim().to_owned();
-    if clean_title
-        .chars()
-        .all(|character| character.is_ascii_digit() || character.is_whitespace())
-    {
-        return clean_title
-            .split_whitespace()
-            .next()
-            .unwrap_or(clean_title.as_str())
-            .to_owned();
-    }
-
-    clean_title
-}
-
-fn fallback_title_and_body(description: &str) -> (String, String) {
-    let mut lines = description.lines();
-    let fallback_title = strip_html_tags(lines.next().unwrap_or_default().trim_start_matches('#'))
-        .trim()
-        .to_owned();
-    let title = if fallback_title.len() > 50 {
-        format!("{}...", fallback_title.chars().take(50).collect::<String>())
-    } else {
-        fallback_title
-    };
-    let body = lines.collect::<Vec<_>>().join("\n").trim().to_owned();
+    let title = extract_title_simplify(trimmed).unwrap_or_else(|| extract_title_fullback(trimmed));
+    let body = extract_description_body(trimmed, &title);
 
     (title, body)
+}
+
+fn extract_title_simplify(description: &str) -> Option<String> {
+    if description.trim().is_empty() {
+        return None;
+    }
+
+    description.lines().find_map(|line| {
+        let heading = line.trim_start().strip_prefix("# ")?;
+        let title = heading.trim();
+        if title.is_empty() {
+            None
+        } else {
+            Some(title.to_owned())
+        }
+    })
+}
+
+fn extract_title_fullback(description: &str) -> String {
+    if description.trim().is_empty() {
+        return String::new();
+    }
+
+    let mut clean_text = String::with_capacity(description.len());
+    for line in strip_markdown_links(&strip_html_tags(description)).lines() {
+        let clean_line = clean_fullback_line(line);
+        clean_text.push_str(&clean_line);
+        clean_text.push('\n');
+    }
+
+    let first_line = clean_text
+        .trim()
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+
+    truncate_title(&first_line)
+}
+
+fn clean_fullback_line(line: &str) -> String {
+    let without_prefix = strip_heading_prefix(line)
+        .or_else(|| strip_line_prefix(line, '-'))
+        .or_else(|| strip_line_prefix(line, '*'))
+        .or_else(|| strip_line_prefix(line, '+'))
+        .unwrap_or(line);
+    let without_rule = if is_horizontal_rule(without_prefix) {
+        ""
+    } else {
+        without_prefix
+    };
+
+    strip_blockquote_prefix(without_rule).to_owned()
+}
+
+fn strip_heading_prefix(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.trim_start_matches('#');
+    if rest == trimmed || !rest.starts_with(char::is_whitespace) {
+        return None;
+    }
+
+    Some(rest.trim_start())
+}
+
+fn strip_line_prefix(line: &str, marker: char) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix(marker)?;
+    if !rest.starts_with(char::is_whitespace) {
+        return None;
+    }
+
+    Some(rest.trim_start())
+}
+
+fn strip_blockquote_prefix(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    let Some(rest) = trimmed.strip_prefix('>') else {
+        return line;
+    };
+
+    if let Some(rest) = rest.strip_prefix(char::is_whitespace) {
+        rest
+    } else {
+        rest
+    }
+}
+
+fn is_horizontal_rule(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.len() >= 3
+        && trimmed
+            .chars()
+            .all(|character| matches!(character, '-' | '*' | '_'))
+}
+
+fn strip_markdown_links(value: &str) -> String {
+    let mut stripped = String::with_capacity(value.len());
+    let mut remaining = value;
+
+    while let Some(open_bracket) = remaining.find('[') {
+        stripped.push_str(&remaining[..open_bracket]);
+        let image_prefix = open_bracket > 0 && remaining[..open_bracket].ends_with('!');
+        if image_prefix {
+            stripped.pop();
+        }
+        let label_start = open_bracket + 1;
+        let Some(label_end_offset) = remaining[label_start..].find(']') else {
+            stripped.push_str(&remaining[open_bracket..]);
+            return stripped;
+        };
+        let label_end = label_start + label_end_offset;
+        let after_label = label_end + 1;
+        if !remaining[after_label..].starts_with('(') {
+            stripped.push_str(&remaining[open_bracket..after_label]);
+            remaining = &remaining[after_label..];
+            continue;
+        }
+        let url_start = after_label + 1;
+        let Some(url_end_offset) = remaining[url_start..].find(')') else {
+            stripped.push_str(&remaining[open_bracket..]);
+            return stripped;
+        };
+        let url_end = url_start + url_end_offset;
+
+        stripped.push_str(&remaining[label_start..label_end]);
+        remaining = &remaining[url_end + 1..];
+    }
+
+    stripped.push_str(remaining);
+    stripped
+}
+
+fn truncate_title(title: &str) -> String {
+    const MAX_LENGTH: usize = 50;
+
+    if title.chars().count() > MAX_LENGTH {
+        format!("{}...", title.chars().take(MAX_LENGTH).collect::<String>())
+    } else {
+        title.to_owned()
+    }
+}
+
+fn extract_description_body(description: &str, title: &str) -> String {
+    if let Some((first_line, body)) = description.split_once('\n') {
+        let first_line_title = extract_title_simplify(first_line)
+            .unwrap_or_else(|| extract_title_fullback(first_line.trim()));
+        if first_line_title == title {
+            return body.trim().to_owned();
+        }
+    }
+
+    description.to_owned()
 }
 
 fn extract_description_tags(description: &str) -> (String, Option<String>, Vec<String>) {

--- a/apps/indexer/tests/proposal_metadata.rs
+++ b/apps/indexer/tests/proposal_metadata.rs
@@ -1,6 +1,6 @@
-use anyhow::anyhow;
 use degov_datalens_indexer::{
-    ProposalTitleExtractor, derive_proposal_metadata, derive_proposal_metadata_with_title_extractor,
+    ProposalTitleExtractionError, ProposalTitleExtractor, derive_proposal_metadata,
+    derive_proposal_metadata_with_title_extractor,
 };
 
 struct StaticTitleExtractor {
@@ -8,7 +8,10 @@ struct StaticTitleExtractor {
 }
 
 impl ProposalTitleExtractor for StaticTitleExtractor {
-    fn extract_title(&self, _description: &str) -> anyhow::Result<Option<String>> {
+    fn extract_title(
+        &self,
+        _description: &str,
+    ) -> Result<Option<String>, ProposalTitleExtractionError> {
         Ok(self.title.clone())
     }
 }
@@ -16,7 +19,10 @@ impl ProposalTitleExtractor for StaticTitleExtractor {
 struct DisabledTitleExtractor;
 
 impl ProposalTitleExtractor for DisabledTitleExtractor {
-    fn extract_title(&self, _description: &str) -> anyhow::Result<Option<String>> {
+    fn extract_title(
+        &self,
+        _description: &str,
+    ) -> Result<Option<String>, ProposalTitleExtractionError> {
         Ok(None)
     }
 }
@@ -24,8 +30,15 @@ impl ProposalTitleExtractor for DisabledTitleExtractor {
 struct FailingTitleExtractor;
 
 impl ProposalTitleExtractor for FailingTitleExtractor {
-    fn extract_title(&self, _description: &str) -> anyhow::Result<Option<String>> {
-        Err(anyhow!("provider unavailable"))
+    fn extract_title(
+        &self,
+        _description: &str,
+    ) -> Result<Option<String>, ProposalTitleExtractionError> {
+        Err(ProposalTitleExtractionError::DecodeTitleJson {
+            content: "not json".to_owned(),
+            source: serde_json::from_str::<serde_json::Value>("not json")
+                .expect_err("invalid JSON should fail"),
+        })
     }
 }
 
@@ -171,4 +184,17 @@ fn test_derive_proposal_metadata_falls_back_when_ai_fails_or_returns_empty_title
     assert_eq!(failure_metadata.description_body, "Body");
     assert_eq!(empty_metadata.title, "Local title");
     assert_eq!(empty_metadata.description_body, "Body");
+}
+
+#[test]
+fn test_derive_proposal_metadata_skips_ai_for_empty_description() {
+    let metadata = derive_proposal_metadata_with_title_extractor(
+        "",
+        &StaticTitleExtractor {
+            title: Some("Fabricated title".to_owned()),
+        },
+    );
+
+    assert_eq!(metadata.title, "");
+    assert_eq!(metadata.description_body, "");
 }

--- a/apps/indexer/tests/proposal_metadata.rs
+++ b/apps/indexer/tests/proposal_metadata.rs
@@ -1,10 +1,45 @@
-use degov_datalens_indexer::derive_proposal_metadata;
+use anyhow::anyhow;
+use degov_datalens_indexer::{
+    ProposalTitleExtractor, derive_proposal_metadata, derive_proposal_metadata_with_title_extractor,
+};
+
+struct StaticTitleExtractor {
+    title: Option<String>,
+}
+
+impl ProposalTitleExtractor for StaticTitleExtractor {
+    fn extract_title(&self, _description: &str) -> anyhow::Result<Option<String>> {
+        Ok(self.title.clone())
+    }
+}
+
+struct DisabledTitleExtractor;
+
+impl ProposalTitleExtractor for DisabledTitleExtractor {
+    fn extract_title(&self, _description: &str) -> anyhow::Result<Option<String>> {
+        Ok(None)
+    }
+}
+
+struct FailingTitleExtractor;
+
+impl ProposalTitleExtractor for FailingTitleExtractor {
+    fn extract_title(&self, _description: &str) -> anyhow::Result<Option<String>> {
+        Err(anyhow!("provider unavailable"))
+    }
+}
+
+fn derive_proposal_metadata_without_ai(
+    description: &str,
+) -> degov_datalens_indexer::ProposalTextMetadata {
+    derive_proposal_metadata_with_title_extractor(description, &DisabledTitleExtractor)
+}
 
 #[test]
 fn test_derive_proposal_metadata_preserves_raw_description_and_hashes_utf8_bytes() {
     let description = "# Proposal title\n\nProposal body";
 
-    let metadata = derive_proposal_metadata(description);
+    let metadata = derive_proposal_metadata_without_ai(description);
 
     assert_eq!(metadata.description, description);
     assert_eq!(metadata.title, "Proposal title");
@@ -17,15 +52,15 @@ fn test_derive_proposal_metadata_preserves_raw_description_and_hashes_utf8_bytes
 
 #[test]
 fn test_derive_proposal_metadata_applies_stable_title_fallback_rules() {
-    let html_heading = derive_proposal_metadata("# <span>Upgrade treasury</span>\nBody");
-    let numeric_heading = derive_proposal_metadata("# 1 1\nBody");
-    let fallback = derive_proposal_metadata(
+    let html_heading = derive_proposal_metadata_without_ai("# <span>Upgrade treasury</span>\nBody");
+    let numeric_heading = derive_proposal_metadata_without_ai("# 1 1\nBody");
+    let fallback = derive_proposal_metadata_without_ai(
         "<b>Plain proposal title that is definitely longer than fifty characters</b>\nBody",
     );
 
-    assert_eq!(html_heading.title, "Upgrade treasury");
+    assert_eq!(html_heading.title, "<span>Upgrade treasury</span>");
     assert_eq!(html_heading.description_body, "Body");
-    assert_eq!(numeric_heading.title, "1");
+    assert_eq!(numeric_heading.title, "1 1");
     assert_eq!(numeric_heading.description_body, "Body");
     assert_eq!(
         fallback.title,
@@ -35,22 +70,35 @@ fn test_derive_proposal_metadata_applies_stable_title_fallback_rules() {
 }
 
 #[test]
-fn test_derive_proposal_metadata_preserves_legacy_hash_fallback_titles() {
-    let compact_heading = derive_proposal_metadata("#Title\nBody");
-    let nested_heading = derive_proposal_metadata("## Title\nBody");
-    let indented_heading = derive_proposal_metadata("  # Title\nBody");
+fn test_derive_proposal_metadata_preserves_textplus_fallback_compatibility() {
+    let nested_heading = derive_proposal_metadata_without_ai("Intro\n# Real title\nBody");
+    let list_marker = derive_proposal_metadata_without_ai("- Proposal title\nBody");
+    let markdown_link =
+        derive_proposal_metadata_without_ai("[Proposal title](https://example.com)\nBody");
+    let blockquote = derive_proposal_metadata_without_ai("> Proposal title\nBody");
+    let compact_heading = derive_proposal_metadata_without_ai("#Title\nBody");
+    let nested_hash_heading = derive_proposal_metadata_without_ai("## Title\nBody");
+    let indented_heading = derive_proposal_metadata_without_ai("  # Title\nBody");
 
-    assert_eq!(compact_heading.title, "Title");
+    assert_eq!(nested_heading.title, "Real title");
+    assert_eq!(nested_heading.description_body, "Intro\n# Real title\nBody");
+    assert_eq!(list_marker.title, "Proposal title");
+    assert_eq!(list_marker.description_body, "Body");
+    assert_eq!(markdown_link.title, "Proposal title");
+    assert_eq!(markdown_link.description_body, "Body");
+    assert_eq!(blockquote.title, "Proposal title");
+    assert_eq!(blockquote.description_body, "Body");
+    assert_eq!(compact_heading.title, "#Title");
     assert_eq!(compact_heading.description_body, "Body");
-    assert_eq!(nested_heading.title, "Title");
-    assert_eq!(nested_heading.description_body, "Body");
+    assert_eq!(nested_hash_heading.title, "Title");
+    assert_eq!(nested_hash_heading.description_body, "Body");
     assert_eq!(indented_heading.title, "Title");
     assert_eq!(indented_heading.description_body, "Body");
 }
 
 #[test]
 fn test_derive_proposal_metadata_extracts_deterministic_description_tags() {
-    let metadata = derive_proposal_metadata(
+    let metadata = derive_proposal_metadata_without_ai(
         "# Title\n\nMain text\n\n<discussion>https://forum.example/proposal</discussion>\n\n<signature>[\"transfer(address,uint256)\",\"\"]</signature>",
     );
 
@@ -81,4 +129,46 @@ fn test_derive_proposal_metadata_is_deterministic_without_provider_configuration
             assert_eq!(first, second);
         },
     );
+}
+
+#[test]
+fn test_derive_proposal_metadata_uses_local_fallback_when_ai_is_disabled() {
+    temp_env::with_vars([("OPENROUTER_API_KEY", None::<&str>)], || {
+        let metadata = derive_proposal_metadata("[Proposal title](https://example.com)\nBody");
+
+        assert_eq!(metadata.title, "Proposal title");
+        assert_eq!(metadata.description_body, "Body");
+    });
+}
+
+#[test]
+fn test_derive_proposal_metadata_uses_ai_title_when_provider_returns_title() {
+    let metadata = derive_proposal_metadata_with_title_extractor(
+        "# Local title\nBody",
+        &StaticTitleExtractor {
+            title: Some("AI title".to_owned()),
+        },
+    );
+
+    assert_eq!(metadata.title, "AI title");
+    assert_eq!(metadata.description_body, "Body");
+}
+
+#[test]
+fn test_derive_proposal_metadata_falls_back_when_ai_fails_or_returns_empty_title() {
+    let failure_metadata = derive_proposal_metadata_with_title_extractor(
+        "# Local title\nBody",
+        &FailingTitleExtractor,
+    );
+    let empty_metadata = derive_proposal_metadata_with_title_extractor(
+        "# Local title\nBody",
+        &StaticTitleExtractor {
+            title: Some("  ".to_owned()),
+        },
+    );
+
+    assert_eq!(failure_metadata.title, "Local title");
+    assert_eq!(failure_metadata.description_body, "Body");
+    assert_eq!(empty_metadata.title, "Local title");
+    assert_eq!(empty_metadata.description_body, "Body");
 }


### PR DESCRIPTION
## Summary
- Restore OpenRouter-backed proposal title extraction when `OPENROUTER_API_KEY` is configured, with `OPENROUTER_DEFAULT_MODEL` compatibility.
- Match the old TextPlus local fallback order for ENS proposal titles, including markdown H1 scan and fullback cleanup rules.
- Add injectable title extractor coverage so AI success, empty/failure fallback, and disabled env behavior are tested without real network calls.

## Issue
HBX-400

## Validation
- `cargo fmt --all`
- `cargo test -p degov-datalens-indexer proposal_metadata`
- `cargo test -p degov-datalens-indexer --test proposal_metadata`
- `cargo test -p degov-datalens-indexer --test proposal_projection`
- `git diff --check`

## Notes
- `cargo test -p degov-datalens-indexer` was attempted, but this environment does not define `DEGOV_INDEXER_TEST_DATABASE_URL`; the run stops in `checkpoint_repository` with that required-env error.