### PR TITLE
Optimize ENS onchain refresh batching

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -228,6 +228,9 @@ CREATE TABLE IF NOT EXISTS onchain_refresh_task (
 
 CREATE INDEX IF NOT EXISTS onchain_refresh_task_status_idx
   ON onchain_refresh_task (status, next_run_at);
+CREATE INDEX IF NOT EXISTS onchain_refresh_task_ready_claim_idx
+  ON onchain_refresh_task (next_run_at, updated_at, id)
+  WHERE status IN ('pending', 'failed');
 
 CREATE TABLE IF NOT EXISTS proposal_canceled (
   id TEXT PRIMARY KEY,

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -50,12 +50,12 @@ pub use crate::decode::evm_log::{
 };
 pub use crate::onchain::refresh::{
     ChainToolOnchainRefreshReader, EvmRpcChainTool, LivePowerOverlayReader,
-    LivePowerOverlayRefreshError, MultiChainToolOnchainRefreshReader, OnchainRefreshReadValue,
-    OnchainRefreshReader, OnchainRefreshReaderError, OnchainRefreshRunReport, OnchainRefreshTask,
-    OnchainRefreshTickClock, OnchainRefreshTickConfig, OnchainRefreshTickReport,
-    OnchainRefreshTickRunner, OnchainRefreshTickScheduler, OnchainRefreshTickSkipReason,
-    OnchainRefreshWorker, OnchainRefreshWorkerConfig, OnchainRefreshWorkerError,
-    SystemOnchainRefreshTickClock, refresh_live_power_overlays,
+    LivePowerOverlayRefreshError, MultiChainToolOnchainRefreshReader, OnchainRefreshReadReport,
+    OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError,
+    OnchainRefreshRunReport, OnchainRefreshTask, OnchainRefreshTickClock, OnchainRefreshTickConfig,
+    OnchainRefreshTickReport, OnchainRefreshTickRunner, OnchainRefreshTickScheduler,
+    OnchainRefreshTickSkipReason, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
+    OnchainRefreshWorkerError, SystemOnchainRefreshTickClock, refresh_live_power_overlays,
 };
 pub use crate::projection::data_metric::DataMetricWrite;
 pub use crate::projection::power_reconcile::{
@@ -138,6 +138,6 @@ pub use runtime_config::{
     AdaptiveChunkSizerRuntimeConfig, ContractSetConcurrencyLimit, GraphqlRuntimeConfig,
     IndexerContractSetMode, IndexerContractSetRuntimeConfig, IndexerRuntimeConfig,
     IndexerTargetHeight, OnchainRefreshRpcChainConfig, OnchainRefreshRuntimeConfig,
-    ProvisionalRuntimeConfig, datalens_retry_config, onchain_refresh_worker_enabled,
-    parse_bool_env_value, parse_i64_env_value, required_env,
+    ProvisionalRuntimeConfig, datalens_retry_config, onchain_refresh_debounce_from_env,
+    onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value, required_env,
 };

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -3,14 +3,14 @@ use std::{
     fmt,
     sync::{Arc, Mutex},
     thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use ethabi::{ParamType, Token, decode, encode, ethereum_types::U256};
 use serde::Deserialize;
 use serde_json::json;
 use sha3::{Digest, Keccak256};
-use sqlx::{PgPool, Postgres, Row, Transaction};
+use sqlx::{PgPool, Postgres, QueryBuilder, Row, Transaction};
 use thiserror::Error;
 
 use crate::{
@@ -26,6 +26,7 @@ use crate::{
 pub struct OnchainRefreshWorkerConfig {
     pub batch_size: usize,
     pub max_attempts: i32,
+    pub debounce: Duration,
     pub lock_ttl: Duration,
     pub retry_delay: Duration,
     pub lock_owner: String,
@@ -36,6 +37,14 @@ pub struct OnchainRefreshRunReport {
     pub claimed: usize,
     pub completed: usize,
     pub failed: usize,
+    pub unique_accounts: usize,
+    pub rpc_reads_requested: usize,
+    pub rpc_reads_deduped: usize,
+    pub cache_hits: usize,
+    pub debounced_tasks: usize,
+    pub data_metric_refreshes: usize,
+    pub duration_ms: u128,
+    pub backlog: Option<u64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -206,7 +215,7 @@ where
                 break;
             }
 
-            let batch = runner.run_once(1)?;
+            let batch = runner.run_once(remaining)?;
             if batch.claimed == 0 {
                 report.skipped =
                     (report.processed == 0).then_some(OnchainRefreshTickSkipReason::EmptyQueue);
@@ -277,6 +286,14 @@ pub struct OnchainRefreshReadValue {
     pub power: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct OnchainRefreshReadReport {
+    pub values: Vec<OnchainRefreshReadValue>,
+    pub rpc_reads_requested: usize,
+    pub rpc_reads_deduped: usize,
+    pub cache_hits: usize,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OnchainRefreshReaderError {
     message: String,
@@ -303,6 +320,16 @@ pub trait OnchainRefreshReader: Clone + Send + Sync + 'static {
         &self,
         tasks: &[OnchainRefreshTask],
     ) -> Result<Vec<OnchainRefreshReadValue>, OnchainRefreshReaderError>;
+
+    fn read_tasks_with_report(
+        &self,
+        tasks: &[OnchainRefreshTask],
+    ) -> Result<OnchainRefreshReadReport, OnchainRefreshReaderError> {
+        Ok(OnchainRefreshReadReport {
+            values: self.read_tasks(tasks)?,
+            ..OnchainRefreshReadReport::default()
+        })
+    }
 }
 
 #[derive(Debug, Error)]
@@ -362,6 +389,7 @@ where
         &self,
         batch_size: usize,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
+        let started_at = Instant::now();
         let now_ms = unix_time_millis();
         let tasks = self.claim_tasks(now_ms, batch_size).await?;
         if tasks.is_empty() {
@@ -370,8 +398,10 @@ where
 
         let mut report = OnchainRefreshRunReport {
             claimed: tasks.len(),
+            unique_accounts: unique_account_count(&tasks),
             completed: 0,
             failed: 0,
+            ..OnchainRefreshRunReport::default()
         };
 
         let mut tasks_by_chain = BTreeMap::<i32, Vec<OnchainRefreshTask>>::new();
@@ -380,11 +410,8 @@ where
         }
 
         for (_chain_id, tasks) in tasks_by_chain {
-            let values = match self.reader.read_tasks(&tasks) {
-                Ok(values) => values
-                    .into_iter()
-                    .map(|value| (value.task_id.clone(), value))
-                    .collect::<BTreeMap<_, _>>(),
+            let read_report = match self.reader.read_tasks_with_report(&tasks) {
+                Ok(report) => report,
                 Err(error) => {
                     let message = error.to_string();
                     self.mark_tasks_failed(&tasks, &message, now_ms).await?;
@@ -393,11 +420,21 @@ where
                     continue;
                 }
             };
+            report.rpc_reads_requested += read_report.rpc_reads_requested;
+            report.rpc_reads_deduped += read_report.rpc_reads_deduped;
+            report.cache_hits += read_report.cache_hits;
 
-            for task in tasks {
+            let values = read_report
+                .values
+                .into_iter()
+                .map(|value| (value.task_id.clone(), value))
+                .collect::<BTreeMap<_, _>>();
+            let mut successes = Vec::new();
+
+            for task in &tasks {
                 match values.get(&task.id) {
-                    Some(value) => match self.apply_success(&task, value, now_ms).await {
-                        Ok(()) => report.completed += 1,
+                    Some(value) => match validate_read_value(task, value) {
+                        Ok(()) => successes.push((task.clone(), value.clone())),
                         Err(error) => {
                             let message = error.to_string();
                             self.mark_task_failed(&task.id, &message, now_ms).await?;
@@ -411,7 +448,47 @@ where
                     }
                 }
             }
+            if !successes.is_empty() {
+                match self.apply_success_batch(&successes, now_ms).await {
+                    Ok(batch_report) => {
+                        report.completed += batch_report.completed;
+                        report.debounced_tasks += batch_report.debounced_tasks;
+                        report.data_metric_refreshes += batch_report.data_metric_refreshes;
+                    }
+                    Err(error) => {
+                        let message = error.to_string();
+                        let failed_tasks = successes
+                            .iter()
+                            .map(|(task, _value)| task.clone())
+                            .collect::<Vec<_>>();
+                        self.mark_tasks_failed(&failed_tasks, &message, now_ms)
+                            .await?;
+                        report.failed += failed_tasks.len();
+                    }
+                }
+            }
         }
+
+        report.duration_ms = started_at.elapsed().as_millis();
+        report.backlog = self.ready_backlog().await.ok();
+
+        log::info!(
+            "onchain refresh batch completed claimed={} completed={} failed={} unique_accounts={} rpc_reads_requested={} rpc_reads_deduped={} cache_hits={} debounced_tasks={} data_metric_refreshes={} duration_ms={} backlog={}",
+            report.claimed,
+            report.completed,
+            report.failed,
+            report.unique_accounts,
+            report.rpc_reads_requested,
+            report.rpc_reads_deduped,
+            report.cache_hits,
+            report.debounced_tasks,
+            report.data_metric_refreshes,
+            report.duration_ms,
+            report
+                .backlog
+                .map(|backlog| backlog.to_string())
+                .unwrap_or_else(|| "unknown".to_owned())
+        );
 
         Ok(report)
     }
@@ -523,43 +600,34 @@ where
             .collect())
     }
 
-    async fn apply_success(
+    async fn apply_success_batch(
         &self,
-        task: &OnchainRefreshTask,
-        value: &OnchainRefreshReadValue,
+        successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
         now_ms: i64,
-    ) -> Result<(), OnchainRefreshWorkerError> {
-        if task.refresh_power && value.power.is_none() {
-            return Err(OnchainRefreshWorkerError::MissingReadValue {
-                task_id: task.id.clone(),
-                field: "power",
-            });
-        }
-        if task.refresh_balance && value.balance.is_none() {
-            return Err(OnchainRefreshWorkerError::MissingReadValue {
-                task_id: task.id.clone(),
-                field: "balance",
-            });
-        }
-
+    ) -> Result<OnchainRefreshApplyBatchReport, OnchainRefreshWorkerError> {
         let mut transaction = self.pool.begin().await?;
 
-        let previous = read_contributor_refresh_values(&mut transaction, task).await?;
-        upsert_contributor_refresh(&mut transaction, task, value).await?;
+        let previous_values = read_contributor_refresh_values(&mut transaction, successes).await?;
+        upsert_contributor_refresh(&mut transaction, successes).await?;
         insert_refresh_checkpoints(
             &mut transaction,
-            task,
-            value,
-            previous,
+            successes,
+            &previous_values,
             self.current_power_method,
         )
         .await?;
-        refresh_data_metric(&mut transaction, task).await?;
-        complete_task(&mut transaction, &task.id, now_ms).await?;
+        upsert_live_power_overlays(&mut transaction, successes).await?;
+        let data_metric_refreshes = refresh_data_metrics(&mut transaction, successes).await?;
+        let debounced_tasks =
+            complete_tasks(&mut transaction, successes, now_ms, self.config.debounce).await?;
 
         transaction.commit().await?;
 
-        Ok(())
+        Ok(OnchainRefreshApplyBatchReport {
+            completed: successes.len(),
+            debounced_tasks,
+            data_metric_refreshes,
+        })
     }
 
     async fn mark_tasks_failed(
@@ -634,6 +702,13 @@ where
         &self,
         tasks: &[OnchainRefreshTask],
     ) -> Result<Vec<OnchainRefreshReadValue>, OnchainRefreshReaderError> {
+        Ok(self.read_tasks_with_report(tasks)?.values)
+    }
+
+    fn read_tasks_with_report(
+        &self,
+        tasks: &[OnchainRefreshTask],
+    ) -> Result<OnchainRefreshReadReport, OnchainRefreshReaderError> {
         let mut tasks_by_chain = BTreeMap::<i32, Vec<OnchainRefreshTask>>::new();
         for task in tasks {
             tasks_by_chain
@@ -642,7 +717,7 @@ where
                 .push(task.clone());
         }
 
-        let mut values = Vec::new();
+        let mut read_report = OnchainRefreshReadReport::default();
         for (chain_id, tasks) in tasks_by_chain {
             let chain_tool = self.chain_tools.get(&chain_id).ok_or_else(|| {
                 OnchainRefreshReaderError::new(format!(
@@ -654,10 +729,14 @@ where
                 self.read_plan_config,
                 self.current_power_method,
             );
-            values.extend(reader.read_tasks(&tasks)?);
+            let chain_report = reader.read_tasks_with_report(&tasks)?;
+            read_report.rpc_reads_requested += chain_report.rpc_reads_requested;
+            read_report.rpc_reads_deduped += chain_report.rpc_reads_deduped;
+            read_report.cache_hits += chain_report.cache_hits;
+            read_report.values.extend(chain_report.values);
         }
 
-        Ok(values)
+        Ok(read_report)
     }
 }
 
@@ -690,6 +769,13 @@ where
         &self,
         tasks: &[OnchainRefreshTask],
     ) -> Result<Vec<OnchainRefreshReadValue>, OnchainRefreshReaderError> {
+        Ok(self.read_tasks_with_report(tasks)?.values)
+    }
+
+    fn read_tasks_with_report(
+        &self,
+        tasks: &[OnchainRefreshTask],
+    ) -> Result<OnchainRefreshReadReport, OnchainRefreshReaderError> {
         let mut groups = BTreeMap::<(i32, String, String), Vec<&OnchainRefreshTask>>::new();
         for task in tasks {
             groups
@@ -703,6 +789,7 @@ where
         }
 
         let mut values_by_key = BTreeMap::<(i32, String, String, ChainReadMethod), String>::new();
+        let mut read_report = OnchainRefreshReadReport::default();
         for ((chain_id, governor_address, token_address), group_tasks) in groups {
             let mut builder = ChainReadPlanBuilder::new(
                 chain_id,
@@ -737,6 +824,9 @@ where
                 .chain_tool
                 .execute_read_plan(&plan)
                 .map_err(|failures| OnchainRefreshReaderError::new(format_failures(&failures)))?;
+            read_report.rpc_reads_requested += report.metrics.requested_reads;
+            read_report.rpc_reads_deduped += report.metrics.deduped_reads;
+            read_report.cache_hits += report.metrics.cache_hits;
 
             for result in report.results {
                 let Some(account) = result.key.args.first() else {
@@ -763,7 +853,7 @@ where
             }
         }
 
-        tasks
+        read_report.values = tasks
             .iter()
             .map(|task| {
                 let power = if task.refresh_power {
@@ -813,7 +903,9 @@ where
                     power,
                 })
             })
-            .collect()
+            .collect::<Result<Vec<_>, OnchainRefreshReaderError>>()?;
+
+        Ok(read_report)
     }
 }
 
@@ -1362,23 +1454,101 @@ impl EvmRpcChainTool {
     }
 }
 
-async fn upsert_contributor_refresh(
-    transaction: &mut Transaction<'_, Postgres>,
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct OnchainRefreshApplyBatchReport {
+    completed: usize,
+    debounced_tasks: usize,
+    data_metric_refreshes: usize,
+}
+
+fn validate_read_value(
     task: &OnchainRefreshTask,
     value: &OnchainRefreshReadValue,
+) -> Result<(), OnchainRefreshWorkerError> {
+    if task.refresh_power && value.power.is_none() {
+        return Err(OnchainRefreshWorkerError::MissingReadValue {
+            task_id: task.id.clone(),
+            field: "power",
+        });
+    }
+    if task.refresh_balance && value.balance.is_none() {
+        return Err(OnchainRefreshWorkerError::MissingReadValue {
+            task_id: task.id.clone(),
+            field: "balance",
+        });
+    }
+
+    Ok(())
+}
+
+async fn upsert_contributor_refresh(
+    transaction: &mut Transaction<'_, Postgres>,
+    successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
 ) -> Result<(), sqlx::Error> {
-    sqlx::query(
+    for refresh_power in [false, true] {
+        for refresh_balance in [false, true] {
+            let group = successes
+                .iter()
+                .filter(|(task, _value)| {
+                    task.refresh_power == refresh_power && task.refresh_balance == refresh_balance
+                })
+                .collect::<Vec<_>>();
+            if group.is_empty() {
+                continue;
+            }
+            upsert_contributor_refresh_group(transaction, &group, refresh_power, refresh_balance)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn upsert_contributor_refresh_group(
+    transaction: &mut Transaction<'_, Postgres>,
+    successes: &[&(OnchainRefreshTask, OnchainRefreshReadValue)],
+    refresh_power: bool,
+    refresh_balance: bool,
+) -> Result<(), sqlx::Error> {
+    let mut query = QueryBuilder::<Postgres>::new(
         "INSERT INTO contributor (
             id, contract_set_id, chain_id, dao_code, governor_address, token_address, contract_address,
             log_index, transaction_index, block_number, block_timestamp, transaction_hash,
             power, balance, delegates_count_all, delegates_count_effective
          )
-         VALUES (
-            $1, $2, $3, $4, $5, $6, $6, 0, 0, $7::NUMERIC(78, 0), $8::NUMERIC(78, 0), $9,
-            CASE WHEN $10 THEN $11::NUMERIC(78, 0) ELSE 0::NUMERIC(78, 0) END,
-            CASE WHEN $12 THEN $13::NUMERIC(78, 0) ELSE NULL END,
-            0, 0
-         )
+         ",
+    );
+    query.push_values(successes, |mut values, (task, value)| {
+        values
+            .push_bind(contributor_ref(task))
+            .push_bind(&task.contract_set_id)
+            .push_bind(task.chain_id)
+            .push_bind(&task.dao_code)
+            .push_bind(&task.governor_address)
+            .push_bind(&task.token_address)
+            .push_bind(&task.token_address)
+            .push("0")
+            .push("0")
+            .push_bind(&task.last_seen_block_number)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&task.last_seen_block_timestamp)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&task.last_seen_transaction_hash)
+            .push("CASE WHEN ")
+            .push_bind_unseparated(task.refresh_power)
+            .push_unseparated(" THEN ")
+            .push_bind_unseparated(value.power.as_deref())
+            .push_unseparated("::NUMERIC(78, 0) ELSE 0::NUMERIC(78, 0) END")
+            .push("CASE WHEN ")
+            .push_bind_unseparated(task.refresh_balance)
+            .push_unseparated(" THEN ")
+            .push_bind_unseparated(value.balance.as_deref())
+            .push_unseparated("::NUMERIC(78, 0) ELSE NULL END")
+            .push("0")
+            .push("0");
+    });
+    query.push(
+        "
          ON CONFLICT (contract_set_id, id) DO UPDATE
          SET chain_id = EXCLUDED.chain_id,
              dao_code = EXCLUDED.dao_code,
@@ -1388,24 +1558,14 @@ async fn upsert_contributor_refresh(
              block_number = GREATEST(contributor.block_number, EXCLUDED.block_number),
              block_timestamp = GREATEST(contributor.block_timestamp, EXCLUDED.block_timestamp),
              transaction_hash = EXCLUDED.transaction_hash,
-             power = CASE WHEN $10 THEN EXCLUDED.power ELSE contributor.power END,
-             balance = CASE WHEN $12 THEN EXCLUDED.balance ELSE contributor.balance END",
-    )
-    .bind(contributor_ref(task))
-    .bind(&task.contract_set_id)
-    .bind(task.chain_id)
-    .bind(&task.dao_code)
-    .bind(&task.governor_address)
-    .bind(&task.token_address)
-    .bind(&task.last_seen_block_number)
-    .bind(&task.last_seen_block_timestamp)
-    .bind(&task.last_seen_transaction_hash)
-    .bind(task.refresh_power)
-    .bind(value.power.as_deref())
-    .bind(task.refresh_balance)
-    .bind(value.balance.as_deref())
-    .execute(&mut **transaction)
-    .await?;
+             power = CASE WHEN ",
+    );
+    query
+        .push_bind(refresh_power)
+        .push(" THEN EXCLUDED.power ELSE contributor.power END, balance = CASE WHEN ")
+        .push_bind(refresh_balance)
+        .push(" THEN EXCLUDED.balance ELSE contributor.balance END");
+    query.build().execute(&mut **transaction).await?;
 
     Ok(())
 }
@@ -1418,114 +1578,445 @@ struct ContributorRefreshValues {
 
 async fn read_contributor_refresh_values(
     transaction: &mut Transaction<'_, Postgres>,
-    task: &OnchainRefreshTask,
-) -> Result<ContributorRefreshValues, sqlx::Error> {
-    let row = sqlx::query(
-        "SELECT power::TEXT AS power, balance::TEXT AS balance
+    successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
+) -> Result<BTreeMap<(String, String), ContributorRefreshValues>, sqlx::Error> {
+    let mut query = QueryBuilder::<Postgres>::new(
+        "SELECT contract_set_id, id, power::TEXT AS power, balance::TEXT AS balance
          FROM contributor
-         WHERE contract_set_id = $1 AND id = $2",
-    )
-    .bind(&task.contract_set_id)
-    .bind(contributor_ref(task))
-    .fetch_optional(&mut **transaction)
-    .await?;
+         WHERE (contract_set_id, id) IN ",
+    );
+    query.push_tuples(successes, |mut values, (task, _value)| {
+        values
+            .push_bind(&task.contract_set_id)
+            .push_bind(contributor_ref(task));
+    });
+    let rows = query.build().fetch_all(&mut **transaction).await?;
 
-    Ok(row
-        .map(|row| ContributorRefreshValues {
-            power: row.get("power"),
-            balance: row.get("balance"),
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            (
+                (row.get("contract_set_id"), row.get("id")),
+                ContributorRefreshValues {
+                    power: row.get("power"),
+                    balance: row.get("balance"),
+                },
+            )
         })
-        .unwrap_or_default())
+        .collect())
 }
 
 async fn insert_refresh_checkpoints(
     transaction: &mut Transaction<'_, Postgres>,
-    task: &OnchainRefreshTask,
-    value: &OnchainRefreshReadValue,
-    previous: ContributorRefreshValues,
+    successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
+    previous_values: &BTreeMap<(String, String), ContributorRefreshValues>,
     current_power_method: ChainReadMethod,
 ) -> Result<(), sqlx::Error> {
-    if task.refresh_balance {
-        let previous_balance = previous.balance.as_deref().unwrap_or("0");
-        let new_balance = value.balance.as_deref().unwrap_or("0");
-        sqlx::query(
+    let balance_successes = successes
+        .iter()
+        .filter(|(task, _value)| task.refresh_balance)
+        .collect::<Vec<_>>();
+    if !balance_successes.is_empty() {
+        let mut query = QueryBuilder::<Postgres>::new(
             "INSERT INTO token_balance_checkpoint (
                 id, contract_set_id, chain_id, dao_code, governor_address, token_address, contract_address,
                 account, previous_balance, new_balance, delta, source, cause, block_number,
                 block_timestamp, transaction_hash
              )
-             VALUES (
-                $1, $2, $3, $4, $5, $6, $6, $7, $8::NUMERIC(78, 0), $9::NUMERIC(78, 0),
-                ($9::NUMERIC(78, 0) - $8::NUMERIC(78, 0)), 'balanceOf', 'onchain-refresh',
-                $10::NUMERIC(78, 0), $11::NUMERIC(78, 0), 'onchain-refresh'
-             )
-             ON CONFLICT (contract_set_id, id) DO NOTHING",
-        )
-        .bind(format!(
-            "onchain-refresh-balance-{}",
-            onchain_refresh_checkpoint_scope(task)
-        ))
-        .bind(&task.contract_set_id)
-        .bind(task.chain_id)
-        .bind(&task.dao_code)
-        .bind(&task.governor_address)
-        .bind(&task.token_address)
-        .bind(&task.account)
-        .bind(previous_balance)
-        .bind(new_balance)
-        .bind(&task.last_seen_block_number)
-        .bind(&task.last_seen_block_timestamp)
-        .execute(&mut **transaction)
-        .await?;
+             ",
+        );
+        query.push_values(balance_successes, |mut values, (task, value)| {
+            let previous = previous_values
+                .get(&(task.contract_set_id.clone(), contributor_ref(task)))
+                .cloned()
+                .unwrap_or_default();
+            let previous_balance = previous.balance.unwrap_or_else(|| "0".to_owned());
+            let new_balance = value.balance.as_deref().unwrap_or("0");
+            values
+                .push_bind(format!(
+                    "onchain-refresh-balance-{}",
+                    onchain_refresh_checkpoint_scope(task)
+                ))
+                .push_bind(&task.contract_set_id)
+                .push_bind(task.chain_id)
+                .push_bind(&task.dao_code)
+                .push_bind(&task.governor_address)
+                .push_bind(&task.token_address)
+                .push_bind(&task.token_address)
+                .push_bind(&task.account)
+                .push_bind(previous_balance.clone())
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push_bind(new_balance)
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push("(")
+                .push_bind_unseparated(new_balance)
+                .push_unseparated("::NUMERIC(78, 0) - ")
+                .push_bind_unseparated(previous_balance)
+                .push_unseparated("::NUMERIC(78, 0))")
+                .push("'balanceOf'")
+                .push("'onchain-refresh'")
+                .push_bind(&task.last_seen_block_number)
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push_bind(&task.last_seen_block_timestamp)
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push("'onchain-refresh'");
+        });
+        query.push(" ON CONFLICT (contract_set_id, id) DO NOTHING");
+        query.build().execute(&mut **transaction).await?;
     }
 
-    if task.refresh_power {
-        let previous_power = previous.power.as_deref().unwrap_or("0");
-        let new_power = value.power.as_deref().unwrap_or("0");
-        sqlx::query(
+    let power_successes = successes
+        .iter()
+        .filter(|(task, _value)| task.refresh_power)
+        .collect::<Vec<_>>();
+    if !power_successes.is_empty() {
+        let source = current_power_checkpoint_source(current_power_method);
+        let mut query = QueryBuilder::<Postgres>::new(
             "INSERT INTO vote_power_checkpoint (
                 id, contract_set_id, chain_id, dao_code, governor_address, token_address, contract_address,
                 account, clock_mode, timepoint, previous_power, new_power, delta, source, cause,
                 block_number, block_timestamp, transaction_hash
              )
-             VALUES (
-                $1, $2, $3, $4, $5, $6, $6, $7, 'blocknumber', $8::NUMERIC(78, 0),
-                $9::NUMERIC(78, 0), $10::NUMERIC(78, 0),
-                ($10::NUMERIC(78, 0) - $9::NUMERIC(78, 0)), $11, 'onchain-refresh',
-                $8::NUMERIC(78, 0), $12::NUMERIC(78, 0), 'onchain-refresh'
-             )
-             ON CONFLICT (contract_set_id, id) DO NOTHING",
-        )
-        .bind(format!(
-            "onchain-refresh-power-{}",
-            onchain_refresh_checkpoint_scope(task)
-        ))
-        .bind(&task.contract_set_id)
-        .bind(task.chain_id)
-        .bind(&task.dao_code)
-        .bind(&task.governor_address)
-        .bind(&task.token_address)
-        .bind(&task.account)
-        .bind(&task.last_seen_block_number)
-        .bind(previous_power)
-        .bind(new_power)
-        .bind(current_power_checkpoint_source(current_power_method))
-        .bind(&task.last_seen_block_timestamp)
-        .execute(&mut **transaction)
-        .await?;
+             ",
+        );
+        query.push_values(power_successes, |mut values, (task, value)| {
+            let previous = previous_values
+                .get(&(task.contract_set_id.clone(), contributor_ref(task)))
+                .cloned()
+                .unwrap_or_default();
+            let previous_power = previous.power.unwrap_or_else(|| "0".to_owned());
+            let new_power = value.power.as_deref().unwrap_or("0");
+            values
+                .push_bind(format!(
+                    "onchain-refresh-power-{}",
+                    onchain_refresh_checkpoint_scope(task)
+                ))
+                .push_bind(&task.contract_set_id)
+                .push_bind(task.chain_id)
+                .push_bind(&task.dao_code)
+                .push_bind(&task.governor_address)
+                .push_bind(&task.token_address)
+                .push_bind(&task.token_address)
+                .push_bind(&task.account)
+                .push("'blocknumber'")
+                .push_bind(&task.last_seen_block_number)
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push_bind(previous_power.clone())
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push_bind(new_power)
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push("(")
+                .push_bind_unseparated(new_power)
+                .push_unseparated("::NUMERIC(78, 0) - ")
+                .push_bind_unseparated(previous_power)
+                .push_unseparated("::NUMERIC(78, 0))")
+                .push_bind(source)
+                .push("'onchain-refresh'")
+                .push_bind(&task.last_seen_block_number)
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push_bind(&task.last_seen_block_timestamp)
+                .push_unseparated("::NUMERIC(78, 0)")
+                .push("'onchain-refresh'");
+        });
+        query.push(" ON CONFLICT (contract_set_id, id) DO NOTHING");
+        query.build().execute(&mut **transaction).await?;
     }
 
     Ok(())
 }
 
-async fn refresh_data_metric(
+async fn upsert_live_power_overlays(
     transaction: &mut Transaction<'_, Postgres>,
-    task: &OnchainRefreshTask,
+    successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
+) -> Result<(), sqlx::Error> {
+    let contributors = live_contributor_power_overlay_writes(successes);
+    if contributors.is_empty() {
+        return Ok(());
+    }
+
+    upsert_live_contributor_power_overlays(transaction, &contributors).await?;
+    let relations = read_live_delegate_power_overlay_relations(transaction, &contributors).await?;
+    let delegates = provisional_delegate_power_overlay_writes(&contributors, &relations);
+    upsert_live_delegate_power_overlays(transaction, &delegates).await?;
+
+    Ok(())
+}
+
+fn live_contributor_power_overlay_writes(
+    successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
+) -> Vec<ProvisionalContributorPowerOverlayWrite> {
+    successes
+        .iter()
+        .filter_map(|(task, value)| {
+            let power = value.power.as_ref()?;
+            task.refresh_power
+                .then(|| ProvisionalContributorPowerOverlayWrite {
+                    id: provisional_contributor_power_overlay_id(task),
+                    segment_id: None,
+                    dao_code: task.dao_code.clone(),
+                    contract_set_id: task.contract_set_id.clone(),
+                    chain_id: Some(task.chain_id),
+                    chain_name: None,
+                    governor_address: Some(normalize_identifier(&task.governor_address)),
+                    token_address: Some(normalize_identifier(&task.token_address)),
+                    account: normalize_identifier(&task.account),
+                    power: power.clone(),
+                    balance: value.balance.clone(),
+                    delegates_count_all: 0,
+                    delegates_count_effective: 0,
+                    last_vote_block_number: None,
+                    last_vote_timestamp: None,
+                    source: "live-onchain".to_owned(),
+                    status: "available".to_owned(),
+                    anchor_block_number: Some(task.last_seen_block_number.clone()),
+                    anchor_block_hash: None,
+                    anchor_parent_hash: None,
+                    anchor_block_timestamp: Some(task.last_seen_block_timestamp.clone()),
+                })
+        })
+        .collect()
+}
+
+async fn upsert_live_contributor_power_overlays(
+    transaction: &mut Transaction<'_, Postgres>,
+    contributors: &[ProvisionalContributorPowerOverlayWrite],
+) -> Result<(), sqlx::Error> {
+    let mut query = QueryBuilder::<Postgres>::new(
+        "INSERT INTO degov_provisional_contributor_power_overlay (
+             id, segment_id, contract_set_id, chain_id, chain_name, dao_code, governor_address,
+             token_address, account, power, balance, delegates_count_all,
+             delegates_count_effective, last_vote_block_number, last_vote_timestamp, source,
+             status, anchor_block_number, anchor_block_hash, anchor_parent_hash,
+             anchor_block_timestamp
+         )
+         ",
+    );
+    query.push_values(contributors, |mut values, contributor| {
+        values
+            .push_bind(&contributor.id)
+            .push_bind(&contributor.segment_id)
+            .push_bind(&contributor.contract_set_id)
+            .push_bind(contributor.chain_id)
+            .push_bind(&contributor.chain_name)
+            .push_bind(&contributor.dao_code)
+            .push_bind(&contributor.governor_address)
+            .push_bind(&contributor.token_address)
+            .push_bind(&contributor.account)
+            .push_bind(&contributor.power)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&contributor.balance)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(contributor.delegates_count_all)
+            .push_bind(contributor.delegates_count_effective)
+            .push_bind(&contributor.last_vote_block_number)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&contributor.last_vote_timestamp)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&contributor.source)
+            .push_bind(&contributor.status)
+            .push_bind(&contributor.anchor_block_number)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&contributor.anchor_block_hash)
+            .push_bind(&contributor.anchor_parent_hash)
+            .push_bind(&contributor.anchor_block_timestamp)
+            .push_unseparated("::NUMERIC(78, 0)");
+    });
+    query.push(
+        "
+         ON CONFLICT ON CONSTRAINT degov_provisional_contributor_power_overlay_scope_unique
+         DO UPDATE SET
+             id = EXCLUDED.id,
+             segment_id = EXCLUDED.segment_id,
+             power = EXCLUDED.power,
+             balance = EXCLUDED.balance,
+             delegates_count_all = EXCLUDED.delegates_count_all,
+             delegates_count_effective = EXCLUDED.delegates_count_effective,
+             last_vote_block_number = EXCLUDED.last_vote_block_number,
+             last_vote_timestamp = EXCLUDED.last_vote_timestamp,
+             status = EXCLUDED.status,
+             anchor_block_number = EXCLUDED.anchor_block_number,
+             anchor_block_hash = EXCLUDED.anchor_block_hash,
+             anchor_parent_hash = EXCLUDED.anchor_parent_hash,
+             anchor_block_timestamp = EXCLUDED.anchor_block_timestamp,
+             updated_at = now()",
+    );
+    query.build().execute(&mut **transaction).await?;
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct LiveDelegateRelationScope {
+    contract_set_id: String,
+    chain_id: Option<i32>,
+    dao_code: Option<String>,
+    governor_address: Option<String>,
+    token_address: Option<String>,
+}
+
+async fn read_live_delegate_power_overlay_relations(
+    transaction: &mut Transaction<'_, Postgres>,
+    contributors: &[ProvisionalContributorPowerOverlayWrite],
+) -> Result<Vec<ProvisionalDelegatePowerOverlayRelation>, sqlx::Error> {
+    let mut accounts_by_scope = BTreeMap::<LiveDelegateRelationScope, Vec<String>>::new();
+    for contributor in contributors {
+        accounts_by_scope
+            .entry(LiveDelegateRelationScope {
+                contract_set_id: contributor.contract_set_id.clone(),
+                chain_id: contributor.chain_id,
+                dao_code: contributor.dao_code.clone(),
+                governor_address: contributor.governor_address.clone(),
+                token_address: contributor.token_address.clone(),
+            })
+            .or_default()
+            .push(contributor.account.clone());
+    }
+
+    let mut relations = Vec::new();
+    for (scope, mut accounts) in accounts_by_scope {
+        accounts.sort();
+        accounts.dedup();
+        let rows = sqlx::query(
+            "SELECT
+                 contract_set_id, chain_id, dao_code, governor_address, token_address,
+                 from_delegate, to_delegate, is_current
+             FROM delegate
+             WHERE contract_set_id = $1
+               AND chain_id IS NOT DISTINCT FROM $2
+               AND dao_code IS NOT DISTINCT FROM $3
+               AND governor_address IS NOT DISTINCT FROM $4
+               AND (token_address IS NOT DISTINCT FROM $5 OR token_address IS NULL)
+               AND from_delegate = ANY($6)
+               AND is_current = TRUE",
+        )
+        .bind(&scope.contract_set_id)
+        .bind(scope.chain_id)
+        .bind(&scope.dao_code)
+        .bind(&scope.governor_address)
+        .bind(&scope.token_address)
+        .bind(&accounts)
+        .fetch_all(&mut **transaction)
+        .await?;
+
+        relations.extend(rows.into_iter().map(|row| {
+            ProvisionalDelegatePowerOverlayRelation {
+                contract_set_id: row.get("contract_set_id"),
+                chain_id: row.get("chain_id"),
+                chain_name: None,
+                dao_code: row.get("dao_code"),
+                governor_address: row.get("governor_address"),
+                token_address: row
+                    .get::<Option<String>, _>("token_address")
+                    .or_else(|| scope.token_address.clone()),
+                delegator: row.get("from_delegate"),
+                delegate: row.get("to_delegate"),
+                is_current: row.get("is_current"),
+            }
+        }));
+    }
+
+    Ok(relations)
+}
+
+async fn upsert_live_delegate_power_overlays(
+    transaction: &mut Transaction<'_, Postgres>,
+    delegates: &[ProvisionalDelegatePowerOverlayWrite],
+) -> Result<(), sqlx::Error> {
+    if delegates.is_empty() {
+        return Ok(());
+    }
+
+    let mut query = QueryBuilder::<Postgres>::new(
+        "INSERT INTO degov_provisional_delegate_power_overlay (
+             id, segment_id, contract_set_id, chain_id, chain_name, dao_code, governor_address,
+             token_address, delegator, delegate, power, is_current, source, status,
+             anchor_block_number, anchor_block_hash, anchor_parent_hash, anchor_block_timestamp
+         )
+         ",
+    );
+    query.push_values(delegates, |mut values, delegate| {
+        values
+            .push_bind(&delegate.id)
+            .push_bind(&delegate.segment_id)
+            .push_bind(&delegate.contract_set_id)
+            .push_bind(delegate.chain_id)
+            .push_bind(&delegate.chain_name)
+            .push_bind(&delegate.dao_code)
+            .push_bind(&delegate.governor_address)
+            .push_bind(&delegate.token_address)
+            .push_bind(&delegate.delegator)
+            .push_bind(&delegate.delegate)
+            .push_bind(&delegate.power)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(delegate.is_current)
+            .push_bind(&delegate.source)
+            .push_bind(&delegate.status)
+            .push_bind(&delegate.anchor_block_number)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&delegate.anchor_block_hash)
+            .push_bind(&delegate.anchor_parent_hash)
+            .push_bind(&delegate.anchor_block_timestamp)
+            .push_unseparated("::NUMERIC(78, 0)");
+    });
+    query.push(
+        "
+         ON CONFLICT ON CONSTRAINT degov_provisional_delegate_power_overlay_scope_unique
+         DO UPDATE SET
+             id = EXCLUDED.id,
+             segment_id = EXCLUDED.segment_id,
+             power = EXCLUDED.power,
+             is_current = EXCLUDED.is_current,
+             status = EXCLUDED.status,
+             anchor_block_number = EXCLUDED.anchor_block_number,
+             anchor_block_hash = EXCLUDED.anchor_block_hash,
+             anchor_parent_hash = EXCLUDED.anchor_parent_hash,
+             anchor_block_timestamp = EXCLUDED.anchor_block_timestamp,
+             updated_at = now()",
+    );
+    query.build().execute(&mut **transaction).await?;
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct DataMetricRefreshScope {
+    contract_set_id: String,
+    chain_id: i32,
+    dao_code: Option<String>,
+    governor_address: String,
+    token_address: String,
+}
+
+async fn refresh_data_metrics(
+    transaction: &mut Transaction<'_, Postgres>,
+    successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
+) -> Result<usize, sqlx::Error> {
+    let scopes = successes
+        .iter()
+        .map(|(task, _value)| DataMetricRefreshScope {
+            contract_set_id: task.contract_set_id.clone(),
+            chain_id: task.chain_id,
+            dao_code: task.dao_code.clone(),
+            governor_address: task.governor_address.clone(),
+            token_address: task.token_address.clone(),
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+
+    for scope in &scopes {
+        refresh_data_metric_scope(transaction, scope).await?;
+    }
+
+    Ok(scopes.len())
+}
+
+async fn refresh_data_metric_scope(
+    transaction: &mut Transaction<'_, Postgres>,
+    scope: &DataMetricRefreshScope,
 ) -> Result<(), sqlx::Error> {
     let metric_id = data_metric_id(
-        task.chain_id,
-        &task.governor_address,
-        task.dao_code.as_deref(),
+        scope.chain_id,
+        &scope.governor_address,
+        scope.dao_code.as_deref(),
     );
 
     sqlx::query(
@@ -1544,29 +2035,35 @@ async fn refresh_data_metric(
              member_count = EXCLUDED.member_count",
     )
     .bind(metric_id)
-    .bind(&task.contract_set_id)
-    .bind(task.chain_id)
-    .bind(&task.dao_code)
-    .bind(&task.governor_address)
-    .bind(&task.token_address)
+    .bind(&scope.contract_set_id)
+    .bind(scope.chain_id)
+    .bind(&scope.dao_code)
+    .bind(&scope.governor_address)
+    .bind(&scope.token_address)
     .execute(&mut **transaction)
     .await?;
 
     Ok(())
 }
 
-async fn complete_task(
+async fn complete_tasks(
     transaction: &mut Transaction<'_, Postgres>,
-    task_id: &str,
+    successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
     now_ms: i64,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
+    debounce: Duration,
+) -> Result<usize, sqlx::Error> {
+    let task_ids = successes
+        .iter()
+        .map(|(task, _value)| task.id.clone())
+        .collect::<Vec<_>>();
+    let next_run_at = now_ms.saturating_add(duration_millis_i64(debounce));
+    let rows = sqlx::query(
         "UPDATE onchain_refresh_task
          SET status = CASE WHEN pending_after_lock THEN 'pending' ELSE 'completed' END,
              next_run_at = CASE WHEN pending_after_lock THEN $2::NUMERIC(78, 0) ELSE next_run_at END,
              locked_at = NULL,
              locked_by = NULL,
-             processed_at = CASE WHEN pending_after_lock THEN processed_at ELSE $2::NUMERIC(78, 0) END,
+             processed_at = CASE WHEN pending_after_lock THEN processed_at ELSE $3::NUMERIC(78, 0) END,
              error = NULL,
              last_seen_block_number = COALESCE(pending_after_lock_block_number, last_seen_block_number),
              last_seen_block_timestamp = COALESCE(pending_after_lock_block_timestamp, last_seen_block_timestamp),
@@ -1575,15 +2072,20 @@ async fn complete_task(
              pending_after_lock_block_number = NULL,
              pending_after_lock_block_timestamp = NULL,
              pending_after_lock_transaction_hash = NULL,
-             updated_at = $2::NUMERIC(78, 0)
-         WHERE id = $1",
+             updated_at = $3::NUMERIC(78, 0)
+         WHERE id = ANY($1)
+         RETURNING status",
     )
-    .bind(task_id)
+    .bind(&task_ids)
+    .bind(next_run_at.to_string())
     .bind(now_ms.to_string())
-    .execute(&mut **transaction)
+    .fetch_all(&mut **transaction)
     .await?;
 
-    Ok(())
+    Ok(rows
+        .into_iter()
+        .filter(|row| row.get::<String, _>("status") == "pending")
+        .count())
 }
 
 fn unix_time_millis() -> i64 {
@@ -1596,6 +2098,23 @@ fn unix_time_millis() -> i64 {
 
 fn duration_millis_i64(duration: Duration) -> i64 {
     duration.as_millis().min(i64::MAX as u128) as i64
+}
+
+fn unique_account_count(tasks: &[OnchainRefreshTask]) -> usize {
+    tasks
+        .iter()
+        .map(|task| {
+            (
+                task.chain_id,
+                task.contract_set_id.clone(),
+                task.dao_code.clone(),
+                normalize_identifier(&task.governor_address),
+                normalize_identifier(&task.token_address),
+                normalize_identifier(&task.account),
+            )
+        })
+        .collect::<std::collections::BTreeSet<_>>()
+        .len()
 }
 
 fn truncate_error(error: &str) -> String {

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -15,7 +15,7 @@ use crate::{
     OnchainRefreshTickRunner, OnchainRefreshTickScheduler, OnchainRefreshWorker,
     OnchainRefreshWorkerError, PostgresIndexerRunnerStore, PostgresProvisionalCleanupStore,
     classify_datalens_query_error, datalens_retry_config, ensure_datalens_warmup_task,
-    required_env,
+    onchain_refresh_debounce_from_env, required_env,
 };
 
 use super::{datalens::verify_datalens, migrate::apply_migrations};
@@ -760,6 +760,8 @@ async fn run_contract_set_pass(
         build_onchain_refresh_tick(&runtime, pool.clone()).map_err(ContractSetPassError::setup)?;
     let projection_chain_tool =
         build_projection_chain_tool(&runtime, &config).map_err(ContractSetPassError::setup)?;
+    let onchain_refresh_debounce =
+        onchain_refresh_debounce_from_env().map_err(ContractSetPassError::setup)?;
 
     task::spawn_blocking(move || -> std::result::Result<_, ContractSetPassError> {
         let mut client = DatalensNativeClient::from_config_with_retry_config(
@@ -771,7 +773,8 @@ async fn run_contract_set_pass(
         if let Some(gate) = datalens_query_gate {
             client = client.with_query_concurrency_gate(gate);
         }
-        let store = PostgresIndexerRunnerStore::new(pool);
+        let store = PostgresIndexerRunnerStore::new(pool)
+            .with_onchain_refresh_debounce(onchain_refresh_debounce);
         let options = runtime
             .options(&config, &contracts)
             .map_err(ContractSetPassError::setup)?;

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -535,6 +535,7 @@ pub struct OnchainRefreshRuntimeConfig {
     pub max_batches_per_poll: usize,
     pub poll_interval: Duration,
     pub run_once: bool,
+    pub debounce: Duration,
     pub lock_ttl: Duration,
     pub retry_delay: Duration,
     pub request_timeout: Duration,
@@ -601,6 +602,7 @@ impl OnchainRefreshRuntimeConfig {
         let run_once = optional_env_bool("DEGOV_ONCHAIN_REFRESH_RUN_ONCE")?
             .or(optional_env_bool("DEGOV_INDEXER_RUN_ONCE")?)
             .unwrap_or(false);
+        let debounce = onchain_refresh_debounce_from_env()?;
         let lock_ttl = Duration::from_millis(
             optional_env_u64("DEGOV_ONCHAIN_REFRESH_LOCK_TTL_MS")?.unwrap_or(300_000),
         );
@@ -638,6 +640,7 @@ impl OnchainRefreshRuntimeConfig {
             max_batches_per_poll,
             poll_interval,
             run_once,
+            debounce,
             lock_ttl,
             retry_delay,
             request_timeout,
@@ -660,6 +663,7 @@ impl OnchainRefreshRuntimeConfig {
         OnchainRefreshWorkerConfig {
             batch_size: self.batch_size,
             max_attempts: self.max_attempts,
+            debounce: self.debounce,
             lock_ttl: self.lock_ttl,
             retry_delay: self.retry_delay,
             lock_owner: format!("degov-onchain-refresh-worker:{}", std::process::id()),
@@ -1061,6 +1065,12 @@ pub fn parse_bool_env_value(name: &'static str, value: &str) -> Result<bool> {
 
 pub fn onchain_refresh_worker_enabled(value: &str) -> Result<bool> {
     parse_bool_env_value("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED", value)
+}
+
+pub fn onchain_refresh_debounce_from_env() -> Result<Duration> {
+    Ok(Duration::from_millis(
+        optional_env_u64("DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS")?.unwrap_or(120_000),
+    ))
 }
 
 fn parse_current_power_method(value: &str) -> Result<ChainReadMethod> {

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt,
     future::Future,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use sqlx::{PgPool, Postgres, QueryBuilder, Row, Transaction};
@@ -32,6 +33,7 @@ use crate::{
 pub struct PostgresIndexerRunnerStore {
     pool: PgPool,
     checkpoint_repository: CheckpointRepository,
+    onchain_refresh_debounce: Duration,
 }
 
 impl PostgresIndexerRunnerStore {
@@ -39,9 +41,17 @@ impl PostgresIndexerRunnerStore {
         Self {
             checkpoint_repository: CheckpointRepository::new(pool.clone()),
             pool,
+            onchain_refresh_debounce: DEFAULT_ONCHAIN_REFRESH_DEBOUNCE,
         }
     }
+
+    pub fn with_onchain_refresh_debounce(mut self, debounce: Duration) -> Self {
+        self.onchain_refresh_debounce = debounce;
+        self
+    }
 }
+
+const DEFAULT_ONCHAIN_REFRESH_DEBOUNCE: Duration = Duration::from_millis(120_000);
 
 impl IndexerRunnerStore for PostgresIndexerRunnerStore {
     type Error = PostgresIndexerRunnerStoreError;
@@ -65,6 +75,7 @@ impl IndexerRunnerStore for PostgresIndexerRunnerStore {
         Ok(PostgresIndexerRunnerTransaction {
             transaction: Some(transaction),
             checkpoint_repository: self.checkpoint_repository.clone(),
+            onchain_refresh_debounce: self.onchain_refresh_debounce,
         })
     }
 
@@ -83,6 +94,7 @@ impl IndexerRunnerStore for PostgresIndexerRunnerStore {
 pub struct PostgresIndexerRunnerTransaction<'a> {
     transaction: Option<Transaction<'a, Postgres>>,
     checkpoint_repository: CheckpointRepository,
+    onchain_refresh_debounce: Duration,
 }
 
 impl IndexerRunnerTransaction for PostgresIndexerRunnerTransaction<'_> {
@@ -97,7 +109,11 @@ impl IndexerRunnerTransaction for PostgresIndexerRunnerTransaction<'_> {
             .as_mut()
             .ok_or_else(|| PostgresIndexerRunnerStoreError::new("transaction is closed"))?;
 
-        block_on_runtime(write_projection_batch(transaction, batch))
+        block_on_runtime(write_projection_batch(
+            transaction,
+            batch,
+            self.onchain_refresh_debounce,
+        ))
     }
 
     fn advance_checkpoint(
@@ -173,6 +189,7 @@ where
 async fn write_projection_batch(
     transaction: &mut Transaction<'_, Postgres>,
     batch: &IndexerProjectionBatch,
+    onchain_refresh_debounce: Duration,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     if let Some(proposal) = &batch.proposal {
         write_proposal_batch_rows(transaction, proposal).await?;
@@ -200,13 +217,30 @@ async fn write_projection_batch(
         refresh_vote_data_metric(transaction, &vote.contributor_vote_signals).await?;
     }
     if let Some(token) = &batch.token {
-        upsert_onchain_refresh_tasks(transaction, &token.reconcile_plan.candidates).await?;
+        upsert_onchain_refresh_tasks(
+            transaction,
+            &token.reconcile_plan.candidates,
+            onchain_refresh_debounce,
+        )
+        .await?;
     }
     if let Some(batch) = &batch.timelock {
         write_timelock_batch(transaction, batch).await?;
     }
 
     Ok(())
+}
+
+fn unix_time_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(i64::MAX as u128) as i64
+}
+
+fn duration_millis_i64(duration: Duration) -> i64 {
+    duration.as_millis().min(i64::MAX as u128) as i64
 }
 
 include!("proposal.rs");

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -4,9 +4,12 @@ const MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS: usize = 1_000;
 async fn upsert_onchain_refresh_tasks(
     transaction: &mut Transaction<'_, Postgres>,
     rows: &[PowerReconcileCandidate],
+    debounce: Duration,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let now_ms = unix_time_millis();
+    let next_run_at = now_ms.saturating_add(duration_millis_i64(debounce));
     for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
-        upsert_onchain_refresh_task_chunk(transaction, chunk).await?;
+        upsert_onchain_refresh_task_chunk(transaction, chunk, now_ms, next_run_at).await?;
     }
 
     Ok(())
@@ -15,6 +18,8 @@ async fn upsert_onchain_refresh_tasks(
 async fn upsert_onchain_refresh_task_chunk(
     transaction: &mut Transaction<'_, Postgres>,
     rows: &[PowerReconcileCandidate],
+    now_ms: i64,
+    next_run_at: i64,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     let mut query = QueryBuilder::<Postgres>::new(
         "INSERT INTO onchain_refresh_task (
@@ -65,11 +70,12 @@ async fn upsert_onchain_refresh_task_chunk(
             .push_bind(&status.last_seen_transaction_hash)
             .push("'pending'")
             .push("0")
-            .push("0::NUMERIC(78, 0)")
-            .push("false")
-            .push_bind(last_seen_block_number.clone())
+            .push_bind(next_run_at.to_string())
             .push_unseparated("::NUMERIC(78, 0)")
-            .push_bind(last_seen_block_number)
+            .push("false")
+            .push_bind(now_ms.to_string())
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(now_ms.to_string())
             .push_unseparated("::NUMERIC(78, 0)");
     });
     query.push(
@@ -88,7 +94,7 @@ async fn upsert_onchain_refresh_task_chunk(
              END,
              next_run_at = CASE
                WHEN onchain_refresh_task.status = 'processing' THEN onchain_refresh_task.next_run_at
-               ELSE 0::NUMERIC(78, 0)
+               ELSE EXCLUDED.next_run_at
              END,
              processed_at = CASE
                WHEN onchain_refresh_task.status = 'processing' THEN onchain_refresh_task.processed_at

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use degov_datalens_indexer::{
     ContractSetConcurrencyLimit, DatalensConfig, DatalensProvisionalFinality,
     DatalensQueryConcurrencyConfig, GraphqlRuntimeConfig, IndexerContractSetMode,
-    IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshTickConfig, ProvisionalRuntimeConfig,
-    datalens_retry_config, onchain_refresh_worker_enabled, parse_bool_env_value,
-    parse_i64_env_value,
+    IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshRuntimeConfig,
+    OnchainRefreshTickConfig, ProvisionalRuntimeConfig, datalens_retry_config,
+    onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value,
 };
 
 #[test]
@@ -23,6 +23,44 @@ fn test_onchain_refresh_worker_enabled_rejects_ambiguous_values() {
         error
             .to_string()
             .contains("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED")
+    );
+}
+
+#[test]
+fn test_onchain_refresh_runtime_config_defaults_debounce() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED", Some("false")),
+            ("DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS", None::<&str>),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(config.debounce, Duration::from_millis(120_000));
+            assert_eq!(
+                config.worker_config().debounce,
+                Duration::from_millis(120_000)
+            );
+        },
+    );
+}
+
+#[test]
+fn test_onchain_refresh_runtime_config_accepts_debounce_override() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED", Some("false")),
+            ("DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS", Some("2500")),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(config.debounce, Duration::from_millis(2_500));
+            assert_eq!(
+                config.worker_config().debounce,
+                Duration::from_millis(2_500)
+            );
+        },
     );
 }
 

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -264,6 +264,15 @@ fn test_fresh_init_declares_provisional_overlay_schema() {
     }
 }
 
+#[test]
+fn test_fresh_init_declares_onchain_refresh_ready_claim_index() {
+    let init_migration = include_str!("../migrations/0001_init.sql");
+
+    assert!(init_migration.contains("onchain_refresh_task_ready_claim_idx"));
+    assert!(init_migration.contains("ON onchain_refresh_task (next_run_at, updated_at, id)"));
+    assert!(init_migration.contains("WHERE status IN ('pending', 'failed')"));
+}
+
 async fn assert_table_exists(
     pool: &PgPool,
     schema: &str,

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -34,6 +34,7 @@ fn test_onchain_refresh_tick_skips_when_disabled() {
         claimed: 1,
         completed: 1,
         failed: 0,
+        ..OnchainRefreshRunReport::default()
     }]);
     let mut scheduler = OnchainRefreshTickScheduler::new(
         OnchainRefreshTickConfig {
@@ -72,7 +73,7 @@ fn test_onchain_refresh_tick_reports_empty_queue() {
         report.skipped,
         Some(OnchainRefreshTickSkipReason::EmptyQueue)
     );
-    assert_eq!(runner.calls, vec![1]);
+    assert_eq!(runner.calls, vec![10]);
 }
 
 #[test]
@@ -101,6 +102,7 @@ fn test_onchain_refresh_tick_empty_queue_does_not_advance_schedule() {
         claimed: 1,
         completed: 1,
         failed: 0,
+        ..OnchainRefreshRunReport::default()
     }]);
     let task_report = scheduler
         .run_tick(101, &mut task_runner)
@@ -108,26 +110,23 @@ fn test_onchain_refresh_tick_empty_queue_does_not_advance_schedule() {
 
     assert_eq!(task_report.processed, 1);
     assert_eq!(task_report.skipped, None);
-    assert_eq!(task_runner.calls, vec![1, 1]);
+    assert_eq!(task_runner.calls, vec![10, 9]);
 }
 
 #[test]
-fn test_onchain_refresh_tick_stops_at_task_budget() {
+fn test_onchain_refresh_tick_claims_remaining_task_budget_per_call() {
     let mut runner = ScriptedTickRunner::new([
         OnchainRefreshRunReport {
-            claimed: 1,
-            completed: 1,
+            claimed: 2,
+            completed: 2,
             failed: 0,
+            ..OnchainRefreshRunReport::default()
         },
         OnchainRefreshRunReport {
             claimed: 1,
             completed: 1,
             failed: 0,
-        },
-        OnchainRefreshRunReport {
-            claimed: 1,
-            completed: 1,
-            failed: 0,
+            ..OnchainRefreshRunReport::default()
         },
     ]);
     let mut scheduler = OnchainRefreshTickScheduler::new(
@@ -145,7 +144,7 @@ fn test_onchain_refresh_tick_stops_at_task_budget() {
     assert_eq!(report.processed, 3);
     assert!(report.task_budget_hit);
     assert!(!report.duration_budget_hit);
-    assert_eq!(runner.calls, vec![1, 1, 1]);
+    assert_eq!(runner.calls, vec![3, 1]);
 }
 
 #[test]
@@ -155,11 +154,13 @@ fn test_onchain_refresh_tick_stops_at_duration_budget_between_single_task_claims
             claimed: 1,
             completed: 1,
             failed: 0,
+            ..OnchainRefreshRunReport::default()
         },
         OnchainRefreshRunReport {
             claimed: 1,
             completed: 1,
             failed: 0,
+            ..OnchainRefreshRunReport::default()
         },
     ]);
     let mut scheduler = OnchainRefreshTickScheduler::new(
@@ -177,7 +178,7 @@ fn test_onchain_refresh_tick_stops_at_duration_budget_between_single_task_claims
     assert_eq!(report.processed, 1);
     assert!(!report.task_budget_hit);
     assert!(report.duration_budget_hit);
-    assert_eq!(runner.calls, vec![1]);
+    assert_eq!(runner.calls, vec![10]);
 }
 
 #[test]
@@ -207,7 +208,7 @@ fn test_onchain_refresh_tick_failure_does_not_advance_schedule() {
         report.skipped,
         Some(OnchainRefreshTickSkipReason::EmptyQueue)
     );
-    assert_eq!(retry_runner.calls, vec![1]);
+    assert_eq!(retry_runner.calls, vec![10]);
 }
 
 #[tokio::test]
@@ -292,6 +293,16 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     let database = TestDatabase::connect().await?;
     seed_contributor(&database.pool, ACCOUNT_ONE, "3", Some("4")).await?;
     seed_data_metric(&database.pool, "7").await?;
+    seed_final_delegate_with_scope(
+        &database.pool,
+        "demo-dao",
+        "demo-dao",
+        46,
+        ACCOUNT_ONE,
+        ACCOUNT_TWO,
+        "3",
+    )
+    .await?;
     seed_task(
         &database.pool,
         "task-one",
@@ -336,6 +347,7 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
             lock_owner: "test-worker".to_owned(),
@@ -348,6 +360,8 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     assert_eq!(report.claimed, 2);
     assert_eq!(report.completed, 2);
     assert_eq!(report.failed, 0);
+    assert_eq!(report.unique_accounts, 2);
+    assert_eq!(report.data_metric_refreshes, 1);
     assert_eq!(
         contributor_values(&database.pool, ACCOUNT_ONE).await?,
         ("11".to_owned(), Some("17".to_owned()))
@@ -363,6 +377,10 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     assert_power_checkpoint(&database.pool, ACCOUNT_TWO, "0", "5", "5").await?;
     assert_balance_checkpoint(&database.pool, ACCOUNT_ONE, "4", "17", "13").await?;
     assert_table_count(&database.pool, "token_balance_checkpoint", 1).await?;
+    assert_contributor_overlay(&database.pool, ACCOUNT_ONE, "11").await?;
+    assert_contributor_overlay(&database.pool, ACCOUNT_TWO, "5").await?;
+    assert_delegate_overlay_with_scope(&database.pool, "demo-dao", ACCOUNT_ONE, ACCOUNT_TWO, "11")
+        .await?;
 
     database.cleanup().await?;
 
@@ -397,6 +415,7 @@ async fn test_onchain_refresh_worker_uses_current_votes_checkpoint_source()
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
             lock_owner: "test-worker".to_owned(),
@@ -437,6 +456,7 @@ async fn test_onchain_refresh_worker_marks_claimed_tasks_failed_when_reader_fail
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
             lock_owner: "test-worker".to_owned(),
@@ -544,6 +564,7 @@ async fn test_onchain_refresh_worker_checkpoint_ids_include_scope() -> Result<()
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
             lock_owner: "test-worker".to_owned(),
@@ -621,6 +642,7 @@ async fn test_onchain_refresh_worker_updates_only_matching_contract_set_contribu
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
             lock_owner: "test-worker".to_owned(),
@@ -650,6 +672,81 @@ async fn test_onchain_refresh_worker_updates_only_matching_contract_set_contribu
     assert_table_count(&database.pool, "contributor", 2).await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_ONE, "3", "11", "8").await?;
     assert_balance_checkpoint(&database.pool, ACCOUNT_ONE, "4", "17", "13").await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_reschedules_pending_after_lock_with_debounce()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        false,
+        true,
+    )
+    .await?;
+    sqlx::query(
+        "UPDATE onchain_refresh_task
+         SET pending_after_lock = TRUE,
+             pending_after_lock_block_number = 13::NUMERIC(78, 0),
+             pending_after_lock_block_timestamp = 13000::NUMERIC(78, 0),
+             pending_after_lock_transaction_hash = '0xnew'
+         WHERE id = 'task-one'",
+    )
+    .execute(&database.pool)
+    .await?;
+    let before = unix_time_millis_for_test();
+
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            max_attempts: 3,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::new([(
+            "task-one",
+            OnchainRefreshReadValue {
+                task_id: "task-one".to_owned(),
+                balance: None,
+                power: Some("11".to_owned()),
+            },
+        )]),
+    );
+
+    let report = worker.run_once().await?;
+    let after = unix_time_millis_for_test();
+
+    assert_eq!(report.completed, 1);
+    let row = sqlx::query(
+        "SELECT status, next_run_at::TEXT AS next_run_at, processed_at::TEXT AS processed_at,
+                last_seen_block_number::TEXT AS last_seen_block_number,
+                last_seen_block_timestamp::TEXT AS last_seen_block_timestamp,
+                last_seen_transaction_hash, pending_after_lock
+         FROM onchain_refresh_task
+         WHERE id = 'task-one'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    let next_run_at = row.get::<String, _>("next_run_at").parse::<i64>()?;
+    assert_eq!(row.get::<String, _>("status"), "pending");
+    assert!(next_run_at >= before + 120_000);
+    assert!(next_run_at <= after + 120_000);
+    assert_eq!(row.get::<Option<String>, _>("processed_at"), None);
+    assert_eq!(row.get::<String, _>("last_seen_block_number"), "13");
+    assert_eq!(row.get::<String, _>("last_seen_block_timestamp"), "13000");
+    assert_eq!(row.get::<String, _>("last_seen_transaction_hash"), "0xnew");
+    assert!(!row.get::<bool, _>("pending_after_lock"));
 
     database.cleanup().await?;
 
@@ -695,6 +792,35 @@ fn test_multi_chain_reader_routes_tasks_to_matching_chain_tool() {
             assert_eq!(read.key.block_mode, BlockReadMode::Safe);
         }
     }
+}
+
+#[test]
+fn test_chain_tool_onchain_refresh_reader_dedupes_duplicate_reads_in_one_batch() {
+    let chain_tool = StaticValueChainTool::new("101");
+    let reader = degov_datalens_indexer::ChainToolOnchainRefreshReader::new(
+        chain_tool.clone(),
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+
+    let values = reader
+        .read_tasks(&[
+            task_for_chain("task-one", 1, ACCOUNT_ONE),
+            task_for_chain("task-two", 1, ACCOUNT_ONE),
+        ])
+        .expect("read tasks");
+
+    assert_eq!(values.len(), 2);
+    assert!(
+        values
+            .iter()
+            .all(|value| value.power.as_deref() == Some("101"))
+    );
+    let plans = chain_tool.captured_plans();
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].metrics.requested_reads, 2);
+    assert_eq!(plans[0].metrics.deduped_reads, 1);
+    assert_eq!(plans[0].reads.len(), 1);
 }
 
 #[test]
@@ -859,6 +985,7 @@ async fn test_onchain_refresh_worker_fails_only_missing_rpc_chain_group()
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
             lock_owner: "test-worker".to_owned(),
@@ -1098,6 +1225,18 @@ async fn seed_final_delegate(
     delegate: &str,
     power: &str,
 ) -> Result<(), sqlx::Error> {
+    seed_final_delegate_with_scope(pool, "scope-46", "dao-46", 46, delegator, delegate, power).await
+}
+
+async fn seed_final_delegate_with_scope(
+    pool: &PgPool,
+    contract_set_id: &str,
+    dao_code: &str,
+    chain_id: i32,
+    delegator: &str,
+    delegate: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO delegate (
             id, contract_set_id, chain_id, dao_code, governor_address, token_address,
@@ -1105,12 +1244,15 @@ async fn seed_final_delegate(
             is_current, power
          )
          VALUES (
-            $1, 'scope-46', 46, 'dao-46', $2, $3, $4, $5,
+            $1, $2, $3, $4, $5, $6, $7, $8,
             12::NUMERIC(78, 0), 12000::NUMERIC(78, 0), '0xdelegate', TRUE,
-            $6::NUMERIC(78, 0)
+            $9::NUMERIC(78, 0)
          )",
     )
     .bind(format!("{delegator}_{delegate}"))
+    .bind(contract_set_id)
+    .bind(chain_id)
+    .bind(dao_code)
     .bind(GOVERNOR)
     .bind(TOKEN)
     .bind(delegator)
@@ -1490,15 +1632,26 @@ async fn assert_delegate_overlay(
     delegate: &str,
     power: &str,
 ) -> Result<(), sqlx::Error> {
+    assert_delegate_overlay_with_scope(pool, "scope-46", delegator, delegate, power).await
+}
+
+async fn assert_delegate_overlay_with_scope(
+    pool: &PgPool,
+    contract_set_id: &str,
+    delegator: &str,
+    delegate: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
     let row = sqlx::query(
         "SELECT delegator, delegate, power::TEXT AS power, source, status,
                 segment_id, anchor_block_number::TEXT AS anchor_block_number,
                 anchor_block_timestamp::TEXT AS anchor_block_timestamp
          FROM degov_provisional_delegate_power_overlay
-         WHERE contract_set_id = 'scope-46'
-           AND delegator = $1
-           AND delegate = $2",
+         WHERE contract_set_id = $1
+           AND delegator = $2
+           AND delegate = $3",
     )
+    .bind(contract_set_id)
     .bind(delegator)
     .bind(delegate)
     .fetch_one(pool)
@@ -1518,6 +1671,29 @@ async fn assert_delegate_overlay(
         row.get::<Option<String>, _>("anchor_block_timestamp"),
         Some("12000".to_owned())
     );
+
+    Ok(())
+}
+
+async fn assert_contributor_overlay(
+    pool: &PgPool,
+    account: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT account, power::TEXT AS power, source, status, anchor_block_number::TEXT AS anchor_block_number
+         FROM degov_provisional_contributor_power_overlay
+         WHERE contract_set_id = 'demo-dao' AND account = $1",
+    )
+    .bind(account)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("account"), account);
+    assert_eq!(row.get::<String, _>("power"), power);
+    assert_eq!(row.get::<String, _>("source"), "live-onchain");
+    assert_eq!(row.get::<String, _>("status"), "available");
+    assert_eq!(row.get::<String, _>("anchor_block_number"), "12");
 
     Ok(())
 }
@@ -1554,6 +1730,14 @@ fn unique_schema_name() -> String {
         millis,
         sequence
     )
+}
+
+fn unix_time_millis_for_test() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_millis()
+        .min(i64::MAX as u128) as i64
 }
 
 #[derive(Default)]

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -712,7 +712,8 @@ async fn test_postgres_token_same_batch_mapping_mutations_remain_ordered()
 async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
-    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone())
+        .with_onchain_refresh_debounce(Duration::from_secs(120));
     seed_refresh_task_for_account(
         &database.pool,
         DELEGATOR,
@@ -774,6 +775,7 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
         .status
         .reason
         .clear();
+    let before = unix_time_millis_for_test();
     apply_projection_batch(
         &mut store,
         IndexerProjectionBatch {
@@ -781,6 +783,7 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
             ..IndexerProjectionBatch::default()
         },
     )?;
+    let after = unix_time_millis_for_test();
 
     let rows = sqlx::query(
         "SELECT id, account, refresh_balance, refresh_power, reason, status, attempts,
@@ -810,7 +813,9 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
     );
     assert_eq!(pending.get::<String, _>("status"), "pending");
     assert_eq!(pending.get::<i32, _>("attempts"), 0);
-    assert_eq!(pending.get::<String, _>("next_run_at"), "0");
+    let pending_next_run_at = pending.get::<String, _>("next_run_at").parse::<i64>()?;
+    assert!(pending_next_run_at >= before + 120_000);
+    assert!(pending_next_run_at <= after + 120_000);
     assert_eq!(pending.get::<String, _>("first_seen_block_number"), "10");
     assert_eq!(pending.get::<String, _>("last_seen_block_number"), "22");
     assert_eq!(
@@ -838,6 +843,9 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
     assert_eq!(inserted.get::<String, _>("first_seen_block_number"), "20");
     assert_eq!(inserted.get::<String, _>("last_seen_block_number"), "20");
     assert_eq!(inserted.get::<String, _>("status"), "pending");
+    let inserted_next_run_at = inserted.get::<String, _>("next_run_at").parse::<i64>()?;
+    assert!(inserted_next_run_at >= before + 120_000);
+    assert!(inserted_next_run_at <= after + 120_000);
 
     let processing = rows
         .iter()
@@ -923,7 +931,8 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
     for index in [0, DENSE_CANDIDATE_COUNT - 1] {
         let account = indexed_account(index);
         let row = sqlx::query(
-            "SELECT id, reason, status, last_seen_block_number::TEXT AS last_seen_block_number
+            "SELECT id, reason, status, next_run_at::TEXT AS next_run_at,
+                    last_seen_block_number::TEXT AS last_seen_block_number
              FROM onchain_refresh_task
              WHERE contract_set_id = $1 AND account = $2",
         )
@@ -938,6 +947,7 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
             row.get::<String, _>("last_seen_block_number"),
             (30 + index as u64).to_string()
         );
+        assert!(row.get::<String, _>("next_run_at").parse::<i64>()? > 0);
     }
 
     database.cleanup().await?;
@@ -2179,6 +2189,14 @@ async fn seed_refresh_task_for_account(
 
 fn refresh_task_id(account: &str) -> String {
     format!("{CONTRACT_SET_ID}:demo-dao:1:{GOVERNOR}:{TOKEN}:{account}")
+}
+
+fn unix_time_millis_for_test() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_millis()
+        .min(i64::MAX as u128) as i64
 }
 
 fn indexed_account(index: usize) -> String {


### PR DESCRIPTION
## Summary
- Debounce onchain refresh task creation/coalescing with `DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS` defaulting to 120s.
- Batch tick claims by remaining task budget and batch durable worker application per claimed group.
- Reuse successful onchain power reads to write live contributor power overlays and add refresh observability fields.
- Add a ready-claim index for pending/failed task ordering.

## Validation
- `cargo fmt --all --check`
- `cargo build --locked -p degov-datalens-indexer`
- `cargo test --locked -p degov-datalens-indexer onchain_refresh_tick --test onchain_refresh_worker`
- `cargo test --locked -p degov-datalens-indexer test_chain_tool_onchain_refresh_reader_dedupes_duplicate_reads_in_one_batch --test onchain_refresh_worker`
- `cargo test --locked -p degov-datalens-indexer onchain_refresh_runtime_config --test cli_runtime_config`
- `cargo test --locked -p degov-datalens-indexer test_fresh_init_declares_onchain_refresh_ready_claim_index --test migration_schema`
- `node apps/indexer/scripts/check-rust-conventions.mjs`

## Caveat
- `cargo test --locked -p degov-datalens-indexer` is blocked locally because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set; it stops at the Postgres integration tests in `checkpoint_repository` with that error after earlier suites pass.
- The requested command `node ./scripts/check-rust-conventions.mjs` does not exist from the repo root, so I ran the checked-in script at `apps/indexer/scripts/check-rust-conventions.mjs`.
