### PR TITLE
fix(indexer): inherit onchain refresh run budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,9 @@ DEGOV_ONCHAIN_REFRESH_CURRENT_POWER_METHOD=getVotes
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED=false
 # Total task budget per indexer tick.
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS=10
-# Per worker run/claim budget inside one tick. Leave unset to inherit MAX_TASKS.
-DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN=10
+# Optional per worker run/claim budget inside one tick.
+# Leave commented to inherit MAX_TASKS; uncommenting pins the per-run cap.
+# DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN=10
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_DURATION_MS=500
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MIN_BLOCKS=100
 

--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,9 @@ DEGOV_ONCHAIN_REFRESH_CURRENT_POWER_METHOD=getVotes
 # Bounded onchain refresh ticks during Datalens indexer chunk sync.
 # Disabled by default; enable only when RPC URLs are configured.
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED=false
+# Total task budget per indexer tick.
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS=10
+# Per worker run/claim budget inside one tick. Leave unset to inherit MAX_TASKS.
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN=10
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_DURATION_MS=500
 DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MIN_BLOCKS=100

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -673,15 +673,16 @@ impl OnchainRefreshRuntimeConfig {
 
 fn load_onchain_refresh_tick_config() -> Result<OnchainRefreshTickConfig> {
     let defaults = OnchainRefreshTickConfig::default();
+    let max_tasks_per_tick = optional_env_usize("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS")?
+        .unwrap_or(defaults.max_tasks_per_tick);
     let config = OnchainRefreshTickConfig {
         enabled: optional_env_bool("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED")?
             .unwrap_or(defaults.enabled),
-        max_tasks_per_tick: optional_env_usize("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS")?
-            .unwrap_or(defaults.max_tasks_per_tick),
+        max_tasks_per_tick,
         max_tasks_per_run: optional_env_usize(
             "DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN",
         )?
-        .unwrap_or(defaults.max_tasks_per_run),
+        .unwrap_or(max_tasks_per_tick),
         max_duration_per_tick: Duration::from_millis(
             optional_env_u64("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_DURATION_MS")?
                 .unwrap_or(duration_millis_u64(defaults.max_duration_per_tick)),

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -470,6 +470,27 @@ fn test_indexer_runtime_config_accepts_onchain_refresh_tick_overrides() {
 }
 
 #[test]
+fn test_indexer_runtime_config_inherits_onchain_refresh_tick_run_budget_from_total_budget() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED", Some("true")),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS", Some("1000")),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN", None),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_DURATION_MS", None),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MIN_BLOCKS", None),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(config.onchain_refresh_tick.max_tasks_per_tick, 1000);
+            assert_eq!(config.onchain_refresh_tick.max_tasks_per_run, 1000);
+        },
+    );
+}
+
+#[test]
 fn test_indexer_runtime_config_rejects_enabled_onchain_refresh_tick_zero_total_budget() {
     temp_env::with_vars(
         [


### PR DESCRIPTION
## Summary

Implements HBX-420 under HBX-397.

- Make `DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN` inherit the effective `DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS` value when unset.
- Preserve the existing 10/10 default when both variables are unset.
- Keep explicit `MAX_TASKS_PER_RUN` overrides respected.
- Clarify `.env.example` comments for total tick budget vs per-run/claim budget.

## Validation

- `cargo test -p degov-datalens-indexer --test cli_runtime_config`
- `cargo fmt -p degov-datalens-indexer --check`
- `git diff --check`