### PR TITLE
fix(indexer): align ENS proposal fields

### DIFF
--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -1391,11 +1391,11 @@ fn estimate_blocknumber_timestamp(
     anchor_block_timestamp: Option<&str>,
     block_interval: Option<&str>,
 ) -> Option<String> {
-    let target = timepoint.parse::<i128>().ok()?;
-    let anchor = anchor_block_number.parse::<i128>().ok()?;
-    let timestamp = anchor_block_timestamp?.parse::<i128>().ok()?;
-    let interval_ms = block_interval?.parse::<i128>().ok()? * 1_000;
-    let estimated = timestamp.checked_add(target.checked_sub(anchor)?.checked_mul(interval_ms)?)?;
+    let target = timepoint.parse::<f64>().ok()?;
+    let anchor = anchor_block_number.parse::<f64>().ok()?;
+    let timestamp = anchor_block_timestamp?.parse::<f64>().ok()?;
+    let interval_ms = block_interval?.parse::<f64>().ok()? * 1_000.0;
+    let estimated = (timestamp + (target - anchor) * interval_ms).round() as i128;
 
     (estimated >= 0).then(|| estimated.to_string())
 }
@@ -1403,7 +1403,8 @@ fn estimate_blocknumber_timestamp(
 fn block_interval(chain_id: i32, clock_mode: &str) -> Option<String> {
     const ETHEREUM_MAINNET_CHAIN_ID: i32 = 1;
 
-    (chain_id == ETHEREUM_MAINNET_CHAIN_ID && clock_mode == "blocknumber").then(|| "12".to_owned())
+    (chain_id == ETHEREUM_MAINNET_CHAIN_ID && clock_mode == "blocknumber")
+        .then(|| "13.333333333333334".to_owned())
 }
 
 fn timepoint_timestamp_for_proposal(proposal: &ProposalWrite, timepoint: &str) -> String {

--- a/apps/indexer/src/projection/proposal_metadata.rs
+++ b/apps/indexer/src/projection/proposal_metadata.rs
@@ -158,11 +158,11 @@ pub fn derive_proposal_metadata_with_title_extractor(
     description: &str,
     title_extractor: &dyn ProposalTitleExtractor,
 ) -> ProposalTextMetadata {
-    let (title, description_body) = extract_title_and_body(description);
-    let title = if description.trim().is_empty() || title.trim().is_empty() {
-        title
+    let (local_title, description_body) = extract_title_and_body(description);
+    let title = if description.trim().is_empty() {
+        local_title
     } else {
-        extract_ai_title(title_extractor, description).unwrap_or(title)
+        extract_ai_title(title_extractor, description).unwrap_or(local_title)
     };
     let (description_body, discussion, signature_content) =
         extract_description_tags(&description_body);
@@ -220,7 +220,11 @@ fn extract_title_simplify(description: &str) -> Option<String> {
     }
 
     description.lines().find_map(|line| {
-        let heading = line.trim_start().strip_prefix("# ")?;
+        let trimmed = line.trim_start();
+        let heading = trimmed.strip_prefix('#')?;
+        if !starts_with_whitespace(heading) {
+            return None;
+        }
         let title = heading.trim();
         if title.is_empty() {
             None
@@ -419,6 +423,29 @@ fn strip_html_tags(value: &str) -> String {
     }
 
     stripped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StaticTitleExtractor;
+
+    impl ProposalTitleExtractor for StaticTitleExtractor {
+        fn extract_title(
+            &self,
+            _description: &str,
+        ) -> Result<Option<String>, ProposalTitleExtractionError> {
+            Ok(Some("AI title".to_owned()))
+        }
+    }
+
+    #[test]
+    fn test_title_extractor_runs_when_local_fallback_is_empty() {
+        let metadata = derive_proposal_metadata_with_title_extractor("<br>", &StaticTitleExtractor);
+
+        assert_eq!(metadata.title, "AI title");
+    }
 }
 
 fn description_hash(description: &str) -> String {

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -210,14 +210,7 @@ async fn insert_proposal_id_event(
     Ok(())
 }
 
-async fn upsert_proposal(
-    transaction: &mut Transaction<'_, Postgres>,
-    row: &ProposalWrite,
-) -> Result<(), PostgresIndexerRunnerStoreError> {
-    relink_existing_proposal_to_raw_id(transaction, row).await?;
-
-    sqlx::query(
-        "INSERT INTO proposal (
+const UPSERT_PROPOSAL_SQL: &str = "INSERT INTO proposal (
             id, contract_set_id, chain_id, dao_code, governor_address, contract_address, log_index,
             transaction_index, proposal_id, proposer, targets, values, signatures, calldatas,
             vote_start, vote_end, description, block_number, block_timestamp, transaction_hash,
@@ -251,10 +244,17 @@ async fn upsert_proposal(
              queue_expires_at = COALESCE(EXCLUDED.queue_expires_at, proposal.queue_expires_at),
              block_interval = COALESCE(EXCLUDED.block_interval, proposal.block_interval),
              clock_mode = EXCLUDED.clock_mode,
-             quorum = EXCLUDED.quorum,
-             decimals = EXCLUDED.decimals,
-             timelock_address = COALESCE(EXCLUDED.timelock_address, proposal.timelock_address)",
-    )
+             quorum = CASE WHEN EXCLUDED.quorum = 0::NUMERIC(78, 0) THEN proposal.quorum ELSE EXCLUDED.quorum END,
+             decimals = CASE WHEN EXCLUDED.decimals = 0::NUMERIC(78, 0) THEN proposal.decimals ELSE EXCLUDED.decimals END,
+             timelock_address = COALESCE(EXCLUDED.timelock_address, proposal.timelock_address)";
+
+async fn upsert_proposal(
+    transaction: &mut Transaction<'_, Postgres>,
+    row: &ProposalWrite,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    relink_existing_proposal_to_raw_id(transaction, row).await?;
+
+    sqlx::query(UPSERT_PROPOSAL_SQL)
     .bind(&row.id)
     .bind(&row.contract_set_id)
     .bind(row.chain_id)
@@ -477,4 +477,19 @@ async fn insert_proposal_deadline_extension(
     .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod proposal_tests {
+    use super::*;
+
+    #[test]
+    fn test_upsert_proposal_preserves_existing_quorum_and_decimals_when_excluded_zero() {
+        assert!(UPSERT_PROPOSAL_SQL.contains(
+            "quorum = CASE WHEN EXCLUDED.quorum = 0::NUMERIC(78, 0) THEN proposal.quorum ELSE EXCLUDED.quorum END"
+        ));
+        assert!(UPSERT_PROPOSAL_SQL.contains(
+            "decimals = CASE WHEN EXCLUDED.decimals = 0::NUMERIC(78, 0) THEN proposal.decimals ELSE EXCLUDED.decimals END"
+        ));
+    }
 }

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -2252,11 +2252,11 @@ async fn assert_proposal_projection_parity_state(pool: &PgPool) -> Result<(), sq
     );
     assert_eq!(
         proposal.get::<String, _>("vote_start_timestamp"),
-        "1700001178000"
+        "1700001308667"
     );
     assert_eq!(
         proposal.get::<String, _>("vote_end_timestamp"),
-        "1700002378000"
+        "1700002642000"
     );
     assert_eq!(proposal.get::<String, _>("proposal_eta"), "1234");
     assert_eq!(proposal.get::<String, _>("clock_mode"), "blocknumber");
@@ -2264,7 +2264,7 @@ async fn assert_proposal_projection_parity_state(pool: &PgPool) -> Result<(), sq
     assert_eq!(proposal.get::<String, _>("decimals"), "18");
     assert_eq!(
         proposal.get::<Option<String>, _>("block_interval"),
-        Some("12".to_owned())
+        Some("13.333333333333334".to_owned())
     );
     assert_eq!(
         proposal.get::<Option<String>, _>("timelock_address"),

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -170,6 +170,26 @@ fn test_project_proposal_created_skips_erc721_decimals_enrichment_read() {
 }
 
 #[test]
+fn test_project_proposal_created_uses_ethereum_float_block_interval_fallback() {
+    let batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: production_log("block-interval", 100, 0, 1, 1_700_000_000_000),
+            event: proposal_created("42", "# Proposal title\n\nProposal body"),
+        }],
+    )
+    .expect("projection succeeds");
+
+    let proposal = &batch.proposals[0];
+    assert_eq!(
+        proposal.block_interval.as_deref(),
+        Some("13.333333333333334")
+    );
+    assert_eq!(proposal.vote_start_timestamp, "1699998933333");
+    assert_eq!(proposal.vote_end_timestamp, "1699999200000");
+}
+
+#[test]
 fn test_project_proposal_created_uses_raw_log_id_and_timestamp_clock_enrichment() {
     let batch = project_proposal_events(
         &context(),
@@ -313,7 +333,10 @@ fn test_project_proposal_created_estimates_blocknumber_vote_timestamps_from_prop
     assert_eq!(proposal.clock_mode, "blocknumber");
     assert_eq!(proposal.vote_start_timestamp, "1745507999000");
     assert_eq!(proposal.vote_end_timestamp, "1746060503000");
-    assert_eq!(proposal.block_interval.as_deref(), Some("12"));
+    assert_eq!(
+        proposal.block_interval.as_deref(),
+        Some("13.333333333333334")
+    );
     assert_eq!(
         proposal.timelock_address.as_deref(),
         Some("0x2222222222222222222222222222222222222222")


### PR DESCRIPTION
## Summary
- Preserve existing nonzero proposal quorum/decimals when replay or lifecycle stubs carry default zero values.
- Align deterministic proposal title extraction and OpenRouter fallback ordering with the old indexer behavior.
- Match the old ENS block-number fallback interval (`13.333333333333334`) and round fractional timestamp estimates.

## Vote metric investigation
The ENS proposal vote metric mismatch appears to come from a local ingestion gap, not vote projection aggregation: old indexer has 66 nested voter rows for proposal `0xe553b6c5519f775a0b9595d74addbe7ecb4893184f3de4b6c60bc088cdb3d6c5`, while the local DB has 57. The missing rows are a consecutive mid-range block slice from `24850076` through `24853888`; local `vote_cast_group`, `vote_cast`, and `vote_cast_with_params` have zero rows in that range even though the checkpoint is processed past it. The focused `vote_projection` suite passes and no vote aggregation code was changed.

## Validation
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --test proposal_projection --locked`
- `cargo test -p degov-datalens-indexer --test proposal_metadata --locked`
- `cargo test -p degov-datalens-indexer --test vote_projection --locked`
- `cargo test -p degov-datalens-indexer test_upsert_proposal_preserves_existing_quorum_and_decimals_when_excluded_zero --locked`
- `DEGOV_INDEXER_TEST_DATABASE_URL=... cargo test -p degov-datalens-indexer --test postgres_runtime_run test_run_path_processes_datalens_pages_into_postgres --locked`
- `cargo test -p degov-datalens-indexer --test native_runner_integration --locked`