### PR TITLE
fix(indexer): rollback failed runner transactions

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -637,18 +637,37 @@ where
     ) -> Result<OnchainRefreshApplyBatchReport, OnchainRefreshWorkerError> {
         let mut transaction = self.pool.begin().await?;
 
-        let previous_values = read_contributor_refresh_values(&mut transaction, successes).await?;
-        upsert_contributor_refresh(&mut transaction, successes).await?;
-        insert_refresh_checkpoints(
-            &mut transaction,
-            successes,
-            &previous_values,
-            self.current_power_method,
-        )
-        .await?;
-        let data_metric_refreshes = refresh_data_metrics(&mut transaction, successes).await?;
-        let debounced_tasks =
-            complete_tasks(&mut transaction, successes, now_ms, self.config.debounce).await?;
+        let result = async {
+            let previous_values =
+                read_contributor_refresh_values(&mut transaction, successes).await?;
+            upsert_contributor_refresh(&mut transaction, successes).await?;
+            insert_refresh_checkpoints(
+                &mut transaction,
+                successes,
+                &previous_values,
+                self.current_power_method,
+            )
+            .await?;
+            let data_metric_refreshes = refresh_data_metrics(&mut transaction, successes).await?;
+            let debounced_tasks =
+                complete_tasks(&mut transaction, successes, now_ms, self.config.debounce).await?;
+
+            Ok::<_, OnchainRefreshWorkerError>((data_metric_refreshes, debounced_tasks))
+        }
+        .await;
+        let (data_metric_refreshes, debounced_tasks) = match result {
+            Ok(report) => report,
+            Err(error) => {
+                if let Err(rollback_error) = transaction.rollback().await {
+                    log::warn!(
+                        "onchain refresh success batch rollback failed error={} rollback_error={}",
+                        error,
+                        rollback_error
+                    );
+                }
+                return Err(error);
+            }
+        };
 
         transaction.commit().await?;
 
@@ -668,7 +687,16 @@ where
         successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
     ) -> Result<(), OnchainRefreshWorkerError> {
         let mut transaction = self.pool.begin().await?;
-        upsert_live_power_overlays(&mut transaction, successes).await?;
+        if let Err(error) = upsert_live_power_overlays(&mut transaction, successes).await {
+            if let Err(rollback_error) = transaction.rollback().await {
+                log::warn!(
+                    "onchain refresh live power overlay rollback failed error={} rollback_error={}",
+                    error,
+                    rollback_error
+                );
+            }
+            return Err(error.into());
+        }
         transaction.commit().await?;
 
         Ok(())

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -500,6 +500,8 @@ pub trait IndexerRunnerTransaction {
     ) -> Result<(), Self::Error>;
 
     fn commit(self) -> Result<(), Self::Error>;
+
+    fn rollback(self) -> Result<(), Self::Error>;
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -759,16 +761,26 @@ where
                 .store
                 .begin_transaction()
                 .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
-            transaction
-                .apply_projection_batch(&processing.batch)
-                .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
-            transaction
-                .advance_checkpoint(
-                    &self.options.checkpoint_identity,
-                    range.to_block,
-                    Some(effective_target),
-                )
-                .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
+            if let Err(error) = transaction.apply_projection_batch(&processing.batch) {
+                return Err(rollback_transaction_after_error(
+                    &checkpoint_identity,
+                    range,
+                    transaction,
+                    error,
+                ));
+            }
+            if let Err(error) = transaction.advance_checkpoint(
+                &self.options.checkpoint_identity,
+                range.to_block,
+                Some(effective_target),
+            ) {
+                return Err(rollback_transaction_after_error(
+                    &checkpoint_identity,
+                    range,
+                    transaction,
+                    error,
+                ));
+            }
             transaction
                 .commit()
                 .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
@@ -1326,6 +1338,38 @@ fn transaction_error(
     IndexerRunnerError::Transaction(error.to_string())
 }
 
+fn rollback_transaction_after_error<T>(
+    identity: &IndexerCheckpointIdentity,
+    range: CheckpointBlockRange,
+    transaction: T,
+    error: impl fmt::Display,
+) -> IndexerRunnerError
+where
+    T: IndexerRunnerTransaction,
+    T::Error: fmt::Display,
+{
+    let message = error.to_string();
+    if let Err(rollback_error) = transaction.rollback() {
+        error!(
+            "Datalens indexer chunk transaction rollback failed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} from_block={} to_block={} error={} rollback_error={}",
+            identity.dao_code,
+            identity.chain_id,
+            identity.contract_set_id,
+            identity.stream_id,
+            identity.data_source_version,
+            range.from_block,
+            range.to_block,
+            message,
+            rollback_error
+        );
+        return IndexerRunnerError::Transaction(format!(
+            "{message}; rollback failed: {rollback_error}"
+        ));
+    }
+
+    transaction_error(identity, range, message)
+}
+
 fn range_block_count(range: CheckpointBlockRange) -> u32 {
     range
         .to_block
@@ -1366,6 +1410,8 @@ pub struct InMemoryIndexerRunnerStore {
     token_repository: InMemoryTokenProjectionRepository,
     timelock_repository: InMemoryTimelockProjectionRepository,
     commit_count: u64,
+    rollback_count: u64,
+    apply_failures: VecDeque<String>,
     commit_failures: VecDeque<String>,
 }
 
@@ -1378,6 +1424,8 @@ impl InMemoryIndexerRunnerStore {
             token_repository: InMemoryTokenProjectionRepository::default(),
             timelock_repository: InMemoryTimelockProjectionRepository::default(),
             commit_count: 0,
+            rollback_count: 0,
+            apply_failures: VecDeque::new(),
             commit_failures: VecDeque::new(),
         }
     }
@@ -1388,6 +1436,14 @@ impl InMemoryIndexerRunnerStore {
 
     pub fn commit_count(&self) -> u64 {
         self.commit_count
+    }
+
+    pub fn rollback_count(&self) -> u64 {
+        self.rollback_count
+    }
+
+    pub fn fail_next_apply(&mut self, message: impl Into<String>) {
+        self.apply_failures.push_back(message.into());
     }
 
     pub fn fail_next_commit(&mut self, message: impl Into<String>) {
@@ -1482,6 +1538,9 @@ impl IndexerRunnerTransaction for InMemoryIndexerRunnerTransaction<'_> {
         &mut self,
         batch: &IndexerProjectionBatch,
     ) -> Result<(), Self::Error> {
+        if let Some(message) = self.store.apply_failures.pop_front() {
+            return Err(InMemoryIndexerRunnerStoreError::new(message));
+        }
         if let Some(batch) = &batch.proposal {
             let repository = self
                 .proposal_repository
@@ -1570,6 +1629,11 @@ impl IndexerRunnerTransaction for InMemoryIndexerRunnerTransaction<'_> {
             self.store.checkpoint = Some(checkpoint);
         }
         self.store.commit_count += 1;
+        Ok(())
+    }
+
+    fn rollback(self) -> Result<(), Self::Error> {
+        self.store.rollback_count += 1;
         Ok(())
     }
 }

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -158,6 +158,15 @@ impl IndexerRunnerTransaction for PostgresIndexerRunnerTransaction<'_> {
 
         block_on_runtime(transaction.commit()).map_err(PostgresIndexerRunnerStoreError::from)
     }
+
+    fn rollback(mut self) -> Result<(), Self::Error> {
+        let transaction = self
+            .transaction
+            .take()
+            .ok_or_else(|| PostgresIndexerRunnerStoreError::new("transaction is closed"))?;
+
+        block_on_runtime(transaction.rollback()).map_err(PostgresIndexerRunnerStoreError::from)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -244,6 +244,30 @@ fn test_runner_keeps_checkpoint_unchanged_when_transaction_fails() {
 }
 
 #[test]
+fn test_runner_rolls_back_when_projection_write_fails() {
+    let tick_blocks = Arc::new(Mutex::new(Vec::new()));
+    let tick = RecordingOnchainRefreshTick {
+        blocks: Arc::clone(&tick_blocks),
+    };
+    let mut runner =
+        runner(vec![vec![row(1, 0, 0)]], ScriptedDecoder).with_onchain_refresh_tick(Box::new(tick));
+    runner
+        .store_mut()
+        .fail_next_apply("projection write failed");
+
+    let error = runner.run_to_target(1).expect_err("projection write fails");
+
+    assert!(error.to_string().contains("projection write failed"));
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        1
+    );
+    assert_eq!(runner.store().commit_count(), 0);
+    assert_eq!(runner.store().rollback_count(), 1);
+    assert_eq!(*tick_blocks.lock().expect("tick blocks"), Vec::<i64>::new());
+}
+
+#[test]
 fn test_runner_runs_onchain_refresh_tick_after_chunk_commit() {
     let tick_blocks = Arc::new(Mutex::new(Vec::new()));
     let tick = RecordingOnchainRefreshTick {

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -528,6 +528,10 @@ impl IndexerRunnerTransaction for CapturingTransaction<'_> {
 
         Ok(())
     }
+
+    fn rollback(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -578,6 +578,54 @@ async fn test_onchain_refresh_worker_marks_claimed_tasks_failed_when_reader_fail
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_rolls_back_when_apply_fails() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        false,
+        true,
+    )
+    .await?;
+
+    let reader = MockOnchainRefreshReader::new([(
+        "task-one",
+        OnchainRefreshReadValue {
+            task_id: "task-one".to_owned(),
+            balance: None,
+            power: Some("not-a-number".to_owned()),
+        },
+    )]);
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            max_attempts: 3,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.claimed, 1);
+    assert_eq!(report.completed, 0);
+    assert_eq!(report.failed, 1);
+    assert_failed_task_error_contains(&database.pool, "task-one", "invalid input syntax").await?;
+    assert_eq!(idle_transaction_count(&database.pool).await?, 0);
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_checkpoint_ids_include_scope() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_task_with_scope(
@@ -1581,6 +1629,29 @@ async fn assert_failed_task_error_contains(
     );
 
     Ok(())
+}
+
+async fn idle_transaction_count(_pool: &PgPool) -> Result<i64, sqlx::Error> {
+    let database_url = env::var("DEGOV_INDEXER_TEST_DATABASE_URL").map_err(|error| {
+        sqlx::Error::Configuration(
+            format!("DEGOV_INDEXER_TEST_DATABASE_URL is required: {error}").into(),
+        )
+    })?;
+    let probe_pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await?;
+    let row = sqlx::query(
+        "SELECT count(*)::BIGINT AS count
+         FROM pg_stat_activity
+         WHERE datname = current_database()
+           AND pid <> pg_backend_pid()
+           AND state = 'idle in transaction'",
+    )
+    .fetch_one(&probe_pool)
+    .await?;
+
+    Ok(row.get("count"))
 }
 
 async fn assert_data_metric(


### PR DESCRIPTION
## Root cause

HBX-418 traced the local empty-DB stall to an open PostgreSQL transaction in the Datalens indexer runner. The runner transaction interface only exposed `commit(self)`, so errors from `apply_projection_batch` or `advance_checkpoint` returned through the runner without an explicit rollback. In multi-DAO all-mode this can leave a connection idle in transaction while holding row/transaction locks from contributor/delegate/data_metric writes, blocking unrelated DAO writers.

The onchain refresh apply path had the same lifecycle risk on mid-transaction write failures: it relied on transaction drop cleanup instead of explicitly rolling back before returning the error.

## Fix

- Add explicit `rollback(self)` to `IndexerRunnerTransaction`.
- Roll back projection transactions immediately when projection writes or checkpoint advance fail.
- Implement rollback for `PostgresIndexerRunnerTransaction` and in-memory test transactions.
- Explicitly roll back onchain refresh success-batch and live-power-overlay write transactions when an apply step fails.
- Preserve PR #837 behavior: inline onchain refresh tick batching remains capped by `DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN`.
- Preserve existing onchain duplicate-read optimization; this change does not alter chain read planning or account dedupe.

## Tests run

```bash
cargo fmt --all -- --check
CARGO_TARGET_DIR=/code/helixbox/degov-worktrees/hbx-418-fix-runner-db-transaction-stall/target cargo test -p degov-datalens-indexer --locked --test indexer_runner -- --nocapture
CARGO_TARGET_DIR=/code/helixbox/degov-worktrees/hbx-418-fix-runner-db-transaction-stall/target cargo test -p degov-datalens-indexer --locked --test native_runner_integration -- --nocapture
DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@localhost:7432/degov_datalens_test CARGO_TARGET_DIR=/code/helixbox/degov-worktrees/hbx-418-fix-runner-db-transaction-stall/target cargo test -p degov-datalens-indexer --locked --test onchain_refresh_worker -- --nocapture
```

## Local validation guidance

After merge, restart the local empty-DB runner and monitor:

- `pg_stat_activity` should not show long-lived `idle in transaction` blockers for the runner DB.
- `degov_indexer_checkpoint` should keep advancing across DAOs instead of stalling after the first write conflict.
- Inline onchain refresh logs should continue to show small capped batches, not a single 1000-task batch.
- `onchain_refresh_task` should show processed/failed/pending changing over time rather than being blocked behind one open transaction.

Refs HBX-418.
