### PR TITLE
fix(indexer): align ENS proposal parity

### DIFF
--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -127,7 +127,7 @@ pub fn plan_dao_log_queries(
             DatalensError::Query("Datalens log range end exceeds SDK limit".to_owned())
         })?;
 
-        plans.push(query_plan(config, addresses, range_start, range_end));
+        plans.extend(query_plans(config, addresses, range_start, range_end));
 
         if chunk_end == to_block {
             break;
@@ -179,35 +179,61 @@ pub fn fetch_provisional_dao_log_pages(
     Ok(pages)
 }
 
-fn query_plan(
+fn query_plans(
     config: &DatalensConfig,
     addresses: &DaoContractAddresses,
     from_block: i32,
     to_block: i32,
+) -> Vec<DaoLogQueryPlan> {
+    vec![
+        query_plan(
+            config,
+            DaoLogAddressSource {
+                address: addresses.governor.clone(),
+                source: DaoLogSource::Governor,
+            },
+            GOVERNOR_TOPIC0_FILTERS,
+            from_block,
+            to_block,
+        ),
+        query_plan(
+            config,
+            DaoLogAddressSource {
+                address: addresses.governor_token.clone(),
+                source: DaoLogSource::GovernorToken,
+            },
+            GOVERNOR_TOKEN_TOPIC0_FILTERS,
+            from_block,
+            to_block,
+        ),
+        query_plan(
+            config,
+            DaoLogAddressSource {
+                address: addresses.timelock.clone(),
+                source: DaoLogSource::Timelock,
+            },
+            TIMELOCK_TOPIC0_FILTERS,
+            from_block,
+            to_block,
+        ),
+    ]
+}
+
+fn query_plan(
+    config: &DatalensConfig,
+    source: DaoLogAddressSource,
+    topic0_filters: &[&str],
+    from_block: i32,
+    to_block: i32,
 ) -> DaoLogQueryPlan {
-    let sources = vec![
-        DaoLogAddressSource {
-            address: addresses.governor.clone(),
-            source: DaoLogSource::Governor,
-        },
-        DaoLogAddressSource {
-            address: addresses.governor_token.clone(),
-            source: DaoLogSource::GovernorToken,
-        },
-        DaoLogAddressSource {
-            address: addresses.timelock.clone(),
-            source: DaoLogSource::Timelock,
-        },
-    ];
-    let topic0_filters = GOVERNOR_TOPIC0_FILTERS
+    let topics = topic0_filters
         .iter()
-        .chain(GOVERNOR_TOKEN_TOPIC0_FILTERS)
-        .chain(TIMELOCK_TOPIC0_FILTERS)
         .map(|topic| topic.to_string())
         .collect();
+    let address = source.address.clone();
 
     DaoLogQueryPlan {
-        sources,
+        sources: vec![source],
         from_block,
         to_block,
         input: QueryInput {
@@ -229,12 +255,8 @@ fn query_plan(
             selector: QuerySelectorInput {
                 kind: SelectorKindInput::EvmLogs,
                 evm_logs: Some(EvmLogsSelectorInput {
-                    addresses: vec![
-                        addresses.governor.clone(),
-                        addresses.governor_token.clone(),
-                        addresses.timelock.clone(),
-                    ],
-                    topics: vec![topic0_filters],
+                    addresses: vec![address],
+                    topics: vec![topics],
                 }),
                 other: None,
             },

--- a/apps/indexer/src/datalens/warmup.rs
+++ b/apps/indexer/src/datalens/warmup.rs
@@ -136,8 +136,10 @@ pub fn ensure_datalens_warmup_task(
     }
 
     let result = match config.warmup.kind {
-        DatalensWarmupKind::FollowQuery => follow_query_request(config, addresses, start_block)
-            .and_then(|request| ensurer.ensure_warmup_task(request)),
+        DatalensWarmupKind::FollowQuery => {
+            let requests = follow_query_requests(config, addresses, start_block)?;
+            ensure_follow_query_requests(ensurer, requests)
+        }
     };
 
     match result {
@@ -161,30 +163,73 @@ pub fn follow_query_request(
     addresses: &DaoContractAddresses,
     start_block: i64,
 ) -> Result<DatalensWarmupSubmitRequest, DatalensError> {
+    follow_query_requests(config, addresses, start_block)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| DatalensError::Warmup("Datalens warmup query plan was empty".to_owned()))
+}
+
+fn follow_query_requests(
+    config: &DatalensConfig,
+    addresses: &DaoContractAddresses,
+    start_block: i64,
+) -> Result<Vec<DatalensWarmupSubmitRequest>, DatalensError> {
     if start_block < 0 {
         return Err(DatalensError::Warmup(format!(
             "Datalens warmup start block must be non-negative: {start_block}"
         )));
     }
-    let query = crate::plan_dao_log_queries(config, addresses, start_block, start_block)?
-        .into_iter()
-        .next()
-        .ok_or_else(|| DatalensError::Warmup("Datalens warmup query plan was empty".to_owned()))?;
-    let selector = query.input.selector.evm_logs.as_ref().ok_or_else(|| {
-        DatalensError::Warmup("Datalens warmup selector is not evm_logs".to_owned())
-    })?;
 
-    Ok(DatalensWarmupSubmitRequest {
-        chain: warmup_chain_identity(&config.chain)?,
-        dataset_key: warmup_dataset_key(&config.dataset),
-        selector: warmup_evm_logs_selector(&query.input.selector, selector)?,
-        range_kind: warmup_range_kind(&query.input.range.kind)?,
-        start: start_block as u64,
-        end: None,
-        mode: "follow_query".to_owned(),
-        chunk_policy: WarmupChunkPolicy {
-            max_range_len: config.query_limits.block_range_limit,
-        },
+    let queries = crate::plan_dao_log_queries(config, addresses, start_block, start_block)?;
+    if queries.is_empty() {
+        return Err(DatalensError::Warmup(
+            "Datalens warmup query plan was empty".to_owned(),
+        ));
+    }
+
+    queries
+        .into_iter()
+        .map(|query| {
+            let selector = query.input.selector.evm_logs.as_ref().ok_or_else(|| {
+                DatalensError::Warmup("Datalens warmup selector is not evm_logs".to_owned())
+            })?;
+
+            Ok(DatalensWarmupSubmitRequest {
+                chain: warmup_chain_identity(&config.chain)?,
+                dataset_key: warmup_dataset_key(&config.dataset),
+                selector: warmup_evm_logs_selector(&query.input.selector, selector)?,
+                range_kind: warmup_range_kind(&query.input.range.kind)?,
+                start: start_block as u64,
+                end: None,
+                mode: "follow_query".to_owned(),
+                chunk_policy: WarmupChunkPolicy {
+                    max_range_len: config.query_limits.block_range_limit,
+                },
+            })
+        })
+        .collect()
+}
+
+fn ensure_follow_query_requests(
+    ensurer: &mut impl DatalensWarmupEnsurer,
+    requests: Vec<DatalensWarmupSubmitRequest>,
+) -> Result<DatalensWarmupEnsureOutcome, DatalensError> {
+    let mut task_ids = Vec::new();
+    let mut created_any = false;
+
+    for request in requests {
+        match ensurer.ensure_warmup_task(request)? {
+            DatalensWarmupEnsureOutcome::Submitted { task_id, created } => {
+                task_ids.push(task_id);
+                created_any |= created;
+            }
+            outcome => return Ok(outcome),
+        }
+    }
+
+    Ok(DatalensWarmupEnsureOutcome::Submitted {
+        task_id: task_ids.join(","),
+        created: created_any,
     })
 }
 

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -1403,8 +1403,7 @@ fn estimate_blocknumber_timestamp(
 fn block_interval(chain_id: i32, clock_mode: &str) -> Option<String> {
     const ETHEREUM_MAINNET_CHAIN_ID: i32 = 1;
 
-    (chain_id == ETHEREUM_MAINNET_CHAIN_ID && clock_mode == "blocknumber")
-        .then(|| "13.333333333333334".to_owned())
+    (chain_id == ETHEREUM_MAINNET_CHAIN_ID && clock_mode == "blocknumber").then(|| "12".to_owned())
 }
 
 fn timepoint_timestamp_for_proposal(proposal: &ProposalWrite, timepoint: &str) -> String {

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -14,23 +14,13 @@ fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelo
     let config = config(1_000, DatalensFinality::DurableOnly);
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 1);
+    assert_eq!(plans.len(), 3);
     assert_query(
         &plans[0],
-        &[
-            DaoLogAddressSource {
-                address: "0x1111111111111111111111111111111111111111".to_owned(),
-                source: DaoLogSource::Governor,
-            },
-            DaoLogAddressSource {
-                address: "0x2222222222222222222222222222222222222222".to_owned(),
-                source: DaoLogSource::GovernorToken,
-            },
-            DaoLogAddressSource {
-                address: "0x3333333333333333333333333333333333333333".to_owned(),
-                source: DaoLogSource::Timelock,
-            },
-        ],
+        &[DaoLogAddressSource {
+            address: "0x1111111111111111111111111111111111111111".to_owned(),
+            source: DaoLogSource::Governor,
+        }],
         &[
             "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0",
             "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892",
@@ -45,9 +35,33 @@ fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelo
             "0x08f74ea46ef7894f65eabfb5e6e695de773a000b47c529ab559178069b226401",
             "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4",
             "0xe2babfbac5889a709b63bb7f598b324e08bc5a4fb9ec647fb3cbc9ec07eb8712",
+        ],
+        100,
+        199,
+        "durable_only",
+    );
+    assert_query(
+        &plans[1],
+        &[DaoLogAddressSource {
+            address: "0x2222222222222222222222222222222222222222".to_owned(),
+            source: DaoLogSource::GovernorToken,
+        }],
+        &[
             "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
             "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f",
             "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
+        ],
+        100,
+        199,
+        "durable_only",
+    );
+    assert_query(
+        &plans[2],
+        &[DaoLogAddressSource {
+            address: "0x3333333333333333333333333333333333333333".to_owned(),
+            source: DaoLogSource::Timelock,
+        }],
+        &[
             "0x4cf4410cc57040e44862ef0f45f3dd5a5e02db8eb8add648d4b0e236f1d07dca",
             "0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58",
             "0x20fda5fd27a1ea7bf5b9567f143ac5470bb059374a27e8f67cb44f946f6d0387",
@@ -72,7 +86,20 @@ fn test_plan_dao_log_queries_chunks_ranges_by_config_limit() {
         .map(|plan| (plan.from_block, plan.to_block))
         .collect::<Vec<_>>();
 
-    assert_eq!(ranges, vec![(100, 149), (150, 199), (200, 220)]);
+    assert_eq!(
+        ranges,
+        vec![
+            (100, 149),
+            (100, 149),
+            (100, 149),
+            (150, 199),
+            (150, 199),
+            (150, 199),
+            (200, 220),
+            (200, 220),
+            (200, 220),
+        ]
+    );
 }
 
 #[test]

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -32,17 +32,30 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
         outcome,
         DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.requests.len(), 1);
-    let request = &ensurer.requests[0];
-    assert_eq!(request.chain.configured_name, "ethereum");
-    assert_eq!(request.chain.network_id, Some(1));
-    assert_eq!(request.dataset_key, "evm.logs");
-    assert_eq!(request.range_kind, "block");
-    assert_eq!(request.start, 100);
-    assert_eq!(request.end, None);
-    assert_eq!(request.mode, "follow_query");
-    assert_eq!(request.selector.addresses.len(), 3);
-    assert_eq!(request.selector.topics.len(), 1);
+    assert_eq!(ensurer.requests.len(), 3);
+    let selector_addresses: Vec<_> = ensurer
+        .requests
+        .iter()
+        .map(|request| request.selector.addresses.clone())
+        .collect();
+    assert_eq!(
+        selector_addresses,
+        vec![
+            vec!["0x1111111111111111111111111111111111111111".to_owned()],
+            vec!["0x2222222222222222222222222222222222222222".to_owned()],
+            vec!["0x3333333333333333333333333333333333333333".to_owned()],
+        ]
+    );
+    for request in &ensurer.requests {
+        assert_eq!(request.chain.configured_name, "ethereum");
+        assert_eq!(request.chain.network_id, Some(1));
+        assert_eq!(request.dataset_key, "evm.logs");
+        assert_eq!(request.range_kind, "block");
+        assert_eq!(request.start, 100);
+        assert_eq!(request.end, None);
+        assert_eq!(request.mode, "follow_query");
+        assert_eq!(request.selector.topics.len(), 1);
+    }
 }
 
 #[test]
@@ -63,7 +76,7 @@ fn test_ensure_datalens_warmup_task_reuses_existing_matching_task() {
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 1);
+    assert_eq!(ensurer.created_tasks.len(), 3);
 }
 
 #[test]
@@ -81,7 +94,7 @@ fn test_ensure_datalens_warmup_task_submits_distinct_task_for_selector_mismatch(
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 2);
+    assert_eq!(ensurer.created_tasks.len(), 4);
 }
 
 #[test]

--- a/apps/indexer/tests/datalens_warmup_effectiveness.rs
+++ b/apps/indexer/tests/datalens_warmup_effectiveness.rs
@@ -110,20 +110,46 @@ fn test_warmup_effectiveness_aggregation_builds_operator_log_fields() {
 fn test_fetch_dao_log_pages_preserves_cache_summary() {
     let config = config();
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
-    let mut reader = MockLogReader::new(vec![Ok(DatalensLogQueryResult {
-        rows: json!([]),
-        cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
-            "hit_ranges": [],
-            "missing_ranges": [{ "kind": "block", "start": 100, "end": 100 }],
-            "provider_fill_ranges": [{ "kind": "block", "start": 100, "end": 100 }]
-        })),
-    })]);
+    let mut reader = MockLogReader::new(vec![
+        Ok(DatalensLogQueryResult {
+            rows: json!([]),
+            cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+                "hit_ranges": [],
+                "missing_ranges": [{ "kind": "block", "start": 100, "end": 100 }],
+                "provider_fill_ranges": [{ "kind": "block", "start": 100, "end": 100 }]
+            })),
+        }),
+        Ok(DatalensLogQueryResult {
+            rows: json!([]),
+            cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+                "hit_ranges": [{ "kind": "block", "start": 100, "end": 100 }],
+                "missing_ranges": [],
+                "provider_fill_ranges": []
+            })),
+        }),
+        Ok(DatalensLogQueryResult {
+            rows: json!([]),
+            cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+                "hit_ranges": [{ "kind": "block", "start": 100, "end": 100 }],
+                "missing_ranges": [],
+                "provider_fill_ranges": []
+            })),
+        }),
+    ]);
 
     let pages = fetch_dao_log_pages(&mut reader, &plans).expect("pages");
 
-    assert_eq!(pages.len(), 1);
+    assert_eq!(pages.len(), 3);
     assert_eq!(pages[0].cache.outcome, DatalensLogQueryCacheOutcome::Miss);
     assert_eq!(pages[0].cache.provider_fill_range_count, Some(1));
+    assert_eq!(
+        pages[1].cache.outcome,
+        DatalensLogQueryCacheOutcome::FullHit
+    );
+    assert_eq!(
+        pages[2].cache.outcome,
+        DatalensLogQueryCacheOutcome::FullHit
+    );
 }
 
 fn identity() -> IndexerCheckpointIdentity {

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -359,7 +358,15 @@ fn test_runner_splits_provider_limit_range_and_advances_checkpoint_after_subrang
     assert_eq!(runner.store().commit_count(), 2);
     assert_eq!(
         *observed_ranges.lock().expect("observed ranges"),
-        vec![(1, 1_000), (1, 500), (501, 1_000)]
+        vec![
+            (1, 1_000),
+            (1, 500),
+            (1, 500),
+            (1, 500),
+            (501, 1_000),
+            (501, 1_000),
+            (501, 1_000),
+        ]
     );
 }
 
@@ -677,7 +684,11 @@ fn test_runner_decodes_duplicate_address_token_log_with_token_source() {
 
     assert_eq!(
         *attempts.lock().expect("attempts"),
-        vec![DaoLogSource::Governor, DaoLogSource::GovernorToken]
+        vec![
+            DaoLogSource::Governor,
+            DaoLogSource::GovernorToken,
+            DaoLogSource::Timelock
+        ]
     );
     assert_eq!(
         runner.store().token_repository().delegate_changed().len(),
@@ -719,14 +730,46 @@ fn test_runner_keeps_duplicate_address_unsupported_topic_unsupported() {
 }
 
 struct ScriptedDatalensReader {
-    rows: VecDeque<Vec<Value>>,
+    rows: Vec<Vec<Value>>,
 }
 
 impl DatalensLogQueryReader for ScriptedDatalensReader {
-    fn query_logs(&mut self, _input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
-        Ok(DatalensLogQueryResult::rows_only(Value::Array(
-            self.rows.pop_front().expect("scripted query response"),
-        )))
+    fn query_logs(&mut self, input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
+        let addresses = input
+            .selector
+            .evm_logs
+            .as_ref()
+            .map(|selector| {
+                selector
+                    .addresses
+                    .iter()
+                    .map(|address| address.to_ascii_lowercase())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let rows = self
+            .rows
+            .iter()
+            .flatten()
+            .filter(|row| {
+                let block_number = row
+                    .get("block_number")
+                    .or_else(|| row.get("blockNumber"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or_default();
+                let address = row
+                    .get("address")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_ascii_lowercase();
+
+                (input.range.start..=input.range.end).contains(&block_number)
+                    && addresses.iter().any(|candidate| candidate == &address)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        Ok(DatalensLogQueryResult::rows_only(Value::Array(rows)))
     }
 }
 
@@ -996,9 +1039,7 @@ fn runner_with_store<D: IndexerEventDecoder>(
     IndexerRunner::new(
         options,
         contexts(),
-        ScriptedDatalensReader {
-            rows: VecDeque::from(rows),
-        },
+        ScriptedDatalensReader { rows },
         store,
         decoder,
     )

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::fmt;
 use std::time::Duration;
 
@@ -291,9 +290,7 @@ fn native_runner_with_options(
     IndexerRunner::new(
         options,
         contexts(),
-        ScriptedReader {
-            rows: VecDeque::from(pages),
-        },
+        ScriptedReader { rows: pages },
         store,
         DaoEventDecoder,
     )
@@ -344,14 +341,46 @@ impl ChainTool for ScriptedChainTool {
 
 #[derive(Clone, Debug)]
 struct ScriptedReader {
-    rows: VecDeque<Vec<Value>>,
+    rows: Vec<Vec<Value>>,
 }
 
 impl DatalensLogQueryReader for ScriptedReader {
-    fn query_logs(&mut self, _input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
-        Ok(DatalensLogQueryResult::rows_only(Value::Array(
-            self.rows.pop_front().expect("scripted query response"),
-        )))
+    fn query_logs(&mut self, input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
+        let addresses = input
+            .selector
+            .evm_logs
+            .as_ref()
+            .map(|selector| {
+                selector
+                    .addresses
+                    .iter()
+                    .map(|address| address.to_ascii_lowercase())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let rows = self
+            .rows
+            .iter()
+            .flatten()
+            .filter(|row| {
+                let block_number = row
+                    .get("block_number")
+                    .or_else(|| row.get("blockNumber"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or_default();
+                let address = row
+                    .get("address")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_ascii_lowercase();
+
+                (input.range.start..=input.range.end).contains(&block_number)
+                    && addresses.iter().any(|candidate| candidate == &address)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        Ok(DatalensLogQueryResult::rows_only(Value::Array(rows)))
     }
 }
 

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -2252,11 +2252,11 @@ async fn assert_proposal_projection_parity_state(pool: &PgPool) -> Result<(), sq
     );
     assert_eq!(
         proposal.get::<String, _>("vote_start_timestamp"),
-        "1700001308667"
+        "1700001178000"
     );
     assert_eq!(
         proposal.get::<String, _>("vote_end_timestamp"),
-        "1700002642000"
+        "1700002378000"
     );
     assert_eq!(proposal.get::<String, _>("proposal_eta"), "1234");
     assert_eq!(proposal.get::<String, _>("clock_mode"), "blocknumber");
@@ -2264,7 +2264,7 @@ async fn assert_proposal_projection_parity_state(pool: &PgPool) -> Result<(), sq
     assert_eq!(proposal.get::<String, _>("decimals"), "18");
     assert_eq!(
         proposal.get::<Option<String>, _>("block_interval"),
-        Some("13.333333333333334".to_owned())
+        Some("12".to_owned())
     );
     assert_eq!(
         proposal.get::<Option<String>, _>("timelock_address"),

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -128,7 +128,7 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
     run_indexer_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 1);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
     assert_table_count(&database.pool, "proposal_created", 1).await?;
     assert_table_count(&database.pool, "proposal", 1).await?;
     assert_table_count(&database.pool, "vote_cast", 1).await?;
@@ -157,7 +157,7 @@ async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
     run_indexer_all_contract_sets_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 0);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
     assert_checkpoint_scope(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_scope(&database.pool, SECOND_CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_row_count(&database.pool, 2).await?;
@@ -2066,12 +2066,16 @@ fn handle_datalens_request(
         })
     } else {
         query_count.fetch_add(1, Ordering::Relaxed);
-        let rows = governor_rows
-            .iter()
-            .chain(token_rows)
-            .chain(timelock_rows)
-            .cloned()
-            .collect::<Vec<_>>();
+        let request_body = request.split("\r\n\r\n").nth(1).unwrap_or_default();
+        let rows = if request_body.contains(GOVERNOR) || request_body.contains(SECOND_GOVERNOR) {
+            governor_rows.to_vec()
+        } else if request_body.contains(TOKEN) || request_body.contains(SECOND_TOKEN) {
+            token_rows.to_vec()
+        } else if request_body.contains(TIMELOCK) || request_body.contains(SECOND_TIMELOCK) {
+            timelock_rows.to_vec()
+        } else {
+            Vec::new()
+        };
 
         json!({
             "chain": {},

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -170,7 +170,7 @@ fn test_project_proposal_created_skips_erc721_decimals_enrichment_read() {
 }
 
 #[test]
-fn test_project_proposal_created_uses_ethereum_float_block_interval_fallback() {
+fn test_project_proposal_created_uses_legacy_ethereum_block_interval_fallback() {
     let batch = project_proposal_events(
         &context(),
         vec![ProposalProjectionEvent {
@@ -181,12 +181,9 @@ fn test_project_proposal_created_uses_ethereum_float_block_interval_fallback() {
     .expect("projection succeeds");
 
     let proposal = &batch.proposals[0];
-    assert_eq!(
-        proposal.block_interval.as_deref(),
-        Some("13.333333333333334")
-    );
-    assert_eq!(proposal.vote_start_timestamp, "1699998933333");
-    assert_eq!(proposal.vote_end_timestamp, "1699999200000");
+    assert_eq!(proposal.block_interval.as_deref(), Some("12"));
+    assert_eq!(proposal.vote_start_timestamp, "1699999040000");
+    assert_eq!(proposal.vote_end_timestamp, "1699999280000");
 }
 
 #[test]
@@ -333,10 +330,7 @@ fn test_project_proposal_created_estimates_blocknumber_vote_timestamps_from_prop
     assert_eq!(proposal.clock_mode, "blocknumber");
     assert_eq!(proposal.vote_start_timestamp, "1745507999000");
     assert_eq!(proposal.vote_end_timestamp, "1746060503000");
-    assert_eq!(
-        proposal.block_interval.as_deref(),
-        Some("13.333333333333334")
-    );
+    assert_eq!(proposal.block_interval.as_deref(), Some("12"));
     assert_eq!(
         proposal.timelock_address.as_deref(),
         Some("0x2222222222222222222222222222222222222222")

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -29,18 +29,33 @@ static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 #[test]
 fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
     let config = datalens_config();
-    let mut reader = MockProvisionalReader::new(vec![Ok(DatalensProvisionalLogQueryResult {
-        rows: serde_json::json!([]),
-        segments: vec![cache_segment("provider", "latest", 100, 105)],
-    })]);
+    let mut reader = MockProvisionalReader::new(vec![
+        Ok(DatalensProvisionalLogQueryResult {
+            rows: serde_json::json!([]),
+            segments: vec![cache_segment("provider", "latest", 100, 105)],
+        }),
+        Ok(DatalensProvisionalLogQueryResult {
+            rows: serde_json::json!([]),
+            segments: Vec::new(),
+        }),
+        Ok(DatalensProvisionalLogQueryResult {
+            rows: serde_json::json!([]),
+            segments: Vec::new(),
+        }),
+    ]);
     let mut store = RecordingProvisionalStore::default();
     let mut worker = ProvisionalWorker::new(options(&config), &mut reader, &mut store);
 
     let report = worker.run_once().expect("worker runs once");
 
     assert_eq!(report.segments_written, 1);
-    assert_eq!(reader.calls.len(), 1);
-    assert_eq!(reader.calls[0].finality.as_deref(), Some("safe_to_latest"));
+    assert_eq!(reader.calls.len(), 3);
+    assert!(
+        reader
+            .calls
+            .iter()
+            .all(|call| call.finality.as_deref() == Some("safe_to_latest"))
+    );
     assert_eq!(store.writes.len(), 1);
     assert_eq!(store.writes[0].segment_finality, "latest");
 }


### PR DESCRIPTION
## Summary

- Align ENS blocknumber proposal `blockInterval` with the existing production GraphQL value (`12`) while keeping exact block timestamp enrichment as the preferred timestamp source.
- Split Datalens durable log queries into source-specific selectors for governor, governor token, and timelock logs. This avoids trusting a stale combined-selector full-hit cache segment that missed standard ENS `VoteCast` logs in the affected proposal range.
- Update planner/runner tests so scripted Datalens readers behave like selector-filtered Datalens responses.

## Root Cause

The remaining ENS vote metric mismatch for proposal `0xe553b6c5519f775a0b9595d74addbe7ecb4893184f3de4b6c60bc088cdb3d6c5` was caused by missing standard governor `VoteCast` logs in the local run. RPC receipt checks showed the missing votes are normal OZ governor `VoteCast(address,uint256,uint8,uint256,string)` events, and the decoder already supports that topic. The local run had consumed a Datalens `full_hit` response for the combined governor/token/timelock selector, but that cached response did not include all governor logs for the range.

Using source-specific selectors gives governor votes their own selector/cache key and prevents a combined cache segment from hiding missing governor rows.

## Notes

Title compatibility is already covered by the existing TextPlus fallback tests in `proposal_metadata`; this PR does not change title extraction behavior.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p degov-datalens-indexer --test datalens_planner --test indexer_runner --test native_runner_integration --test proposal_projection --test vote_projection --test proposal_metadata`

Full crate test was also attempted:

- `cargo test -p degov-datalens-indexer`

It reached Postgres-backed tests and failed because `DEGOV_INDEXER_TEST_DATABASE_URL` is not configured in this local shell.
