### PR TITLE
fix(indexer): scope inline onchain refresh ticks

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -52,10 +52,11 @@ pub use crate::onchain::refresh::{
     ChainToolOnchainRefreshReader, EvmRpcChainTool, LivePowerOverlayReader,
     LivePowerOverlayRefreshError, MultiChainToolOnchainRefreshReader, OnchainRefreshReadReport,
     OnchainRefreshReadValue, OnchainRefreshReader, OnchainRefreshReaderError,
-    OnchainRefreshRunReport, OnchainRefreshTask, OnchainRefreshTickClock, OnchainRefreshTickConfig,
-    OnchainRefreshTickReport, OnchainRefreshTickRunner, OnchainRefreshTickScheduler,
-    OnchainRefreshTickSkipReason, OnchainRefreshWorker, OnchainRefreshWorkerConfig,
-    OnchainRefreshWorkerError, SystemOnchainRefreshTickClock, refresh_live_power_overlays,
+    OnchainRefreshRunReport, OnchainRefreshTask, OnchainRefreshTaskScope, OnchainRefreshTickClock,
+    OnchainRefreshTickConfig, OnchainRefreshTickReport, OnchainRefreshTickRunner,
+    OnchainRefreshTickScheduler, OnchainRefreshTickSkipReason, OnchainRefreshWorker,
+    OnchainRefreshWorkerConfig, OnchainRefreshWorkerError, SystemOnchainRefreshTickClock,
+    refresh_live_power_overlays,
 };
 pub use crate::projection::data_metric::DataMetricWrite;
 pub use crate::projection::power_reconcile::{

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -20,7 +20,9 @@ use crate::{
     PartialChainReadFailureReport, ProvisionalContributorPowerOverlayWrite,
     ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
     ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ReadRequirement,
-    store::postgres::drain_deferred_onchain_refresh_tasks,
+    store::postgres::{
+        drain_deferred_onchain_refresh_tasks, drain_deferred_onchain_refresh_tasks_for_scope,
+    },
 };
 
 const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = 1_000;
@@ -53,6 +55,13 @@ pub struct OnchainRefreshRunReport {
     pub data_metric_refreshes: usize,
     pub duration_ms: u128,
     pub backlog: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OnchainRefreshTaskScope {
+    pub chain_id: i32,
+    pub contract_set_id: String,
+    pub dao_code: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -432,24 +441,61 @@ where
         &self,
         batch_size: usize,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
+        self.run_once_with_batch_size_and_scope(batch_size, None)
+            .await
+    }
+
+    pub async fn run_once_with_batch_size_for_scope(
+        &self,
+        batch_size: usize,
+        scope: &OnchainRefreshTaskScope,
+    ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
+        self.run_once_with_batch_size_and_scope(batch_size, Some(scope))
+            .await
+    }
+
+    async fn run_once_with_batch_size_and_scope(
+        &self,
+        batch_size: usize,
+        scope: Option<&OnchainRefreshTaskScope>,
+    ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
         let started_at = Instant::now();
         let now_ms = unix_time_millis();
         let deferred_drain_started_at = Instant::now();
         let deferred_drain_batch_size =
             worker_deferred_drain_batch_size(self.config.deferred_drain_batch_size, batch_size);
-        let deferred_drain_count =
-            drain_deferred_onchain_refresh_tasks(&self.pool, deferred_drain_batch_size)
+        let deferred_drain_count = match scope {
+            Some(scope) => {
+                drain_deferred_onchain_refresh_tasks_for_scope(
+                    &self.pool,
+                    deferred_drain_batch_size,
+                    scope,
+                )
                 .await
-                .map_err(|error| OnchainRefreshWorkerError::DeferredDrain(error.to_string()))?;
+            }
+            None => {
+                drain_deferred_onchain_refresh_tasks(&self.pool, deferred_drain_batch_size).await
+            }
+        }
+        .map_err(|error| OnchainRefreshWorkerError::DeferredDrain(error.to_string()))?;
         if deferred_drain_count > 0 {
             log::info!(
-                "onchain refresh worker materialized deferred tasks deferred_drain_count={} deferred_drain_batch_size={} deferred_drain_duration_ms={}",
+                "onchain refresh worker materialized deferred tasks dao_code={} chain_id={} contract_set_id={} deferred_drain_count={} deferred_drain_batch_size={} deferred_drain_duration_ms={}",
+                scope
+                    .map(|scope| scope.dao_code.as_str())
+                    .unwrap_or("global"),
+                scope
+                    .map(|scope| scope.chain_id.to_string())
+                    .unwrap_or_else(|| "global".to_owned()),
+                scope
+                    .map(|scope| scope.contract_set_id.as_str())
+                    .unwrap_or("global"),
                 deferred_drain_count,
                 deferred_drain_batch_size,
                 deferred_drain_started_at.elapsed().as_millis()
             );
         }
-        let tasks = self.claim_tasks(now_ms, batch_size).await?;
+        let tasks = self.claim_tasks(now_ms, batch_size, scope).await?;
         if tasks.is_empty() {
             return Ok(OnchainRefreshRunReport::default());
         }
@@ -496,13 +542,13 @@ where
                         Ok(()) => successes.push((task.clone(), value.clone())),
                         Err(error) => {
                             let message = error.to_string();
-                            self.mark_task_failed(&task.id, &message, now_ms).await?;
+                            self.mark_task_failed(task, &message, now_ms).await?;
                             report.failed += 1;
                             report.validation_failures += 1;
                         }
                     },
                     None => {
-                        self.mark_task_failed(&task.id, "missing reader result", now_ms)
+                        self.mark_task_failed(task, "missing reader result", now_ms)
                             .await?;
                         report.failed += 1;
                         report.validation_failures += 1;
@@ -533,10 +579,22 @@ where
         }
 
         report.duration_ms = started_at.elapsed().as_millis();
-        report.backlog = self.ready_backlog().await.ok();
+        report.backlog = match scope {
+            Some(scope) => self.ready_backlog_for_scope(scope).await.ok(),
+            None => self.ready_backlog().await.ok(),
+        };
 
         log::info!(
-            "onchain refresh batch completed claimed={} completed={} failed={} skipped_tasks={} rpc_error_failures={} validation_failures={} db_update_failures={} unique_accounts={} rpc_reads_requested={} rpc_reads_deduped={} cache_hits={} debounced_tasks={} data_metric_refreshes={} duration_ms={} backlog={}",
+            "onchain refresh batch completed dao_code={} chain_id={} contract_set_id={} claimed={} completed={} failed={} skipped_tasks={} rpc_error_failures={} validation_failures={} db_update_failures={} unique_accounts={} rpc_reads_requested={} rpc_reads_deduped={} cache_hits={} debounced_tasks={} data_metric_refreshes={} duration_ms={} backlog={}",
+            scope
+                .map(|scope| scope.dao_code.as_str())
+                .unwrap_or("global"),
+            scope
+                .map(|scope| scope.chain_id.to_string())
+                .unwrap_or_else(|| "global".to_owned()),
+            scope
+                .map(|scope| scope.contract_set_id.as_str())
+                .unwrap_or("global"),
             report.claimed,
             report.completed,
             report.failed,
@@ -561,9 +619,23 @@ where
     }
 
     pub async fn ready_backlog(&self) -> Result<u64, OnchainRefreshWorkerError> {
+        self.ready_backlog_with_scope(None).await
+    }
+
+    pub async fn ready_backlog_for_scope(
+        &self,
+        scope: &OnchainRefreshTaskScope,
+    ) -> Result<u64, OnchainRefreshWorkerError> {
+        self.ready_backlog_with_scope(Some(scope)).await
+    }
+
+    async fn ready_backlog_with_scope(
+        &self,
+        scope: Option<&OnchainRefreshTaskScope>,
+    ) -> Result<u64, OnchainRefreshWorkerError> {
         let now_ms = unix_time_millis();
         let stale_before = now_ms.saturating_sub(duration_millis_i64(self.config.lock_ttl));
-        let row = sqlx::query(
+        let mut query = QueryBuilder::<Postgres>::new(
             "SELECT count(*)::BIGINT AS task_count
              FROM onchain_refresh_task
              WHERE (
@@ -571,17 +643,21 @@ where
                 OR (
                     status = 'processing'
                     AND locked_at IS NOT NULL
-                    AND locked_at <= $2::NUMERIC(78, 0)
+                    AND locked_at <= ",
+        );
+        query
+            .push_bind(stale_before.to_string())
+            .push(
+                "::NUMERIC(78, 0)
                 )
              )
-             AND next_run_at <= $1::NUMERIC(78, 0)
-             AND attempts < $3",
-        )
-        .bind(now_ms.to_string())
-        .bind(stale_before.to_string())
-        .bind(self.config.max_attempts)
-        .fetch_one(&self.pool)
-        .await?;
+             AND next_run_at <= ",
+            )
+            .push_bind(now_ms.to_string())
+            .push("::NUMERIC(78, 0) AND attempts < ")
+            .push_bind(self.config.max_attempts);
+        push_onchain_refresh_scope_filter(&mut query, scope);
+        let row = query.build().fetch_one(&self.pool).await?;
 
         let count: i64 = row.get("task_count");
 
@@ -592,12 +668,13 @@ where
         &self,
         now_ms: i64,
         batch_size: usize,
+        scope: Option<&OnchainRefreshTaskScope>,
     ) -> Result<Vec<OnchainRefreshTask>, OnchainRefreshWorkerError> {
         let stale_before = now_ms.saturating_sub(duration_millis_i64(self.config.lock_ttl));
         let batch_size =
             i64::try_from(batch_size).map_err(|_| OnchainRefreshWorkerError::BatchSizeOverflow)?;
 
-        let rows = sqlx::query(
+        let mut query = QueryBuilder::<Postgres>::new(
             "WITH candidates AS (
                 SELECT id
                 FROM onchain_refresh_task
@@ -606,22 +683,47 @@ where
                     OR (
                         status = 'processing'
                         AND locked_at IS NOT NULL
-                        AND locked_at <= $2::NUMERIC(78, 0)
+                        AND locked_at <= ",
+        );
+        query
+            .push_bind(stale_before.to_string())
+            .push(
+                "::NUMERIC(78, 0)
                     )
                 )
-                AND next_run_at <= $1::NUMERIC(78, 0)
-                AND attempts < $4
+                AND next_run_at <= ",
+            )
+            .push_bind(now_ms.to_string())
+            .push("::NUMERIC(78, 0) AND attempts < ")
+            .push_bind(self.config.max_attempts);
+        push_onchain_refresh_scope_filter(&mut query, scope);
+        query
+            .push(
+                "
                 ORDER BY next_run_at ASC, updated_at ASC, id ASC
-                LIMIT $3
+                LIMIT ",
+            )
+            .push_bind(batch_size)
+            .push(
+                "
                 FOR UPDATE SKIP LOCKED
              )
              UPDATE onchain_refresh_task
              SET status = 'processing',
                  attempts = attempts + 1,
-                 locked_at = $1::NUMERIC(78, 0),
-                 locked_by = $5,
+                 locked_at = ",
+            )
+            .push_bind(now_ms.to_string())
+            .push("::NUMERIC(78, 0), locked_by = ")
+            .push_bind(&self.config.lock_owner)
+            .push(
+                ",
                  error = NULL,
-                 updated_at = $1::NUMERIC(78, 0)
+                 updated_at = ",
+            )
+            .push_bind(now_ms.to_string())
+            .push(
+                "::NUMERIC(78, 0)
              FROM candidates
              WHERE onchain_refresh_task.id = candidates.id
              RETURNING
@@ -638,14 +740,8 @@ where
                  onchain_refresh_task.last_seen_block_timestamp::TEXT AS last_seen_block_timestamp,
                  onchain_refresh_task.last_seen_transaction_hash,
                  onchain_refresh_task.attempts",
-        )
-        .bind(now_ms.to_string())
-        .bind(stale_before.to_string())
-        .bind(batch_size)
-        .bind(self.config.max_attempts)
-        .bind(&self.config.lock_owner)
-        .fetch_all(&self.pool)
-        .await?;
+            );
+        let rows = query.build().fetch_all(&self.pool).await?;
 
         Ok(rows
             .into_iter()
@@ -746,7 +842,7 @@ where
         now_ms: i64,
     ) -> Result<(), OnchainRefreshWorkerError> {
         for task in tasks {
-            self.mark_task_failed(&task.id, error, now_ms).await?;
+            self.mark_task_failed(task, error, now_ms).await?;
         }
 
         Ok(())
@@ -754,11 +850,13 @@ where
 
     async fn mark_task_failed(
         &self,
-        task_id: &str,
+        task: &OnchainRefreshTask,
         error: &str,
         now_ms: i64,
     ) -> Result<(), OnchainRefreshWorkerError> {
-        let next_run_at = now_ms.saturating_add(duration_millis_i64(self.config.retry_delay));
+        let next_run_at = now_ms.saturating_add(duration_millis_i64(
+            onchain_refresh_retry_backoff_delay(self.config.retry_delay, task.attempts),
+        ));
 
         sqlx::query(
             "UPDATE onchain_refresh_task
@@ -771,7 +869,7 @@ where
                  updated_at = $4::NUMERIC(78, 0)
              WHERE id = $1",
         )
-        .bind(task_id)
+        .bind(&task.id)
         .bind(next_run_at.to_string())
         .bind(truncate_error(error))
         .bind(now_ms.to_string())
@@ -787,6 +885,28 @@ fn worker_deferred_drain_batch_size(
     claim_batch_size: usize,
 ) -> usize {
     configured_batch_size.max(claim_batch_size)
+}
+
+fn onchain_refresh_retry_backoff_delay(base_delay: Duration, attempts: i32) -> Duration {
+    let exponent = attempts.saturating_sub(1).clamp(0, 5) as u32;
+    let multiplier = 1u32.checked_shl(exponent).unwrap_or(32);
+
+    base_delay.saturating_mul(multiplier)
+}
+
+fn push_onchain_refresh_scope_filter<'args>(
+    query: &mut QueryBuilder<'args, Postgres>,
+    scope: Option<&'args OnchainRefreshTaskScope>,
+) {
+    if let Some(scope) = scope {
+        query
+            .push(" AND chain_id = ")
+            .push_bind(scope.chain_id)
+            .push(" AND contract_set_id = ")
+            .push_bind(&scope.contract_set_id)
+            .push(" AND dao_code IS NOT DISTINCT FROM ")
+            .push_bind(&scope.dao_code);
+    }
 }
 
 #[derive(Clone)]

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -11,11 +11,11 @@ use crate::{
     DatalensRuntimeContractSet, DatalensWarmupEnsureOutcome, EvmRpcChainTool,
     IndexerContractSetMode, IndexerContractSetRuntimeConfig, IndexerOnchainRefreshTick,
     IndexerRunner, IndexerRunnerReport, IndexerRuntimeConfig, IndexerTargetHeight,
-    MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig, OnchainRefreshTickReport,
-    OnchainRefreshTickRunner, OnchainRefreshTickScheduler, OnchainRefreshWorker,
-    OnchainRefreshWorkerError, PostgresIndexerRunnerStore, PostgresProvisionalCleanupStore,
-    classify_datalens_query_error, datalens_retry_config, ensure_datalens_warmup_task,
-    onchain_refresh_debounce_from_env, required_env,
+    MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig, OnchainRefreshTaskScope,
+    OnchainRefreshTickReport, OnchainRefreshTickRunner, OnchainRefreshTickScheduler,
+    OnchainRefreshWorker, OnchainRefreshWorkerError, PostgresIndexerRunnerStore,
+    PostgresProvisionalCleanupStore, classify_datalens_query_error, datalens_retry_config,
+    ensure_datalens_warmup_task, onchain_refresh_debounce_from_env, required_env,
 };
 
 use super::{datalens::verify_datalens, migrate::apply_migrations};
@@ -756,8 +756,8 @@ async fn run_contract_set_pass(
         runtime.target_height
     );
 
-    let onchain_refresh_tick =
-        build_onchain_refresh_tick(&runtime, pool.clone()).map_err(ContractSetPassError::setup)?;
+    let onchain_refresh_tick = build_onchain_refresh_tick(&runtime, &config, pool.clone())
+        .map_err(ContractSetPassError::setup)?;
     let projection_chain_tool =
         build_projection_chain_tool(&runtime, &config).map_err(ContractSetPassError::setup)?;
     let onchain_refresh_debounce =
@@ -843,6 +843,7 @@ fn build_projection_chain_tool(
 
 fn build_onchain_refresh_tick(
     runtime: &IndexerContractSetRuntimeConfig,
+    config: &DatalensConfig,
     pool: sqlx::PgPool,
 ) -> Result<Option<Box<dyn IndexerOnchainRefreshTick>>> {
     if !runtime.onchain_refresh_tick.enabled {
@@ -875,9 +876,20 @@ fn build_onchain_refresh_tick(
     worker_config.lock_owner = format!("degov-indexer-onchain-refresh-tick:{}", std::process::id());
     let worker = OnchainRefreshWorker::new(pool, worker_config, reader)
         .with_current_power_method(refresh_runtime.current_power_method);
+    let chain_id = config.chain.network_id.with_context(|| {
+        format!(
+            "missing onchain refresh tick chain id for dao_code={}",
+            runtime.dao_code
+        )
+    })?;
     let runner = OnchainRefreshWorkerTickRunner {
         worker,
         handle: Handle::current(),
+        scope: OnchainRefreshTaskScope {
+            chain_id,
+            contract_set_id: runtime.checkpoint_contract_set_id.clone(),
+            dao_code: runtime.dao_code.clone(),
+        },
     };
     let tick = IndexerOnchainRefreshWorkerTick {
         scheduler: OnchainRefreshTickScheduler::from_config(runtime.onchain_refresh_tick.clone()),
@@ -909,6 +921,7 @@ where
 struct OnchainRefreshWorkerTickRunner<R> {
     worker: OnchainRefreshWorker<R>,
     handle: Handle,
+    scope: OnchainRefreshTaskScope,
 }
 
 impl<R> OnchainRefreshTickRunner for OnchainRefreshWorkerTickRunner<R>
@@ -921,12 +934,16 @@ where
         &mut self,
         max_tasks: usize,
     ) -> std::result::Result<crate::OnchainRefreshRunReport, Self::Error> {
-        self.handle
-            .block_on(self.worker.run_once_with_batch_size(max_tasks))
+        self.handle.block_on(
+            self.worker
+                .run_once_with_batch_size_for_scope(max_tasks, &self.scope),
+        )
     }
 
     fn backlog(&mut self) -> Option<u64> {
-        self.handle.block_on(self.worker.ready_backlog()).ok()
+        self.handle
+            .block_on(self.worker.ready_backlog_for_scope(&self.scope))
+            .ok()
     }
 }
 

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -40,5 +40,25 @@ async fn ensure_runtime_indexes(pool: &PgPool) -> Result<()> {
     .await
     .context("ensure onchain refresh claim queue index")?;
 
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS onchain_refresh_task_scope_claim_queue_idx
+         ON onchain_refresh_task (
+            chain_id, contract_set_id, dao_code, status, next_run_at, updated_at, id
+         )",
+    )
+    .execute(pool)
+    .await
+    .context("ensure scoped onchain refresh claim queue index")?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS onchain_refresh_deferred_candidate_scope_drain_idx
+         ON onchain_refresh_deferred_candidate (
+            chain_id, contract_set_id, dao_code, next_run_at, updated_at, id
+         )",
+    )
+    .execute(pool)
+    .await
+    .context("ensure scoped onchain refresh deferred drain index")?;
+
     Ok(())
 }

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -57,6 +57,7 @@ async fn upsert_onchain_refresh_tasks(
         transaction,
         plan.ready_drain_count,
         now_ms,
+        None,
     )
     .await?;
 
@@ -80,6 +81,22 @@ pub async fn drain_deferred_onchain_refresh_tasks(
     pool: &PgPool,
     max_rows: usize,
 ) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    drain_deferred_onchain_refresh_tasks_with_scope(pool, max_rows, None).await
+}
+
+pub async fn drain_deferred_onchain_refresh_tasks_for_scope(
+    pool: &PgPool,
+    max_rows: usize,
+    scope: &crate::OnchainRefreshTaskScope,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    drain_deferred_onchain_refresh_tasks_with_scope(pool, max_rows, Some(scope)).await
+}
+
+async fn drain_deferred_onchain_refresh_tasks_with_scope(
+    pool: &PgPool,
+    max_rows: usize,
+    scope: Option<&crate::OnchainRefreshTaskScope>,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
     if max_rows == 0 {
         return Ok(0);
     }
@@ -88,13 +105,27 @@ pub async fn drain_deferred_onchain_refresh_tasks(
     let mut transaction = pool.begin().await?;
     let now_ms = unix_time_millis();
     let drained_count =
-        drain_deferred_onchain_refresh_tasks_in_transaction(&mut transaction, max_rows, now_ms)
-            .await?;
+        drain_deferred_onchain_refresh_tasks_in_transaction(
+            &mut transaction,
+            max_rows,
+            now_ms,
+            scope,
+        )
+        .await?;
     transaction.commit().await?;
 
     if drained_count > 0 {
         log::info!(
-            "onchain refresh deferred drain completed deferred_drain_count={} deferred_drain_batch_size={} deferred_drain_duration_ms={}",
+            "onchain refresh deferred drain completed dao_code={} chain_id={} contract_set_id={} deferred_drain_count={} deferred_drain_batch_size={} deferred_drain_duration_ms={}",
+            scope
+                .map(|scope| scope.dao_code.as_str())
+                .unwrap_or("global"),
+            scope
+                .map(|scope| scope.chain_id.to_string())
+                .unwrap_or_else(|| "global".to_owned()),
+            scope
+                .map(|scope| scope.contract_set_id.as_str())
+                .unwrap_or("global"),
             drained_count,
             max_rows,
             started_at.elapsed().as_millis()
@@ -140,12 +171,14 @@ async fn drain_deferred_onchain_refresh_tasks_in_transaction(
     transaction: &mut Transaction<'_, Postgres>,
     max_rows: usize,
     now_ms: i64,
+    scope: Option<&crate::OnchainRefreshTaskScope>,
 ) -> Result<usize, PostgresIndexerRunnerStoreError> {
     if max_rows == 0 {
         return Ok(0);
     }
 
-    let rows = read_deferred_onchain_refresh_candidates(transaction, max_rows, now_ms).await?;
+    let rows =
+        read_deferred_onchain_refresh_candidates(transaction, max_rows, now_ms, scope).await?;
     if rows.is_empty() {
         return Ok(0);
     }
@@ -508,10 +541,11 @@ async fn read_deferred_onchain_refresh_candidates(
     transaction: &mut Transaction<'_, Postgres>,
     max_rows: usize,
     now_ms: i64,
+    scope: Option<&crate::OnchainRefreshTaskScope>,
 ) -> Result<Vec<OnchainRefreshTaskWrite>, PostgresIndexerRunnerStoreError> {
     let max_rows = i64::try_from(max_rows)
         .map_err(|_| PostgresIndexerRunnerStoreError::new("deferred drain batch size exceeds i64"))?;
-    let rows = sqlx::query(
+    let mut query = QueryBuilder::<Postgres>::new(
         "SELECT id, contract_set_id, chain_id, dao_code, governor_address, token_address, account,
                 refresh_balance, refresh_power, reason,
                 first_seen_block_number::TEXT AS first_seen_block_number,
@@ -520,17 +554,21 @@ async fn read_deferred_onchain_refresh_candidates(
                 last_seen_transaction_hash,
                 next_run_at::TEXT AS next_run_at
          FROM onchain_refresh_deferred_candidate
-         WHERE next_run_at <= $2::NUMERIC(78, 0)
+         WHERE next_run_at <= ",
+    );
+    query.push_bind(now_ms.to_string()).push("::NUMERIC(78, 0)");
+    push_deferred_onchain_refresh_scope_filter(&mut query, scope);
+    query
+        .push(
+            "
          ORDER BY onchain_refresh_deferred_candidate.next_run_at,
                   onchain_refresh_deferred_candidate.updated_at,
                   onchain_refresh_deferred_candidate.id
-         LIMIT $1
-         FOR UPDATE SKIP LOCKED",
-    )
-    .bind(max_rows)
-    .bind(now_ms)
-    .fetch_all(&mut **transaction)
-    .await?;
+         LIMIT ",
+        )
+        .push_bind(max_rows)
+        .push(" FOR UPDATE SKIP LOCKED");
+    let rows = query.build().fetch_all(&mut **transaction).await?;
 
     Ok(rows
         .into_iter()
@@ -552,6 +590,21 @@ async fn read_deferred_onchain_refresh_candidates(
             next_run_at: row.get("next_run_at"),
         })
         .collect())
+}
+
+fn push_deferred_onchain_refresh_scope_filter<'args>(
+    query: &mut QueryBuilder<'args, Postgres>,
+    scope: Option<&'args crate::OnchainRefreshTaskScope>,
+) {
+    if let Some(scope) = scope {
+        query
+            .push(" AND chain_id = ")
+            .push_bind(scope.chain_id)
+            .push(" AND contract_set_id = ")
+            .push_bind(&scope.contract_set_id)
+            .push(" AND dao_code IS NOT DISTINCT FROM ")
+            .push_bind(&scope.dao_code);
+    }
 }
 
 #[cfg(test)]

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -14,9 +14,9 @@ use degov_datalens_indexer::{
     ChainReadMetrics, ChainReadPlan, ChainReadResult, ChainReadValue, ChainTool, EvmRpcChainTool,
     LivePowerOverlayReader, MultiChainToolOnchainRefreshReader, OnchainRefreshReadValue,
     OnchainRefreshReader, OnchainRefreshReaderError, OnchainRefreshRunReport, OnchainRefreshTask,
-    OnchainRefreshTickClock, OnchainRefreshTickConfig, OnchainRefreshTickRunner,
-    OnchainRefreshTickScheduler, OnchainRefreshTickSkipReason, OnchainRefreshWorker,
-    OnchainRefreshWorkerConfig, PartialChainReadFailureReport,
+    OnchainRefreshTaskScope, OnchainRefreshTickClock, OnchainRefreshTickConfig,
+    OnchainRefreshTickRunner, OnchainRefreshTickScheduler, OnchainRefreshTickSkipReason,
+    OnchainRefreshWorker, OnchainRefreshWorkerConfig, PartialChainReadFailureReport,
     PostgresProvisionalPowerOverlayStore, ProvisionalContributorPowerOverlayWrite,
     ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
     ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, refresh_live_power_overlays,
@@ -612,6 +612,138 @@ async fn test_onchain_refresh_worker_marks_claimed_tasks_failed_when_reader_fail
     assert_eq!(row.get::<Option<String>, _>("processed_at"), None);
     assert!(row.get::<String, _>("next_run_at").parse::<i64>()? > 0);
     assert_data_metric(&database.pool, "7", 1, 7).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_scoped_run_claims_only_matching_contract_set()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task_with_contract_set(
+        &database.pool,
+        "ens-task",
+        SCOPE_ONE,
+        1,
+        "ens-dao",
+        GOVERNOR,
+        TOKEN,
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        false,
+        true,
+    )
+    .await?;
+    seed_task_with_contract_set(
+        &database.pool,
+        "lisk-task",
+        SCOPE_TWO,
+        1135,
+        "lisk-dao",
+        GOVERNOR_TWO,
+        TOKEN_TWO,
+        ACCOUNT_TWO,
+        "pending",
+        0,
+        false,
+        true,
+    )
+    .await?;
+
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::new([(
+            "lisk-task",
+            OnchainRefreshReadValue {
+                task_id: "lisk-task".to_owned(),
+                balance: None,
+                power: Some("13".to_owned()),
+            },
+        )]),
+    );
+
+    let report = worker
+        .run_once_with_batch_size_for_scope(
+            10,
+            &OnchainRefreshTaskScope {
+                chain_id: 1135,
+                contract_set_id: SCOPE_TWO.to_owned(),
+                dao_code: "lisk-dao".to_owned(),
+            },
+        )
+        .await?;
+
+    assert_eq!(report.claimed, 1);
+    assert_eq!(report.completed, 1);
+    assert_task_status(&database.pool, "lisk-task", "completed", 1).await?;
+    assert_task_status(&database.pool, "ens-task", "pending", 0).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_failed_task_uses_attempt_backoff() -> Result<(), Box<dyn Error>>
+{
+    let database = TestDatabase::connect().await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        2,
+        false,
+        true,
+    )
+    .await?;
+    let before = unix_time_millis_for_test();
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            max_attempts: 5,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        FailingOnchainRefreshReader,
+    );
+
+    let report = worker.run_once().await?;
+    let after = unix_time_millis_for_test();
+
+    assert_eq!(report.claimed, 1);
+    assert_eq!(report.failed, 1);
+    let row = sqlx::query(
+        "SELECT status, attempts, next_run_at::TEXT AS next_run_at
+         FROM onchain_refresh_task
+         WHERE id = 'task-one'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    let next_run_at = row.get::<String, _>("next_run_at").parse::<i64>()?;
+    assert_eq!(row.get::<String, _>("status"), "failed");
+    assert_eq!(row.get::<i32, _>("attempts"), 3);
+    assert!(next_run_at >= before + 120_000);
+    assert!(next_run_at <= after + 120_000);
+
+    let retry_report = worker.run_once().await?;
+    assert_eq!(retry_report.claimed, 0);
 
     database.cleanup().await?;
 
@@ -1675,6 +1807,27 @@ async fn assert_failed_task_error_contains(
             .expect("error")
             .contains(expected_error)
     );
+
+    Ok(())
+}
+
+async fn assert_task_status(
+    pool: &PgPool,
+    task_id: &str,
+    expected_status: &str,
+    expected_attempts: i32,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT status, attempts
+         FROM onchain_refresh_task
+         WHERE id = $1",
+    )
+    .bind(task_id)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("status"), expected_status);
+    assert_eq!(row.get::<i32, _>("attempts"), expected_attempts);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Scope inline onchain refresh ticks to the current DAO/chain/contract set so Lisk/GMX/Base runners no longer consume ENS-heavy refresh backlog.
- Preserve the global onchain refresh worker path by keeping unscoped worker methods for explicit global processing.
- Add attempt-based retry backoff for failed refresh tasks so full RPC send failures do not immediately hot-loop across runner ticks.
- Add runtime scoped queue indexes for existing databases without editing the already-applied init migration.

Fixes HBX-425

## Tests
- `cargo fmt -p degov-datalens-indexer --check`
- `git diff --check`
- `cargo build -p degov-datalens-indexer`
- `DEGOV_INDEXER_TEST_DATABASE_URL=<temp db> cargo test -p degov-datalens-indexer --test onchain_refresh_worker`
- `DEGOV_INDEXER_TEST_DATABASE_URL=<temp db> cargo test -p degov-datalens-indexer --test migration_schema`

## Validation notes
- Root cause: inline tick runner previously used the same unscoped worker drain/claim/backlog SQL as the global worker, so every contract-set runner could claim unrelated DAO tasks from the global queue.
- The new scoped path filters deferred drain, claim, and backlog by `chain_id`, `contract_set_id`, and `dao_code`; the standalone worker still uses the global path.