### PR TITLE
fix(indexer): configure onchain refresh deferred drain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,9 @@ DEGOV_ONCHAIN_REFRESH_RUN_ONCE=false
 
 # Number of pending refresh tasks processed per batch.
 DEGOV_ONCHAIN_REFRESH_BATCH_SIZE=100
+# Number of deferred refresh candidates materialized before each worker claim.
+# Increase with BATCH_SIZE/TICK_MAX_TASKS during dense sync, for example 1000.
+DEGOV_ONCHAIN_REFRESH_DEFERRED_DRAIN_BATCH_SIZE=100
 DEGOV_ONCHAIN_REFRESH_MAX_ATTEMPTS=3
 
 # Number of known accounts scanned per reconcile seed pass.

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -140,5 +140,6 @@ pub use runtime_config::{
     IndexerContractSetMode, IndexerContractSetRuntimeConfig, IndexerRuntimeConfig,
     IndexerTargetHeight, OnchainRefreshRpcChainConfig, OnchainRefreshRuntimeConfig,
     ProvisionalRuntimeConfig, datalens_retry_config, onchain_refresh_debounce_from_env,
-    onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value, required_env,
+    onchain_refresh_deferred_drain_batch_size_from_env, onchain_refresh_worker_enabled,
+    parse_bool_env_value, parse_i64_env_value, required_env,
 };

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -20,9 +20,7 @@ use crate::{
     PartialChainReadFailureReport, ProvisionalContributorPowerOverlayWrite,
     ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
     ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ReadRequirement,
-    store::postgres::{
-        DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS, drain_deferred_onchain_refresh_tasks,
-    },
+    store::postgres::drain_deferred_onchain_refresh_tasks,
 };
 
 const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = 1_000;
@@ -31,6 +29,7 @@ const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = 1_000;
 pub struct OnchainRefreshWorkerConfig {
     pub batch_size: usize,
     pub max_attempts: i32,
+    pub deferred_drain_batch_size: usize,
     pub debounce: Duration,
     pub lock_ttl: Duration,
     pub retry_delay: Duration,
@@ -436,16 +435,17 @@ where
         let started_at = Instant::now();
         let now_ms = unix_time_millis();
         let deferred_drain_started_at = Instant::now();
-        let deferred_drain_count = drain_deferred_onchain_refresh_tasks(
-            &self.pool,
-            DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS,
-        )
-        .await
-        .map_err(|error| OnchainRefreshWorkerError::DeferredDrain(error.to_string()))?;
+        let deferred_drain_batch_size =
+            worker_deferred_drain_batch_size(self.config.deferred_drain_batch_size, batch_size);
+        let deferred_drain_count =
+            drain_deferred_onchain_refresh_tasks(&self.pool, deferred_drain_batch_size)
+                .await
+                .map_err(|error| OnchainRefreshWorkerError::DeferredDrain(error.to_string()))?;
         if deferred_drain_count > 0 {
             log::info!(
-                "onchain refresh worker materialized deferred tasks deferred_drain_count={} deferred_drain_duration_ms={}",
+                "onchain refresh worker materialized deferred tasks deferred_drain_count={} deferred_drain_batch_size={} deferred_drain_duration_ms={}",
                 deferred_drain_count,
+                deferred_drain_batch_size,
                 deferred_drain_started_at.elapsed().as_millis()
             );
         }
@@ -780,6 +780,13 @@ where
 
         Ok(())
     }
+}
+
+fn worker_deferred_drain_batch_size(
+    configured_batch_size: usize,
+    claim_batch_size: usize,
+) -> usize {
+    configured_batch_size.max(claim_batch_size)
 }
 
 #[derive(Clone)]
@@ -2646,6 +2653,12 @@ mod tests {
             .expect("hex proposal id encodes");
 
         assert_eq!(hex, decimal);
+    }
+
+    #[test]
+    fn test_worker_deferred_drain_batch_size_tracks_claim_budget() {
+        assert_eq!(worker_deferred_drain_batch_size(100, 1_000), 1_000);
+        assert_eq!(worker_deferred_drain_batch_size(2_000, 1_000), 2_000);
     }
 
     #[test]

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -26,7 +26,6 @@ use crate::{
 
 use crate::OnchainRefreshTickReport;
 use crate::checkpoint::configured_range_progress;
-use crate::store::postgres::DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS;
 
 #[derive(Clone, Debug)]
 pub struct IndexerRunnerOptions {
@@ -37,6 +36,7 @@ pub struct IndexerRunnerOptions {
     pub safe_height: Option<i64>,
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerConfig,
+    pub onchain_refresh_deferred_drain_batch_size: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -786,10 +786,9 @@ where
                 .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
             let write_duration = write_started_at.elapsed();
             let deferred_drain_started_at = Instant::now();
-            let deferred_drain_count = match self
-                .store
-                .drain_deferred_onchain_refresh_tasks(DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS)
-            {
+            let deferred_drain_count = match self.store.drain_deferred_onchain_refresh_tasks(
+                self.options.onchain_refresh_deferred_drain_batch_size,
+            ) {
                 Ok(count) => count,
                 Err(error) => {
                     warn!(
@@ -828,7 +827,7 @@ where
                 self.options.progress_refresh_lag_blocks,
             );
             info!(
-                "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={} adaptive_cache_full_hit_count={} adaptive_cache_partial_hit_count={} adaptive_cache_miss_count={} adaptive_cache_provider_fill_range_count={} adaptive_query_duration_max_ms={} onchain_refresh_deferred_drain_count={} onchain_refresh_deferred_drain_duration_ms={}",
+                "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={} adaptive_cache_full_hit_count={} adaptive_cache_partial_hit_count={} adaptive_cache_miss_count={} adaptive_cache_provider_fill_range_count={} adaptive_query_duration_max_ms={} onchain_refresh_deferred_drain_batch_size={} onchain_refresh_deferred_drain_count={} onchain_refresh_deferred_drain_duration_ms={}",
                 self.options.checkpoint_identity.dao_code,
                 self.options.checkpoint_identity.chain_id,
                 self.options.checkpoint_identity.contract_set_id,
@@ -876,6 +875,7 @@ where
                         .warmup_effectiveness
                         .query_duration_max_ms()
                 ),
+                self.options.onchain_refresh_deferred_drain_batch_size,
                 deferred_drain_count,
                 deferred_drain_duration.as_millis()
             );
@@ -1417,6 +1417,7 @@ pub struct InMemoryIndexerRunnerStore {
     timelock_repository: InMemoryTimelockProjectionRepository,
     commit_count: u64,
     rollback_count: u64,
+    deferred_drain_requests: Vec<usize>,
     apply_failures: VecDeque<String>,
     commit_failures: VecDeque<String>,
 }
@@ -1431,6 +1432,7 @@ impl InMemoryIndexerRunnerStore {
             timelock_repository: InMemoryTimelockProjectionRepository::default(),
             commit_count: 0,
             rollback_count: 0,
+            deferred_drain_requests: Vec::new(),
             apply_failures: VecDeque::new(),
             commit_failures: VecDeque::new(),
         }
@@ -1446,6 +1448,10 @@ impl InMemoryIndexerRunnerStore {
 
     pub fn rollback_count(&self) -> u64 {
         self.rollback_count
+    }
+
+    pub fn deferred_drain_requests(&self) -> &[usize] {
+        &self.deferred_drain_requests
     }
 
     pub fn fail_next_apply(&mut self, message: impl Into<String>) {
@@ -1525,6 +1531,14 @@ impl IndexerRunnerStore for InMemoryIndexerRunnerStore {
             ));
         }
         Ok(links)
+    }
+
+    fn drain_deferred_onchain_refresh_tasks(
+        &mut self,
+        max_rows: usize,
+    ) -> Result<usize, Self::Error> {
+        self.deferred_drain_requests.push(max_rows);
+        Ok(0)
     }
 }
 

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -774,7 +774,10 @@ async fn run_contract_set_pass(
             client = client.with_query_concurrency_gate(gate);
         }
         let store = PostgresIndexerRunnerStore::new(pool)
-            .with_onchain_refresh_debounce(onchain_refresh_debounce);
+            .with_onchain_refresh_debounce(onchain_refresh_debounce)
+            .with_onchain_refresh_deferred_drain_batch_size(
+                runtime.onchain_refresh_deferred_drain_batch_size,
+            );
         let options = runtime
             .options(&config, &contracts)
             .map_err(ContractSetPassError::setup)?;
@@ -986,6 +989,7 @@ mod tests {
             progress_refresh_lag_blocks: 100,
             adaptive_chunk_sizer: Default::default(),
             onchain_refresh_tick: Default::default(),
+            onchain_refresh_deferred_drain_batch_size: 100,
             provisional: ProvisionalRuntimeConfig {
                 enabled: false,
                 finality: DatalensProvisionalFinality::SafeToLatest,

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -11,6 +11,7 @@ use crate::{
     IndexerCheckpointIdentity, IndexerRunnerContexts, IndexerRunnerOptions,
     OnchainRefreshTickConfig, OnchainRefreshWorkerConfig, ProposalProjectionContext, SecretString,
     TimelockProjectionContext, TokenProjectionContext, VoteProjectionContext,
+    store::postgres::DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -150,6 +151,7 @@ pub struct IndexerRuntimeConfig {
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
+    pub onchain_refresh_deferred_drain_batch_size: usize,
     pub provisional: ProvisionalRuntimeConfig,
 }
 
@@ -240,6 +242,7 @@ pub struct IndexerContractSetRuntimeConfig {
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub max_chunks_per_run: Option<u64>,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
+    pub onchain_refresh_deferred_drain_batch_size: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -339,6 +342,8 @@ impl IndexerRuntimeConfig {
             .unwrap_or(100),
             adaptive_chunk_sizer: load_adaptive_chunk_sizer_runtime_config()?,
             onchain_refresh_tick: load_onchain_refresh_tick_config()?,
+            onchain_refresh_deferred_drain_batch_size:
+                onchain_refresh_deferred_drain_batch_size_from_env()?,
             provisional: ProvisionalRuntimeConfig::from_env()?,
             poll_interval,
             run_once,
@@ -407,6 +412,8 @@ impl IndexerRuntimeConfig {
             adaptive_chunk_sizer: self.adaptive_chunk_sizer,
             max_chunks_per_run: self.max_chunks_per_run,
             onchain_refresh_tick: self.onchain_refresh_tick.clone(),
+            onchain_refresh_deferred_drain_batch_size: self
+                .onchain_refresh_deferred_drain_batch_size,
         };
 
         Ok(runtime
@@ -474,6 +481,8 @@ impl IndexerContractSetRuntimeConfig {
             adaptive_chunk_sizer: self
                 .adaptive_chunk_sizer
                 .for_block_range_limit(config.query_limits.block_range_limit),
+            onchain_refresh_deferred_drain_batch_size: self
+                .onchain_refresh_deferred_drain_batch_size,
         })
     }
 
@@ -533,6 +542,7 @@ pub struct OnchainRefreshRuntimeConfig {
     pub batch_size: usize,
     pub max_attempts: i32,
     pub max_batches_per_poll: usize,
+    pub deferred_drain_batch_size: usize,
     pub poll_interval: Duration,
     pub run_once: bool,
     pub debounce: Duration,
@@ -595,6 +605,7 @@ impl OnchainRefreshRuntimeConfig {
         if max_batches_per_poll == 0 {
             bail!("DEGOV_ONCHAIN_REFRESH_MAX_BATCHES_PER_POLL must be greater than zero");
         }
+        let deferred_drain_batch_size = onchain_refresh_deferred_drain_batch_size_from_env()?;
 
         let poll_interval = Duration::from_millis(
             optional_env_u64("DEGOV_ONCHAIN_REFRESH_POLL_INTERVAL_MS")?.unwrap_or(10_000),
@@ -638,6 +649,7 @@ impl OnchainRefreshRuntimeConfig {
             batch_size,
             max_attempts,
             max_batches_per_poll,
+            deferred_drain_batch_size,
             poll_interval,
             run_once,
             debounce,
@@ -663,6 +675,7 @@ impl OnchainRefreshRuntimeConfig {
         OnchainRefreshWorkerConfig {
             batch_size: self.batch_size,
             max_attempts: self.max_attempts,
+            deferred_drain_batch_size: self.deferred_drain_batch_size,
             debounce: self.debounce,
             lock_ttl: self.lock_ttl,
             retry_delay: self.retry_delay,
@@ -1079,6 +1092,16 @@ pub fn onchain_refresh_debounce_from_env() -> Result<Duration> {
     Ok(Duration::from_millis(
         optional_env_u64("DEGOV_ONCHAIN_REFRESH_DEBOUNCE_MS")?.unwrap_or(120_000),
     ))
+}
+
+pub fn onchain_refresh_deferred_drain_batch_size_from_env() -> Result<usize> {
+    let batch_size = optional_env_usize("DEGOV_ONCHAIN_REFRESH_DEFERRED_DRAIN_BATCH_SIZE")?
+        .unwrap_or(DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS);
+    if batch_size == 0 {
+        bail!("DEGOV_ONCHAIN_REFRESH_DEFERRED_DRAIN_BATCH_SIZE must be greater than zero");
+    }
+
+    Ok(batch_size)
 }
 
 fn parse_current_power_method(value: &str) -> Result<ChainReadMethod> {

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -34,6 +34,7 @@ pub struct PostgresIndexerRunnerStore {
     pool: PgPool,
     checkpoint_repository: CheckpointRepository,
     onchain_refresh_debounce: Duration,
+    onchain_refresh_deferred_drain_batch_size: usize,
 }
 
 impl PostgresIndexerRunnerStore {
@@ -42,11 +43,17 @@ impl PostgresIndexerRunnerStore {
             checkpoint_repository: CheckpointRepository::new(pool.clone()),
             pool,
             onchain_refresh_debounce: DEFAULT_ONCHAIN_REFRESH_DEBOUNCE,
+            onchain_refresh_deferred_drain_batch_size: DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS,
         }
     }
 
     pub fn with_onchain_refresh_debounce(mut self, debounce: Duration) -> Self {
         self.onchain_refresh_debounce = debounce;
+        self
+    }
+
+    pub fn with_onchain_refresh_deferred_drain_batch_size(mut self, batch_size: usize) -> Self {
+        self.onchain_refresh_deferred_drain_batch_size = batch_size;
         self
     }
 
@@ -83,6 +90,8 @@ impl IndexerRunnerStore for PostgresIndexerRunnerStore {
             transaction: Some(transaction),
             checkpoint_repository: self.checkpoint_repository.clone(),
             onchain_refresh_debounce: self.onchain_refresh_debounce,
+            onchain_refresh_deferred_drain_batch_size: self
+                .onchain_refresh_deferred_drain_batch_size,
         })
     }
 
@@ -109,6 +118,7 @@ pub struct PostgresIndexerRunnerTransaction<'a> {
     transaction: Option<Transaction<'a, Postgres>>,
     checkpoint_repository: CheckpointRepository,
     onchain_refresh_debounce: Duration,
+    onchain_refresh_deferred_drain_batch_size: usize,
 }
 
 impl IndexerRunnerTransaction for PostgresIndexerRunnerTransaction<'_> {
@@ -127,6 +137,7 @@ impl IndexerRunnerTransaction for PostgresIndexerRunnerTransaction<'_> {
             transaction,
             batch,
             self.onchain_refresh_debounce,
+            self.onchain_refresh_deferred_drain_batch_size,
         ))
     }
 
@@ -213,6 +224,7 @@ async fn write_projection_batch(
     transaction: &mut Transaction<'_, Postgres>,
     batch: &IndexerProjectionBatch,
     onchain_refresh_debounce: Duration,
+    onchain_refresh_deferred_drain_batch_size: usize,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     if let Some(proposal) = &batch.proposal {
         write_proposal_batch_rows(transaction, proposal).await?;
@@ -244,6 +256,7 @@ async fn write_projection_batch(
             transaction,
             &token.reconcile_plan.candidates,
             onchain_refresh_debounce,
+            onchain_refresh_deferred_drain_batch_size,
         )
         .await?;
     }

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -9,12 +9,13 @@ struct OnchainRefreshEnqueuePlan {
     ready_drain_count: usize,
 }
 
-fn plan_onchain_refresh_enqueue(
+fn plan_onchain_refresh_enqueue_with_drain_budget(
     deduped_count: usize,
     debounce: Duration,
+    deferred_drain_batch_size: usize,
 ) -> OnchainRefreshEnqueuePlan {
     let ready_drain_count = if debounce.is_zero() {
-        deduped_count.min(DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS)
+        deduped_count.min(deferred_drain_batch_size)
     } else {
         0
     };
@@ -30,6 +31,7 @@ async fn upsert_onchain_refresh_tasks(
     transaction: &mut Transaction<'_, Postgres>,
     rows: &[PowerReconcileCandidate],
     debounce: Duration,
+    deferred_drain_batch_size: usize,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     let original_count = rows.len();
     let mut rows = dedupe_onchain_refresh_tasks(rows)
@@ -42,7 +44,8 @@ async fn upsert_onchain_refresh_tasks(
         row.next_run_at = next_run_at.to_string();
     }
 
-    let plan = plan_onchain_refresh_enqueue(rows.len(), debounce);
+    let plan =
+        plan_onchain_refresh_enqueue_with_drain_budget(rows.len(), debounce, deferred_drain_batch_size);
     for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
         upsert_deferred_onchain_refresh_candidate_chunk(transaction, chunk, now_ms, next_run_at)
             .await?;
@@ -58,12 +61,14 @@ async fn upsert_onchain_refresh_tasks(
     .await?;
 
     log::info!(
-        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} inline_upsert_count={} deferred_count={} rescheduled_materialized_count={} ready_drain_count={} materialized_count={}",
+        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} deduped_duplicate_count={} inline_upsert_count={} deferred_count={} rescheduled_materialized_count={} ready_drain_batch_size={} ready_drain_count={} materialized_count={}",
         original_count,
         rows.len(),
+        original_count.saturating_sub(rows.len()),
         plan.inline_upsert_count,
         plan.deferred_candidate_count,
         rescheduled_count,
+        deferred_drain_batch_size,
         plan.ready_drain_count,
         drained_count
     );
@@ -89,8 +94,9 @@ pub async fn drain_deferred_onchain_refresh_tasks(
 
     if drained_count > 0 {
         log::info!(
-            "onchain refresh deferred drain completed deferred_drain_count={} deferred_drain_duration_ms={}",
+            "onchain refresh deferred drain completed deferred_drain_count={} deferred_drain_batch_size={} deferred_drain_duration_ms={}",
             drained_count,
+            max_rows,
             started_at.elapsed().as_millis()
         );
     }
@@ -610,15 +616,36 @@ mod tests {
 
     #[test]
     fn test_plan_onchain_refresh_enqueue_buffers_dense_candidates() {
-        let debounced = plan_onchain_refresh_enqueue(1_205, Duration::from_secs(120));
+        let debounced = plan_onchain_refresh_enqueue_with_drain_budget(
+            1_205,
+            Duration::from_secs(120),
+            DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS,
+        );
         assert_eq!(debounced.inline_upsert_count, 0);
         assert_eq!(debounced.deferred_candidate_count, 1_205);
         assert_eq!(debounced.ready_drain_count, 0);
 
-        let immediate = plan_onchain_refresh_enqueue(1_205, Duration::ZERO);
+        let immediate = plan_onchain_refresh_enqueue_with_drain_budget(
+            1_205,
+            Duration::ZERO,
+            DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS,
+        );
         assert_eq!(immediate.inline_upsert_count, 0);
         assert_eq!(immediate.deferred_candidate_count, 1_205);
         assert_eq!(immediate.ready_drain_count, DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS);
+    }
+
+    #[test]
+    fn test_plan_onchain_refresh_enqueue_uses_configured_ready_drain_budget() {
+        let immediate = plan_onchain_refresh_enqueue_with_drain_budget(
+            1_205,
+            Duration::ZERO,
+            1_000,
+        );
+
+        assert_eq!(immediate.inline_upsert_count, 0);
+        assert_eq!(immediate.deferred_candidate_count, 1_205);
+        assert_eq!(immediate.ready_drain_count, 1_000);
     }
 
     fn candidate(

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -65,6 +65,45 @@ fn test_onchain_refresh_runtime_config_accepts_debounce_override() {
 }
 
 #[test]
+fn test_onchain_refresh_runtime_config_accepts_deferred_drain_batch_override() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED", Some("false")),
+            (
+                "DEGOV_ONCHAIN_REFRESH_DEFERRED_DRAIN_BATCH_SIZE",
+                Some("1000"),
+            ),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(config.deferred_drain_batch_size, 1000);
+            assert_eq!(config.worker_config().deferred_drain_batch_size, 1000);
+        },
+    );
+}
+
+#[test]
+fn test_onchain_refresh_runtime_config_rejects_zero_deferred_drain_batch() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED", Some("false")),
+            ("DEGOV_ONCHAIN_REFRESH_DEFERRED_DRAIN_BATCH_SIZE", Some("0")),
+        ],
+        || {
+            let error = OnchainRefreshRuntimeConfig::from_env()
+                .expect_err("zero deferred drain batch is invalid");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("DEGOV_ONCHAIN_REFRESH_DEFERRED_DRAIN_BATCH_SIZE")
+            );
+        },
+    );
+}
+
+#[test]
 fn test_parse_bool_env_value_accepts_runtime_flag_values() {
     assert!(parse_bool_env_value("DEGOV_INDEXER_RUN_ONCE", "yes").expect("yes parses"));
     assert!(!parse_bool_env_value("DEGOV_INDEXER_RUN_ONCE", "0").expect("0 parses"));
@@ -599,6 +638,7 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        onchain_refresh_deferred_drain_batch_size: 100,
         provisional: ProvisionalRuntimeConfig {
             enabled: false,
             finality: DatalensProvisionalFinality::SafeToLatest,
@@ -679,6 +719,7 @@ fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        onchain_refresh_deferred_drain_batch_size: 100,
         provisional: ProvisionalRuntimeConfig {
             enabled: false,
             finality: DatalensProvisionalFinality::SafeToLatest,
@@ -719,6 +760,7 @@ fn test_indexer_runtime_latest_target_height_does_not_skip_all_mode_contract_set
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        onchain_refresh_deferred_drain_batch_size: 100,
         provisional: ProvisionalRuntimeConfig {
             enabled: false,
             finality: DatalensProvisionalFinality::SafeToLatest,

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -283,6 +283,17 @@ fn test_runner_runs_onchain_refresh_tick_after_chunk_commit() {
 }
 
 #[test]
+fn test_runner_drains_deferred_onchain_refresh_with_configured_budget_after_chunk_commit() {
+    let mut options = options();
+    options.onchain_refresh_deferred_drain_batch_size = 1_000;
+    let mut runner = runner_with_decoder(vec![vec![row(1, 0, 0)]], ScriptedDecoder, options);
+
+    runner.run_to_target(1).expect("runner succeeds");
+
+    assert_eq!(runner.store().deferred_drain_requests(), &[1_000]);
+}
+
+#[test]
 fn test_runner_does_not_run_onchain_refresh_tick_when_chunk_commit_fails() {
     let tick_blocks = Arc::new(Mutex::new(Vec::new()));
     let tick = RecordingOnchainRefreshTick {
@@ -1023,6 +1034,7 @@ fn options() -> IndexerRunnerOptions {
         safe_height: None,
         progress_refresh_lag_blocks: 0,
         adaptive_chunk_sizer: AdaptiveChunkSizerConfig::for_max_chunk_size(1),
+        onchain_refresh_deferred_drain_batch_size: 100,
     }
 }
 

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -573,6 +573,7 @@ fn options() -> IndexerRunnerOptions {
         safe_height: None,
         progress_refresh_lag_blocks: 0,
         adaptive_chunk_sizer: AdaptiveChunkSizerConfig::for_max_chunk_size(10),
+        onchain_refresh_deferred_drain_batch_size: 100,
     }
 }
 

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -455,6 +455,7 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            deferred_drain_batch_size: 100,
             debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
@@ -523,6 +524,7 @@ async fn test_onchain_refresh_worker_uses_current_votes_checkpoint_source()
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            deferred_drain_batch_size: 100,
             debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
@@ -564,6 +566,7 @@ async fn test_onchain_refresh_worker_marks_claimed_tasks_failed_when_reader_fail
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            deferred_drain_batch_size: 100,
             debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
@@ -642,6 +645,7 @@ async fn test_onchain_refresh_worker_rolls_back_when_apply_fails() -> Result<(),
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            deferred_drain_batch_size: 100,
             debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
@@ -720,6 +724,7 @@ async fn test_onchain_refresh_worker_checkpoint_ids_include_scope() -> Result<()
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            deferred_drain_batch_size: 100,
             debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
@@ -798,6 +803,7 @@ async fn test_onchain_refresh_worker_updates_only_matching_contract_set_contribu
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            deferred_drain_batch_size: 100,
             debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
@@ -865,6 +871,7 @@ async fn test_onchain_refresh_worker_reschedules_pending_after_lock_with_debounc
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            deferred_drain_batch_size: 100,
             debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),
@@ -1143,6 +1150,7 @@ async fn test_onchain_refresh_worker_fails_only_missing_rpc_chain_group()
         OnchainRefreshWorkerConfig {
             batch_size: 10,
             max_attempts: 3,
+            deferred_drain_batch_size: 100,
             debounce: Duration::from_secs(120),
             lock_ttl: Duration::from_secs(60),
             retry_delay: Duration::from_secs(30),


### PR DESCRIPTION
## Summary
- add DEGOV_ONCHAIN_REFRESH_DEFERRED_DRAIN_BATCH_SIZE with the existing 100-row default
- use the configured drain budget after chunk commits and before worker claims, with worker drains tracking larger claim budgets
- add focused runtime config, drain planning, runner, and worker budget tests plus clearer enqueue/drain logs

Fixes HBX-422.

## Tests
- cargo test -p degov-datalens-indexer --test cli_runtime_config
- cargo test -p degov-datalens-indexer onchain_refresh (non-DB tests passed; DB-backed onchain_refresh_worker tests require DEGOV_INDEXER_TEST_DATABASE_URL locally)
- cargo fmt -p degov-datalens-indexer --check
- git diff --check