### PR TITLE
fix(indexer): dedupe onchain refresh task upserts

### DIFF
--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -297,6 +297,10 @@ mod tests {
             candidate("demo-set", 2, "demo-dao", "0xabc", 10, 20, 1, "transfer"),
             candidate("demo-set", 1, "other-dao", "0xabc", 10, 20, 1, "transfer"),
             candidate("demo-set", 1, "demo-dao", "0xdef", 10, 20, 1, "transfer"),
+            candidate("demo-set", 1, "demo-dao", "0xabc", 10, 20, 1, "transfer")
+                .with_governor("0x3333333333333333333333333333333333333333"),
+            candidate("demo-set", 1, "demo-dao", "0xabc", 10, 20, 1, "transfer")
+                .with_governor_token("0x4444444444444444444444444444444444444444"),
         ];
 
         let deduped = dedupe_onchain_refresh_tasks(&rows);
@@ -348,6 +352,25 @@ mod tests {
                 last_seen_transaction_index: 0,
                 last_seen_log_index: log_index,
             },
+        }
+    }
+
+    trait CandidateTestExt {
+        fn with_governor(self, governor: &str) -> Self;
+        fn with_governor_token(self, governor_token: &str) -> Self;
+    }
+
+    impl CandidateTestExt for PowerReconcileCandidate {
+        fn with_governor(mut self, governor: &str) -> Self {
+            self.governor = governor.to_owned();
+            self.status.governor = governor.to_owned();
+            self
+        }
+
+        fn with_governor_token(mut self, governor_token: &str) -> Self {
+            self.governor_token = governor_token.to_owned();
+            self.status.governor_token = governor_token.to_owned();
+            self
         }
     }
 }

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -6,6 +6,7 @@ async fn upsert_onchain_refresh_tasks(
     rows: &[PowerReconcileCandidate],
     debounce: Duration,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let rows = dedupe_onchain_refresh_tasks(rows);
     let now_ms = unix_time_millis();
     let next_run_at = now_ms.saturating_add(duration_millis_i64(debounce));
     for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
@@ -13,6 +14,112 @@ async fn upsert_onchain_refresh_tasks(
     }
 
     Ok(())
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct OnchainRefreshTaskKey {
+    chain_id: i32,
+    contract_set_id: String,
+    dao_code: String,
+    governor: String,
+    governor_token: String,
+    account: String,
+}
+
+fn dedupe_onchain_refresh_tasks(rows: &[PowerReconcileCandidate]) -> Vec<PowerReconcileCandidate> {
+    let mut order = Vec::new();
+    let mut deduped = HashMap::<OnchainRefreshTaskKey, PowerReconcileCandidate>::new();
+
+    for row in rows {
+        let key = OnchainRefreshTaskKey::from(row);
+        if let Some(existing) = deduped.get_mut(&key) {
+            merge_onchain_refresh_task(existing, row);
+        } else {
+            order.push(key.clone());
+            deduped.insert(key, row.clone());
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|key| deduped.remove(&key))
+        .collect()
+}
+
+impl From<&PowerReconcileCandidate> for OnchainRefreshTaskKey {
+    fn from(row: &PowerReconcileCandidate) -> Self {
+        Self {
+            chain_id: row.status.chain_id,
+            contract_set_id: row.status.contract_set_id.clone(),
+            dao_code: row.status.dao_code.clone(),
+            governor: row.status.governor.clone(),
+            governor_token: row.status.governor_token.clone(),
+            account: row.status.account.clone(),
+        }
+    }
+}
+
+fn merge_onchain_refresh_task(
+    existing: &mut PowerReconcileCandidate,
+    row: &PowerReconcileCandidate,
+) {
+    existing.reasons.extend(row.reasons.iter().copied());
+    existing.status.refresh_balance |= row.status.refresh_balance;
+    existing.status.refresh_power |= row.status.refresh_power;
+    existing.status.reason = merge_onchain_refresh_reason(&existing.status.reason, &row.status.reason);
+    existing.status.first_seen_activity_block = existing
+        .status
+        .first_seen_activity_block
+        .min(row.status.first_seen_activity_block);
+
+    if row.status_position() >= existing.status_position() {
+        existing.latest_activity_block = row.latest_activity_block;
+        existing.latest_transaction_index = row.latest_transaction_index;
+        existing.latest_log_index = row.latest_log_index;
+        existing.observed_log_power = row.observed_log_power.clone();
+        existing.status.last_seen_activity_block = row.status.last_seen_activity_block;
+        existing.status.last_seen_block_timestamp_ms = row.status.last_seen_block_timestamp_ms;
+        existing.status.last_seen_transaction_hash = row.status.last_seen_transaction_hash.clone();
+        existing.status.last_seen_transaction_index = row.status.last_seen_transaction_index;
+        existing.status.last_seen_log_index = row.status.last_seen_log_index;
+    }
+}
+
+trait PowerReconcileCandidatePosition {
+    fn status_position(&self) -> (u64, u64, u64);
+}
+
+impl PowerReconcileCandidatePosition for PowerReconcileCandidate {
+    fn status_position(&self) -> (u64, u64, u64) {
+        (
+            self.status.last_seen_activity_block,
+            self.status.last_seen_transaction_index,
+            self.status.last_seen_log_index,
+        )
+    }
+}
+
+fn merge_onchain_refresh_reason(left: &str, right: &str) -> String {
+    let mut labels = std::collections::BTreeSet::new();
+    collect_onchain_refresh_reason_labels(&mut labels, left);
+    collect_onchain_refresh_reason_labels(&mut labels, right);
+
+    labels.into_iter().collect::<Vec<_>>().join("+")
+}
+
+fn collect_onchain_refresh_reason_labels(labels: &mut std::collections::BTreeSet<String>, reason: &str) {
+    if reason.is_empty() {
+        labels.insert("token-activity".to_owned());
+        return;
+    }
+
+    labels.extend(
+        reason
+            .split('+')
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+            .map(str::to_owned),
+    );
 }
 
 async fn upsert_onchain_refresh_task_chunk(
@@ -139,4 +246,108 @@ async fn upsert_onchain_refresh_task_chunk(
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        PowerActivityReason, PowerRefreshReadSource, PowerRefreshStatus, PowerRefreshStatusRecord,
+    };
+
+    #[test]
+    fn test_dedupe_onchain_refresh_tasks_merges_duplicate_account_metadata() {
+        let mut first = candidate("demo-set", 1, "demo-dao", "0xabc", 10, 20, 1, "transfer");
+        first.status.refresh_balance = true;
+        let mut second = candidate(
+            "demo-set",
+            1,
+            "demo-dao",
+            "0xabc",
+            8,
+            25,
+            2,
+            "delegate-votes-changed",
+        );
+        second.status.refresh_power = true;
+
+        let deduped = dedupe_onchain_refresh_tasks(&[first, second]);
+
+        assert_eq!(deduped.len(), 1);
+        assert!(deduped[0].status.refresh_balance);
+        assert!(deduped[0].status.refresh_power);
+        assert_eq!(
+            deduped[0].status.reason,
+            "delegate-votes-changed+transfer"
+        );
+        assert_eq!(deduped[0].status.first_seen_activity_block, 8);
+        assert_eq!(deduped[0].status.last_seen_activity_block, 25);
+        assert_eq!(
+            deduped[0].status.last_seen_block_timestamp_ms,
+            Some(1_700_000_025_000)
+        );
+        assert_eq!(deduped[0].status.last_seen_transaction_hash, "0xtx25");
+    }
+
+    #[test]
+    fn test_dedupe_onchain_refresh_tasks_uses_full_database_uniqueness_key() {
+        let rows = vec![
+            candidate("demo-set", 1, "demo-dao", "0xabc", 10, 20, 1, "transfer"),
+            candidate("other-set", 1, "demo-dao", "0xabc", 10, 20, 1, "transfer"),
+            candidate("demo-set", 2, "demo-dao", "0xabc", 10, 20, 1, "transfer"),
+            candidate("demo-set", 1, "other-dao", "0xabc", 10, 20, 1, "transfer"),
+            candidate("demo-set", 1, "demo-dao", "0xdef", 10, 20, 1, "transfer"),
+        ];
+
+        let deduped = dedupe_onchain_refresh_tasks(&rows);
+
+        assert_eq!(deduped.len(), rows.len());
+    }
+
+    fn candidate(
+        contract_set_id: &str,
+        chain_id: i32,
+        dao_code: &str,
+        account: &str,
+        first_block: u64,
+        last_block: u64,
+        log_index: u64,
+        reason: &str,
+    ) -> PowerReconcileCandidate {
+        let governor = "0x1111111111111111111111111111111111111111".to_owned();
+        let governor_token = "0x2222222222222222222222222222222222222222".to_owned();
+        let account = account.to_owned();
+        PowerReconcileCandidate {
+            contract_set_id: contract_set_id.to_owned(),
+            dao_code: dao_code.to_owned(),
+            chain_id,
+            governor: governor.clone(),
+            governor_token: governor_token.clone(),
+            account: account.clone(),
+            latest_activity_block: last_block,
+            latest_transaction_index: 0,
+            latest_log_index: log_index,
+            reasons: [PowerActivityReason::Transfer].into(),
+            observed_log_power: None,
+            status: PowerRefreshStatusRecord {
+                contract_set_id: contract_set_id.to_owned(),
+                dao_code: dao_code.to_owned(),
+                chain_id,
+                governor,
+                governor_token,
+                account,
+                source: PowerRefreshReadSource::OnchainRpc,
+                status: PowerRefreshStatus::Pending,
+                refresh_balance: false,
+                refresh_power: false,
+                reason: reason.to_owned(),
+                first_seen_activity_block: first_block,
+                last_seen_activity_block: last_block,
+                last_seen_block_timestamp_ms: Some(1_700_000_000_000 + last_block * 1_000),
+                last_seen_transaction_hash: format!("0xtx{last_block}"),
+                last_seen_transaction_index: 0,
+                last_seen_log_index: log_index,
+            },
+        }
+    }
 }

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -889,6 +889,157 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_reconcile_tasks_dedupe_duplicate_accounts_before_sql()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone())
+        .with_onchain_refresh_debounce(Duration::from_secs(120));
+    seed_refresh_task_for_account(
+        &database.pool,
+        SECOND_DELEGATE,
+        "processing",
+        5,
+        999,
+        Some("rpc still running"),
+        false,
+    )
+    .await?;
+
+    let mut token_batch = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000020-transfer", 20, 0, 1),
+                event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                    from: DELEGATOR.to_owned(),
+                    to: RECEIVER.to_owned(),
+                    value: "40".to_owned(),
+                    standard: GovernanceTokenStandard::Erc20,
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000022-delegator-votes", 22, 0, 2),
+                event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                    delegate: DELEGATOR.to_owned(),
+                    previous_votes: "0".to_owned(),
+                    new_votes: "100".to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000025-processing-votes", 25, 0, 3),
+                event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                    delegate: SECOND_DELEGATE.to_owned(),
+                    previous_votes: "0".to_owned(),
+                    new_votes: "80".to_owned(),
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("token projection failed: {error:?}"))?;
+
+    let mut duplicate_delegator = token_batch
+        .reconcile_plan
+        .candidates
+        .iter()
+        .find(|candidate| candidate.account == DELEGATOR)
+        .expect("delegator candidate")
+        .clone();
+    duplicate_delegator.status.last_seen_activity_block = 40;
+    duplicate_delegator.status.last_seen_block_timestamp_ms = Some(1_700_000_040_000);
+    duplicate_delegator.status.last_seen_transaction_hash = "0xtx400".to_owned();
+    duplicate_delegator.latest_activity_block = 40;
+    duplicate_delegator.latest_transaction_index = 0;
+    duplicate_delegator.latest_log_index = 4;
+    let mut duplicate_processing = token_batch
+        .reconcile_plan
+        .candidates
+        .iter()
+        .find(|candidate| candidate.account == SECOND_DELEGATE)
+        .expect("processing candidate")
+        .clone();
+    duplicate_processing.status.last_seen_activity_block = 42;
+    duplicate_processing.status.last_seen_block_timestamp_ms = Some(1_700_000_042_000);
+    duplicate_processing.status.last_seen_transaction_hash = "0xtx420".to_owned();
+    duplicate_processing.latest_activity_block = 42;
+    duplicate_processing.latest_transaction_index = 0;
+    duplicate_processing.latest_log_index = 5;
+    token_batch
+        .reconcile_plan
+        .candidates
+        .push(duplicate_delegator);
+    token_batch
+        .reconcile_plan
+        .candidates
+        .push(duplicate_processing);
+
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(token_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let rows = sqlx::query(
+        "SELECT account, reason, status,
+                first_seen_block_number::TEXT AS first_seen_block_number,
+                last_seen_block_number::TEXT AS last_seen_block_number,
+                last_seen_block_timestamp::TEXT AS last_seen_block_timestamp,
+                last_seen_transaction_hash, pending_after_lock,
+                pending_after_lock_block_number::TEXT AS pending_after_lock_block_number,
+                pending_after_lock_block_timestamp::TEXT AS pending_after_lock_block_timestamp,
+                pending_after_lock_transaction_hash
+         FROM onchain_refresh_task
+         ORDER BY account ASC",
+    )
+    .fetch_all(&database.pool)
+    .await?;
+    assert_eq!(rows.len(), 3);
+
+    let deduped = rows
+        .iter()
+        .find(|row| row.get::<String, _>("account") == DELEGATOR)
+        .expect("deduped delegator row");
+    assert_eq!(
+        deduped.get::<String, _>("reason"),
+        "delegate-votes-changed+transfer"
+    );
+    assert_eq!(deduped.get::<String, _>("first_seen_block_number"), "20");
+    assert_eq!(deduped.get::<String, _>("last_seen_block_number"), "40");
+    assert_eq!(
+        deduped.get::<String, _>("last_seen_block_timestamp"),
+        "1700000040000"
+    );
+    assert_eq!(
+        deduped.get::<String, _>("last_seen_transaction_hash"),
+        "0xtx400"
+    );
+
+    let processing = rows
+        .iter()
+        .find(|row| row.get::<String, _>("account") == SECOND_DELEGATE)
+        .expect("processing row");
+    assert_eq!(processing.get::<String, _>("status"), "processing");
+    assert!(processing.get::<bool, _>("pending_after_lock"));
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_block_number"),
+        Some("42".to_owned())
+    );
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_block_timestamp"),
+        Some("1700000042000".to_owned())
+    );
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_transaction_hash"),
+        Some("0xtx420".to_owned())
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
 -> Result<(), Box<dyn Error>> {
     const DENSE_CANDIDATE_COUNT: usize = 1_001;

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -950,6 +950,8 @@ async fn test_postgres_token_reconcile_tasks_dedupe_duplicate_accounts_before_sq
     duplicate_delegator.latest_activity_block = 40;
     duplicate_delegator.latest_transaction_index = 0;
     duplicate_delegator.latest_log_index = 4;
+    duplicate_delegator.status.last_seen_transaction_index = 0;
+    duplicate_delegator.status.last_seen_log_index = 4;
     let mut duplicate_processing = token_batch
         .reconcile_plan
         .candidates
@@ -963,6 +965,8 @@ async fn test_postgres_token_reconcile_tasks_dedupe_duplicate_accounts_before_sq
     duplicate_processing.latest_activity_block = 42;
     duplicate_processing.latest_transaction_index = 0;
     duplicate_processing.latest_log_index = 5;
+    duplicate_processing.status.last_seen_transaction_index = 0;
+    duplicate_processing.status.last_seen_log_index = 5;
     token_batch
         .reconcile_plan
         .candidates


### PR DESCRIPTION
## Summary
- HBX-406: dedupe onchain refresh task candidates in memory before building `onchain_refresh_task` upsert SQL
- merge duplicate candidates using the DB uniqueness scope: chain_id, contract_set_id, dao_code, governor_address, token_address, account
- preserve merged reason labels, refresh flags, first-seen block, latest activity metadata, and processing-collision pending-after-lock semantics

## Why
Dense ENS chunks can return quickly from Datalens but spend hundreds of seconds in local projection/write work. Avoiding repeated `onchain_refresh_task` rows for the same account inside a projection batch reduces SQL bind volume and repeated `ON CONFLICT DO UPDATE` pressure.

## Tests
- `cargo fmt --all --check`
- `cargo test --locked -p degov-datalens-indexer store::postgres::tests::test_dedupe_onchain_refresh_tasks -- --nocapture`
- `cargo test --locked -p degov-datalens-indexer --test token_projection`
- `cargo test --locked -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token_reconcile_tasks_dedupe_duplicate_accounts_before_sql -- --nocapture` (blocked locally: `DEGOV_INDEXER_TEST_DATABASE_URL is required`)
- `cargo test --locked -p degov-datalens-indexer` (blocked locally when DB-backed `checkpoint_repository` tests require `DEGOV_INDEXER_TEST_DATABASE_URL`)
