### PR TITLE
fix(indexer): optimize ENS onchain refresh batching

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -22,6 +22,8 @@ use crate::{
     ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ReadRequirement,
 };
 
+const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = 1_000;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OnchainRefreshWorkerConfig {
     pub batch_size: usize,
@@ -616,18 +618,32 @@ where
             self.current_power_method,
         )
         .await?;
-        upsert_live_power_overlays(&mut transaction, successes).await?;
         let data_metric_refreshes = refresh_data_metrics(&mut transaction, successes).await?;
         let debounced_tasks =
             complete_tasks(&mut transaction, successes, now_ms, self.config.debounce).await?;
 
         transaction.commit().await?;
 
+        if let Err(error) = self.write_live_power_overlays(successes).await {
+            log::warn!("onchain refresh live power overlay write failed error={error}");
+        }
+
         Ok(OnchainRefreshApplyBatchReport {
             completed: successes.len(),
             debounced_tasks,
             data_metric_refreshes,
         })
+    }
+
+    async fn write_live_power_overlays(
+        &self,
+        successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
+    ) -> Result<(), OnchainRefreshWorkerError> {
+        let mut transaction = self.pool.begin().await?;
+        upsert_live_power_overlays(&mut transaction, successes).await?;
+        transaction.commit().await?;
+
+        Ok(())
     }
 
     async fn mark_tasks_failed(
@@ -1580,30 +1596,35 @@ async fn read_contributor_refresh_values(
     transaction: &mut Transaction<'_, Postgres>,
     successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
 ) -> Result<BTreeMap<(String, String), ContributorRefreshValues>, sqlx::Error> {
-    let mut query = QueryBuilder::<Postgres>::new(
-        "SELECT contract_set_id, id, power::TEXT AS power, balance::TEXT AS balance
-         FROM contributor
-         WHERE (contract_set_id, id) IN ",
-    );
-    query.push_tuples(successes, |mut values, (task, _value)| {
-        values
-            .push_bind(&task.contract_set_id)
-            .push_bind(contributor_ref(task));
-    });
-    let rows = query.build().fetch_all(&mut **transaction).await?;
+    if successes.is_empty() {
+        return Ok(BTreeMap::new());
+    }
 
-    Ok(rows
-        .into_iter()
-        .map(|row| {
-            (
+    let mut values = BTreeMap::new();
+    for chunk in successes.chunks(MAX_ONCHAIN_REFRESH_APPLY_ROWS) {
+        let mut query = QueryBuilder::<Postgres>::new(
+            "SELECT contract_set_id, id, power::TEXT AS power, balance::TEXT AS balance
+             FROM contributor
+             WHERE (contract_set_id, id) IN ",
+        );
+        query.push_tuples(chunk, |mut tuple, (task, _value)| {
+            tuple
+                .push_bind(&task.contract_set_id)
+                .push_bind(contributor_ref(task));
+        });
+
+        for row in query.build().fetch_all(&mut **transaction).await? {
+            values.insert(
                 (row.get("contract_set_id"), row.get("id")),
                 ContributorRefreshValues {
                     power: row.get("power"),
                     balance: row.get("balance"),
                 },
-            )
-        })
-        .collect())
+            );
+        }
+    }
+
+    Ok(values)
 }
 
 async fn insert_refresh_checkpoints(

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -26,6 +26,19 @@ pub async fn apply_migrations(pool: &PgPool) -> Result<()> {
         .run(pool)
         .await
         .context("apply Datalens-native DeGov indexer init migration")?;
+    ensure_runtime_indexes(pool).await?;
+
+    Ok(())
+}
+
+async fn ensure_runtime_indexes(pool: &PgPool) -> Result<()> {
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS onchain_refresh_task_claim_queue_idx
+         ON onchain_refresh_task (status, next_run_at, updated_at, id)",
+    )
+    .execute(pool)
+    .await
+    .context("ensure onchain refresh claim queue index")?;
 
     Ok(())
 }

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -32,6 +32,14 @@ use tokio::time::{sleep, timeout};
 
 static SCHEMA_COUNTER: AtomicU64 = AtomicU64::new(0);
 static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+const DEFAULT_ONCHAIN_REFRESH_DEBOUNCE_MS: i64 = 120_000;
+
+fn onchain_refresh_debounce_ms() -> i64 {
+    env::var("DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS")
+        .ok()
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or(DEFAULT_ONCHAIN_REFRESH_DEBOUNCE_MS)
+}
 
 struct TestDatabase {
     _guard: MutexGuard<'static, ()>,
@@ -814,8 +822,9 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
     assert_eq!(pending.get::<String, _>("status"), "pending");
     assert_eq!(pending.get::<i32, _>("attempts"), 0);
     let pending_next_run_at = pending.get::<String, _>("next_run_at").parse::<i64>()?;
-    assert!(pending_next_run_at >= before + 120_000);
-    assert!(pending_next_run_at <= after + 120_000);
+    let debounce_ms = onchain_refresh_debounce_ms();
+    assert!(pending_next_run_at >= before + debounce_ms);
+    assert!(pending_next_run_at <= after + debounce_ms);
     assert_eq!(pending.get::<String, _>("first_seen_block_number"), "10");
     assert_eq!(pending.get::<String, _>("last_seen_block_number"), "22");
     assert_eq!(
@@ -844,8 +853,8 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
     assert_eq!(inserted.get::<String, _>("last_seen_block_number"), "20");
     assert_eq!(inserted.get::<String, _>("status"), "pending");
     let inserted_next_run_at = inserted.get::<String, _>("next_run_at").parse::<i64>()?;
-    assert!(inserted_next_run_at >= before + 120_000);
-    assert!(inserted_next_run_at <= after + 120_000);
+    assert!(inserted_next_run_at >= before + debounce_ms);
+    assert!(inserted_next_run_at <= after + debounce_ms);
 
     let processing = rows
         .iter()


### PR DESCRIPTION
## Summary
- add onchain refresh debounce config and debounce-aware task upserts/follow-up runs
- let indexer ticks process remaining batch budget and surface refresh metrics
- batch durable contributor/checkpoint/task/data_metric apply and write live power overlays from the same read values
- add the onchain refresh claim queue index and regression coverage

## Verification
- cargo fmt --all --check
- cargo build --locked -p degov-datalens-indexer
- cargo test --locked -p degov-datalens-indexer --no-run
- cargo test --locked -p degov-datalens-indexer --test cli_runtime_config
- cargo test --locked -p degov-datalens-indexer --test migration_schema test_fresh_init_declares_onchain_refresh_claim_queue_index -- --exact
- cargo test --locked -p degov-datalens-indexer --test onchain_refresh_worker test_onchain_refresh_tick_stops_at_task_budget -- --exact
- cargo test --locked -p degov-datalens-indexer --test onchain_refresh_worker test_chain_tool_onchain_refresh_reader_dedupes_duplicate_account_reads_within_batch -- --exact
- node ./apps/indexer/scripts/check-rust-conventions.mjs

## Caveats
- cargo test --locked -p degov-datalens-indexer was attempted but DB-backed tests stop because DEGOV_INDEXER_TEST_DATABASE_URL is not set in this environment.
- node ./scripts/check-rust-conventions.mjs was attempted as requested, but this checkout has the script at apps/indexer/scripts/check-rust-conventions.mjs.