### PR TITLE
fix(indexer): reconcile delegate relation power from balance

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -786,6 +786,8 @@ where
             let previous_values =
                 read_contributor_refresh_values(&mut transaction, successes).await?;
             upsert_contributor_refresh(&mut transaction, successes).await?;
+            reconcile_current_delegate_relation_power_from_balance(&mut transaction, successes)
+                .await?;
             insert_refresh_checkpoints(
                 &mut transaction,
                 successes,
@@ -2122,6 +2124,154 @@ async fn upsert_contributor_refresh_group(
         .push_bind(refresh_balance)
         .push(" THEN EXCLUDED.balance ELSE contributor.balance END");
     query.build().execute(&mut **transaction).await?;
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct DelegateRelationBalanceRefreshKey {
+    contract_set_id: String,
+    chain_id: i32,
+    dao_code: Option<String>,
+    governor_address: String,
+    token_address: String,
+    account: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DelegateRelationBalanceRefresh {
+    key: DelegateRelationBalanceRefreshKey,
+    balance: String,
+}
+
+async fn reconcile_current_delegate_relation_power_from_balance(
+    transaction: &mut Transaction<'_, Postgres>,
+    successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
+) -> Result<(), sqlx::Error> {
+    let mut refreshes_by_key = BTreeMap::new();
+    for (task, value) in successes {
+        let Some(balance) = value.balance.as_ref().filter(|_| task.refresh_balance) else {
+            continue;
+        };
+        let key = DelegateRelationBalanceRefreshKey {
+            contract_set_id: task.contract_set_id.clone(),
+            chain_id: task.chain_id,
+            dao_code: task.dao_code.clone(),
+            governor_address: task.governor_address.clone(),
+            token_address: task.token_address.clone(),
+            account: task.account.clone(),
+        };
+        refreshes_by_key.insert(
+            key.clone(),
+            DelegateRelationBalanceRefresh {
+                key,
+                balance: balance.clone(),
+            },
+        );
+    }
+
+    if refreshes_by_key.is_empty() {
+        return Ok(());
+    }
+
+    let refreshes = refreshes_by_key.into_values().collect::<Vec<_>>();
+    for chunk in refreshes.chunks(MAX_ONCHAIN_REFRESH_APPLY_ROWS) {
+        let mut query = QueryBuilder::<Postgres>::new(
+            "WITH refreshed (
+                contract_set_id, chain_id, dao_code, governor_address, token_address,
+                delegator, balance
+             ) AS (",
+        );
+        query.push_values(chunk, |mut values, refresh| {
+            values
+                .push_bind(&refresh.key.contract_set_id)
+                .push_bind(refresh.key.chain_id)
+                .push_bind(&refresh.key.dao_code)
+                .push_bind(&refresh.key.governor_address)
+                .push_bind(&refresh.key.token_address)
+                .push_bind(&refresh.key.account)
+                .push_bind(&refresh.balance)
+                .push_unseparated("::NUMERIC(78, 0)");
+        });
+        query.push(
+            "),
+             current_edges AS (
+                SELECT DISTINCT ON (delegate.contract_set_id, delegate.id)
+                    delegate.contract_set_id,
+                    delegate.id,
+                    delegate.from_delegate,
+                    delegate.to_delegate,
+                    delegate.power AS previous_power,
+                    refreshed.balance AS new_power
+                FROM delegate
+                JOIN refreshed
+                  ON refreshed.contract_set_id = delegate.contract_set_id
+                 AND refreshed.chain_id = delegate.chain_id
+                 AND refreshed.dao_code IS NOT DISTINCT FROM delegate.dao_code
+                 AND refreshed.governor_address IS NOT DISTINCT FROM delegate.governor_address
+                 AND (
+                    delegate.token_address IS NOT DISTINCT FROM refreshed.token_address
+                    OR delegate.token_address IS NULL
+                 )
+                 AND refreshed.delegator = delegate.from_delegate
+                WHERE delegate.is_current = TRUE
+                ORDER BY delegate.contract_set_id, delegate.id
+             ),
+             effective_deltas AS (
+                SELECT
+                    contract_set_id,
+                    to_delegate,
+                    SUM(
+                        CASE
+                            WHEN previous_power = 0::NUMERIC(78, 0)
+                             AND new_power <> 0::NUMERIC(78, 0) THEN 1
+                            WHEN previous_power <> 0::NUMERIC(78, 0)
+                             AND new_power = 0::NUMERIC(78, 0) THEN -1
+                            ELSE 0
+                        END
+                    )::INT AS delta
+                FROM current_edges
+                GROUP BY contract_set_id, to_delegate
+             ),
+             updated_delegates AS (
+                UPDATE delegate
+                SET power = current_edges.new_power
+                FROM current_edges
+                WHERE delegate.contract_set_id = current_edges.contract_set_id
+                  AND delegate.id = current_edges.id
+                  AND delegate.power IS DISTINCT FROM current_edges.new_power
+                RETURNING delegate.id
+             ),
+             updated_delegate_mappings AS (
+                UPDATE delegate_mapping
+                SET power = current_edges.new_power
+                FROM current_edges
+                WHERE delegate_mapping.contract_set_id = current_edges.contract_set_id
+                  AND delegate_mapping.id = current_edges.from_delegate
+                  AND delegate_mapping.\"from\" = current_edges.from_delegate
+                  AND delegate_mapping.\"to\" = current_edges.to_delegate
+                  AND delegate_mapping.power IS DISTINCT FROM current_edges.new_power
+                RETURNING delegate_mapping.id
+             ),
+             updated_effective_counts AS (
+                UPDATE contributor
+                SET delegates_count_effective = GREATEST(
+                    0,
+                    contributor.delegates_count_effective + effective_deltas.delta
+                )
+                FROM effective_deltas
+                WHERE contributor.contract_set_id = effective_deltas.contract_set_id
+                  AND contributor.id = effective_deltas.to_delegate
+                  AND effective_deltas.delta <> 0
+                RETURNING contributor.id
+             )
+             SELECT
+                (SELECT count(*)::BIGINT FROM updated_delegates) AS delegate_updates,
+                (SELECT count(*)::BIGINT FROM updated_delegate_mappings) AS mapping_updates,
+                (SELECT count(*)::BIGINT FROM updated_effective_counts) AS count_updates",
+        );
+        query.build().fetch_one(&mut **transaction).await?;
+    }
 
     Ok(())
 }

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -500,6 +500,150 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_reconciles_current_delegate_relation_power_from_balance()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_contributor(&database.pool, ACCOUNT_ONE, "3", Some("4")).await?;
+    seed_data_metric(&database.pool, "3").await?;
+    seed_final_delegate_with_scope(
+        &database.pool,
+        "demo-dao",
+        "demo-dao",
+        46,
+        ACCOUNT_ONE,
+        ACCOUNT_TWO,
+        "64",
+    )
+    .await?;
+    seed_final_delegate_mapping(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "64").await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        true,
+        true,
+    )
+    .await?;
+
+    let reader = MockOnchainRefreshReader::new([(
+        "task-one",
+        OnchainRefreshReadValue {
+            task_id: "task-one".to_owned(),
+            balance: Some("32".to_owned()),
+            power: Some("0".to_owned()),
+        },
+    )]);
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker.run_once().await?;
+
+    if report.failed > 0 {
+        panic!(
+            "task failed: {:?}",
+            task_error(&database.pool, "task-one").await?
+        );
+    }
+    assert_eq!(report.completed, 1, "{report:?}");
+    assert_eq!(
+        contributor_values(&database.pool, ACCOUNT_ONE).await?,
+        ("0".to_owned(), Some("32".to_owned()))
+    );
+    assert_final_delegate(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "32").await?;
+    assert_final_delegate_mapping(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "32").await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_zeros_current_delegate_relation_power_from_zero_balance()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_contributor(&database.pool, ACCOUNT_ONE, "7", Some("77")).await?;
+    seed_data_metric(&database.pool, "7").await?;
+    seed_final_delegate_with_scope(
+        &database.pool,
+        "demo-dao",
+        "demo-dao",
+        46,
+        ACCOUNT_ONE,
+        ACCOUNT_TWO,
+        "77",
+    )
+    .await?;
+    seed_final_delegate_mapping(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "77").await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        true,
+        true,
+    )
+    .await?;
+
+    let reader = MockOnchainRefreshReader::new([(
+        "task-one",
+        OnchainRefreshReadValue {
+            task_id: "task-one".to_owned(),
+            balance: Some("0".to_owned()),
+            power: Some("0".to_owned()),
+        },
+    )]);
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker.run_once().await?;
+
+    if report.failed > 0 {
+        panic!(
+            "task failed: {:?}",
+            task_error(&database.pool, "task-one").await?
+        );
+    }
+    assert_eq!(report.completed, 1, "{report:?}");
+    assert_eq!(
+        contributor_values(&database.pool, ACCOUNT_ONE).await?,
+        ("0".to_owned(), Some("0".to_owned()))
+    );
+    assert_final_delegate(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "0").await?;
+    assert_final_delegate_mapping(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "0").await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_uses_current_votes_checkpoint_source()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -1669,6 +1813,34 @@ async fn seed_final_delegate_with_scope(
     Ok(())
 }
 
+async fn seed_final_delegate_mapping(
+    pool: &PgPool,
+    delegator: &str,
+    delegate: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"INSERT INTO delegate_mapping (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            "from", "to", power, block_number, block_timestamp, transaction_hash
+         )
+         VALUES (
+            $1, 'demo-dao', 46, 'demo-dao', $2, $3, $4, $5, $6::NUMERIC(78, 0),
+            12::NUMERIC(78, 0), 12000::NUMERIC(78, 0), '0xdelegate-mapping'
+         )"#,
+    )
+    .bind(delegator)
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .bind(delegator)
+    .bind(delegate)
+    .bind(power)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 async fn seed_data_metric(pool: &PgPool, power_sum: &str) -> Result<(), sqlx::Error> {
     seed_data_metric_with_scope(pool, "demo-dao", power_sum, 1, 7).await
 }
@@ -1918,6 +2090,14 @@ async fn assert_failed_task_error_contains(
     Ok(())
 }
 
+async fn task_error(pool: &PgPool, task_id: &str) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query("SELECT error FROM onchain_refresh_task WHERE id = $1")
+        .bind(task_id)
+        .fetch_one(pool)
+        .await
+        .map(|row| row.get("error"))
+}
+
 async fn assert_task_status(
     pool: &PgPool,
     task_id: &str,
@@ -2120,6 +2300,54 @@ async fn assert_delegate_overlay_with_scope(
         row.get::<Option<String>, _>("anchor_block_timestamp"),
         Some("12000".to_owned())
     );
+
+    Ok(())
+}
+
+async fn assert_final_delegate(
+    pool: &PgPool,
+    delegator: &str,
+    delegate: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT from_delegate, to_delegate, power::TEXT AS power
+         FROM delegate
+         WHERE contract_set_id = 'demo-dao'
+           AND from_delegate = $1
+           AND to_delegate = $2
+           AND is_current = TRUE",
+    )
+    .bind(delegator)
+    .bind(delegate)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("from_delegate"), delegator);
+    assert_eq!(row.get::<String, _>("to_delegate"), delegate);
+    assert_eq!(row.get::<String, _>("power"), power);
+
+    Ok(())
+}
+
+async fn assert_final_delegate_mapping(
+    pool: &PgPool,
+    delegator: &str,
+    delegate: &str,
+    power: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        r#"SELECT "from", "to", power::TEXT AS power
+         FROM delegate_mapping
+         WHERE contract_set_id = 'demo-dao' AND id = $1"#,
+    )
+    .bind(delegator)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("from"), delegator);
+    assert_eq!(row.get::<String, _>("to"), delegate);
+    assert_eq!(row.get::<String, _>("power"), power);
 
     Ok(())
 }

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -576,6 +576,8 @@ async fn test_onchain_refresh_worker_zeros_current_delegate_relation_power_from_
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_contributor(&database.pool, ACCOUNT_ONE, "7", Some("77")).await?;
+    seed_contributor(&database.pool, ACCOUNT_TWO, "0", Some("0")).await?;
+    set_contributor_delegate_counts(&database.pool, ACCOUNT_TWO, 1, 1).await?;
     seed_data_metric(&database.pool, "7").await?;
     seed_final_delegate_with_scope(
         &database.pool,
@@ -637,6 +639,7 @@ async fn test_onchain_refresh_worker_zeros_current_delegate_relation_power_from_
     );
     assert_final_delegate(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "0").await?;
     assert_final_delegate_mapping(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "0").await?;
+    assert_contributor_delegate_counts(&database.pool, ACCOUNT_TWO, 1, 0).await?;
 
     database.cleanup().await?;
 
@@ -1768,6 +1771,26 @@ async fn seed_contributor_with_scope(
     Ok(())
 }
 
+async fn set_contributor_delegate_counts(
+    pool: &PgPool,
+    account: &str,
+    all: i32,
+    effective: i32,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE contributor
+         SET delegates_count_all = $2, delegates_count_effective = $3
+         WHERE contract_set_id = 'demo-dao' AND id = $1",
+    )
+    .bind(account)
+    .bind(all)
+    .bind(effective)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 async fn seed_final_delegate(
     pool: &PgPool,
     delegator: &str,
@@ -2014,6 +2037,27 @@ async fn contributor_values_by_scope(
         row.get::<String, _>("power"),
         row.get::<Option<String>, _>("balance"),
     ))
+}
+
+async fn assert_contributor_delegate_counts(
+    pool: &PgPool,
+    account: &str,
+    all: i32,
+    effective: i32,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT delegates_count_all, delegates_count_effective
+         FROM contributor
+         WHERE contract_set_id = 'demo-dao' AND id = $1",
+    )
+    .bind(account)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<i32, _>("delegates_count_all"), all);
+    assert_eq!(row.get::<i32, _>("delegates_count_effective"), effective);
+
+    Ok(())
 }
 
 async fn data_metric_values_by_scope(


### PR DESCRIPTION
## Summary

- Reconciles current delegate/delegateMapping edge power from refreshed onchain `balanceOf(delegator)` during onchain refresh.
- Keeps contributor/global power sourced from `getVotes` and does not replace contributor power with balance.
- Dedupes balance refresh inputs by scope/account before applying relation corrections.
- Updates current `delegate` rows, current `delegate_mapping` rows, and effective delegate counts when a relation crosses zero/non-zero.

## Why

ENS parity checks found current relation edge power could remain stale or doubled after historical projection. The projection still applies event deltas, but onchain refresh is the durable correctness pass for current power, so current relation edges should be corrected from the delegator's current voting units/balance.

## Tests

- `cargo test -p degov-datalens-indexer current_delegate_relation_power --test onchain_refresh_worker`
- `cargo test -p degov-datalens-indexer --test onchain_refresh_worker`
- `cargo test -p degov-datalens-indexer --test token_projection`
- `cargo test -p degov-datalens-indexer --test graphql_service`

Note: local worktree has unrelated unstaged changes in datalens planner/indexer runner files; this PR commit contains only the onchain refresh fix and its tests.
