### PR TITLE
fix(indexer): correct ENS delegate edge power

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -1222,6 +1222,11 @@ where
                     crate::ChainReadReason::TokenActivityPowerRefresh,
                     self.current_power_method,
                 );
+                builder.add_account_balance_refresh(
+                    &task.account,
+                    parse_u64(&task.last_seen_block_number)?,
+                    crate::ChainReadReason::TokenActivityPowerRefresh,
+                );
             }
 
             let plan = builder.build();
@@ -1230,6 +1235,8 @@ where
                 .execute_read_plan(&plan)
                 .map_err(|failures| OnchainRefreshReaderError::new(format_failures(&failures)))?;
 
+            let mut powers_by_account = BTreeMap::<String, String>::new();
+            let mut balances_by_account = BTreeMap::<String, String>::new();
             for result in report.results {
                 let Some(account) = result.key.args.first() else {
                     continue;
@@ -1243,9 +1250,21 @@ where
                         )));
                     }
                 };
-                let Some(task) = tasks_by_account.get(account) else {
-                    continue;
-                };
+                match result.key.method {
+                    method if method == self.current_power_method => {
+                        powers_by_account.insert(account.clone(), value);
+                    }
+                    ChainReadMethod::BalanceOf => {
+                        balances_by_account.insert(account.clone(), value);
+                    }
+                    _ => {}
+                }
+            }
+
+            for (account, task) in tasks_by_account {
+                let power = powers_by_account.get(&account).cloned().ok_or_else(|| {
+                    OnchainRefreshReaderError::new(format!("missing power read for {account}"))
+                })?;
                 writes.push(ProvisionalContributorPowerOverlayWrite {
                     id: provisional_contributor_power_overlay_id(task),
                     segment_id: None,
@@ -1256,8 +1275,8 @@ where
                     governor_address: Some(normalize_identifier(&governor_address)),
                     token_address: Some(normalize_identifier(&token_address)),
                     account: normalize_identifier(&task.account),
-                    power: value,
-                    balance: None,
+                    power,
+                    balance: balances_by_account.get(&account).cloned(),
                     delegates_count_all: 0,
                     delegates_count_effective: 0,
                     last_vote_block_number: None,
@@ -2748,6 +2767,7 @@ fn provisional_delegate_power_overlay_writes(
                 relation.token_address.clone(),
                 relation.delegator.clone(),
             ))?;
+            let power = contributor.balance.as_ref()?;
 
             Some(ProvisionalDelegatePowerOverlayWrite {
                 id: provisional_delegate_power_overlay_id(relation),
@@ -2760,7 +2780,7 @@ fn provisional_delegate_power_overlay_writes(
                 token_address: relation.token_address.clone(),
                 delegator: relation.delegator.clone(),
                 delegate: relation.delegate.clone(),
-                power: contributor.power.clone(),
+                power: power.clone(),
                 is_current: relation.is_current,
                 source: contributor.source.clone(),
                 status: contributor.status.clone(),

--- a/apps/indexer/src/projection/power_reconcile.rs
+++ b/apps/indexer/src/projection/power_reconcile.rs
@@ -126,18 +126,19 @@ pub fn plan_power_reconcile(
     let mut candidates = BTreeMap::<String, PendingPowerCandidate>::new();
 
     for event in events {
-        for (account, reason) in affected_accounts(&event.event) {
-            if is_zero_address(&account) {
+        for activity in affected_accounts(&event.event) {
+            if is_zero_address(&activity.account) {
                 continue;
             }
 
             candidate_count += 1;
-            let normalized_account = normalize_identifier(&account);
+            let normalized_account = normalize_identifier(&activity.account);
             candidates
                 .entry(normalized_account.clone())
                 .and_modify(|candidate| {
                     candidate.first_seen_activity_block =
                         candidate.first_seen_activity_block.min(event.block_number);
+                    candidate.refresh_balance |= activity.refresh_balance;
                     if event.log_position() >= candidate.latest_position() {
                         candidate.latest_activity_block = event.block_number;
                         candidate.latest_transaction_index = event.transaction_index;
@@ -145,7 +146,7 @@ pub fn plan_power_reconcile(
                         candidate.last_seen_block_timestamp_ms = event.block_timestamp_ms;
                         candidate.last_seen_transaction_hash = event.transaction_hash.clone();
                     }
-                    candidate.reasons.insert(reason);
+                    candidate.reasons.insert(activity.reason);
                 })
                 .or_insert_with(|| PendingPowerCandidate {
                     account: normalized_account,
@@ -155,7 +156,8 @@ pub fn plan_power_reconcile(
                     latest_log_index: event.log_index,
                     last_seen_block_timestamp_ms: event.block_timestamp_ms,
                     last_seen_transaction_hash: event.transaction_hash.clone(),
-                    reasons: [reason].into(),
+                    refresh_balance: activity.refresh_balance,
+                    reasons: [activity.reason].into(),
                 });
         }
     }
@@ -216,6 +218,7 @@ struct PendingPowerCandidate {
     latest_log_index: u64,
     last_seen_block_timestamp_ms: Option<u64>,
     last_seen_transaction_hash: String,
+    refresh_balance: bool,
     reasons: BTreeSet<PowerActivityReason>,
 }
 
@@ -269,33 +272,57 @@ impl PendingPowerCandidate {
     }
 
     fn refresh_balance(&self) -> bool {
-        self.reasons.contains(&PowerActivityReason::DelegateChanged)
-            || self.reasons.contains(&PowerActivityReason::Transfer)
+        self.refresh_balance
     }
 }
 
-fn affected_accounts(event: &DecodedDaoEvent) -> Vec<(String, PowerActivityReason)> {
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AccountActivity {
+    account: String,
+    reason: PowerActivityReason,
+    refresh_balance: bool,
+}
+
+impl AccountActivity {
+    fn power_only(account: String, reason: PowerActivityReason) -> Self {
+        Self {
+            account,
+            reason,
+            refresh_balance: false,
+        }
+    }
+
+    fn with_balance(account: String, reason: PowerActivityReason) -> Self {
+        Self {
+            account,
+            reason,
+            refresh_balance: true,
+        }
+    }
+}
+
+fn affected_accounts(event: &DecodedDaoEvent) -> Vec<AccountActivity> {
     match event {
         DecodedDaoEvent::Token(DecodedTokenEvent::Transfer(event)) => vec![
-            (event.from.clone(), PowerActivityReason::Transfer),
-            (event.to.clone(), PowerActivityReason::Transfer),
+            AccountActivity::with_balance(event.from.clone(), PowerActivityReason::Transfer),
+            AccountActivity::with_balance(event.to.clone(), PowerActivityReason::Transfer),
         ],
         DecodedDaoEvent::Token(DecodedTokenEvent::DelegateChanged(event)) => vec![
-            (
+            AccountActivity::with_balance(
                 event.delegator.clone(),
                 PowerActivityReason::DelegateChanged,
             ),
-            (
+            AccountActivity::power_only(
                 event.from_delegate.clone(),
                 PowerActivityReason::DelegateChanged,
             ),
-            (
+            AccountActivity::power_only(
                 event.to_delegate.clone(),
                 PowerActivityReason::DelegateChanged,
             ),
         ],
         DecodedDaoEvent::Token(DecodedTokenEvent::DelegateVotesChanged(event)) => {
-            vec![(
+            vec![AccountActivity::power_only(
                 event.delegate.clone(),
                 PowerActivityReason::DelegateVotesChanged,
             )]

--- a/apps/indexer/src/projection/power_reconcile.rs
+++ b/apps/indexer/src/projection/power_reconcile.rs
@@ -168,6 +168,13 @@ pub fn plan_power_reconcile(
     let candidates = candidates
         .into_values()
         .map(|candidate| {
+            if candidate.refresh_balance() {
+                read_plan_builder.add_account_balance_refresh(
+                    &candidate.account,
+                    candidate.latest_activity_block,
+                    ChainReadReason::TokenActivityPowerRefresh,
+                );
+            }
             read_plan_builder.add_account_power_refresh_with_method(
                 &candidate.account,
                 candidate.latest_activity_block,
@@ -217,6 +224,7 @@ impl PendingPowerCandidate {
         let governor = normalize_identifier(&context.contracts.governor);
         let governor_token = normalize_identifier(&context.contracts.governor_token);
         let reason = reason_label(&self.reasons);
+        let refresh_balance = self.refresh_balance();
 
         PowerReconcileCandidate {
             contract_set_id: context.contract_set_id.clone(),
@@ -239,7 +247,7 @@ impl PendingPowerCandidate {
                 account: self.account,
                 source: PowerRefreshReadSource::OnchainRpc,
                 status: PowerRefreshStatus::Pending,
-                refresh_balance: false,
+                refresh_balance,
                 refresh_power: true,
                 reason,
                 first_seen_activity_block: self.first_seen_activity_block,
@@ -258,6 +266,11 @@ impl PendingPowerCandidate {
             self.latest_transaction_index,
             self.latest_log_index,
         )
+    }
+
+    fn refresh_balance(&self) -> bool {
+        self.reasons.contains(&PowerActivityReason::DelegateChanged)
+            || self.reasons.contains(&PowerActivityReason::Transfer)
     }
 }
 

--- a/apps/indexer/src/projection/token.rs
+++ b/apps/indexer/src/projection/token.rs
@@ -336,6 +336,7 @@ impl InMemoryTokenProjectionRepository {
         };
         self.delegate_mappings
             .insert(mapping.id.clone(), mapping.clone());
+        self.upsert_delegate_snapshot(common, delegator, to_delegate, true, &mapping.power);
     }
 
     fn apply_delegate_votes_changed(
@@ -391,12 +392,14 @@ impl InMemoryTokenProjectionRepository {
             return;
         }
 
-        let mapping_power = self
+        let Some(previous_mapping_power) = self
             .delegate_mappings
             .get(from_delegate)
             .filter(|mapping| mapping.to == to_delegate)
-            .map(|mapping| mapping.power.clone());
-        let previous_mapping_power = mapping_power.unwrap_or_else(|| "0".to_owned());
+            .map(|mapping| mapping.power.clone())
+        else {
+            return;
+        };
         let next_mapping_power = apply_signed_decimal(&previous_mapping_power, delta);
         if let Some(mapping) = self.delegate_mappings.get_mut(from_delegate)
             && mapping.to == to_delegate
@@ -436,10 +439,6 @@ impl InMemoryTokenProjectionRepository {
             return;
         }
         let id = delegate_ref(from_delegate, to_delegate);
-        if is_current && !is_nonzero_decimal(power) {
-            self.delegates.remove(&id);
-            return;
-        }
         let row = DelegateWrite {
             id: id.clone(),
             common: common.clone(),

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -523,6 +523,7 @@ async fn apply_delegate_changed_operation(
         "0",
     )
     .await?;
+    upsert_delegate_snapshot(transaction, common, delegator, to_delegate, true, "0").await?;
 
     Ok(())
 }
@@ -654,30 +655,26 @@ async fn apply_delegate_delta(
         return Ok(());
     }
 
-    let previous_mapping_power =
+    let Some(previous_mapping_power) =
         read_delegate_mapping_cached(transaction, delegate_mapping_cache, common, from_delegate)
             .await?
             .filter(|mapping| mapping.to == to_delegate)
             .map(|mapping| mapping.power)
-            .unwrap_or_else(|| "0".to_owned());
+    else {
+        return Ok(());
+    };
     let next_mapping_power = add_signed_decimal(&previous_mapping_power, delta);
 
-    if previous_mapping_power != "0"
-        || read_delegate_mapping_cached(transaction, delegate_mapping_cache, common, from_delegate)
-            .await?
-            .is_some_and(|mapping| mapping.to == to_delegate)
-    {
-        delegate_mapping_cache.stage(
-            common,
-            from_delegate,
-            Some(DelegateMappingSnapshot {
-                common: common.clone(),
-                from: from_delegate.to_owned(),
-                to: to_delegate.to_owned(),
-                power: next_mapping_power.clone(),
-            }),
-        );
-    }
+    delegate_mapping_cache.stage(
+        common,
+        from_delegate,
+        Some(DelegateMappingSnapshot {
+            common: common.clone(),
+            from: from_delegate.to_owned(),
+            to: to_delegate.to_owned(),
+            power: next_mapping_power.clone(),
+        }),
+    );
 
     let previous_effective = is_nonzero_decimal(&previous_mapping_power);
     let next_effective = is_nonzero_decimal(&next_mapping_power);
@@ -717,15 +714,6 @@ async fn upsert_delegate_snapshot(
         return Ok(());
     }
     let id = delegate_ref(common, from_delegate, to_delegate);
-    if is_current && !is_nonzero_decimal(power) {
-        sqlx::query("DELETE FROM delegate WHERE contract_set_id = $1 AND id = $2")
-            .bind(&common.contract_set_id)
-            .bind(&id)
-            .execute(&mut **transaction)
-            .await?;
-        return Ok(());
-    }
-
     sqlx::query(
         "INSERT INTO delegate (
             id, contract_set_id, chain_id, dao_code, governor_address, token_address, contract_address,

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -242,15 +242,27 @@ fn assert_onchain_refresh_plans(store: &CapturingStore) {
     assert!(vote_reads.contains(&ChainReadMethod::State));
 
     let token_batch = batch.token.as_ref().expect("token batch");
-    assert_eq!(token_batch.reconcile_plan.metrics.read_count, 3);
+    assert_eq!(token_batch.reconcile_plan.metrics.read_count, 5);
     assert_eq!(token_batch.reconcile_plan.candidates.len(), 3);
-    assert!(
+    assert_eq!(
         token_batch
             .reconcile_plan
             .chain_read_plan
             .reads
             .iter()
-            .all(|read| read.key.method == ChainReadMethod::GetVotes)
+            .filter(|read| read.key.method == ChainReadMethod::GetVotes)
+            .count(),
+        3
+    );
+    assert_eq!(
+        token_batch
+            .reconcile_plan
+            .chain_read_plan
+            .reads
+            .iter()
+            .filter(|read| read.key.method == ChainReadMethod::BalanceOf)
+            .count(),
+        2
     );
 
     let timelock_reads = batch

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -1281,7 +1281,7 @@ async fn test_refresh_live_power_overlays_writes_delegate_overlay_from_current_f
         1,
     )
     .await?;
-    assert_contributor_overlay(&database.pool, ACCOUNT_ONE, "11").await?;
+    assert_contributor_overlay_with_scope(&database.pool, "scope-46", ACCOUNT_ONE, "11").await?;
     assert_delegate_overlay(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "23").await?;
     assert_table_count(&database.pool, "delegate", 1).await?;
     assert_table_count(&database.pool, "vote_power_checkpoint", 0).await?;
@@ -2129,11 +2129,21 @@ async fn assert_contributor_overlay(
     account: &str,
     power: &str,
 ) -> Result<(), sqlx::Error> {
+    assert_contributor_overlay_with_scope(pool, "demo-dao", account, power).await
+}
+
+async fn assert_contributor_overlay_with_scope(
+    pool: &PgPool,
+    contract_set_id: &str,
+    account: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
     let row = sqlx::query(
         "SELECT account, power::TEXT AS power, source, status, anchor_block_number::TEXT AS anchor_block_number
          FROM degov_provisional_contributor_power_overlay
-         WHERE contract_set_id = 'demo-dao' AND account = $1",
+         WHERE contract_set_id = $1 AND account = $2",
     )
+    .bind(contract_set_id)
     .bind(account)
     .fetch_one(pool)
     .await?;

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -491,7 +491,7 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     assert_table_count(&database.pool, "token_balance_checkpoint", 1).await?;
     assert_contributor_overlay(&database.pool, ACCOUNT_ONE, "11").await?;
     assert_contributor_overlay(&database.pool, ACCOUNT_TWO, "5").await?;
-    assert_delegate_overlay_with_scope(&database.pool, "demo-dao", ACCOUNT_ONE, ACCOUNT_TWO, "11")
+    assert_delegate_overlay_with_scope(&database.pool, "demo-dao", ACCOUNT_ONE, ACCOUNT_TWO, "17")
         .await?;
 
     database.cleanup().await?;
@@ -1178,19 +1178,33 @@ fn test_live_power_overlay_reader_uses_latest_block_mode_and_dedupes_accounts() 
     assert_eq!(writes.len(), 1);
     assert_eq!(writes[0].account, account);
     assert_eq!(writes[0].power, "19");
+    assert_eq!(writes[0].balance.as_deref(), Some("19"));
     assert_eq!(writes[0].source, "live-onchain");
     assert_eq!(writes[0].status, "available");
     assert_eq!(writes[0].segment_id, None);
 
     let plans = chain_tool.captured_plans();
     assert_eq!(plans.len(), 1);
-    assert_eq!(plans[0].reads.len(), 1);
-    assert_eq!(plans[0].reads[0].key.block_mode, BlockReadMode::Latest);
+    assert_eq!(plans[0].reads.len(), 2);
+    assert!(
+        plans[0]
+            .reads
+            .iter()
+            .any(|read| read.key.method == ChainReadMethod::GetVotes
+                && read.key.block_mode == BlockReadMode::Latest)
+    );
+    assert!(
+        plans[0]
+            .reads
+            .iter()
+            .any(|read| read.key.method == ChainReadMethod::BalanceOf
+                && read.key.block_mode == BlockReadMode::Safe)
+    );
 }
 
 #[test]
 fn test_refresh_live_power_overlays_writes_provisional_store_only() {
-    let chain_tool = StaticValueChainTool::new("23");
+    let chain_tool = MethodValueChainTool::new("11", "23");
     let reader = LivePowerOverlayReader::new(
         chain_tool,
         BatchReadPlanConfig::default(),
@@ -1222,7 +1236,8 @@ fn test_refresh_live_power_overlays_writes_provisional_store_only() {
 
     assert_eq!(written, 2);
     assert_eq!(store.contributors.len(), 1);
-    assert_eq!(store.contributors[0].power, "23");
+    assert_eq!(store.contributors[0].power, "11");
+    assert_eq!(store.contributors[0].balance.as_deref(), Some("23"));
     assert_eq!(store.delegates.len(), 1);
     assert_eq!(store.delegates[0].delegator, store.contributors[0].account);
     assert_eq!(
@@ -1240,7 +1255,7 @@ async fn test_refresh_live_power_overlays_writes_delegate_overlay_from_current_f
     let database = TestDatabase::connect().await?;
     seed_final_delegate(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "7").await?;
     let reader = LivePowerOverlayReader::new(
-        StaticValueChainTool::new("23"),
+        MethodValueChainTool::new("11", "23"),
         BatchReadPlanConfig::default(),
         ChainReadMethod::GetVotes,
     );
@@ -1266,6 +1281,7 @@ async fn test_refresh_live_power_overlays_writes_delegate_overlay_from_current_f
         1,
     )
     .await?;
+    assert_contributor_overlay(&database.pool, ACCOUNT_ONE, "11").await?;
     assert_delegate_overlay(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "23").await?;
     assert_table_count(&database.pool, "delegate", 1).await?;
     assert_table_count(&database.pool, "vote_power_checkpoint", 0).await?;
@@ -1393,6 +1409,13 @@ struct StaticValueChainTool {
     plans: Arc<StdMutex<Vec<ChainReadPlan>>>,
 }
 
+#[derive(Clone, Debug)]
+struct MethodValueChainTool {
+    power: String,
+    balance: String,
+    plans: Arc<StdMutex<Vec<ChainReadPlan>>>,
+}
+
 #[derive(Default)]
 struct RecordingPowerOverlayStore {
     relations: Vec<ProvisionalDelegatePowerOverlayRelation>,
@@ -1445,6 +1468,51 @@ impl ProvisionalPowerOverlayStore for RecordingPowerOverlayStore {
         self.contributors.extend_from_slice(contributors);
         self.delegates.extend_from_slice(delegates);
         Ok(())
+    }
+}
+
+impl MethodValueChainTool {
+    fn new(power: &str, balance: &str) -> Self {
+        Self {
+            power: power.to_owned(),
+            balance: balance.to_owned(),
+            plans: Arc::new(StdMutex::new(Vec::new())),
+        }
+    }
+}
+
+impl ChainTool for MethodValueChainTool {
+    fn execute_read_plan(
+        &self,
+        plan: &ChainReadPlan,
+    ) -> Result<ChainReadExecutionReport, PartialChainReadFailureReport> {
+        self.plans.lock().expect("plans lock").push(plan.clone());
+        Ok(ChainReadExecutionReport {
+            metrics: ChainReadMetrics {
+                requested_reads: plan.metrics.requested_reads,
+                deduped_reads: plan.metrics.deduped_reads,
+                executed_rpc_calls: plan.reads.len(),
+                multicall_batch_size: plan.metrics.multicall_batch_size,
+                ..ChainReadMetrics::default()
+            },
+            results: plan
+                .reads
+                .iter()
+                .enumerate()
+                .map(|(read_index, read)| ChainReadResult {
+                    read_index,
+                    key: read.key.clone(),
+                    value: ChainReadValue::Integer(match read.key.method {
+                        ChainReadMethod::BalanceOf => self.balance.clone(),
+                        ChainReadMethod::GetVotes | ChainReadMethod::CurrentVotes => {
+                            self.power.clone()
+                        }
+                        _ => self.power.clone(),
+                    }),
+                })
+                .collect(),
+            ..ChainReadExecutionReport::default()
+        })
     }
 }
 

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -1139,7 +1139,7 @@ async fn test_postgres_token_reconcile_tasks_preserve_conflict_semantics()
         .iter()
         .find(|row| row.get::<String, _>("account") == DELEGATOR)
         .expect("pending conflict row");
-    assert!(!pending.get::<bool, _>("refresh_balance"));
+    assert!(pending.get::<bool, _>("refresh_balance"));
     assert!(pending.get::<bool, _>("refresh_power"));
     assert_eq!(
         pending.get::<String, _>("reason"),

--- a/apps/indexer/tests/power_reconcile.rs
+++ b/apps/indexer/tests/power_reconcile.rs
@@ -153,6 +153,51 @@ fn test_plan_power_reconcile_does_not_write_log_derived_power() {
 }
 
 #[test]
+fn test_plan_power_reconcile_refreshes_balance_only_for_delegate_change_delegator() {
+    let delegator = account("aaaa");
+    let from_delegate = account("bbbb");
+    let to_delegate = account("cccc");
+    let events = vec![PowerReconcileEvent {
+        block_number: 150,
+        block_timestamp_ms: Some(150_000),
+        transaction_hash: "0xtx150".to_owned(),
+        transaction_index: 0,
+        log_index: 0,
+        event: DecodedDaoEvent::Token(DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+            delegator: delegator.clone(),
+            from_delegate: from_delegate.clone(),
+            to_delegate: to_delegate.clone(),
+        })),
+    }];
+
+    let plan = plan_power_reconcile(&context(150, 150, Some(150)), &events);
+
+    let delegator_candidate = plan
+        .candidates
+        .iter()
+        .find(|candidate| candidate.account == delegator)
+        .expect("delegator candidate");
+    assert!(delegator_candidate.status.refresh_balance);
+
+    for delegate in [&from_delegate, &to_delegate] {
+        let candidate = plan
+            .candidates
+            .iter()
+            .find(|candidate| candidate.account == *delegate)
+            .expect("delegate candidate");
+        assert!(candidate.status.refresh_power);
+        assert!(!candidate.status.refresh_balance);
+        assert!(
+            !plan.chain_read_plan.reads.iter().any(|read| {
+                read.metadata.accounts.contains(delegate)
+                    && read.key.method == ChainReadMethod::BalanceOf
+            }),
+            "delegatee accounts should not receive balanceOf refresh reads"
+        );
+    }
+}
+
+#[test]
 fn test_plan_power_reconcile_emits_chaintool_get_votes_reads() {
     let acct = account("aaaa");
     let events = vec![PowerReconcileEvent {

--- a/apps/indexer/tests/power_reconcile.rs
+++ b/apps/indexer/tests/power_reconcile.rs
@@ -27,7 +27,7 @@ fn test_plan_power_reconcile_dedupes_large_batch_before_chain_reads() {
 
     assert_eq!(plan.metrics.candidate_count, 20_000);
     assert_eq!(plan.metrics.deduped_count, 19_998);
-    assert_eq!(plan.metrics.read_count, 2);
+    assert_eq!(plan.metrics.read_count, 4);
     assert_eq!(plan.metrics.processed_count, 0);
     assert_eq!(plan.metrics.failed_count, 0);
     assert_eq!(plan.metrics.sync_lag_blocks, Some(10));
@@ -36,7 +36,7 @@ fn test_plan_power_reconcile_dedupes_large_batch_before_chain_reads() {
         PowerFreshnessState::SyncLag { lag_blocks: 10 }
     );
     assert_eq!(plan.candidates.len(), 2);
-    assert_eq!(plan.chain_read_plan.reads.len(), 2);
+    assert_eq!(plan.chain_read_plan.reads.len(), 4);
 }
 
 #[test]
@@ -106,6 +106,8 @@ fn test_plan_power_reconcile_keeps_latest_activity_block_and_merges_reasons() {
     );
     assert_eq!(candidate.status.status, PowerRefreshStatus::Pending);
     assert_eq!(candidate.status.source, PowerRefreshReadSource::OnchainRpc);
+    assert!(candidate.status.refresh_power);
+    assert!(candidate.status.refresh_balance);
     assert_eq!(candidate.status.first_seen_activity_block, 99);
     assert_eq!(candidate.status.last_seen_activity_block, 103);
     assert_eq!(candidate.status.last_seen_block_timestamp_ms, Some(103_000));
@@ -172,7 +174,9 @@ fn test_plan_power_reconcile_emits_chaintool_get_votes_reads() {
         .chain_read_plan
         .reads
         .iter()
-        .find(|read| read.metadata.accounts.contains(&acct))
+        .find(|read| {
+            read.metadata.accounts.contains(&acct) && read.key.method == ChainReadMethod::GetVotes
+        })
         .expect("account read");
 
     assert_eq!(read.key.chain_id, 1);
@@ -182,12 +186,24 @@ fn test_plan_power_reconcile_emits_chaintool_get_votes_reads() {
     );
     assert_eq!(read.key.method, ChainReadMethod::GetVotes);
     assert_eq!(read.key.block_mode, BlockReadMode::Safe);
-    assert_eq!(read.key.args, vec![acct]);
+    assert_eq!(read.key.args, vec![acct.clone()]);
     assert_eq!(
         read.metadata.reasons,
         [ChainReadReason::TokenActivityPowerRefresh].into()
     );
     assert_eq!(read.activity_blocks, vec![200]);
+
+    let balance_read = plan
+        .chain_read_plan
+        .reads
+        .iter()
+        .find(|read| {
+            read.metadata.accounts.contains(&acct) && read.key.method == ChainReadMethod::BalanceOf
+        })
+        .expect("balance read");
+    assert_eq!(balance_read.key.contract_address, read.key.contract_address);
+    assert_eq!(balance_read.key.block_mode, BlockReadMode::Safe);
+    assert_eq!(balance_read.key.args, read.key.args);
 }
 
 #[test]
@@ -270,7 +286,10 @@ fn test_plan_power_reconcile_can_emit_current_votes_fallback_reads() {
         .chain_read_plan
         .reads
         .iter()
-        .find(|read| read.metadata.accounts.contains(&acct))
+        .find(|read| {
+            read.metadata.accounts.contains(&acct)
+                && read.key.method == ChainReadMethod::CurrentVotes
+        })
         .expect("account read");
 
     assert_eq!(read.key.method, ChainReadMethod::CurrentVotes);

--- a/apps/indexer/tests/support/fixtures/known-dao-ranges/expected/projected-outputs.json
+++ b/apps/indexer/tests/support/fixtures/known-dao-ranges/expected/projected-outputs.json
@@ -226,7 +226,15 @@
         "previous_votes": "10"
       }
     ],
-    "delegates": [],
+    "delegates": [
+      {
+        "from_delegate": "0x0000000000000000000000000000000000003001",
+        "id": "0x0000000000000000000000000000000000003001_0x0000000000000000000000000000000000003003",
+        "is_current": true,
+        "power": "0",
+        "to_delegate": "0x0000000000000000000000000000000000003003"
+      }
+    ],
     "event_order": [
       "evm:1:20000:0x00000000000000000000000000000000000000000000000000000000001e8480:0:0",
       "evm:1:20001:0x00000000000000000000000000000000000000000000000000000000001e84e4:0:0",
@@ -236,7 +244,7 @@
       "candidate_count": 6,
       "deduped_count": 2,
       "deduped_reads": 0,
-      "requested_reads": 4
+      "requested_reads": 6
     },
     "token_transfers": [
       {
@@ -266,7 +274,7 @@
       "candidate_count": 2,
       "deduped_count": 0,
       "deduped_reads": 0,
-      "requested_reads": 2
+      "requested_reads": 4
     },
     "token_transfers": [
       {

--- a/apps/indexer/tests/token_projection.rs
+++ b/apps/indexer/tests/token_projection.rs
@@ -90,7 +90,7 @@ fn test_project_token_events_preserves_history_mappings_relations_and_reconcile_
 
     assert_eq!(batch.reconcile_plan.metrics.candidate_count, 7);
     assert_eq!(batch.reconcile_plan.metrics.deduped_count, 4);
-    assert_eq!(batch.reconcile_plan.chain_read_plan.reads.len(), 3);
+    assert_eq!(batch.reconcile_plan.chain_read_plan.reads.len(), 6);
     let accounts = batch
         .reconcile_plan
         .candidates
@@ -117,8 +117,27 @@ fn test_project_token_events_preserves_history_mappings_relations_and_reconcile_
     );
     for read in &batch.reconcile_plan.chain_read_plan.reads {
         assert_eq!(read.requirement, ReadRequirement::Required);
-        assert_eq!(read.key.method, ChainReadMethod::GetVotes);
     }
+    assert_eq!(
+        batch
+            .reconcile_plan
+            .chain_read_plan
+            .reads
+            .iter()
+            .filter(|read| read.key.method == ChainReadMethod::GetVotes)
+            .count(),
+        3
+    );
+    assert_eq!(
+        batch
+            .reconcile_plan
+            .chain_read_plan
+            .reads
+            .iter()
+            .filter(|read| read.key.method == ChainReadMethod::BalanceOf)
+            .count(),
+        3
+    );
 }
 
 #[test]
@@ -337,7 +356,7 @@ fn test_project_token_events_undelegation_old_side_delta_removes_relation_withou
 }
 
 #[test]
-fn test_project_token_events_delegate_change_without_voting_units_does_not_emit_delegate_edge() {
+fn test_project_token_events_delegate_change_without_voting_units_keeps_zero_power_edge() {
     let batch = project_token_events(
         &context(GovernanceTokenStandard::Erc20),
         vec![TokenProjectionEvent {
@@ -356,7 +375,12 @@ fn test_project_token_events_delegate_change_without_voting_units_does_not_emit_
         .expect("mapping is preserved");
     assert_eq!(mapping.to, account("bbbb"));
     assert_eq!(mapping.power, "0");
-    assert!(repository.delegates().is_empty());
+    let relation = repository
+        .delegates()
+        .get(&format!("{}_{}", account("aaaa"), account("bbbb")))
+        .expect("current zero-power delegate relation");
+    assert!(relation.is_current);
+    assert_eq!(relation.power, "0");
     assert_eq!(
         repository
             .contributors()
@@ -414,6 +438,54 @@ fn test_project_token_events_applies_same_transaction_delegate_vote_delta_to_rel
         1
     );
     assert_eq!(repository.data_metric().power_sum, "0");
+}
+
+#[test]
+fn test_project_token_events_delegate_vote_aggregate_does_not_overwrite_edge_power() {
+    let mut repository = InMemoryTokenProjectionRepository::default();
+    let initial = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![
+            TokenProjectionEvent {
+                log: log(10, 0, 1),
+                event: delegate_changed(account("BBBB"), zero(), account("CCCC")),
+            },
+            TokenProjectionEvent {
+                log: log(11, 0, 1),
+                event: transfer(
+                    account("DDDD"),
+                    account("BBBB"),
+                    "40",
+                    GovernanceTokenStandard::Erc20,
+                ),
+            },
+        ],
+    )
+    .expect("initial projection succeeds");
+    repository.apply(&initial).expect("initial write succeeds");
+
+    let aggregate_change = project_token_events(
+        &context(GovernanceTokenStandard::Erc20),
+        vec![TokenProjectionEvent {
+            log: log(12, 0, 1),
+            event: delegate_votes_changed(account("CCCC"), "40", "1000"),
+        }],
+    )
+    .expect("aggregate projection succeeds");
+    repository
+        .apply(&aggregate_change)
+        .expect("aggregate write succeeds");
+
+    let mapping = repository
+        .delegate_mappings()
+        .get(&account("bbbb"))
+        .expect("current mapping");
+    assert_eq!(mapping.power, "40");
+    let relation = repository
+        .delegates()
+        .get(&format!("{}_{}", account("bbbb"), account("cccc")))
+        .expect("current relation");
+    assert_eq!(relation.power, "40");
 }
 
 #[test]

--- a/apps/indexer/tests/token_projection.rs
+++ b/apps/indexer/tests/token_projection.rs
@@ -90,7 +90,7 @@ fn test_project_token_events_preserves_history_mappings_relations_and_reconcile_
 
     assert_eq!(batch.reconcile_plan.metrics.candidate_count, 7);
     assert_eq!(batch.reconcile_plan.metrics.deduped_count, 4);
-    assert_eq!(batch.reconcile_plan.chain_read_plan.reads.len(), 6);
+    assert_eq!(batch.reconcile_plan.chain_read_plan.reads.len(), 5);
     let accounts = batch
         .reconcile_plan
         .candidates
@@ -136,7 +136,7 @@ fn test_project_token_events_preserves_history_mappings_relations_and_reconcile_
             .iter()
             .filter(|read| read.key.method == ChainReadMethod::BalanceOf)
             .count(),
-        3
+        2
     );
 }
 


### PR DESCRIPTION
## Summary

- Keep active zero-power delegate edges materialized so `delegates` represents current and historical delegator -> delegatee relations, while `delegateMapping` remains the current edge table.
- Keep delegate edge power tied to the delegator voting units/token balance semantics: transfer deltas and same-transaction delegate-change vote deltas can move the edge, but unrelated aggregate `DelegateVotesChanged` events do not overwrite it.
- Refresh delegate live overlays from the delegator `balanceOf` value, while contributor overlays and `data_metric.power_sum` continue to use `getVotes` / configured current power.

## Investigation: ENS differences

- New bug: `delegates` omitted active zero-power relations because the Rust projection deleted current delegate rows when edge power reached zero. The old handler intentionally kept zero-power rows, and that is logically correct for the API shape: the relation exists even when its current edge power is zero.
- New bug: live delegate overlays used contributor `getVotes` as edge power. Under OpenZeppelin Votes, `getVotes(delegator)` is aggregate voting power delegated to that account, not the token balance/voting units contributed by that delegator to its selected delegatee. This can corrupt `delegates.power` in GraphQL while `delegateMapping.power` remains stored event state.
- Old behavior accepted as correct: old onchain delegate mapping refresh used `delegateOf(delegator)` plus `tokenBalance(delegator)` for edge power. This matches OZ delegate edge semantics better than copying aggregate `getVotes` onto the edge.
- Accepted semantic difference: contributor power and global `power_sum` remain onchain `getVotes` based. Edge power and contributor/global power are intentionally different concepts.
- Guarded old-side event issue: redelegation transactions can emit old delegate vote decreases after the mapping has moved. Those aggregate events now cannot reactivate the old relation as current.

## Tests

- `cargo test --locked --test token_projection -- --nocapture`
- `cargo test --locked --test power_reconcile -- --nocapture`
- `cargo test --locked --lib token_store_tests -- --nocapture`
- `cargo test --locked --test onchain_refresh_worker test_live_power_overlay_reader_uses_latest_block_mode_and_dedupes_accounts -- --nocapture`
- `cargo test --locked --test onchain_refresh_worker test_refresh_live_power_overlays_writes_provisional_store_only -- --nocapture`
- `git diff --check -- apps/indexer/src/onchain/refresh.rs apps/indexer/src/projection/power_reconcile.rs apps/indexer/src/projection/token.rs apps/indexer/src/store/postgres/token.rs apps/indexer/tests/onchain_refresh_worker.rs apps/indexer/tests/power_reconcile.rs apps/indexer/tests/token_projection.rs`

Not fully run locally:

- `cargo test --locked --test onchain_refresh_worker test_onchain_refresh_worker_updates_contributors_tasks_and_metrics -- --nocapture` fails before exercising assertions because `DEGOV_INDEXER_TEST_DATABASE_URL` is not configured.
- Full `cargo fmt --check` is blocked by unrelated, uncommitted proposal metadata edits already present in the worktree; HBX-429 scoped whitespace check passes.

## Expected ENS impact

- `delegates` row count should increase for active zero-power relations, reducing the prior `missing_new` gap.
- `delegates.power` and `delegateMappings.power` should converge toward balance/voting-unit edge semantics after resync/onchain refresh.
- Mismatches where the old indexer copied balance-based edge power are expected to converge; mismatches caused by old aggregate-vote interpretation should remain accepted rather than copied.
