### PR TITLE
fix(indexer): bound datalens query waits

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -1,12 +1,16 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, Condvar, Mutex},
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
     time::{Duration, Instant},
 };
 
 use datalens_sdk::{
     ApiErrorKind, DatalensClient, Error as DatalensSdkError, RetryConfig,
-    native::{ChainHeadFinalityInput, QueryInput},
+    native::{ChainHeadFinalityInput, QueryInput, QueryResponse},
     safety::{CacheSegment, DataFinality, extract_cache_segments},
 };
 use log::{info, warn};
@@ -38,6 +42,8 @@ pub struct DatalensNativeClient {
     http: reqwest::blocking::Client,
     query_gate: Option<DatalensQueryConcurrencyGate>,
     query_key: DatalensQueryConcurrencyKey,
+    query_timeout: Duration,
+    blocking_query_in_flight: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -217,6 +223,7 @@ pub fn classify_datalens_query_error(error: &str) -> DatalensQueryErrorClass {
     }
     if normalized.contains("provider_timeout")
         || normalized.contains("timeout")
+        || normalized.contains("timed out")
         || normalized.contains("request_rate_limit")
         || normalized.contains("rate_limit")
         || normalized.contains("transport")
@@ -259,6 +266,8 @@ impl DatalensNativeClient {
                 .map_err(|error| DatalensError::SdkConfig(error.to_string()))?,
             query_gate: None,
             query_key: DatalensQueryConcurrencyKey::from_config(config),
+            query_timeout: config.timeout,
+            blocking_query_in_flight: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -293,6 +302,8 @@ impl DatalensNativeClient {
                 .map_err(|error| DatalensError::SdkConfig(error.to_string()))?,
             query_gate: None,
             query_key: DatalensQueryConcurrencyKey::from_config(config),
+            query_timeout: config.timeout,
+            blocking_query_in_flight: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -324,7 +335,7 @@ impl DatalensNativeClient {
         let started_at = Instant::now();
         let mut attempt = 1;
         loop {
-            match self.client.native().query(input.clone()) {
+            match self.query_with_deadline(input.clone()) {
                 Ok(response) => {
                     return Ok(crate::DatalensLogQueryResult {
                         rows: response.rows,
@@ -361,7 +372,7 @@ impl DatalensNativeClient {
         let started_at = Instant::now();
         let mut attempt = 1;
         loop {
-            match self.client.native().query_provisional(input.clone()) {
+            match self.query_provisional_with_deadline(input.clone()) {
                 Ok(response) => {
                     let segments = extract_cache_segments(&response)
                         .into_iter()
@@ -392,6 +403,104 @@ impl DatalensNativeClient {
             }
         }
     }
+
+    fn query_with_deadline(&self, input: QueryInput) -> Result<QueryResponse, DatalensSdkError> {
+        self.run_query_with_deadline("query", move |client| client.native().query(input))
+    }
+
+    fn query_provisional_with_deadline(
+        &self,
+        input: QueryInput,
+    ) -> Result<QueryResponse, DatalensSdkError> {
+        self.run_query_with_deadline("provisional query", move |client| {
+            client.native().query_provisional(input)
+        })
+    }
+
+    fn run_query_with_deadline<F>(
+        &self,
+        operation: &'static str,
+        run: F,
+    ) -> Result<QueryResponse, DatalensSdkError>
+    where
+        F: FnOnce(DatalensClient) -> Result<QueryResponse, DatalensSdkError> + Send + 'static,
+    {
+        if self
+            .blocking_query_in_flight
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(datalens_query_timeout_error(operation, self.query_timeout));
+        }
+
+        let permit = match self.acquire_query_concurrency_permit(operation) {
+            Ok(permit) => permit,
+            Err(error) => {
+                self.blocking_query_in_flight
+                    .store(false, Ordering::Release);
+                return Err(DatalensSdkError::Transport(error.to_string()));
+            }
+        };
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let client = self.client.clone();
+        let blocking_query_in_flight = self.blocking_query_in_flight.clone();
+        let spawn_result = std::thread::Builder::new()
+            .name(format!("degov-datalens-{operation}"))
+            .spawn(move || {
+                let _in_flight_reset = DatalensBlockingQueryReset(blocking_query_in_flight);
+                let _permit = permit;
+                let result = run(client);
+                let _ = sender.send(result);
+            });
+
+        if let Err(error) = spawn_result {
+            self.blocking_query_in_flight
+                .store(false, Ordering::Release);
+            return Err(DatalensSdkError::Transport(format!(
+                "spawn Datalens {operation} worker: {error}"
+            )));
+        }
+
+        match receiver.recv_timeout(self.query_timeout) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                Err(datalens_query_timeout_error(operation, self.query_timeout))
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(DatalensSdkError::Transport(format!(
+                "Datalens {operation} worker stopped before returning a response"
+            ))),
+        }
+    }
+
+    fn acquire_query_concurrency_permit(
+        &self,
+        operation: &str,
+    ) -> Result<Option<DatalensQueryConcurrencyPermit>, DatalensError> {
+        self.query_gate
+            .as_ref()
+            .map(|gate| {
+                let permit = gate.acquire(&self.query_key)?;
+                info!(
+                    "Datalens process-local {operation} concurrency permit acquired chain_family={} chain_name={} chain_network_id={} wait_ms={} process_in_flight={} chain_in_flight={}",
+                    self.query_key.family,
+                    self.query_key.configured_name,
+                    self.query_key.log_network_id(),
+                    permit.wait_duration.as_millis(),
+                    permit.global_in_flight,
+                    permit.chain_in_flight
+                );
+                Ok::<_, DatalensError>(permit)
+            })
+            .transpose()
+    }
+}
+
+struct DatalensBlockingQueryReset(Arc<AtomicBool>);
+
+impl Drop for DatalensBlockingQueryReset {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
 }
 
 fn fallback_retry_delay(
@@ -415,6 +524,13 @@ fn fallback_retry_delay(
         return None;
     }
     Some(delay)
+}
+
+fn datalens_query_timeout_error(operation: &str, timeout: Duration) -> DatalensSdkError {
+    DatalensSdkError::Transport(format!(
+        "Datalens {operation} timed out after {}ms",
+        timeout.as_millis()
+    ))
 }
 
 fn is_transient_sdk_api_error(error: &DatalensSdkError) -> bool {
@@ -457,24 +573,6 @@ impl DatalensLogQueryReader for DatalensNativeClient {
         &mut self,
         input: QueryInput,
     ) -> Result<crate::DatalensLogQueryResult, DatalensError> {
-        let _permit = self
-            .query_gate
-            .as_ref()
-            .map(|gate| {
-                let permit = gate.acquire(&self.query_key)?;
-                info!(
-                    "Datalens process-local query concurrency permit acquired chain_family={} chain_name={} chain_network_id={} wait_ms={} process_in_flight={} chain_in_flight={}",
-                    self.query_key.family,
-                    self.query_key.configured_name,
-                    self.query_key.log_network_id(),
-                    permit.wait_duration.as_millis(),
-                    permit.global_in_flight,
-                    permit.chain_in_flight
-                );
-                Ok::<_, DatalensError>(permit)
-            })
-            .transpose()?;
-
         self.query_with_transient_fallback(input).map_err(|error| {
             let error_message = error.to_string();
             warn!(
@@ -493,24 +591,6 @@ impl DatalensProvisionalLogQueryReader for DatalensNativeClient {
         &mut self,
         input: QueryInput,
     ) -> Result<DatalensProvisionalLogQueryResult, DatalensError> {
-        let _permit = self
-            .query_gate
-            .as_ref()
-            .map(|gate| {
-                let permit = gate.acquire(&self.query_key)?;
-                info!(
-                    "Datalens process-local provisional query concurrency permit acquired chain_family={} chain_name={} chain_network_id={} wait_ms={} process_in_flight={} chain_in_flight={}",
-                    self.query_key.family,
-                    self.query_key.configured_name,
-                    self.query_key.log_network_id(),
-                    permit.wait_duration.as_millis(),
-                    permit.global_in_flight,
-                    permit.chain_in_flight
-                );
-                Ok::<_, DatalensError>(permit)
-            })
-            .transpose()?;
-
         self.query_provisional_with_transient_fallback(input)
             .map_err(|error| {
                 let error_message = error.to_string();

--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{
-        Arc, Condvar, Mutex,
+        Arc, Condvar, Mutex, OnceLock,
         atomic::{AtomicBool, Ordering},
         mpsc,
     },
@@ -94,6 +94,23 @@ impl DatalensQueryConcurrencyKey {
         self.network_id
             .map(|network_id| network_id.to_string())
             .unwrap_or_else(|| "none".to_owned())
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct DatalensBlockingQueryKey {
+    endpoint: String,
+    application: String,
+    query_key: DatalensQueryConcurrencyKey,
+}
+
+impl DatalensBlockingQueryKey {
+    fn from_config(config: &DatalensConfig) -> Self {
+        Self {
+            endpoint: config.endpoint.clone(),
+            application: config.application.clone(),
+            query_key: DatalensQueryConcurrencyKey::from_config(config),
+        }
     }
 }
 
@@ -267,7 +284,7 @@ impl DatalensNativeClient {
             query_gate: None,
             query_key: DatalensQueryConcurrencyKey::from_config(config),
             query_timeout: config.timeout,
-            blocking_query_in_flight: Arc::new(AtomicBool::new(false)),
+            blocking_query_in_flight: blocking_query_guard_for_config(config)?,
         })
     }
 
@@ -303,7 +320,7 @@ impl DatalensNativeClient {
             query_gate: None,
             query_key: DatalensQueryConcurrencyKey::from_config(config),
             query_timeout: config.timeout,
-            blocking_query_in_flight: Arc::new(AtomicBool::new(false)),
+            blocking_query_in_flight: blocking_query_guard_for_config(config)?,
         })
     }
 
@@ -430,7 +447,11 @@ impl DatalensNativeClient {
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
-            return Err(datalens_query_timeout_error(operation, self.query_timeout));
+            return Err(datalens_query_timeout_error(
+                operation,
+                self.query_timeout,
+                Some("previous SDK query is still in flight"),
+            ));
         }
 
         let permit = match self.acquire_query_concurrency_permit(operation) {
@@ -463,9 +484,11 @@ impl DatalensNativeClient {
 
         match receiver.recv_timeout(self.query_timeout) {
             Ok(result) => result,
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                Err(datalens_query_timeout_error(operation, self.query_timeout))
-            }
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(datalens_query_timeout_error(
+                operation,
+                self.query_timeout,
+                None,
+            )),
             Err(mpsc::RecvTimeoutError::Disconnected) => Err(DatalensSdkError::Transport(format!(
                 "Datalens {operation} worker stopped before returning a response"
             ))),
@@ -526,11 +549,38 @@ fn fallback_retry_delay(
     Some(delay)
 }
 
-fn datalens_query_timeout_error(operation: &str, timeout: Duration) -> DatalensSdkError {
-    DatalensSdkError::Transport(format!(
+fn blocking_query_guard_for_config(
+    config: &DatalensConfig,
+) -> Result<Arc<AtomicBool>, DatalensError> {
+    static BLOCKING_QUERY_GUARDS: OnceLock<
+        Mutex<HashMap<DatalensBlockingQueryKey, Arc<AtomicBool>>>,
+    > = OnceLock::new();
+
+    let key = DatalensBlockingQueryKey::from_config(config);
+    let guards = BLOCKING_QUERY_GUARDS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guards = guards.lock().map_err(|_| {
+        DatalensError::Query("Datalens blocking query guard lock poisoned".to_owned())
+    })?;
+    Ok(guards
+        .entry(key)
+        .or_insert_with(|| Arc::new(AtomicBool::new(false)))
+        .clone())
+}
+
+fn datalens_query_timeout_error(
+    operation: &str,
+    timeout: Duration,
+    context: Option<&str>,
+) -> DatalensSdkError {
+    let mut message = format!(
         "Datalens {operation} timed out after {}ms",
         timeout.as_millis()
-    ))
+    );
+    if let Some(context) = context {
+        message.push_str(": ");
+        message.push_str(context);
+    }
+    DatalensSdkError::Transport(message)
 }
 
 fn is_transient_sdk_api_error(error: &DatalensSdkError) -> bool {

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -333,6 +333,47 @@ fn test_datalens_log_query_rejects_second_call_while_sdk_query_is_still_in_fligh
 }
 
 #[test]
+fn test_datalens_log_query_rejects_new_client_while_sdk_query_is_still_in_flight() {
+    let server = FakeHangingQueryServer::start(Duration::from_millis(500));
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(50);
+    let mut first_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("first client");
+    let mut second_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("second client");
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+
+    let first_error = first_client
+        .query_logs(plans[0].input.clone())
+        .expect_err("first stalled query times out");
+    assert!(first_error.to_string().contains("timed out"));
+
+    let started_at = std::time::Instant::now();
+    let second_error = second_client
+        .query_logs(plans[0].input.clone())
+        .expect_err("new client fails without spawning another SDK worker");
+
+    assert!(
+        started_at.elapsed() < Duration::from_millis(150),
+        "new client should fail fast while the first SDK worker is still blocked"
+    );
+    assert!(
+        second_error
+            .to_string()
+            .contains("previous SDK query is still in flight"),
+        "{second_error}"
+    );
+    assert_eq!(
+        classify_datalens_query_error(&second_error.to_string()),
+        DatalensQueryErrorClass::Transient
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+}
+
+#[test]
 fn test_datalens_log_query_does_not_retry_non_retryable_quota_error() {
     let server = FakeQueryServer::start(vec![api_error_response(
         429,

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -267,6 +267,72 @@ fn test_datalens_log_query_retries_transport_failure_before_success() {
 }
 
 #[test]
+fn test_datalens_log_query_returns_degov_timeout_for_stalled_sdk_query() {
+    let server = FakeHangingQueryServer::start(Duration::from_millis(500));
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(50);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(2))
+            .expect("client");
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+    let started_at = std::time::Instant::now();
+
+    let error = client
+        .query_logs(plans[0].input.clone())
+        .expect_err("stalled query times out");
+
+    assert!(
+        started_at.elapsed() < Duration::from_millis(300),
+        "outer timeout should bound the stalled SDK call"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("Datalens query timed out after 50ms"),
+        "{error}"
+    );
+    assert_eq!(
+        classify_datalens_query_error(&error.to_string()),
+        DatalensQueryErrorClass::Transient
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+}
+
+#[test]
+fn test_datalens_log_query_rejects_second_call_while_sdk_query_is_still_in_flight() {
+    let server = FakeHangingQueryServer::start(Duration::from_millis(500));
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(50);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("client");
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+
+    let first_error = client
+        .query_logs(plans[0].input.clone())
+        .expect_err("first stalled query times out");
+    assert!(first_error.to_string().contains("timed out"));
+
+    let started_at = std::time::Instant::now();
+    let second_error = client
+        .query_logs(plans[0].input.clone())
+        .expect_err("second query fails without spawning another SDK worker");
+
+    assert!(
+        started_at.elapsed() < Duration::from_millis(150),
+        "second query should fail fast while the first SDK worker is still blocked"
+    );
+    assert!(second_error.to_string().contains("timed out"));
+    assert_eq!(
+        classify_datalens_query_error(&second_error.to_string()),
+        DatalensQueryErrorClass::Transient
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+}
+
+#[test]
 fn test_datalens_log_query_does_not_retry_non_retryable_quota_error() {
     let server = FakeQueryServer::start(vec![api_error_response(
         429,
@@ -319,6 +385,43 @@ fn test_datalens_provisional_log_query_uses_query_provisional_with_safe_to_lates
     assert!(requests[0].contains(r#""finality":"safe_to_latest""#));
 }
 
+#[test]
+fn test_datalens_provisional_log_query_returns_degov_timeout_for_stalled_sdk_query() {
+    let server = FakeHangingQueryServer::start(Duration::from_millis(500));
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(50);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(2))
+            .expect("client");
+    let mut input = plan_dao_log_queries(&config, &addresses(), 100, 105)
+        .expect("query plan builds")
+        .remove(0)
+        .input;
+    input.finality = Some("safe_to_latest".to_owned());
+    let started_at = std::time::Instant::now();
+
+    let error = client
+        .query_provisional_logs(input)
+        .expect_err("stalled provisional query times out");
+
+    assert!(
+        started_at.elapsed() < Duration::from_millis(300),
+        "outer timeout should bound the stalled SDK call"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("Datalens provisional query timed out after 50ms"),
+        "{error}"
+    );
+    assert_eq!(
+        classify_datalens_query_error(&error.to_string()),
+        DatalensQueryErrorClass::Transient
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+}
+
 struct FakeHeadServer {
     endpoint: String,
     handle: thread::JoinHandle<String>,
@@ -346,6 +449,35 @@ impl FakeHeadServer {
 struct FakeQueryServer {
     endpoint: String,
     handle: thread::JoinHandle<Vec<String>>,
+}
+
+struct FakeHangingQueryServer {
+    endpoint: String,
+    handle: thread::JoinHandle<Vec<String>>,
+}
+
+impl FakeHangingQueryServer {
+    fn start(hold_open_for: Duration) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake Datalens query server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let handle = thread::spawn(move || {
+            let mut requests = Vec::new();
+            let (mut stream, _) = listener
+                .accept()
+                .expect("accept fake Datalens query request");
+            requests.push(read_http_request(&mut stream));
+            thread::sleep(hold_open_for);
+            requests
+        });
+
+        Self { endpoint, handle }
+    }
+
+    fn join(self) -> Vec<String> {
+        self.handle
+            .join()
+            .expect("fake hanging Datalens query server joins")
+    }
 }
 
 enum FakeQueryResponse {


### PR DESCRIPTION
## Summary

- add an application-side deadline around Datalens SDK durable and provisional log queries
- return DeGov-side Datalens SDK transport errors containing \`timed out\` when the SDK query outlives \`DatalensConfig.timeout\`
- keep a per-client in-flight guard so a stuck SDK worker cannot cause one \`DatalensNativeClient\` to spawn unbounded blocked query threads
- classify DeGov-side query deadline errors as transient so all-mode jobs retry instead of hanging forever
- add regression tests for stalled durable/provisional SDK calls and same-client in-flight rejection

## Context

During the local empty-DB runner validation after HBX-405, ENS reached chunk \`13578418 -> 13583417\` at \`2026-06-09T17:46:37Z\` and then stopped producing \`chunk observed\` or checkpoint updates while other DAO jobs continued. The onchain refresh backlog fix was working; this exposed a separate stuck blocking Datalens SDK query path.

## Test Plan

- \`cargo fmt --all --check\`
- \`cargo build --locked -p degov-datalens-indexer\`
- \`cargo test --locked -p degov-datalens-indexer --test datalens_client\`
- \`node ./apps/indexer/scripts/check-rust-conventions.mjs\`
- \`git diff --check\`