### PR TITLE
fix(indexer): batch dense token contributor updates

### DIFF
--- a/apps/indexer/src/store/postgres/data_metric.rs
+++ b/apps/indexer/src/store/postgres/data_metric.rs
@@ -63,6 +63,9 @@ async fn write_data_metric_timeline(
         }
     }
     delegate_mapping_cache.flush(transaction).await?;
+    contributor_ensure_cache
+        .flush_contributor_count_deltas(transaction)
+        .await?;
     contributor_ensure_cache.flush_member_count_increments(transaction).await?;
 
     Ok(())

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -825,45 +825,12 @@ async fn apply_delegate_count_delta(
     contributor_ensure_cache
         .ensure(transaction, delegate, common)
         .await?;
-
-    sqlx::query(
-        "UPDATE contributor
-         SET chain_id = $3, dao_code = $4, governor_address = $5, token_address = $6,
-             contract_address = $7, log_index = $8, transaction_index = $9,
-             block_number = $10::NUMERIC(78, 0), block_timestamp = $11::NUMERIC(78, 0),
-             transaction_hash = $12,
-             delegates_count_all = GREATEST(delegates_count_all + $13, 0),
-             delegates_count_effective = GREATEST(delegates_count_effective + $14, 0)
-         WHERE contract_set_id = $1 AND id = $2",
-    )
-    .bind(&common.contract_set_id)
-    .bind(contributor_ref(delegate))
-    .bind(common.chain_id)
-    .bind(&common.dao_code)
-    .bind(&common.governor_address)
-    .bind(&common.token_address)
-    .bind(&common.contract_address)
-    .bind(u64_to_i32(common.log_index, "contributor.log_index")?)
-    .bind(u64_to_i32(
-        common.transaction_index,
-        "contributor.transaction_index",
-    )?)
-    .bind(&common.block_number)
-    .bind(required_numeric(
-        &common.block_timestamp,
-        "contributor.block_timestamp",
-    )?)
-    .bind(&common.transaction_hash)
-    .bind(i64_to_i32(
+    contributor_ensure_cache.stage_contributor_count_delta(
+        common,
+        delegate,
         all_delta,
-        "contributor.delegates_count_all_delta",
-    )?)
-    .bind(i64_to_i32(
         effective_delta,
-        "contributor.delegates_count_effective_delta",
-    )?)
-    .execute(&mut **transaction)
-    .await?;
+    );
 
     Ok(())
 }
@@ -933,10 +900,12 @@ struct ContributorEnsureInsert {
 struct ContributorEnsureCache {
     ensured: HashSet<(String, String)>,
     pending_member_count_increments: HashMap<(String, String), TokenEventCommon>,
-    member_count_increments: HashMap<DataMetricIncrementScope, DataMetricIncrement>,
+    member_count_increments: std::collections::BTreeMap<DataMetricIncrementScope, DataMetricIncrement>,
+    contributor_count_deltas:
+        std::collections::BTreeMap<ContributorCountDeltaKey, ContributorCountDelta>,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct DataMetricIncrementScope {
     contract_set_id: String,
     chain_id: i32,
@@ -959,6 +928,19 @@ impl From<&TokenEventCommon> for DataMetricIncrementScope {
 struct DataMetricIncrement {
     common: TokenEventCommon,
     count: i32,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct ContributorCountDeltaKey {
+    contract_set_id: String,
+    account: String,
+}
+
+#[derive(Clone, Debug)]
+struct ContributorCountDelta {
+    common: TokenEventCommon,
+    all_delta: i64,
+    effective_delta: i64,
 }
 
 impl ContributorEnsureCache {
@@ -1136,6 +1118,122 @@ impl ContributorEnsureCache {
             });
     }
 
+    fn stage_contributor_count_delta(
+        &mut self,
+        common: &TokenEventCommon,
+        delegate: &str,
+        all_delta: i64,
+        effective_delta: i64,
+    ) {
+        let key = ContributorCountDeltaKey {
+            contract_set_id: common.contract_set_id.clone(),
+            account: contributor_ref(delegate),
+        };
+        self.contributor_count_deltas
+            .entry(key)
+            .and_modify(|delta| {
+                delta.common = common.clone();
+                delta.all_delta += all_delta;
+                delta.effective_delta += effective_delta;
+            })
+            .or_insert_with(|| ContributorCountDelta {
+                common: common.clone(),
+                all_delta,
+                effective_delta,
+            });
+    }
+
+    async fn flush_contributor_count_deltas(
+        &mut self,
+        transaction: &mut Transaction<'_, Postgres>,
+    ) -> Result<(), PostgresIndexerRunnerStoreError> {
+        let deltas = std::mem::take(&mut self.contributor_count_deltas)
+            .into_iter()
+            .collect::<Vec<_>>();
+        if deltas.is_empty() {
+            return Ok(());
+        }
+
+        for rows in deltas.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+            let mut query = QueryBuilder::<Postgres>::new(
+                "UPDATE contributor
+                 SET chain_id = delta.chain_id,
+                     dao_code = delta.dao_code,
+                     governor_address = delta.governor_address,
+                     token_address = delta.token_address,
+                     contract_address = delta.contract_address,
+                     log_index = delta.log_index,
+                     transaction_index = delta.transaction_index,
+                     block_number = delta.block_number,
+                     block_timestamp = delta.block_timestamp,
+                     transaction_hash = delta.transaction_hash,
+                     delegates_count_all = GREATEST(contributor.delegates_count_all + delta.all_delta, 0),
+                     delegates_count_effective = GREATEST(contributor.delegates_count_effective + delta.effective_delta, 0)
+                 FROM (VALUES ",
+            );
+            for (index, (key, delta)) in rows.iter().enumerate() {
+                if index > 0 {
+                    query.push(", ");
+                }
+                let common = &delta.common;
+                query
+                    .push("(")
+                    .push_bind(&key.contract_set_id)
+                    .push(", ")
+                    .push_bind(&key.account)
+                    .push(", ")
+                    .push_bind(common.chain_id)
+                    .push(", ")
+                    .push_bind(&common.dao_code)
+                    .push(", ")
+                    .push_bind(&common.governor_address)
+                    .push(", ")
+                    .push_bind(&common.token_address)
+                    .push(", ")
+                    .push_bind(&common.contract_address)
+                    .push(", ")
+                    .push_bind(u64_to_i32(common.log_index, "contributor.log_index")?)
+                    .push(", ")
+                    .push_bind(u64_to_i32(
+                        common.transaction_index,
+                        "contributor.transaction_index",
+                    )?)
+                    .push(", ")
+                    .push_bind(&common.block_number)
+                    .push("::NUMERIC(78, 0), ")
+                    .push_bind(required_numeric(
+                        &common.block_timestamp,
+                        "contributor.block_timestamp",
+                    )?)
+                    .push("::NUMERIC(78, 0), ")
+                    .push_bind(&common.transaction_hash)
+                    .push(", ")
+                    .push_bind(i64_to_i32(
+                        delta.all_delta,
+                        "contributor.delegates_count_all_delta",
+                    )?)
+                    .push(", ")
+                    .push_bind(i64_to_i32(
+                        delta.effective_delta,
+                        "contributor.delegates_count_effective_delta",
+                    )?)
+                    .push(")");
+            }
+            query.push(
+                ") AS delta(
+                    contract_set_id, id, chain_id, dao_code, governor_address, token_address,
+                    contract_address, log_index, transaction_index, block_number, block_timestamp,
+                    transaction_hash, all_delta, effective_delta
+                 )
+                 WHERE contributor.contract_set_id = delta.contract_set_id
+                   AND contributor.id = delta.id",
+            );
+            query.build().execute(&mut **transaction).await?;
+        }
+
+        Ok(())
+    }
+
     async fn flush_member_count_increments(
         &mut self,
         transaction: &mut Transaction<'_, Postgres>,
@@ -1240,7 +1338,7 @@ struct DelegateMappingSnapshot {
 #[derive(Debug, Default)]
 struct DelegateMappingCache {
     mappings: HashMap<(String, String), Option<DelegateMappingSnapshot>>,
-    dirty: HashMap<(String, String), Option<DelegateMappingSnapshot>>,
+    dirty: std::collections::BTreeMap<(String, String), Option<DelegateMappingSnapshot>>,
 }
 
 impl DelegateMappingCache {

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -787,6 +787,128 @@ async fn test_postgres_token_repeated_delegate_ensure_keeps_member_count_once()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_dense_delegate_count_deltas_are_batched() -> Result<(), Box<dyn Error>>
+{
+    const DENSE_EVENT_COUNT: usize = 1_205;
+
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let token_batch = project_token_events(
+        &token_projection_context(),
+        (0..DENSE_EVENT_COUNT)
+            .map(|index| TokenProjectionEvent {
+                log: normalized_token_log(
+                    &format!("0000000010-dense-delegate-{index}"),
+                    10 + index as u64,
+                    0,
+                    1,
+                ),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: indexed_account(index),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: DELEGATE.to_owned(),
+                }),
+            })
+            .collect(),
+    )
+    .map_err(|error| format!("dense token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(token_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let delegate_counts = sqlx::query(
+        "SELECT delegates_count_all, delegates_count_effective
+         FROM contributor
+         WHERE contract_set_id = $1 AND id = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(
+        delegate_counts.get::<i32, _>("delegates_count_all"),
+        DENSE_EVENT_COUNT as i32
+    );
+    assert_eq!(
+        delegate_counts.get::<i32, _>("delegates_count_effective"),
+        0
+    );
+
+    let member_count: Option<i32> = sqlx::query_scalar(
+        "SELECT member_count
+         FROM data_metric
+         WHERE contract_set_id = $1 AND id = 'global'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(member_count, Some(1));
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_zero_net_delegate_count_delta_updates_metadata()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let token_batch = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000010-delegate", 10, 0, 1),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: DELEGATOR.to_owned(),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: DELEGATE.to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000011-undelegate", 11, 0, 1),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: DELEGATOR.to_owned(),
+                    from_delegate: DELEGATE.to_owned(),
+                    to_delegate: ZERO_ADDRESS.to_owned(),
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(token_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let contributor = sqlx::query(
+        "SELECT block_number::TEXT AS block_number, transaction_hash,
+                delegates_count_all, delegates_count_effective
+         FROM contributor
+         WHERE contract_set_id = $1 AND id = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(contributor.get::<String, _>("block_number"), "11");
+    assert_eq!(contributor.get::<String, _>("transaction_hash"), "0xtx110");
+    assert_eq!(contributor.get::<i32, _>("delegates_count_all"), 0);
+    assert_eq!(contributor.get::<i32, _>("delegates_count_effective"), 0);
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_token_bulk_writes_dense_events_across_chunks() -> Result<(), Box<dyn Error>>
 {
     let database = TestDatabase::connect().await?;


### PR DESCRIPTION
## Summary

Fixes HBX-423.

ENS dense token chunks can include thousands of token timeline operations. The old projection path updated `contributor.delegates_count_*` once per operation inside the same chunk transaction, which held hot contributor row locks for a long time and made the ENS 13578418-13583417 chunk repeatedly stall/deadlock with concurrent refresh/write work.

This PR keeps checkpoint atomicity unchanged, but changes the token timeline writer to:

- stage contributor delegate count deltas per `(contract_set_id, account)` during the chunk;
- flush the net contributor count deltas once per chunk in deterministic order with a bounded bulk `UPDATE ... FROM (VALUES ...)`;
- make delegate mapping dirty flush ordering deterministic as well;
- keep existing onchain refresh dedupe/task budget behavior untouched.

## Tests

- `cargo test -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token -- --nocapture`
- `env -i HOME="$HOME" PATH="$PATH" CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" RUST_BACKTRACE=0 DEGOV_INDEXER_TEST_DATABASE_URL="$TEST_DB_URL" cargo test -p degov-datalens-indexer`
- `cargo build -p degov-datalens-indexer`

## Validation note

The new regression test covers dense delegate count aggregation semantics. Runtime validation should clear the local DB and rerun the ENS dense chunk to confirm the checkpoint advances past 13578417 and onchain refresh can continue processing without a large lag.