### PR TITLE
fix(indexer): bound Datalens query gate waits

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -131,6 +131,11 @@ struct DatalensQueryConcurrencyGateState {
     per_chain_in_flight: HashMap<DatalensQueryConcurrencyKey, usize>,
 }
 
+enum DatalensQueryConcurrencyAcquire {
+    Acquired(Option<DatalensQueryConcurrencyPermit>),
+    TimedOut,
+}
+
 pub struct DatalensQueryConcurrencyPermit {
     gate: DatalensQueryConcurrencyGate,
     key: DatalensQueryConcurrencyKey,
@@ -155,13 +160,84 @@ impl DatalensQueryConcurrencyGate {
         &self,
         key: &DatalensQueryConcurrencyKey,
     ) -> Result<DatalensQueryConcurrencyPermit, DatalensError> {
+        self.acquire_with_deadline(key, None).map(|permit| {
+            permit.expect("unbounded query concurrency gate acquire does not time out")
+        })
+    }
+
+    fn acquire_timeout(
+        &self,
+        key: &DatalensQueryConcurrencyKey,
+        timeout: Duration,
+    ) -> Result<Option<DatalensQueryConcurrencyPermit>, DatalensError> {
+        self.acquire_with_deadline(key, Some(timeout))
+    }
+
+    fn acquire_with_deadline(
+        &self,
+        key: &DatalensQueryConcurrencyKey,
+        timeout: Option<Duration>,
+    ) -> Result<Option<DatalensQueryConcurrencyPermit>, DatalensError> {
         let started_at = Instant::now();
         let mut state = self.inner.state.lock().map_err(|_| {
             DatalensError::Query("Datalens query concurrency gate lock poisoned".to_owned())
         })?;
 
-        while self
-            .inner
+        while self.is_limited(&state, key) {
+            match timeout {
+                Some(timeout) => {
+                    let elapsed = started_at.elapsed();
+                    if elapsed >= timeout {
+                        return Ok(None);
+                    }
+                    let remaining = timeout.saturating_sub(elapsed);
+                    let (next_state, wait_result) = self
+                        .inner
+                        .available
+                        .wait_timeout(state, remaining)
+                        .map_err(|_| {
+                            DatalensError::Query(
+                                "Datalens query concurrency gate lock poisoned".to_owned(),
+                            )
+                        })?;
+                    state = next_state;
+                    if wait_result.timed_out() && self.is_limited(&state, key) {
+                        return Ok(None);
+                    }
+                }
+                None => {
+                    state = self.inner.available.wait(state).map_err(|_| {
+                        DatalensError::Query(
+                            "Datalens query concurrency gate lock poisoned".to_owned(),
+                        )
+                    })?;
+                }
+            }
+        }
+
+        state.global_in_flight += 1;
+        let chain_in_flight = {
+            let chain_in_flight = state.per_chain_in_flight.entry(key.clone()).or_default();
+            *chain_in_flight += 1;
+            *chain_in_flight
+        };
+        let global_in_flight = state.global_in_flight;
+
+        Ok(Some(DatalensQueryConcurrencyPermit {
+            gate: self.clone(),
+            key: key.clone(),
+            wait_duration: started_at.elapsed(),
+            global_in_flight,
+            chain_in_flight,
+        }))
+    }
+
+    fn is_limited(
+        &self,
+        state: &DatalensQueryConcurrencyGateState,
+        key: &DatalensQueryConcurrencyKey,
+    ) -> bool {
+        self.inner
             .config
             .global_max_in_flight
             .is_some_and(|limit| state.global_in_flight >= limit)
@@ -177,27 +253,6 @@ impl DatalensQueryConcurrencyGate {
                         .unwrap_or_default()
                         >= limit
                 })
-        {
-            state = self.inner.available.wait(state).map_err(|_| {
-                DatalensError::Query("Datalens query concurrency gate lock poisoned".to_owned())
-            })?;
-        }
-
-        state.global_in_flight += 1;
-        let chain_in_flight = {
-            let chain_in_flight = state.per_chain_in_flight.entry(key.clone()).or_default();
-            *chain_in_flight += 1;
-            *chain_in_flight
-        };
-        let global_in_flight = state.global_in_flight;
-
-        Ok(DatalensQueryConcurrencyPermit {
-            gate: self.clone(),
-            key: key.clone(),
-            wait_duration: started_at.elapsed(),
-            global_in_flight,
-            chain_in_flight,
-        })
     }
 }
 
@@ -442,25 +497,50 @@ impl DatalensNativeClient {
     where
         F: FnOnce(DatalensClient) -> Result<QueryResponse, DatalensSdkError> + Send + 'static,
     {
+        let started_at = Instant::now();
         if self
             .blocking_query_in_flight
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
-            return Err(datalens_query_timeout_error(
+            let error = datalens_query_timeout_error(
                 operation,
                 self.query_timeout,
                 Some("previous SDK query is still in flight"),
-            ));
+            );
+            self.warn_query_timeout(operation, &error);
+            return Err(error);
         }
 
         let permit = match self.acquire_query_concurrency_permit(operation) {
-            Ok(permit) => permit,
+            Ok(DatalensQueryConcurrencyAcquire::Acquired(permit)) => permit,
+            Ok(DatalensQueryConcurrencyAcquire::TimedOut) => {
+                self.blocking_query_in_flight
+                    .store(false, Ordering::Release);
+                let error = datalens_query_timeout_error(
+                    operation,
+                    self.query_timeout,
+                    Some("waiting for query concurrency permit"),
+                );
+                self.warn_query_timeout(operation, &error);
+                return Err(error);
+            }
             Err(error) => {
                 self.blocking_query_in_flight
                     .store(false, Ordering::Release);
                 return Err(DatalensSdkError::Transport(error.to_string()));
             }
+        };
+        let Some(remaining_timeout) = self.query_timeout.checked_sub(started_at.elapsed()) else {
+            self.blocking_query_in_flight
+                .store(false, Ordering::Release);
+            let error = datalens_query_timeout_error(
+                operation,
+                self.query_timeout,
+                Some("waiting for query concurrency permit"),
+            );
+            self.warn_query_timeout(operation, &error);
+            return Err(error);
         };
         let (sender, receiver) = mpsc::sync_channel(1);
         let client = self.client.clone();
@@ -482,13 +562,13 @@ impl DatalensNativeClient {
             )));
         }
 
-        match receiver.recv_timeout(self.query_timeout) {
+        match receiver.recv_timeout(remaining_timeout) {
             Ok(result) => result,
-            Err(mpsc::RecvTimeoutError::Timeout) => Err(datalens_query_timeout_error(
-                operation,
-                self.query_timeout,
-                None,
-            )),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                let error = datalens_query_timeout_error(operation, self.query_timeout, None);
+                self.warn_query_timeout(operation, &error);
+                Err(error)
+            }
             Err(mpsc::RecvTimeoutError::Disconnected) => Err(DatalensSdkError::Transport(format!(
                 "Datalens {operation} worker stopped before returning a response"
             ))),
@@ -498,23 +578,42 @@ impl DatalensNativeClient {
     fn acquire_query_concurrency_permit(
         &self,
         operation: &str,
-    ) -> Result<Option<DatalensQueryConcurrencyPermit>, DatalensError> {
-        self.query_gate
-            .as_ref()
-            .map(|gate| {
-                let permit = gate.acquire(&self.query_key)?;
-                info!(
-                    "Datalens process-local {operation} concurrency permit acquired chain_family={} chain_name={} chain_network_id={} wait_ms={} process_in_flight={} chain_in_flight={}",
-                    self.query_key.family,
-                    self.query_key.configured_name,
-                    self.query_key.log_network_id(),
-                    permit.wait_duration.as_millis(),
-                    permit.global_in_flight,
-                    permit.chain_in_flight
-                );
-                Ok::<_, DatalensError>(permit)
-            })
-            .transpose()
+    ) -> Result<DatalensQueryConcurrencyAcquire, DatalensError> {
+        let Some(gate) = self.query_gate.as_ref() else {
+            return Ok(DatalensQueryConcurrencyAcquire::Acquired(None));
+        };
+
+        let Some(permit) = gate.acquire_timeout(&self.query_key, self.query_timeout)? else {
+            warn!(
+                "Datalens process-local {operation} concurrency permit timed out chain_family={} chain_name={} chain_network_id={} timeout_ms={}",
+                self.query_key.family,
+                self.query_key.configured_name,
+                self.query_key.log_network_id(),
+                self.query_timeout.as_millis()
+            );
+            return Ok(DatalensQueryConcurrencyAcquire::TimedOut);
+        };
+        info!(
+            "Datalens process-local {operation} concurrency permit acquired chain_family={} chain_name={} chain_network_id={} wait_ms={} process_in_flight={} chain_in_flight={}",
+            self.query_key.family,
+            self.query_key.configured_name,
+            self.query_key.log_network_id(),
+            permit.wait_duration.as_millis(),
+            permit.global_in_flight,
+            permit.chain_in_flight
+        );
+        Ok(DatalensQueryConcurrencyAcquire::Acquired(Some(permit)))
+    }
+
+    fn warn_query_timeout(&self, operation: &str, error: &DatalensSdkError) {
+        warn!(
+            "Datalens {operation} deadline fired chain_family={} chain_name={} chain_network_id={} timeout_ms={} error={}",
+            self.query_key.family,
+            self.query_key.configured_name,
+            self.query_key.log_network_id(),
+            self.query_timeout.as_millis(),
+            error
+        );
     }
 }
 

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -1467,6 +1467,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_recovering_contract_set_jobs_do_not_hold_permit_after_datalens_timeout() {
+        #[derive(Clone, Copy)]
+        enum ScriptedJob {
+            Timeout,
+            Pending,
+        }
+
+        let timeout_attempts = Arc::new(AtomicUsize::new(0));
+        let pending_started = Arc::new(AtomicUsize::new(0));
+        let timeout_failed = Arc::new(tokio::sync::Notify::new());
+        let jobs = vec![
+            ContractSetConcurrencyJob {
+                chain_id: 1,
+                contract_set: ScriptedJob::Timeout,
+            },
+            ContractSetConcurrencyJob {
+                chain_id: 2,
+                contract_set: ScriptedJob::Pending,
+            },
+        ];
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            run_recovering_contract_set_jobs(
+                jobs,
+                crate::ContractSetConcurrencyLimit::Limited(1),
+                crate::ContractSetConcurrencyLimit::Unlimited,
+                {
+                    let timeout_attempts = timeout_attempts.clone();
+                    let pending_started = pending_started.clone();
+                    let timeout_failed = timeout_failed.clone();
+                    move |job, permit_scope| {
+                        let timeout_attempts = timeout_attempts.clone();
+                        let pending_started = pending_started.clone();
+                        let timeout_failed = timeout_failed.clone();
+                        async move {
+                            run_recovering_contract_set_pass_loop(
+                                "dao_code=ens-dao chain_id=1 contract_set_id=ens",
+                                Duration::from_secs(60),
+                                move || {
+                                    let permit_scope = permit_scope.clone();
+                                    let timeout_attempts = timeout_attempts.clone();
+                                    let pending_started = pending_started.clone();
+                                    let timeout_failed = timeout_failed.clone();
+                                    async move {
+                                        if matches!(job, ScriptedJob::Pending) {
+                                            timeout_failed.notified().await;
+                                        }
+                                        let _permits = permit_scope
+                                            .acquire()
+                                            .await
+                                            .map_err(ContractSetPassError::setup)?;
+                                        match job {
+                                            ScriptedJob::Timeout => {
+                                                timeout_attempts.fetch_add(1, Ordering::SeqCst);
+                                                timeout_failed.notify_one();
+                                                Err(ContractSetPassError::runner(
+                                                    runtime_anyhow::anyhow!(
+                                                        crate::DatalensError::Query(
+                                                            "Datalens query timed out after 60s"
+                                                                .to_owned()
+                                                        )
+                                                    ),
+                                                ))
+                                            }
+                                            ScriptedJob::Pending => {
+                                                pending_started.fetch_add(1, Ordering::SeqCst);
+                                                Ok(())
+                                            }
+                                        }
+                                    }
+                                },
+                                |_| async {
+                                    std::future::pending::<()>().await;
+                                },
+                            )
+                            .await
+                        }
+                    }
+                },
+            ),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(timeout_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(pending_started.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn test_recovering_contract_set_jobs_unlimited_runs_every_job_without_permit_wait() {
         let started = Arc::new(AtomicUsize::new(0));
         let jobs = (0..5)

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -15,7 +15,10 @@ use degov_datalens_indexer::{
     SecretString, ServiceReadiness, classify_datalens_query_error, plan_dao_log_queries,
     verify_datalens_service,
 };
-use std::sync::mpsc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    mpsc,
+};
 
 struct MockDatalensReader {
     readiness: Result<ServiceReadiness, DatalensError>,
@@ -371,6 +374,57 @@ fn test_datalens_log_query_rejects_new_client_while_sdk_query_is_still_in_flight
     );
     let requests = server.join();
     assert_eq!(requests.len(), 1);
+}
+
+#[test]
+fn test_datalens_log_query_times_out_while_waiting_for_query_gate() {
+    let mut config = datalens_config("http://127.0.0.1:9", DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(50);
+    let gate = DatalensQueryConcurrencyGate::new(DatalensQueryConcurrencyConfig {
+        global_max_in_flight: Some(1),
+        per_chain_max_in_flight: None,
+    })
+    .expect("gate");
+    let held_permit = gate
+        .acquire(&DatalensQueryConcurrencyKey::from_config(&config))
+        .expect("held permit");
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("client")
+            .with_query_concurrency_gate(gate);
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+    let (sender, receiver) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        let started_at = std::time::Instant::now();
+        let error = client
+            .query_logs(plans[0].input.clone())
+            .expect_err("query gate wait times out");
+        sender
+            .send((started_at.elapsed(), error.to_string()))
+            .expect("send timeout result");
+    });
+
+    let result = receiver.recv_timeout(Duration::from_millis(200));
+    drop(held_permit);
+    handle.join().expect("query thread joins");
+    let (elapsed, error) = result.expect("query should timeout while waiting for gate");
+    assert!(
+        elapsed < Duration::from_millis(150),
+        "query gate wait should be bounded by the configured timeout"
+    );
+    assert!(
+        error.contains("Datalens query timed out after 50ms"),
+        "{error}"
+    );
+    assert!(
+        error.contains("waiting for query concurrency permit"),
+        "{error}"
+    );
+    assert_eq!(
+        classify_datalens_query_error(&error),
+        DatalensQueryErrorClass::Transient
+    );
 }
 
 #[test]
@@ -745,9 +799,12 @@ fn addresses() -> DaoContractAddresses {
 }
 
 fn datalens_config(endpoint: &str, finality: DatalensFinality) -> DatalensConfig {
+    static NEXT_APPLICATION_ID: AtomicUsize = AtomicUsize::new(0);
+    let application_id = NEXT_APPLICATION_ID.fetch_add(1, Ordering::SeqCst);
+
     DatalensConfig {
         endpoint: endpoint.to_owned(),
-        application: "degov-test".to_owned(),
+        application: format!("degov-test-{application_id}"),
         bearer_token: SecretString::new("unit-test-redacted-value"),
         timeout: Duration::from_secs(5),
         finality,


### PR DESCRIPTION
## Summary

- Bound Datalens query concurrency gate waits by the configured query timeout so a DAO job cannot hang silently before the SDK worker is spawned.
- Keep the existing SDK-worker deadline and make the total client call budget include both gate wait time and SDK query time.
- Add visible timeout logs with operation and chain context, while preserving runner/all-mode retry and backoff behavior.
- Add focused client and all-mode recovery coverage for Datalens timeout behavior.

## Testing

- `cargo fmt --all --check`
- `cargo test -p degov-datalens-indexer --test datalens_client -- --test-threads=1`
- `cargo test -p degov-datalens-indexer runtime::indexer::tests --lib`
- `cargo test -p degov-datalens-indexer --test indexer_runner`
- `cargo test -p degov-datalens-indexer --test datalens_client`

Refs HBX-410.