### PR TITLE
fix(indexer): smooth ENS onchain refresh backlog

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -97,7 +97,8 @@ pub use crate::projection::vote::{
     VoteProjectionEvent, VoteProjectionRepository, VoteRepositoryWriteError, project_vote_events,
 };
 pub use crate::store::postgres::{
-    PostgresIndexerRunnerStore, PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
+    DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS, PostgresIndexerRunnerStore,
+    PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
     PostgresProvisionalCleanupStore, PostgresProvisionalPowerOverlayStore,
     PostgresProvisionalProposalOverlayStore, PostgresProvisionalSegmentStore,
 };

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -26,6 +26,7 @@ use crate::{
 
 use crate::OnchainRefreshTickReport;
 use crate::checkpoint::configured_range_progress;
+use crate::store::postgres::DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS;
 
 #[derive(Clone, Debug)]
 pub struct IndexerRunnerOptions {
@@ -773,7 +774,9 @@ where
                 .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
             let write_duration = write_started_at.elapsed();
             let deferred_drain_started_at = Instant::now();
-            let deferred_drain_count = match self.store.drain_deferred_onchain_refresh_tasks(1_000)
+            let deferred_drain_count = match self
+                .store
+                .drain_deferred_onchain_refresh_tasks(DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS)
             {
                 Ok(count) => count,
                 Err(error) => {

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -522,7 +522,7 @@ async fn read_deferred_onchain_refresh_candidates(
          FOR UPDATE SKIP LOCKED",
     )
     .bind(max_rows)
-    .bind(now_ms.to_string())
+    .bind(now_ms)
     .fetch_all(&mut **transaction)
     .await?;
 

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -47,6 +47,9 @@ async fn upsert_onchain_refresh_tasks(
         upsert_deferred_onchain_refresh_candidate_chunk(transaction, chunk, now_ms, next_run_at)
             .await?;
     }
+    let rescheduled_count =
+        reschedule_materialized_onchain_refresh_tasks(transaction, &rows, next_run_at, now_ms)
+            .await?;
     let drained_count = drain_deferred_onchain_refresh_tasks_in_transaction(
         transaction,
         plan.ready_drain_count,
@@ -55,11 +58,12 @@ async fn upsert_onchain_refresh_tasks(
     .await?;
 
     log::info!(
-        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} inline_upsert_count={} deferred_count={} ready_drain_count={} materialized_count={}",
+        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} inline_upsert_count={} deferred_count={} rescheduled_materialized_count={} ready_drain_count={} materialized_count={}",
         original_count,
         rows.len(),
         plan.inline_upsert_count,
         plan.deferred_candidate_count,
+        rescheduled_count,
         plan.ready_drain_count,
         drained_count
     );
@@ -92,6 +96,38 @@ pub async fn drain_deferred_onchain_refresh_tasks(
     }
 
     Ok(drained_count)
+}
+
+async fn reschedule_materialized_onchain_refresh_tasks(
+    transaction: &mut Transaction<'_, Postgres>,
+    rows: &[OnchainRefreshTaskWrite],
+    next_run_at: i64,
+    now_ms: i64,
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let mut rescheduled_count = 0;
+    for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
+        let ids = chunk.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+        let result = sqlx::query(
+            "UPDATE onchain_refresh_task
+             SET next_run_at = GREATEST(next_run_at, $2::NUMERIC(78, 0)),
+                 updated_at = $3::NUMERIC(78, 0)
+             WHERE id = ANY($1)
+               AND status IN ('pending', 'failed')
+               AND next_run_at < $2::NUMERIC(78, 0)",
+        )
+        .bind(&ids)
+        .bind(next_run_at.to_string())
+        .bind(now_ms.to_string())
+        .execute(&mut **transaction)
+        .await?;
+        rescheduled_count += result.rows_affected();
+    }
+
+    Ok(rescheduled_count)
 }
 
 async fn drain_deferred_onchain_refresh_tasks_in_transaction(

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -1,7 +1,30 @@
 // Onchain refresh task persistence.
 const MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS: usize = 1_000;
-const MAX_INLINE_ONCHAIN_REFRESH_TASK_UPSERT_ROWS: usize = 1_000;
-pub const DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS: usize = 1_000;
+pub const DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS: usize = 100;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OnchainRefreshEnqueuePlan {
+    inline_upsert_count: usize,
+    deferred_candidate_count: usize,
+    ready_drain_count: usize,
+}
+
+fn plan_onchain_refresh_enqueue(
+    deduped_count: usize,
+    debounce: Duration,
+) -> OnchainRefreshEnqueuePlan {
+    let ready_drain_count = if debounce.is_zero() {
+        deduped_count.min(DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS)
+    } else {
+        0
+    };
+
+    OnchainRefreshEnqueuePlan {
+        inline_upsert_count: 0,
+        deferred_candidate_count: deduped_count,
+        ready_drain_count,
+    }
+}
 
 async fn upsert_onchain_refresh_tasks(
     transaction: &mut Transaction<'_, Postgres>,
@@ -19,22 +42,26 @@ async fn upsert_onchain_refresh_tasks(
         row.next_run_at = next_run_at.to_string();
     }
 
-    let inline_count = rows.len().min(MAX_INLINE_ONCHAIN_REFRESH_TASK_UPSERT_ROWS);
-    let (inline_rows, deferred_rows) = rows.split_at(inline_count);
-    for chunk in inline_rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
-        upsert_onchain_refresh_task_chunk(transaction, chunk, now_ms).await?;
-    }
-    for chunk in deferred_rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
+    let plan = plan_onchain_refresh_enqueue(rows.len(), debounce);
+    for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
         upsert_deferred_onchain_refresh_candidate_chunk(transaction, chunk, now_ms, next_run_at)
             .await?;
     }
+    let drained_count = drain_deferred_onchain_refresh_tasks_in_transaction(
+        transaction,
+        plan.ready_drain_count,
+        now_ms,
+    )
+    .await?;
 
     log::info!(
-        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} inline_upsert_count={} deferred_count={}",
+        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} inline_upsert_count={} deferred_count={} ready_drain_count={} materialized_count={}",
         original_count,
         rows.len(),
-        inline_rows.len(),
-        deferred_rows.len()
+        plan.inline_upsert_count,
+        plan.deferred_candidate_count,
+        plan.ready_drain_count,
+        drained_count
     );
 
     Ok(())
@@ -50,28 +77,45 @@ pub async fn drain_deferred_onchain_refresh_tasks(
 
     let started_at = std::time::Instant::now();
     let mut transaction = pool.begin().await?;
-    let rows = read_deferred_onchain_refresh_candidates(&mut transaction, max_rows).await?;
+    let now_ms = unix_time_millis();
+    let drained_count =
+        drain_deferred_onchain_refresh_tasks_in_transaction(&mut transaction, max_rows, now_ms)
+            .await?;
+    transaction.commit().await?;
+
+    if drained_count > 0 {
+        log::info!(
+            "onchain refresh deferred drain completed deferred_drain_count={} deferred_drain_duration_ms={}",
+            drained_count,
+            started_at.elapsed().as_millis()
+        );
+    }
+
+    Ok(drained_count)
+}
+
+async fn drain_deferred_onchain_refresh_tasks_in_transaction(
+    transaction: &mut Transaction<'_, Postgres>,
+    max_rows: usize,
+    now_ms: i64,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    if max_rows == 0 {
+        return Ok(0);
+    }
+
+    let rows = read_deferred_onchain_refresh_candidates(transaction, max_rows, now_ms).await?;
     if rows.is_empty() {
-        transaction.commit().await?;
         return Ok(0);
     }
 
     let ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
-    let now_ms = unix_time_millis();
     for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
-        upsert_onchain_refresh_task_chunk(&mut transaction, chunk, now_ms).await?;
+        upsert_onchain_refresh_task_chunk(transaction, chunk, now_ms).await?;
     }
     sqlx::query("DELETE FROM onchain_refresh_deferred_candidate WHERE id = ANY($1)")
         .bind(&ids)
-        .execute(&mut *transaction)
+        .execute(&mut **transaction)
         .await?;
-    transaction.commit().await?;
-
-    log::info!(
-        "onchain refresh deferred drain completed deferred_drain_count={} deferred_drain_duration_ms={}",
-        ids.len(),
-        started_at.elapsed().as_millis()
-    );
 
     Ok(ids.len())
 }
@@ -421,6 +465,7 @@ async fn upsert_deferred_onchain_refresh_candidate_chunk(
 async fn read_deferred_onchain_refresh_candidates(
     transaction: &mut Transaction<'_, Postgres>,
     max_rows: usize,
+    now_ms: i64,
 ) -> Result<Vec<OnchainRefreshTaskWrite>, PostgresIndexerRunnerStoreError> {
     let max_rows = i64::try_from(max_rows)
         .map_err(|_| PostgresIndexerRunnerStoreError::new("deferred drain batch size exceeds i64"))?;
@@ -433,6 +478,7 @@ async fn read_deferred_onchain_refresh_candidates(
                 last_seen_transaction_hash,
                 next_run_at::TEXT AS next_run_at
          FROM onchain_refresh_deferred_candidate
+         WHERE next_run_at <= $2::NUMERIC(78, 0)
          ORDER BY onchain_refresh_deferred_candidate.next_run_at,
                   onchain_refresh_deferred_candidate.updated_at,
                   onchain_refresh_deferred_candidate.id
@@ -440,6 +486,7 @@ async fn read_deferred_onchain_refresh_candidates(
          FOR UPDATE SKIP LOCKED",
     )
     .bind(max_rows)
+    .bind(now_ms.to_string())
     .fetch_all(&mut **transaction)
     .await?;
 
@@ -523,6 +570,19 @@ mod tests {
         let deduped = dedupe_onchain_refresh_tasks(&rows);
 
         assert_eq!(deduped.len(), rows.len());
+    }
+
+    #[test]
+    fn test_plan_onchain_refresh_enqueue_buffers_dense_candidates() {
+        let debounced = plan_onchain_refresh_enqueue(1_205, Duration::from_secs(120));
+        assert_eq!(debounced.inline_upsert_count, 0);
+        assert_eq!(debounced.deferred_candidate_count, 1_205);
+        assert_eq!(debounced.ready_drain_count, 0);
+
+        let immediate = plan_onchain_refresh_enqueue(1_205, Duration::ZERO);
+        assert_eq!(immediate.inline_upsert_count, 0);
+        assert_eq!(immediate.deferred_candidate_count, 1_205);
+        assert_eq!(immediate.ready_drain_count, DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS);
     }
 
     fn candidate(

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -1193,6 +1193,66 @@ async fn test_postgres_token_reconcile_tasks_dedupe_duplicate_accounts_before_sq
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_deferred_refresh_reschedules_ready_materialized_task()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone())
+        .with_onchain_refresh_debounce(Duration::from_secs(120));
+    seed_refresh_task_for_account(&database.pool, DELEGATE, "pending", 0, 0, None, false).await?;
+
+    let before = unix_time_millis_for_test();
+    let token_batch = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("0000000030-ready-pending-repeat", 30, 0, 1),
+            event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                delegate: DELEGATE.to_owned(),
+                previous_votes: "0".to_owned(),
+                new_votes: "1".to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(token_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+    let after = unix_time_millis_for_test();
+
+    let pending = sqlx::query(
+        "SELECT status, next_run_at::TEXT AS next_run_at
+         FROM onchain_refresh_task
+         WHERE contract_set_id = $1 AND account = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(pending.get::<String, _>("status"), "pending");
+    let next_run_at = pending.get::<String, _>("next_run_at").parse::<i64>()?;
+    assert!(next_run_at >= before + 120_000);
+    assert!(next_run_at <= after + 120_000);
+
+    let deferred_count: i64 = sqlx::query_scalar(
+        "SELECT count(*)::BIGINT
+         FROM onchain_refresh_deferred_candidate
+         WHERE contract_set_id = $1 AND account = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(deferred_count, 1);
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
 -> Result<(), Box<dyn Error>> {
     const DENSE_EVENT_COUNT: usize = 1_205;

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -32,14 +32,6 @@ use tokio::time::{sleep, timeout};
 
 static SCHEMA_COUNTER: AtomicU64 = AtomicU64::new(0);
 static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
-const DEFAULT_ONCHAIN_REFRESH_DEBOUNCE_MS: i64 = 120_000;
-
-fn onchain_refresh_debounce_ms() -> i64 {
-    env::var("DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS")
-        .ok()
-        .and_then(|value| value.parse::<i64>().ok())
-        .unwrap_or(DEFAULT_ONCHAIN_REFRESH_DEBOUNCE_MS)
-}
 
 struct TestDatabase {
     _guard: MutexGuard<'static, ()>,
@@ -878,7 +870,7 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     let mut store = PostgresIndexerRunnerStore::new(database.pool.clone())
-        .with_onchain_refresh_debounce(Duration::from_secs(120));
+        .with_onchain_refresh_debounce(Duration::ZERO);
     seed_refresh_task_for_account(
         &database.pool,
         DELEGATOR,
@@ -979,7 +971,7 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
     assert_eq!(pending.get::<String, _>("status"), "pending");
     assert_eq!(pending.get::<i32, _>("attempts"), 0);
     let pending_next_run_at = pending.get::<String, _>("next_run_at").parse::<i64>()?;
-    let debounce_ms = onchain_refresh_debounce_ms();
+    let debounce_ms = 0;
     assert!(pending_next_run_at >= before + debounce_ms);
     assert!(pending_next_run_at <= after + debounce_ms);
     assert_eq!(pending.get::<String, _>("first_seen_block_number"), "10");
@@ -1050,7 +1042,7 @@ async fn test_postgres_token_reconcile_tasks_dedupe_duplicate_accounts_before_sq
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     let mut store = PostgresIndexerRunnerStore::new(database.pool.clone())
-        .with_onchain_refresh_debounce(Duration::from_secs(120));
+        .with_onchain_refresh_debounce(Duration::ZERO);
     seed_refresh_task_for_account(
         &database.pool,
         SECOND_DELEGATE,
@@ -1203,24 +1195,17 @@ async fn test_postgres_token_reconcile_tasks_dedupe_duplicate_accounts_before_sq
 #[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
 -> Result<(), Box<dyn Error>> {
-    const DENSE_CANDIDATE_COUNT: usize = 1_001;
+    const DENSE_EVENT_COUNT: usize = 1_205;
+    const DENSE_UNIQUE_ACCOUNT_COUNT: usize = 150;
+    const EXPECTED_MATERIALIZED_BATCH: i64 = 100;
 
     let database = TestDatabase::connect().await?;
-    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
-    let deferred_processing_account = indexed_account(DENSE_CANDIDATE_COUNT - 1);
-    seed_refresh_task_for_account(
-        &database.pool,
-        &deferred_processing_account,
-        "processing",
-        5,
-        999,
-        Some("rpc still running"),
-        false,
-    )
-    .await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone())
+        .with_onchain_refresh_debounce(Duration::from_secs(120));
+    let deferred_account = indexed_account(DENSE_UNIQUE_ACCOUNT_COUNT - 1);
     let token_batch = project_token_events(
         &token_projection_context(),
-        (0..DENSE_CANDIDATE_COUNT)
+        (0..DENSE_EVENT_COUNT)
             .map(|index| TokenProjectionEvent {
                 log: normalized_token_log(
                     &format!("0000000030-dense-votes-{index}"),
@@ -1229,7 +1214,7 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
                     1,
                 ),
                 event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
-                    delegate: indexed_account(index),
+                    delegate: indexed_account(index % DENSE_UNIQUE_ACCOUNT_COUNT),
                     previous_votes: "0".to_owned(),
                     new_votes: "1".to_owned(),
                 }),
@@ -1239,7 +1224,7 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
     .map_err(|error| format!("dense token projection failed: {error:?}"))?;
     assert_eq!(
         token_batch.reconcile_plan.candidates.len(),
-        DENSE_CANDIDATE_COUNT
+        DENSE_UNIQUE_ACCOUNT_COUNT
     );
 
     apply_projection_batch(
@@ -1258,7 +1243,17 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
     .bind(CONTRACT_SET_ID)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(task_count, 1_001);
+    assert_eq!(task_count, 0);
+
+    let pending_count: i64 = sqlx::query_scalar(
+        "SELECT count(*)::BIGINT
+         FROM onchain_refresh_task
+         WHERE contract_set_id = $1 AND status = 'pending'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(pending_count, 0);
 
     let deferred_count: i64 = sqlx::query_scalar(
         "SELECT count(*)::BIGINT
@@ -1268,65 +1263,83 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
     .bind(CONTRACT_SET_ID)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(deferred_count, 1);
+    assert_eq!(deferred_count, DENSE_UNIQUE_ACCOUNT_COUNT as i64);
 
-    let inline_account = indexed_account(999);
-    let missing_inline_task_count: i64 = sqlx::query_scalar(
-        "SELECT count(*)::BIGINT
-         FROM onchain_refresh_task
+    let deferred = sqlx::query(
+        "SELECT account, reason, last_seen_block_number::TEXT AS last_seen_block_number,
+                next_run_at::TEXT AS next_run_at
+         FROM onchain_refresh_deferred_candidate
          WHERE contract_set_id = $1 AND account = $2",
     )
     .bind(CONTRACT_SET_ID)
-    .bind(&inline_account)
+    .bind(&deferred_account)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(missing_inline_task_count, 1);
-
-    for index in [0, 999] {
-        let account = indexed_account(index);
-        let row = sqlx::query(
-            "SELECT id, reason, status, next_run_at::TEXT AS next_run_at,
-                    last_seen_block_number::TEXT AS last_seen_block_number
-             FROM onchain_refresh_task
-             WHERE contract_set_id = $1 AND account = $2",
-        )
-        .bind(CONTRACT_SET_ID)
-        .bind(&account)
-        .fetch_one(&database.pool)
-        .await?;
-        assert_eq!(row.get::<String, _>("id"), refresh_task_id(&account));
-        assert_eq!(row.get::<String, _>("reason"), "delegate-votes-changed");
-        assert_eq!(row.get::<String, _>("status"), "pending");
-        assert_eq!(
-            row.get::<String, _>("last_seen_block_number"),
-            (30 + index as u64).to_string()
-        );
-        assert!(row.get::<String, _>("next_run_at").parse::<i64>()? > 0);
-    }
-
-    let deferred = sqlx::query(
-        "SELECT account, reason, last_seen_block_number::TEXT AS last_seen_block_number
-         FROM onchain_refresh_deferred_candidate
-         WHERE contract_set_id = $1",
-    )
-    .bind(CONTRACT_SET_ID)
-    .fetch_one(&database.pool)
-    .await?;
-    assert_eq!(
-        deferred.get::<String, _>("account"),
-        deferred_processing_account
-    );
+    assert_eq!(deferred.get::<String, _>("account"), deferred_account);
     assert_eq!(
         deferred.get::<String, _>("reason"),
         "delegate-votes-changed"
     );
+    assert_eq!(deferred.get::<String, _>("last_seen_block_number"), "1229");
+    let first_next_run_at = deferred.get::<String, _>("next_run_at").parse::<i64>()?;
+
+    let second_batch = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("0000002000-dense-votes-repeat", 2_000, 0, 1),
+            event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                delegate: deferred_account.clone(),
+                previous_votes: "1".to_owned(),
+                new_votes: "2".to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("repeat token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(second_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let updated_deferred = sqlx::query(
+        "SELECT last_seen_block_number::TEXT AS last_seen_block_number,
+                next_run_at::TEXT AS next_run_at
+         FROM onchain_refresh_deferred_candidate
+         WHERE contract_set_id = $1 AND account = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(&deferred_account)
+    .fetch_one(&database.pool)
+    .await?;
     assert_eq!(
-        deferred.get::<String, _>("last_seen_block_number"),
-        (30 + (DENSE_CANDIDATE_COUNT - 1) as u64).to_string()
+        updated_deferred.get::<String, _>("last_seen_block_number"),
+        "2000"
+    );
+    assert!(
+        updated_deferred
+            .get::<String, _>("next_run_at")
+            .parse::<i64>()?
+            >= first_next_run_at
     );
 
     let drained = store.drain_deferred_onchain_refresh_tasks(1).await?;
-    assert_eq!(drained, 1);
+    assert_eq!(drained, 0);
+
+    sqlx::query(
+        "UPDATE onchain_refresh_deferred_candidate
+         SET next_run_at = 0
+         WHERE contract_set_id = $1",
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+
+    let drained = store
+        .drain_deferred_onchain_refresh_tasks(EXPECTED_MATERIALIZED_BATCH as usize)
+        .await?;
+    assert_eq!(drained, EXPECTED_MATERIALIZED_BATCH as usize);
 
     let deferred_count_after_drain: i64 = sqlx::query_scalar(
         "SELECT count(*)::BIGINT
@@ -1336,45 +1349,20 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
     .bind(CONTRACT_SET_ID)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(deferred_count_after_drain, 0);
+    assert_eq!(
+        deferred_count_after_drain,
+        DENSE_UNIQUE_ACCOUNT_COUNT as i64 - EXPECTED_MATERIALIZED_BATCH
+    );
 
-    let processing = sqlx::query(
-        "SELECT status, attempts, next_run_at::TEXT AS next_run_at, error,
-                last_seen_block_number::TEXT AS last_seen_block_number, pending_after_lock,
-                pending_after_lock_block_number::TEXT AS pending_after_lock_block_number,
-                pending_after_lock_block_timestamp::TEXT AS pending_after_lock_block_timestamp,
-                pending_after_lock_transaction_hash
+    let pending_count_after_drain: i64 = sqlx::query_scalar(
+        "SELECT count(*)::BIGINT
          FROM onchain_refresh_task
-         WHERE contract_set_id = $1 AND account = $2",
+         WHERE contract_set_id = $1 AND status = 'pending'",
     )
     .bind(CONTRACT_SET_ID)
-    .bind(&deferred_processing_account)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(processing.get::<String, _>("status"), "processing");
-    assert_eq!(processing.get::<i32, _>("attempts"), 5);
-    assert_eq!(processing.get::<String, _>("next_run_at"), "999");
-    assert_eq!(
-        processing.get::<Option<String>, _>("error"),
-        Some("rpc still running".to_owned())
-    );
-    assert_eq!(
-        processing.get::<String, _>("last_seen_block_number"),
-        (30 + (DENSE_CANDIDATE_COUNT - 1) as u64).to_string()
-    );
-    assert!(processing.get::<bool, _>("pending_after_lock"));
-    assert_eq!(
-        processing.get::<Option<String>, _>("pending_after_lock_block_number"),
-        Some((30 + (DENSE_CANDIDATE_COUNT - 1) as u64).to_string())
-    );
-    assert_eq!(
-        processing.get::<Option<String>, _>("pending_after_lock_block_timestamp"),
-        Some((1_700_000_000_000 + (30 + (DENSE_CANDIDATE_COUNT - 1) as u64) * 1_000).to_string())
-    );
-    assert_eq!(
-        processing.get::<Option<String>, _>("pending_after_lock_transaction_hash"),
-        Some(format!("0xtx{}0", 30 + (DENSE_CANDIDATE_COUNT - 1) as u64))
-    );
+    assert_eq!(pending_count_after_drain, EXPECTED_MATERIALIZED_BATCH);
 
     database.cleanup().await?;
 

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -14,10 +14,11 @@ use std::{
 
 use degov_datalens_indexer::{
     BatchReadPlanConfig, CallExecutedEvent, CallScheduledEvent, ChainContracts, ChainReadMethod,
-    DecodedGovernorEvent, DecodedTimelockEvent, DecodedTokenEvent, DelegateChangedEvent,
-    DelegateVotesChangedEvent, GovernanceTokenStandard, IndexerProjectionBatch, IndexerRunnerStore,
-    IndexerRunnerTransaction, NormalizedEvmLog, PostgresIndexerRunnerStore, ProposalCreatedEvent,
-    ProposalExtendedEvent, ProposalProjectionContext, ProposalProjectionEvent, ProposalQueuedEvent,
+    DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS, DecodedGovernorEvent, DecodedTimelockEvent,
+    DecodedTokenEvent, DelegateChangedEvent, DelegateVotesChangedEvent, GovernanceTokenStandard,
+    IndexerProjectionBatch, IndexerRunnerStore, IndexerRunnerTransaction, NormalizedEvmLog,
+    PostgresIndexerRunnerStore, ProposalCreatedEvent, ProposalExtendedEvent,
+    ProposalProjectionContext, ProposalProjectionEvent, ProposalQueuedEvent,
     TimelockProjectionContext, TimelockProjectionEvent, TimelockProposalLinkContext,
     TokenProjectionContext, TokenProjectionEvent, TokenTransferEvent, VoteCastEvent,
     VoteProjectionContext, VoteProjectionEvent, project_proposal_events, project_timelock_events,
@@ -1257,7 +1258,7 @@ async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
 -> Result<(), Box<dyn Error>> {
     const DENSE_EVENT_COUNT: usize = 1_205;
     const DENSE_UNIQUE_ACCOUNT_COUNT: usize = 150;
-    const EXPECTED_MATERIALIZED_BATCH: i64 = 100;
+    const EXPECTED_MATERIALIZED_BATCH: i64 = DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS as i64;
 
     let database = TestDatabase::connect().await?;
     let mut store = PostgresIndexerRunnerStore::new(database.pool.clone())


### PR DESCRIPTION
## Summary
- HBX-412: buffer onchain refresh candidates in the deferred table first instead of inline-materializing pending task rows during projection.
- Gate deferred drains by `next_run_at` and cap materialization at the shared 100-row smoothing batch for runner/worker drains.
- Extend dense PostgreSQL coverage for duplicate-heavy candidate sets, debounce-window dedupe, bounded pending backlog, and deferred drain materialization.

## Validation
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@localhost:7432/datalens_test cargo test --locked -p degov-datalens-indexer`
- `cargo build --locked -p degov-datalens-indexer`
- `node ./apps/indexer/scripts/check-rust-conventions.mjs`
- `node ./apps/indexer/scripts/check-rust-conventions.test.mjs`
- `node ./apps/indexer/scripts/compatibility-preflight.test.mjs`