### PR TITLE
fix(indexer): defer dense onchain refresh enqueue

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -232,6 +232,37 @@ CREATE INDEX IF NOT EXISTS onchain_refresh_task_ready_claim_idx
   ON onchain_refresh_task (next_run_at, updated_at, id)
   WHERE status IN ('pending', 'failed');
 
+CREATE TABLE IF NOT EXISTS onchain_refresh_deferred_candidate (
+  id TEXT PRIMARY KEY,
+  contract_set_id TEXT NOT NULL,
+  chain_id INTEGER NOT NULL,
+  dao_code TEXT,
+  governor_address TEXT NOT NULL,
+  token_address TEXT NOT NULL,
+  account TEXT NOT NULL,
+  refresh_balance BOOLEAN NOT NULL,
+  refresh_power BOOLEAN NOT NULL,
+  reason TEXT NOT NULL,
+  first_seen_block_number NUMERIC(78, 0) NOT NULL,
+  last_seen_block_number NUMERIC(78, 0) NOT NULL,
+  last_seen_block_timestamp NUMERIC(78, 0) NOT NULL,
+  last_seen_transaction_hash TEXT NOT NULL,
+  next_run_at NUMERIC(78, 0) NOT NULL,
+  created_at NUMERIC(78, 0) NOT NULL,
+  updated_at NUMERIC(78, 0) NOT NULL,
+  CONSTRAINT onchain_refresh_deferred_candidate_account_unique UNIQUE NULLS NOT DISTINCT (
+    chain_id,
+    contract_set_id,
+    dao_code,
+    governor_address,
+    token_address,
+    account
+  )
+);
+
+CREATE INDEX IF NOT EXISTS onchain_refresh_deferred_candidate_drain_idx
+  ON onchain_refresh_deferred_candidate (next_run_at, updated_at, id);
+
 CREATE TABLE IF NOT EXISTS proposal_canceled (
   id TEXT PRIMARY KEY,
   chain_id INTEGER,

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -20,6 +20,9 @@ use crate::{
     PartialChainReadFailureReport, ProvisionalContributorPowerOverlayWrite,
     ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
     ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ReadRequirement,
+    store::postgres::{
+        DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS, drain_deferred_onchain_refresh_tasks,
+    },
 };
 
 const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = 1_000;
@@ -338,6 +341,8 @@ pub trait OnchainRefreshReader: Clone + Send + Sync + 'static {
 pub enum OnchainRefreshWorkerError {
     #[error("onchain refresh database error: {0}")]
     Database(#[from] sqlx::Error),
+    #[error("onchain refresh deferred drain error: {0}")]
+    DeferredDrain(String),
     #[error("onchain refresh reader error: {0}")]
     Reader(#[from] OnchainRefreshReaderError),
     #[error("onchain refresh batch size exceeds i64")]
@@ -393,6 +398,20 @@ where
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
         let started_at = Instant::now();
         let now_ms = unix_time_millis();
+        let deferred_drain_started_at = Instant::now();
+        let deferred_drain_count = drain_deferred_onchain_refresh_tasks(
+            &self.pool,
+            DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS,
+        )
+        .await
+        .map_err(|error| OnchainRefreshWorkerError::DeferredDrain(error.to_string()))?;
+        if deferred_drain_count > 0 {
+            log::info!(
+                "onchain refresh worker materialized deferred tasks deferred_drain_count={} deferred_drain_duration_ms={}",
+                deferred_drain_count,
+                deferred_drain_started_at.elapsed().as_millis()
+            );
+        }
         let tasks = self.claim_tasks(now_ms, batch_size).await?;
         if tasks.is_empty() {
             return Ok(OnchainRefreshRunReport::default());
@@ -1141,11 +1160,17 @@ impl CachedChainReadValue {
                 .elapsed()
                 .map(|elapsed| elapsed >= QUORUM_CACHE_DURATION)
                 .unwrap_or(true),
+            ChainReadCacheKey::AccountCurrentValue { .. } => self
+                .inserted_at
+                .elapsed()
+                .map(|elapsed| elapsed >= ACCOUNT_CURRENT_VALUE_CACHE_DURATION)
+                .unwrap_or(true),
         }
     }
 }
 
 const QUORUM_CACHE_DURATION: Duration = Duration::from_secs(30 * 60);
+const ACCOUNT_CURRENT_VALUE_CACHE_DURATION: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum ChainReadCacheKey {
@@ -1156,6 +1181,13 @@ enum ChainReadCacheKey {
     Quorum {
         chain_id: i32,
         contract_address: String,
+        args: Vec<String>,
+        block_mode: BlockReadMode,
+    },
+    AccountCurrentValue {
+        chain_id: i32,
+        contract_address: String,
+        method: ChainReadMethod,
         args: Vec<String>,
         block_mode: BlockReadMode,
     },
@@ -1171,6 +1203,19 @@ impl ChainReadCacheKey {
             ChainReadMethod::Quorum => Some(Self::Quorum {
                 chain_id: key.chain_id,
                 contract_address: normalize_identifier(&key.contract_address),
+                args: key
+                    .args
+                    .iter()
+                    .map(|arg| normalize_identifier(arg))
+                    .collect(),
+                block_mode: key.block_mode,
+            }),
+            ChainReadMethod::BalanceOf
+            | ChainReadMethod::GetVotes
+            | ChainReadMethod::CurrentVotes => Some(Self::AccountCurrentValue {
+                chain_id: key.chain_id,
+                contract_address: normalize_identifier(&key.contract_address),
+                method: key.method,
                 args: key
                     .args
                     .iter()
@@ -2563,6 +2608,60 @@ mod tests {
             Some(ChainReadValue::Integer("18".to_owned()))
         );
         assert_eq!(cache.get(&quorum_11), None);
+    }
+
+    #[test]
+    fn test_chain_read_cache_dedupes_current_account_reads_briefly() {
+        let cache = ChainReadCache::default();
+        let power = ChainReadKey {
+            chain_id: 1,
+            contract_address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+            method: ChainReadMethod::GetVotes,
+            args: vec!["0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned()],
+            block_mode: BlockReadMode::Safe,
+        };
+        let same_account_latest = ChainReadKey {
+            block_mode: BlockReadMode::Latest,
+            ..power.clone()
+        };
+        let other_account = ChainReadKey {
+            args: vec!["0xcccccccccccccccccccccccccccccccccccccccc".to_owned()],
+            ..power.clone()
+        };
+
+        cache.insert(&power, ChainReadValue::Integer("100".to_owned()));
+
+        assert_eq!(
+            cache.get(&power),
+            Some(ChainReadValue::Integer("100".to_owned()))
+        );
+        assert_eq!(cache.get(&same_account_latest), None);
+        assert_eq!(cache.get(&other_account), None);
+    }
+
+    #[test]
+    fn test_chain_read_cache_expires_current_account_reads() {
+        let cache = ChainReadCache::default();
+        let balance = ChainReadKey {
+            chain_id: 1,
+            contract_address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+            method: ChainReadMethod::BalanceOf,
+            args: vec!["0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned()],
+            block_mode: BlockReadMode::Safe,
+        };
+
+        cache.insert(&balance, ChainReadValue::Integer("100".to_owned()));
+
+        let expired_at =
+            SystemTime::now() - ACCOUNT_CURRENT_VALUE_CACHE_DURATION - Duration::from_secs(1);
+        let mut values = cache.values.lock().expect("cache lock");
+        values
+            .get_mut(&ChainReadCacheKey::from_read_key(&balance).expect("balance key"))
+            .expect("balance value")
+            .inserted_at = expired_at;
+        drop(values);
+
+        assert_eq!(cache.get(&balance), None);
     }
 
     #[test]

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -476,6 +476,13 @@ pub trait IndexerRunnerStore {
     ) -> Result<TimelockProposalLinkContext, Self::Error> {
         Ok(TimelockProposalLinkContext::default())
     }
+
+    fn drain_deferred_onchain_refresh_tasks(
+        &mut self,
+        _max_rows: usize,
+    ) -> Result<usize, Self::Error> {
+        Ok(0)
+    }
 }
 
 pub trait IndexerRunnerTransaction {
@@ -765,6 +772,26 @@ where
                 .commit()
                 .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
             let write_duration = write_started_at.elapsed();
+            let deferred_drain_started_at = Instant::now();
+            let deferred_drain_count = match self.store.drain_deferred_onchain_refresh_tasks(1_000)
+            {
+                Ok(count) => count,
+                Err(error) => {
+                    warn!(
+                        "Datalens indexer deferred onchain refresh drain failed after checkpoint commit dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} from_block={} to_block={} error={}",
+                        self.options.checkpoint_identity.dao_code,
+                        self.options.checkpoint_identity.chain_id,
+                        self.options.checkpoint_identity.contract_set_id,
+                        self.options.checkpoint_identity.stream_id,
+                        self.options.checkpoint_identity.data_source_version,
+                        range.from_block,
+                        range.to_block,
+                        error
+                    );
+                    0
+                }
+            };
+            let deferred_drain_duration = deferred_drain_started_at.elapsed();
             self.run_onchain_refresh_tick(range.to_block);
 
             chunks_processed += 1;
@@ -786,7 +813,7 @@ where
                 self.options.progress_refresh_lag_blocks,
             );
             info!(
-                "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={} adaptive_cache_full_hit_count={} adaptive_cache_partial_hit_count={} adaptive_cache_miss_count={} adaptive_cache_provider_fill_range_count={} adaptive_query_duration_max_ms={}",
+                "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={} adaptive_cache_full_hit_count={} adaptive_cache_partial_hit_count={} adaptive_cache_miss_count={} adaptive_cache_provider_fill_range_count={} adaptive_query_duration_max_ms={} onchain_refresh_deferred_drain_count={} onchain_refresh_deferred_drain_duration_ms={}",
                 self.options.checkpoint_identity.dao_code,
                 self.options.checkpoint_identity.chain_id,
                 self.options.checkpoint_identity.contract_set_id,
@@ -833,7 +860,9 @@ where
                         .metrics
                         .warmup_effectiveness
                         .query_duration_max_ms()
-                )
+                ),
+                deferred_drain_count,
+                deferred_drain_duration.as_millis()
             );
             let mut warmup_effectiveness_aggregation =
                 processing.metrics.warmup_effectiveness.clone();

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -49,6 +49,13 @@ impl PostgresIndexerRunnerStore {
         self.onchain_refresh_debounce = debounce;
         self
     }
+
+    pub async fn drain_deferred_onchain_refresh_tasks(
+        &self,
+        max_rows: usize,
+    ) -> Result<usize, PostgresIndexerRunnerStoreError> {
+        drain_deferred_onchain_refresh_tasks(&self.pool, max_rows).await
+    }
 }
 
 const DEFAULT_ONCHAIN_REFRESH_DEBOUNCE: Duration = Duration::from_millis(120_000);
@@ -88,6 +95,13 @@ impl IndexerRunnerStore for PostgresIndexerRunnerStore {
         block_on_runtime(read_timelock_proposal_link_context(
             &self.pool, context, events, proposal,
         ))
+    }
+
+    fn drain_deferred_onchain_refresh_tasks(
+        &mut self,
+        max_rows: usize,
+    ) -> Result<usize, Self::Error> {
+        block_on_runtime(drain_deferred_onchain_refresh_tasks(&self.pool, max_rows))
     }
 }
 

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -1,19 +1,79 @@
 // Onchain refresh task persistence.
 const MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS: usize = 1_000;
+const MAX_INLINE_ONCHAIN_REFRESH_TASK_UPSERT_ROWS: usize = 1_000;
+pub const DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS: usize = 1_000;
 
 async fn upsert_onchain_refresh_tasks(
     transaction: &mut Transaction<'_, Postgres>,
     rows: &[PowerReconcileCandidate],
     debounce: Duration,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
-    let rows = dedupe_onchain_refresh_tasks(rows);
+    let original_count = rows.len();
+    let mut rows = dedupe_onchain_refresh_tasks(rows)
+        .into_iter()
+        .map(OnchainRefreshTaskWrite::from)
+        .collect::<Vec<_>>();
     let now_ms = unix_time_millis();
     let next_run_at = now_ms.saturating_add(duration_millis_i64(debounce));
-    for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
-        upsert_onchain_refresh_task_chunk(transaction, chunk, now_ms, next_run_at).await?;
+    for row in &mut rows {
+        row.next_run_at = next_run_at.to_string();
     }
 
+    let inline_count = rows.len().min(MAX_INLINE_ONCHAIN_REFRESH_TASK_UPSERT_ROWS);
+    let (inline_rows, deferred_rows) = rows.split_at(inline_count);
+    for chunk in inline_rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
+        upsert_onchain_refresh_task_chunk(transaction, chunk, now_ms).await?;
+    }
+    for chunk in deferred_rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
+        upsert_deferred_onchain_refresh_candidate_chunk(transaction, chunk, now_ms, next_run_at)
+            .await?;
+    }
+
+    log::info!(
+        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} inline_upsert_count={} deferred_count={}",
+        original_count,
+        rows.len(),
+        inline_rows.len(),
+        deferred_rows.len()
+    );
+
     Ok(())
+}
+
+pub async fn drain_deferred_onchain_refresh_tasks(
+    pool: &PgPool,
+    max_rows: usize,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    if max_rows == 0 {
+        return Ok(0);
+    }
+
+    let started_at = std::time::Instant::now();
+    let mut transaction = pool.begin().await?;
+    let rows = read_deferred_onchain_refresh_candidates(&mut transaction, max_rows).await?;
+    if rows.is_empty() {
+        transaction.commit().await?;
+        return Ok(0);
+    }
+
+    let ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+    let now_ms = unix_time_millis();
+    for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
+        upsert_onchain_refresh_task_chunk(&mut transaction, chunk, now_ms).await?;
+    }
+    sqlx::query("DELETE FROM onchain_refresh_deferred_candidate WHERE id = ANY($1)")
+        .bind(&ids)
+        .execute(&mut *transaction)
+        .await?;
+    transaction.commit().await?;
+
+    log::info!(
+        "onchain refresh deferred drain completed deferred_drain_count={} deferred_drain_duration_ms={}",
+        ids.len(),
+        started_at.elapsed().as_millis()
+    );
+
+    Ok(ids.len())
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -122,11 +182,82 @@ fn collect_onchain_refresh_reason_labels(labels: &mut std::collections::BTreeSet
     );
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct OnchainRefreshTaskWrite {
+    id: String,
+    contract_set_id: String,
+    chain_id: i32,
+    dao_code: String,
+    governor_address: String,
+    token_address: String,
+    account: String,
+    refresh_balance: bool,
+    refresh_power: bool,
+    reason: String,
+    first_seen_block_number: String,
+    last_seen_block_number: String,
+    last_seen_block_timestamp: String,
+    last_seen_transaction_hash: String,
+    next_run_at: String,
+}
+
+impl From<PowerReconcileCandidate> for OnchainRefreshTaskWrite {
+    fn from(row: PowerReconcileCandidate) -> Self {
+        let status = row.status;
+        let id = refresh_task_id(
+            &status.contract_set_id,
+            &status.dao_code,
+            status.chain_id,
+            &status.governor,
+            &status.governor_token,
+            &status.account,
+        );
+        let reason = if status.reason.is_empty() {
+            "token-activity".to_owned()
+        } else {
+            status.reason
+        };
+
+        Self {
+            id,
+            contract_set_id: status.contract_set_id,
+            chain_id: status.chain_id,
+            dao_code: status.dao_code,
+            governor_address: status.governor,
+            token_address: status.governor_token,
+            account: status.account,
+            refresh_balance: status.refresh_balance,
+            refresh_power: status.refresh_power,
+            reason,
+            first_seen_block_number: u64_to_string(status.first_seen_activity_block),
+            last_seen_block_number: u64_to_string(status.last_seen_activity_block),
+            last_seen_block_timestamp: status
+                .last_seen_block_timestamp_ms
+                .map(u64_to_string)
+                .unwrap_or_else(|| "0".to_owned()),
+            last_seen_transaction_hash: status.last_seen_transaction_hash,
+            next_run_at: "0".to_owned(),
+        }
+    }
+}
+
+fn refresh_task_id(
+    contract_set_id: &str,
+    dao_code: &str,
+    chain_id: i32,
+    governor_address: &str,
+    token_address: &str,
+    account: &str,
+) -> String {
+    format!(
+        "{contract_set_id}:{dao_code}:{chain_id}:{governor_address}:{token_address}:{account}"
+    )
+}
+
 async fn upsert_onchain_refresh_task_chunk(
     transaction: &mut Transaction<'_, Postgres>,
-    rows: &[PowerReconcileCandidate],
+    rows: &[OnchainRefreshTaskWrite],
     now_ms: i64,
-    next_run_at: i64,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     let mut query = QueryBuilder::<Postgres>::new(
         "INSERT INTO onchain_refresh_task (
@@ -138,46 +269,27 @@ async fn upsert_onchain_refresh_task_chunk(
          ",
     );
     query.push_values(rows, |mut values, row| {
-        let status = &row.status;
-        let task_id = format!(
-            "{}:{}:{}:{}:{}:{}",
-            status.contract_set_id,
-            status.dao_code,
-            status.chain_id,
-            status.governor,
-            status.governor_token,
-            status.account
-        );
-        let reason = if status.reason.is_empty() {
-            "token-activity".to_owned()
-        } else {
-            status.reason.clone()
-        };
-        let first_seen_block_number = u64_to_string(status.first_seen_activity_block);
-        let last_seen_block_number = u64_to_string(status.last_seen_activity_block);
-        let last_seen_block_timestamp = status.last_seen_block_timestamp_ms.map(u64_to_string);
-
         values
-            .push_bind(task_id)
-            .push_bind(&status.contract_set_id)
-            .push_bind(status.chain_id)
-            .push_bind(&status.dao_code)
-            .push_bind(&status.governor)
-            .push_bind(&status.governor_token)
-            .push_bind(&status.account)
-            .push_bind(status.refresh_balance)
-            .push_bind(status.refresh_power)
-            .push_bind(reason)
-            .push_bind(first_seen_block_number)
+            .push_bind(&row.id)
+            .push_bind(&row.contract_set_id)
+            .push_bind(row.chain_id)
+            .push_bind(&row.dao_code)
+            .push_bind(&row.governor_address)
+            .push_bind(&row.token_address)
+            .push_bind(&row.account)
+            .push_bind(row.refresh_balance)
+            .push_bind(row.refresh_power)
+            .push_bind(&row.reason)
+            .push_bind(&row.first_seen_block_number)
             .push_unseparated("::NUMERIC(78, 0)")
-            .push_bind(last_seen_block_number.clone())
+            .push_bind(&row.last_seen_block_number)
             .push_unseparated("::NUMERIC(78, 0)")
-            .push_bind(last_seen_block_timestamp)
+            .push_bind(&row.last_seen_block_timestamp)
             .push_unseparated("::NUMERIC(78, 0)")
-            .push_bind(&status.last_seen_transaction_hash)
+            .push_bind(&row.last_seen_transaction_hash)
             .push("'pending'")
             .push("0")
-            .push_bind(next_run_at.to_string())
+            .push_bind(&row.next_run_at)
             .push_unseparated("::NUMERIC(78, 0)")
             .push("false")
             .push_bind(now_ms.to_string())
@@ -246,6 +358,111 @@ async fn upsert_onchain_refresh_task_chunk(
         .await?;
 
     Ok(())
+}
+
+async fn upsert_deferred_onchain_refresh_candidate_chunk(
+    transaction: &mut Transaction<'_, Postgres>,
+    rows: &[OnchainRefreshTaskWrite],
+    now_ms: i64,
+    next_run_at: i64,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let mut query = QueryBuilder::<Postgres>::new(
+        "INSERT INTO onchain_refresh_deferred_candidate (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address, account,
+            refresh_balance, refresh_power, reason, first_seen_block_number, last_seen_block_number,
+            last_seen_block_timestamp, last_seen_transaction_hash, next_run_at, created_at, updated_at
+         )
+         ",
+    );
+    query.push_values(rows, |mut values, row| {
+        values
+            .push_bind(&row.id)
+            .push_bind(&row.contract_set_id)
+            .push_bind(row.chain_id)
+            .push_bind(&row.dao_code)
+            .push_bind(&row.governor_address)
+            .push_bind(&row.token_address)
+            .push_bind(&row.account)
+            .push_bind(row.refresh_balance)
+            .push_bind(row.refresh_power)
+            .push_bind(&row.reason)
+            .push_bind(&row.first_seen_block_number)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&row.last_seen_block_number)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&row.last_seen_block_timestamp)
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(&row.last_seen_transaction_hash)
+            .push_bind(next_run_at.to_string())
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(now_ms.to_string())
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(now_ms.to_string())
+            .push_unseparated("::NUMERIC(78, 0)");
+    });
+    query.push(
+        "
+         ON CONFLICT ON CONSTRAINT onchain_refresh_deferred_candidate_account_unique DO UPDATE
+         SET refresh_balance = onchain_refresh_deferred_candidate.refresh_balance OR EXCLUDED.refresh_balance,
+             refresh_power = onchain_refresh_deferred_candidate.refresh_power OR EXCLUDED.refresh_power,
+             reason = EXCLUDED.reason,
+             first_seen_block_number = LEAST(onchain_refresh_deferred_candidate.first_seen_block_number, EXCLUDED.first_seen_block_number),
+             last_seen_block_number = GREATEST(onchain_refresh_deferred_candidate.last_seen_block_number, EXCLUDED.last_seen_block_number),
+             last_seen_block_timestamp = GREATEST(onchain_refresh_deferred_candidate.last_seen_block_timestamp, EXCLUDED.last_seen_block_timestamp),
+             last_seen_transaction_hash = EXCLUDED.last_seen_transaction_hash,
+             next_run_at = GREATEST(onchain_refresh_deferred_candidate.next_run_at, EXCLUDED.next_run_at),
+             updated_at = EXCLUDED.updated_at",
+    );
+    query.build().execute(&mut **transaction).await?;
+
+    Ok(())
+}
+
+async fn read_deferred_onchain_refresh_candidates(
+    transaction: &mut Transaction<'_, Postgres>,
+    max_rows: usize,
+) -> Result<Vec<OnchainRefreshTaskWrite>, PostgresIndexerRunnerStoreError> {
+    let max_rows = i64::try_from(max_rows)
+        .map_err(|_| PostgresIndexerRunnerStoreError::new("deferred drain batch size exceeds i64"))?;
+    let rows = sqlx::query(
+        "SELECT id, contract_set_id, chain_id, dao_code, governor_address, token_address, account,
+                refresh_balance, refresh_power, reason,
+                first_seen_block_number::TEXT AS first_seen_block_number,
+                last_seen_block_number::TEXT AS last_seen_block_number,
+                last_seen_block_timestamp::TEXT AS last_seen_block_timestamp,
+                last_seen_transaction_hash,
+                next_run_at::TEXT AS next_run_at
+         FROM onchain_refresh_deferred_candidate
+         ORDER BY onchain_refresh_deferred_candidate.next_run_at,
+                  onchain_refresh_deferred_candidate.updated_at,
+                  onchain_refresh_deferred_candidate.id
+         LIMIT $1
+         FOR UPDATE SKIP LOCKED",
+    )
+    .bind(max_rows)
+    .fetch_all(&mut **transaction)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| OnchainRefreshTaskWrite {
+            id: row.get("id"),
+            contract_set_id: row.get("contract_set_id"),
+            chain_id: row.get("chain_id"),
+            dao_code: row.get::<Option<String>, _>("dao_code").unwrap_or_default(),
+            governor_address: row.get("governor_address"),
+            token_address: row.get("token_address"),
+            account: row.get("account"),
+            refresh_balance: row.get("refresh_balance"),
+            refresh_power: row.get("refresh_power"),
+            reason: row.get("reason"),
+            first_seen_block_number: row.get("first_seen_block_number"),
+            last_seen_block_number: row.get("last_seen_block_number"),
+            last_seen_block_timestamp: row.get("last_seen_block_timestamp"),
+            last_seen_transaction_hash: row.get("last_seen_transaction_hash"),
+            next_run_at: row.get("next_run_at"),
+        })
+        .collect())
 }
 
 #[cfg(test)]

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -1050,6 +1050,17 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
 
     let database = TestDatabase::connect().await?;
     let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let deferred_processing_account = indexed_account(DENSE_CANDIDATE_COUNT - 1);
+    seed_refresh_task_for_account(
+        &database.pool,
+        &deferred_processing_account,
+        "processing",
+        5,
+        999,
+        Some("rpc still running"),
+        false,
+    )
+    .await?;
     let token_batch = project_token_events(
         &token_projection_context(),
         (0..DENSE_CANDIDATE_COUNT)
@@ -1090,9 +1101,31 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
     .bind(CONTRACT_SET_ID)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(task_count, DENSE_CANDIDATE_COUNT as i64);
+    assert_eq!(task_count, 1_001);
 
-    for index in [0, DENSE_CANDIDATE_COUNT - 1] {
+    let deferred_count: i64 = sqlx::query_scalar(
+        "SELECT count(*)::BIGINT
+         FROM onchain_refresh_deferred_candidate
+         WHERE contract_set_id = $1",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(deferred_count, 1);
+
+    let inline_account = indexed_account(999);
+    let missing_inline_task_count: i64 = sqlx::query_scalar(
+        "SELECT count(*)::BIGINT
+         FROM onchain_refresh_task
+         WHERE contract_set_id = $1 AND account = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(&inline_account)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(missing_inline_task_count, 1);
+
+    for index in [0, 999] {
         let account = indexed_account(index);
         let row = sqlx::query(
             "SELECT id, reason, status, next_run_at::TEXT AS next_run_at,
@@ -1113,6 +1146,78 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
         );
         assert!(row.get::<String, _>("next_run_at").parse::<i64>()? > 0);
     }
+
+    let deferred = sqlx::query(
+        "SELECT account, reason, last_seen_block_number::TEXT AS last_seen_block_number
+         FROM onchain_refresh_deferred_candidate
+         WHERE contract_set_id = $1",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(
+        deferred.get::<String, _>("account"),
+        deferred_processing_account
+    );
+    assert_eq!(
+        deferred.get::<String, _>("reason"),
+        "delegate-votes-changed"
+    );
+    assert_eq!(
+        deferred.get::<String, _>("last_seen_block_number"),
+        (30 + (DENSE_CANDIDATE_COUNT - 1) as u64).to_string()
+    );
+
+    let drained = store.drain_deferred_onchain_refresh_tasks(1).await?;
+    assert_eq!(drained, 1);
+
+    let deferred_count_after_drain: i64 = sqlx::query_scalar(
+        "SELECT count(*)::BIGINT
+         FROM onchain_refresh_deferred_candidate
+         WHERE contract_set_id = $1",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(deferred_count_after_drain, 0);
+
+    let processing = sqlx::query(
+        "SELECT status, attempts, next_run_at::TEXT AS next_run_at, error,
+                last_seen_block_number::TEXT AS last_seen_block_number, pending_after_lock,
+                pending_after_lock_block_number::TEXT AS pending_after_lock_block_number,
+                pending_after_lock_block_timestamp::TEXT AS pending_after_lock_block_timestamp,
+                pending_after_lock_transaction_hash
+         FROM onchain_refresh_task
+         WHERE contract_set_id = $1 AND account = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(&deferred_processing_account)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(processing.get::<String, _>("status"), "processing");
+    assert_eq!(processing.get::<i32, _>("attempts"), 5);
+    assert_eq!(processing.get::<String, _>("next_run_at"), "999");
+    assert_eq!(
+        processing.get::<Option<String>, _>("error"),
+        Some("rpc still running".to_owned())
+    );
+    assert_eq!(
+        processing.get::<String, _>("last_seen_block_number"),
+        (30 + (DENSE_CANDIDATE_COUNT - 1) as u64).to_string()
+    );
+    assert!(processing.get::<bool, _>("pending_after_lock"));
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_block_number"),
+        Some((30 + (DENSE_CANDIDATE_COUNT - 1) as u64).to_string())
+    );
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_block_timestamp"),
+        Some((1_700_000_000_000 + (30 + (DENSE_CANDIDATE_COUNT - 1) as u64) * 1_000).to_string())
+    );
+    assert_eq!(
+        processing.get::<Option<String>, _>("pending_after_lock_transaction_hash"),
+        Some(format!("0xtx{}0", 30 + (DENSE_CANDIDATE_COUNT - 1) as u64))
+    );
 
     database.cleanup().await?;
 


### PR DESCRIPTION
## Summary

Fixes HBX-409 (parent HBX-397) by moving the heavy ENS onchain refresh task materialization out of the main projection/checkpoint write path.

The observed dense ENS historical chunk `from_block=13578418 to_block=13583417` returned `198480` token-event rows and spent most of its `547413ms` total time in synchronous writes: `write_duration_ms=523206`, `local_processing_write_duration_ms=536415`. After PR #829 deduped candidates in memory, that chunk still produced about `51677` unique `onchain_refresh_task` rows, so the remaining issue was materializing tens of thousands of refresh tasks inside the checkpoint transaction.

## Implementation

- Keeps account-level dedupe before enqueue and preserves the existing `onchain_refresh_task` unique key semantics: `chain_id`, `contract_set_id`, `dao_code`, `governor_address`, `token_address`, `account`.
- Adds a fresh-init `onchain_refresh_deferred_candidate` table that stores compact deduped refresh metadata for overflow candidates.
- Bounds inline `onchain_refresh_task` materialization to 1000 rows per projection transaction; remaining unique candidates are deferred.
- Adds bounded deferred materialization after chunk commit and before onchain worker claims, using the same task upsert conflict SQL so `processing` collisions still set `pending_after_lock` metadata.
- Adds logs for original candidate count, deduped unique count, inline count, deferred count, and deferred drain count/duration.

## Verification

- `cargo fmt --all --check`
- `cargo test --locked -p degov-datalens-indexer onchain_refresh --lib -- --nocapture`
- `DEGOV_INDEXER_TEST_DATABASE_URL='postgresql://postgres:password@localhost:7432/degov_indexer_test_hbx408' cargo test --locked -p degov-datalens-indexer --test migration_schema -- --nocapture`
- `DEGOV_INDEXER_TEST_DATABASE_URL='postgresql://postgres:password@localhost:7432/degov_indexer_test_hbx408' cargo test --locked -p degov-datalens-indexer --test postgres_runtime_run -- --nocapture`

## Expected effect

For the ENS dense chunk `13578418-13583417`, checkpoint commit should no longer synchronously upsert all ~51k unique refresh tasks. It will inline only the bounded first 1000 task rows in the projection transaction, persist the remaining deduped candidates to the deferred table, commit the checkpoint, and then materialize ordinary `onchain_refresh_task` rows in bounded batches for the existing worker to claim. Final power correctness remains from onchain RPC/batch reads, not logs.