### PR TITLE
perf(indexer): dedupe dense token projection metadata

### DIFF
--- a/apps/indexer/src/store/postgres/data_metric.rs
+++ b/apps/indexer/src/store/postgres/data_metric.rs
@@ -18,11 +18,13 @@ async fn write_data_metric_timeline(
         .collect::<HashSet<_>>();
     let mut delegate_mapping_cache = DelegateMappingCache::default();
     let mut contributor_ensure_cache = ContributorEnsureCache::default();
+    let mut token_metadata_cache = BatchTokenMetadataCache::default();
     let mut items = Vec::new();
     if let Some(token) = token {
         contributor_ensure_cache
             .preload_batch(transaction, token, &inserted_operation_keys)
             .await?;
+        token_metadata_cache = BatchTokenMetadataCache::preload(transaction, token).await?;
         items.extend(token.operations.iter().map(DataMetricTimelineItem::Token));
     }
     if let Some(proposal) = proposal {
@@ -46,6 +48,7 @@ async fn write_data_metric_timeline(
                         transaction,
                         &mut delegate_mapping_cache,
                         &mut contributor_ensure_cache,
+                        &mut token_metadata_cache,
                         operation,
                     )
                     .await?;

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -25,8 +25,9 @@ async fn write_token_batch_rows(
     for row in &batch.delegate_rollings {
         upsert_delegate_rolling(transaction, row).await?;
     }
+    let mut metadata_cache = BatchTokenMetadataCache::preload(transaction, batch).await?;
     for row in &batch.delegate_votes_changed {
-        insert_vote_power_checkpoint(transaction, row).await?;
+        insert_vote_power_checkpoint(transaction, &mut metadata_cache, row).await?;
     }
     Ok(inserted_operation_keys)
 }
@@ -225,22 +226,14 @@ async fn upsert_delegate_rolling(
 
 async fn insert_vote_power_checkpoint(
     transaction: &mut Transaction<'_, Postgres>,
+    metadata_cache: &mut BatchTokenMetadataCache,
     row: &DelegateVotesChangedWrite,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     let delta = signed_decimal_delta(transaction, &row.new_votes, &row.previous_votes).await?;
-    let rollings = transaction_rollings(transaction, &row.common).await?;
-    let transfers_count: i64 = sqlx::query(
-        "SELECT count(*)::BIGINT
-             FROM token_transfer
-             WHERE contract_set_id = $1 AND transaction_hash = $2",
-    )
-    .bind(&row.common.contract_set_id)
-    .bind(&row.common.transaction_hash)
-    .fetch_one(&mut **transaction)
-    .await?
-    .get(0);
+    let rollings = metadata_cache.rollings(&row.common);
+    let transfers_count = metadata_cache.transfer_count(&row.common);
     let rolling_match =
-        find_rolling_match_from_rows(&rollings, &row.delegate, &delta, row.common.log_index);
+        find_rolling_match_from_rows(rollings, &row.delegate, &delta, row.common.log_index);
     let cause = vote_power_checkpoint_cause(!rollings.is_empty(), transfers_count > 0);
 
     sqlx::query(
@@ -301,6 +294,7 @@ async fn apply_token_operation(
     transaction: &mut Transaction<'_, Postgres>,
     delegate_mapping_cache: &mut DelegateMappingCache,
     contributor_ensure_cache: &mut ContributorEnsureCache,
+    metadata_cache: &mut BatchTokenMetadataCache,
     operation: &TokenProjectionOperation,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     match operation {
@@ -337,6 +331,7 @@ async fn apply_token_operation(
                 previous_votes,
                 new_votes,
                 contributor_ensure_cache,
+                metadata_cache,
             )
             .await
         }
@@ -447,11 +442,11 @@ async fn apply_delegate_votes_changed_operation(
     previous_votes: &str,
     new_votes: &str,
     contributor_ensure_cache: &mut ContributorEnsureCache,
+    metadata_cache: &mut BatchTokenMetadataCache,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     let delta = signed_decimal_delta(transaction, new_votes, previous_votes).await?;
-    let rollings = transaction_rollings(transaction, common).await?;
-    let Some(rolling_match) =
-        find_rolling_match_from_rows(&rollings, delegate, &delta, common.log_index)
+    let rollings = metadata_cache.rollings(common);
+    let Some(rolling_match) = find_rolling_match_from_rows(rollings, delegate, &delta, common.log_index)
     else {
         return Ok(());
     };
@@ -470,6 +465,7 @@ async fn apply_delegate_votes_changed_operation(
             .bind(&common.contract_set_id)
             .execute(&mut **transaction)
             .await?;
+            metadata_cache.mark_rolling_match(common, &rolling_match, new_votes);
             apply_delegate_delta(
                 transaction,
                 delegate_mapping_cache,
@@ -494,6 +490,7 @@ async fn apply_delegate_votes_changed_operation(
             .bind(&common.contract_set_id)
             .execute(&mut **transaction)
             .await?;
+            metadata_cache.mark_rolling_match(common, &rolling_match, new_votes);
             apply_delegate_delta(
                 transaction,
                 delegate_mapping_cache,
@@ -1224,6 +1221,191 @@ struct DelegateRollingMatch {
     side: RollingSide,
 }
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct TransactionMetadataKey {
+    contract_set_id: String,
+    transaction_hash: String,
+}
+
+impl TransactionMetadataKey {
+    fn new(common: &TokenEventCommon) -> Self {
+        Self {
+            contract_set_id: common.contract_set_id.clone(),
+            transaction_hash: common.transaction_hash.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct BatchTokenMetadataCache {
+    transfer_counts: HashMap<TransactionMetadataKey, i64>,
+    rollings: HashMap<TransactionMetadataKey, Vec<DelegateRollingSnapshot>>,
+}
+
+impl BatchTokenMetadataCache {
+    async fn preload(
+        transaction: &mut Transaction<'_, Postgres>,
+        batch: &TokenProjectionBatch,
+    ) -> Result<Self, PostgresIndexerRunnerStoreError> {
+        let keys = collect_transaction_metadata_keys(batch);
+        let mut cache = Self::default();
+        cache.preload_transfer_counts(transaction, &keys).await?;
+        cache.preload_rollings(transaction, &keys).await?;
+        Ok(cache)
+    }
+
+    fn transfer_count(&self, common: &TokenEventCommon) -> i64 {
+        self.transfer_counts
+            .get(&TransactionMetadataKey::new(common))
+            .copied()
+            .unwrap_or_default()
+    }
+
+    fn rollings(&self, common: &TokenEventCommon) -> &[DelegateRollingSnapshot] {
+        self.rollings
+            .get(&TransactionMetadataKey::new(common))
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    fn mark_rolling_match(
+        &mut self,
+        common: &TokenEventCommon,
+        rolling_match: &DelegateRollingMatch,
+        new_votes: &str,
+    ) {
+        let Some(rollings) = self.rollings.get_mut(&TransactionMetadataKey::new(common)) else {
+            return;
+        };
+        let Some(rolling) = rollings
+            .iter_mut()
+            .find(|rolling| rolling.id == rolling_match.id)
+        else {
+            return;
+        };
+        match rolling_match.side {
+            RollingSide::From => {
+                rolling.from_new_votes = Some(new_votes.to_owned());
+            }
+            RollingSide::To => {
+                rolling.to_new_votes = Some(new_votes.to_owned());
+            }
+        }
+    }
+
+    async fn preload_transfer_counts(
+        &mut self,
+        transaction: &mut Transaction<'_, Postgres>,
+        keys: &[TransactionMetadataKey],
+    ) -> Result<(), PostgresIndexerRunnerStoreError> {
+        for key in keys {
+            self.transfer_counts.entry(key.clone()).or_default();
+        }
+        for (contract_set_id, transaction_hashes) in group_transaction_hashes_by_contract_set(keys) {
+            let rows = sqlx::query(
+                "SELECT transaction_hash, count(*)::BIGINT AS transfer_count
+                 FROM token_transfer
+                 WHERE contract_set_id = $1 AND transaction_hash = ANY($2)
+                 GROUP BY transaction_hash",
+            )
+            .bind(&contract_set_id)
+            .bind(&transaction_hashes)
+            .fetch_all(&mut **transaction)
+            .await?;
+            for row in rows {
+                self.transfer_counts.insert(
+                    TransactionMetadataKey {
+                        contract_set_id: contract_set_id.clone(),
+                        transaction_hash: row.get("transaction_hash"),
+                    },
+                    row.get("transfer_count"),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn preload_rollings(
+        &mut self,
+        transaction: &mut Transaction<'_, Postgres>,
+        keys: &[TransactionMetadataKey],
+    ) -> Result<(), PostgresIndexerRunnerStoreError> {
+        for key in keys {
+            self.rollings.entry(key.clone()).or_default();
+        }
+        for (contract_set_id, transaction_hashes) in group_transaction_hashes_by_contract_set(keys) {
+            let rows = sqlx::query(
+                "SELECT transaction_hash, id, log_index, delegator, from_delegate, to_delegate,
+                        from_new_votes::TEXT AS from_new_votes,
+                        to_new_votes::TEXT AS to_new_votes
+                 FROM delegate_rolling
+                 WHERE contract_set_id = $1
+                   AND transaction_hash = ANY($2)
+                   AND from_delegate <> to_delegate
+                 ORDER BY transaction_hash, log_index DESC",
+            )
+            .bind(&contract_set_id)
+            .bind(&transaction_hashes)
+            .fetch_all(&mut **transaction)
+            .await?;
+            for row in rows {
+                self.rollings
+                    .entry(TransactionMetadataKey {
+                        contract_set_id: contract_set_id.clone(),
+                        transaction_hash: row.get("transaction_hash"),
+                    })
+                    .or_default()
+                    .push(DelegateRollingSnapshot {
+                        id: row.get("id"),
+                        log_index: row.get("log_index"),
+                        delegator: row.get("delegator"),
+                        from_delegate: row.get("from_delegate"),
+                        to_delegate: row.get("to_delegate"),
+                        from_new_votes: row.get("from_new_votes"),
+                        to_new_votes: row.get("to_new_votes"),
+                    });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn collect_transaction_metadata_keys(batch: &TokenProjectionBatch) -> Vec<TransactionMetadataKey> {
+    let mut keys = Vec::new();
+    let mut seen = HashSet::new();
+    for row in &batch.delegate_votes_changed {
+        let key = TransactionMetadataKey::new(&row.common);
+        if seen.insert(key.clone()) {
+            keys.push(key);
+        }
+    }
+    keys
+}
+
+fn group_transaction_hashes_by_contract_set(
+    keys: &[TransactionMetadataKey],
+) -> Vec<(String, Vec<String>)> {
+    let mut order = Vec::new();
+    let mut grouped = HashMap::<String, Vec<String>>::new();
+    for key in keys {
+        if !grouped.contains_key(&key.contract_set_id) {
+            order.push(key.contract_set_id.clone());
+        }
+        grouped
+            .entry(key.contract_set_id.clone())
+            .or_default()
+            .push(key.transaction_hash.clone());
+    }
+    order
+        .into_iter()
+        .filter_map(|contract_set_id| {
+            grouped
+                .remove(&contract_set_id)
+                .map(|transaction_hashes| (contract_set_id, transaction_hashes))
+        })
+        .collect()
+}
+
 async fn read_delegate_mapping_cached(
     transaction: &mut Transaction<'_, Postgres>,
     delegate_mapping_cache: &mut DelegateMappingCache,
@@ -1260,39 +1442,6 @@ async fn read_delegate_mapping(
         to: row.get("to"),
         power: row.get("power"),
     }))
-}
-
-async fn transaction_rollings(
-    transaction: &mut Transaction<'_, Postgres>,
-    common: &TokenEventCommon,
-) -> Result<Vec<DelegateRollingSnapshot>, PostgresIndexerRunnerStoreError> {
-    let rows = sqlx::query(
-        "SELECT id, log_index, delegator, from_delegate, to_delegate,
-                from_new_votes::TEXT AS from_new_votes,
-                to_new_votes::TEXT AS to_new_votes
-         FROM delegate_rolling
-         WHERE contract_set_id = $1
-           AND transaction_hash = $2
-           AND from_delegate <> to_delegate
-         ORDER BY log_index DESC",
-    )
-    .bind(&common.contract_set_id)
-    .bind(&common.transaction_hash)
-    .fetch_all(&mut **transaction)
-    .await?;
-
-    Ok(rows
-        .into_iter()
-        .map(|row| DelegateRollingSnapshot {
-            id: row.get("id"),
-            log_index: row.get("log_index"),
-            delegator: row.get("delegator"),
-            from_delegate: row.get("from_delegate"),
-            to_delegate: row.get("to_delegate"),
-            from_new_votes: row.get("from_new_votes"),
-            to_new_votes: row.get("to_new_votes"),
-        })
-        .collect())
 }
 
 fn find_rolling_match_from_rows(
@@ -1508,6 +1657,154 @@ mod token_store_tests {
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].account, "0x00000000000000000000000000000000000000aa");
+    }
+
+    #[test]
+    fn test_collect_transaction_metadata_keys_dedupes_repeated_transaction_hashes() {
+        let common = token_common("scope", "0xtx1", 10, 1);
+        let batch = TokenProjectionBatch {
+            event_order: Vec::new(),
+            delegate_changed: Vec::new(),
+            delegate_votes_changed: vec![
+                delegate_votes_changed("a", common.clone(), "0xdelegate1", "0", "1"),
+                delegate_votes_changed("b", common.clone(), "0xdelegate2", "1", "2"),
+                delegate_votes_changed(
+                    "c",
+                    token_common("scope", "0xtx2", 12, 3),
+                    "0xdelegate3",
+                    "2",
+                    "3",
+                ),
+                delegate_votes_changed(
+                    "d",
+                    token_common("other-scope", "0xtx1", 13, 4),
+                    "0xdelegate4",
+                    "3",
+                    "4",
+                ),
+            ],
+            token_transfers: Vec::new(),
+            delegate_rollings: Vec::new(),
+            operations: Vec::new(),
+            reconcile_plan: empty_reconcile_plan(),
+        };
+
+        let keys = collect_transaction_metadata_keys(&batch);
+
+        assert_eq!(
+            keys,
+            vec![
+                TransactionMetadataKey {
+                    contract_set_id: "scope".to_owned(),
+                    transaction_hash: "0xtx1".to_owned(),
+                },
+                TransactionMetadataKey {
+                    contract_set_id: "scope".to_owned(),
+                    transaction_hash: "0xtx2".to_owned(),
+                },
+                TransactionMetadataKey {
+                    contract_set_id: "other-scope".to_owned(),
+                    transaction_hash: "0xtx1".to_owned(),
+                },
+            ]
+        );
+        assert_eq!(
+            group_transaction_hashes_by_contract_set(&keys),
+            vec![
+                (
+                    "scope".to_owned(),
+                    vec!["0xtx1".to_owned(), "0xtx2".to_owned()]
+                ),
+                ("other-scope".to_owned(), vec!["0xtx1".to_owned()]),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_batch_token_metadata_cache_marks_repeated_delegate_rolling_match_consumed() {
+        let common = token_common("scope", "0xtx1", 10, 5);
+        let key = TransactionMetadataKey::new(&common);
+        let mut cache = BatchTokenMetadataCache {
+            transfer_counts: HashMap::new(),
+            rollings: HashMap::from([(
+                key,
+                vec![DelegateRollingSnapshot {
+                    id: "rolling-1".to_owned(),
+                    log_index: 4,
+                    delegator: "0xdelegator".to_owned(),
+                    from_delegate: "0xfrom".to_owned(),
+                    to_delegate: "0xto".to_owned(),
+                    from_new_votes: None,
+                    to_new_votes: None,
+                }],
+            )]),
+        };
+        let first_match = find_rolling_match_from_rows(cache.rollings(&common), "0xto", "1", 5)
+            .expect("first match should use the to side");
+
+        cache.mark_rolling_match(&common, &first_match, "9");
+        let second_match = find_rolling_match_from_rows(cache.rollings(&common), "0xto", "1", 6);
+
+        assert_eq!(first_match.side, RollingSide::To);
+        assert!(second_match.is_none());
+    }
+
+    fn token_common(
+        contract_set_id: &str,
+        transaction_hash: &str,
+        log_index: u64,
+        transaction_index: u64,
+    ) -> TokenEventCommon {
+        TokenEventCommon {
+            contract_set_id: contract_set_id.to_owned(),
+            chain_id: 1,
+            dao_code: "demo-dao".to_owned(),
+            governor_address: "0xgovernor".to_owned(),
+            token_address: "0xtoken".to_owned(),
+            contract_address: "0xtoken".to_owned(),
+            log_index,
+            transaction_index,
+            block_number: "10".to_owned(),
+            block_timestamp: Some("1000".to_owned()),
+            transaction_hash: transaction_hash.to_owned(),
+        }
+    }
+
+    fn delegate_votes_changed(
+        id: &str,
+        common: TokenEventCommon,
+        delegate: &str,
+        previous_votes: &str,
+        new_votes: &str,
+    ) -> DelegateVotesChangedWrite {
+        DelegateVotesChangedWrite {
+            id: id.to_owned(),
+            common,
+            delegate: delegate.to_owned(),
+            previous_votes: previous_votes.to_owned(),
+            new_votes: new_votes.to_owned(),
+        }
+    }
+
+    fn empty_reconcile_plan() -> crate::PowerReconcilePlan {
+        plan_power_reconcile(
+            &PowerReconcileContext {
+                contract_set_id: "scope".to_owned(),
+                dao_code: "demo-dao".to_owned(),
+                chain_id: 1,
+                contracts: ChainContracts {
+                    governor: "0xgovernor".to_owned(),
+                    governor_token: "0xtoken".to_owned(),
+                    timelock: "0xtimelock".to_owned(),
+                },
+                from_block: 10,
+                to_block: 10,
+                target_height: Some(10),
+                read_plan_config: BatchReadPlanConfig::default().validated(),
+                current_power_method: ChainReadMethod::GetVotes,
+            },
+            &[],
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- preload token transfer counts and delegate rolling rows once per token batch by transaction hash
- reuse the batch-local metadata cache for vote power checkpoints and delegate vote updates
- mark cached delegate rolling sides as consumed after update to preserve event-order-sensitive matching
- add focused unit tests for repeated transaction hashes and repeated delegate rolling cache behavior

## Tests
- cargo test -p degov-datalens-indexer token_store_tests -- --nocapture
- cargo test -p degov-datalens-indexer test_chain_tool_onchain_refresh_reader_dedupes_duplicate_reads_in_one_batch -- --nocapture

Note: cargo test -p degov-datalens-indexer onchain_refresh -- --nocapture was also attempted; non-DB tests passed, but DB integration tests failed because DEGOV_INDEXER_TEST_DATABASE_URL is not set in this environment.