### PR TITLE
Fix transient Datalens chunk splitting

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -279,7 +279,7 @@ pub enum DatalensQueryErrorClass {
 }
 
 impl DatalensQueryErrorClass {
-    fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::ProviderLimit => "provider_limit",
             Self::Transient => "transient",

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -313,6 +313,25 @@ impl AdaptiveChunkSizer {
         }
     }
 
+    pub fn record_transient_query_failure(
+        &mut self,
+        failed_range_block_count: u32,
+    ) -> Option<(u32, u32)> {
+        if failed_range_block_count <= self.config.min_chunk_size {
+            return None;
+        }
+
+        let previous_chunk_size = self.current_chunk_size;
+        self.stable_chunks = 0;
+        self.unstable_chunks = 0;
+        self.current_chunk_size = failed_range_block_count
+            .saturating_div(2)
+            .max(self.config.min_chunk_size)
+            .min(self.current_chunk_size);
+
+        Some((previous_chunk_size, self.current_chunk_size))
+    }
+
     fn shrink_current_chunk_size(&mut self) {
         self.current_chunk_size = shrink_chunk_size(
             self.current_chunk_size,
@@ -736,6 +755,37 @@ where
                             chunk_started_at.elapsed().as_millis()
                         );
                         continue;
+                    }
+                    if let Some(error_class) = datalens_query_error_class(&error)
+                        .filter(|error_class| *error_class == DatalensQueryErrorClass::Transient)
+                    {
+                        if let Some((previous_chunk_size, new_chunk_size)) =
+                            chunk_sizer.record_transient_query_failure(failed_range_block_count)
+                        {
+                            let retry_to_block = range
+                                .from_block
+                                .saturating_add(i64::from(new_chunk_size))
+                                .saturating_sub(1)
+                                .min(range.to_block)
+                                .max(range.from_block);
+                            warn!(
+                                "Datalens indexer chunk transient split dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} from_block={} previous_to_block={} retry_to_block={} previous_chunk_size={} new_chunk_size={} error_class={} error={} duration_ms={}",
+                                self.options.checkpoint_identity.dao_code,
+                                self.options.checkpoint_identity.chain_id,
+                                self.options.checkpoint_identity.contract_set_id,
+                                self.options.checkpoint_identity.stream_id,
+                                self.options.checkpoint_identity.data_source_version,
+                                range.from_block,
+                                range.to_block,
+                                retry_to_block,
+                                previous_chunk_size,
+                                new_chunk_size,
+                                error_class.as_str(),
+                                error,
+                                chunk_started_at.elapsed().as_millis()
+                            );
+                            continue;
+                        }
                     }
 
                     error!(
@@ -1386,12 +1436,15 @@ fn range_block_count(range: CheckpointBlockRange) -> u32 {
 }
 
 fn is_provider_limit_error(error: &IndexerRunnerError) -> bool {
-    let message = match error {
-        IndexerRunnerError::Datalens(DatalensError::Query(message)) => message,
-        _ => return false,
+    datalens_query_error_class(error) == Some(DatalensQueryErrorClass::ProviderLimit)
+}
+
+fn datalens_query_error_class(error: &IndexerRunnerError) -> Option<DatalensQueryErrorClass> {
+    let IndexerRunnerError::Datalens(DatalensError::Query(message)) = error else {
+        return None;
     };
 
-    classify_datalens_query_error(message) == DatalensQueryErrorClass::ProviderLimit
+    Some(classify_datalens_query_error(message))
 }
 
 #[derive(Clone, Debug, Eq, Error, PartialEq)]

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -371,6 +371,68 @@ fn test_runner_splits_provider_limit_range_and_advances_checkpoint_after_subrang
 }
 
 #[test]
+fn test_runner_splits_transient_range_and_retries_without_pass_error() {
+    let mut options = options();
+    set_block_range_limit(&mut options, 5_000);
+    let observed_ranges = Arc::new(Mutex::new(Vec::new()));
+    let reader = TransientDatalensReader::new(2_500, observed_ranges.clone());
+    let mut runner = IndexerRunner::new(
+        options,
+        contexts(),
+        reader,
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+        ScriptedDecoder,
+    );
+    runner.request_shutdown_after_chunks(1);
+
+    let report = runner
+        .run_to_target(5_000)
+        .expect("split transient range succeeds");
+
+    assert_eq!(report.chunks_processed, 1);
+    assert!(report.shutdown_requested);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        2_501
+    );
+    assert_eq!(runner.store().commit_count(), 1);
+    assert_eq!(
+        *observed_ranges.lock().expect("observed ranges"),
+        vec![(1, 5_000), (1, 2_500), (1, 2_500), (1, 2_500)]
+    );
+}
+
+#[test]
+fn test_runner_keeps_transient_min_chunk_as_recoverable_pass_error() {
+    let mut options = options();
+    set_block_range_limit(&mut options, 100);
+    let observed_ranges = Arc::new(Mutex::new(Vec::new()));
+    let reader = TransientDatalensReader::new(99, observed_ranges.clone());
+    let mut runner = IndexerRunner::new(
+        options,
+        contexts(),
+        reader,
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+        ScriptedDecoder,
+    );
+
+    let error = runner
+        .run_to_target(100)
+        .expect_err("min chunk transient remains a pass error");
+
+    assert!(error.to_string().contains("502"));
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        1
+    );
+    assert_eq!(runner.store().commit_count(), 0);
+    assert_eq!(
+        *observed_ranges.lock().expect("observed ranges"),
+        vec![(1, 100)]
+    );
+}
+
+#[test]
 fn test_runner_fails_single_block_provider_limit_without_advancing_checkpoint() {
     let mut options = options();
     set_block_range_limit(&mut options, 1);
@@ -843,6 +905,39 @@ impl DatalensLogQueryReader for ProviderLimitDatalensReader {
         if block_count > self.max_successful_blocks {
             return Err(DatalensError::Query(
                 r#"datalens HTTP error 429: {"error":{"kind":"provider_limit","message":"query returns too many logs, narrow your filter: 20000"}}"#
+                    .to_owned(),
+            ));
+        }
+
+        Ok(DatalensLogQueryResult::rows_only(Value::Array(Vec::new())))
+    }
+}
+
+struct TransientDatalensReader {
+    max_successful_blocks: u64,
+    observed_ranges: Arc<Mutex<Vec<(u64, u64)>>>,
+}
+
+impl TransientDatalensReader {
+    fn new(max_successful_blocks: u64, observed_ranges: Arc<Mutex<Vec<(u64, u64)>>>) -> Self {
+        Self {
+            max_successful_blocks,
+            observed_ranges,
+        }
+    }
+}
+
+impl DatalensLogQueryReader for TransientDatalensReader {
+    fn query_logs(&mut self, input: QueryInput) -> Result<DatalensLogQueryResult, DatalensError> {
+        let range = (input.range.start, input.range.end);
+        self.observed_ranges
+            .lock()
+            .expect("observed ranges")
+            .push(range);
+        let block_count = input.range.end - input.range.start + 1;
+        if block_count > self.max_successful_blocks {
+            return Err(DatalensError::Query(
+                r#"datalens HTTP error 502: {"error":{"kind":"bad_gateway","message":"bad gateway"}}"#
                     .to_owned(),
             ));
         }


### PR DESCRIPTION
## Summary

- Split transient Datalens query failures into smaller ranges when above the adaptive minimum chunk size.
- Keep provider-limit split behavior on its existing path.
- Add runner coverage for transient split retry, min-chunk fallback behavior, provider-limit preservation, and smaller-range checkpoint advancement.

## Validation

- `cargo test -p degov-datalens-indexer --test indexer_runner`
- `cargo test -p degov-datalens-indexer --test datalens_client`
- `cargo test -p degov-datalens-indexer` *(stops at DB-backed `checkpoint_repository` tests because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set; earlier unit and non-DB integration tests passed before that point)*
- `git diff --check`