### PR TITLE
Fix transient Datalens chunk splits

### DIFF
--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -72,6 +72,7 @@ pub struct AdaptiveChunkSizerConfig {
     pub initial_chunk_size: u32,
     pub max_chunk_size: u32,
     pub min_chunk_size: u32,
+    pub transient_query_failure_min_chunk_size: u32,
     pub local_processing_shrink_threshold: Duration,
     pub fast_chunk_duration_threshold: Duration,
     pub high_query_duration_threshold: Duration,
@@ -89,6 +90,7 @@ impl AdaptiveChunkSizerConfig {
             initial_chunk_size: max_chunk_size,
             max_chunk_size,
             min_chunk_size: 100,
+            transient_query_failure_min_chunk_size: 1,
             local_processing_shrink_threshold: Duration::from_secs(10),
             fast_chunk_duration_threshold: Duration::from_secs(1),
             high_query_duration_threshold: Duration::from_secs(10),
@@ -104,6 +106,9 @@ impl AdaptiveChunkSizerConfig {
     pub fn capped_to_block_range_limit(mut self, block_range_limit: u32) -> Self {
         self.max_chunk_size = self.max_chunk_size.min(block_range_limit);
         self.min_chunk_size = self.min_chunk_size.min(self.max_chunk_size);
+        self.transient_query_failure_min_chunk_size = self
+            .transient_query_failure_min_chunk_size
+            .min(self.max_chunk_size);
         self.initial_chunk_size = self.initial_chunk_size.min(self.max_chunk_size);
         self.initial_chunk_size = self.initial_chunk_size.max(self.min_chunk_size);
         self
@@ -173,10 +178,14 @@ impl AdaptiveChunkSizer {
         if config.initial_chunk_size == 0
             || config.max_chunk_size == 0
             || config.min_chunk_size == 0
+            || config.transient_query_failure_min_chunk_size == 0
         {
             return Err(CheckpointError::InvalidRangeLimit);
         }
         if config.min_chunk_size > config.max_chunk_size {
+            return Err(CheckpointError::InvalidRangeLimit);
+        }
+        if config.transient_query_failure_min_chunk_size > config.max_chunk_size {
             return Err(CheckpointError::InvalidRangeLimit);
         }
         if config.initial_chunk_size < config.min_chunk_size
@@ -317,7 +326,7 @@ impl AdaptiveChunkSizer {
         &mut self,
         failed_range_block_count: u32,
     ) -> Option<(u32, u32)> {
-        if failed_range_block_count <= self.config.min_chunk_size {
+        if failed_range_block_count <= self.config.transient_query_failure_min_chunk_size {
             return None;
         }
 
@@ -326,7 +335,7 @@ impl AdaptiveChunkSizer {
         self.unstable_chunks = 0;
         self.current_chunk_size = failed_range_block_count
             .saturating_div(2)
-            .max(self.config.min_chunk_size)
+            .max(self.config.transient_query_failure_min_chunk_size)
             .min(self.current_chunk_size);
 
         Some((previous_chunk_size, self.current_chunk_size))

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -249,6 +249,7 @@ pub struct IndexerContractSetRuntimeConfig {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AdaptiveChunkSizerRuntimeConfig {
     pub min_chunk_size: u32,
+    pub transient_query_failure_min_chunk_size: u32,
     pub max_chunk_size: Option<u32>,
     pub fast_chunk_duration_threshold: Duration,
     pub high_query_duration_threshold: Duration,
@@ -262,6 +263,7 @@ impl Default for AdaptiveChunkSizerRuntimeConfig {
     fn default() -> Self {
         Self {
             min_chunk_size: 100,
+            transient_query_failure_min_chunk_size: 1,
             max_chunk_size: None,
             fast_chunk_duration_threshold: Duration::from_secs(1),
             high_query_duration_threshold: Duration::from_secs(10),
@@ -283,6 +285,9 @@ impl AdaptiveChunkSizerRuntimeConfig {
             initial_chunk_size: max_chunk_size,
             max_chunk_size,
             min_chunk_size: self.min_chunk_size.min(max_chunk_size),
+            transient_query_failure_min_chunk_size: self
+                .transient_query_failure_min_chunk_size
+                .min(max_chunk_size),
             fast_chunk_duration_threshold: self.fast_chunk_duration_threshold,
             high_query_duration_threshold: self.high_query_duration_threshold,
             cache_fill_high_duration_threshold: self.cache_fill_high_duration_threshold,
@@ -760,6 +765,7 @@ fn load_adaptive_chunk_sizer_runtime_config() -> Result<AdaptiveChunkSizerRuntim
     let config = AdaptiveChunkSizerRuntimeConfig {
         min_chunk_size: optional_env_u32("DEGOV_INDEXER_ADAPTIVE_CHUNK_MIN_BLOCKS")?
             .unwrap_or(defaults.min_chunk_size),
+        transient_query_failure_min_chunk_size: defaults.transient_query_failure_min_chunk_size,
         max_chunk_size: optional_env_u32("DEGOV_INDEXER_ADAPTIVE_CHUNK_MAX_BLOCKS")?,
         fast_chunk_duration_threshold: Duration::from_millis(
             optional_env_u64("DEGOV_INDEXER_ADAPTIVE_CHUNK_FAST_DURATION_MS")?

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -403,11 +403,85 @@ fn test_runner_splits_transient_range_and_retries_without_pass_error() {
 }
 
 #[test]
-fn test_runner_keeps_transient_min_chunk_as_recoverable_pass_error() {
+fn test_runner_splits_transient_failure_below_normal_min_and_advances_checkpoint() {
     let mut options = options();
-    set_block_range_limit(&mut options, 100);
+    set_block_range_limit(&mut options, 101);
     let observed_ranges = Arc::new(Mutex::new(Vec::new()));
-    let reader = TransientDatalensReader::new(99, observed_ranges.clone());
+    let reader = TransientDatalensReader::new(1, observed_ranges.clone());
+    let mut runner = IndexerRunner::new(
+        options,
+        contexts(),
+        reader,
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+        ScriptedDecoder,
+    );
+    runner.request_shutdown_after_chunks(1);
+
+    let report = runner
+        .run_to_target(101)
+        .expect("transient range splits below normal min chunk");
+
+    assert_eq!(report.chunks_processed, 1);
+    assert!(report.shutdown_requested);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        2
+    );
+    assert_eq!(runner.store().commit_count(), 1);
+    assert_eq!(
+        *observed_ranges.lock().expect("observed ranges"),
+        vec![
+            (1, 101),
+            (1, 50),
+            (1, 25),
+            (1, 12),
+            (1, 6),
+            (1, 3),
+            (1, 1),
+            (1, 1),
+            (1, 1),
+        ]
+    );
+}
+
+#[test]
+fn test_runner_splits_two_block_transient_failure_to_single_block() {
+    let mut options = options();
+    set_block_range_limit(&mut options, 2);
+    let observed_ranges = Arc::new(Mutex::new(Vec::new()));
+    let reader = TransientDatalensReader::new(1, observed_ranges.clone());
+    let mut runner = IndexerRunner::new(
+        options,
+        contexts(),
+        reader,
+        InMemoryIndexerRunnerStore::new(identity(), 1),
+        ScriptedDecoder,
+    );
+    runner.request_shutdown_after_chunks(1);
+
+    let report = runner
+        .run_to_target(2)
+        .expect("two-block transient failure splits to one block");
+
+    assert_eq!(report.chunks_processed, 1);
+    assert!(report.shutdown_requested);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        2
+    );
+    assert_eq!(runner.store().commit_count(), 1);
+    assert_eq!(
+        *observed_ranges.lock().expect("observed ranges"),
+        vec![(1, 2), (1, 1), (1, 1), (1, 1)]
+    );
+}
+
+#[test]
+fn test_runner_keeps_single_block_transient_failure_as_recoverable_pass_error() {
+    let mut options = options();
+    set_block_range_limit(&mut options, 1);
+    let observed_ranges = Arc::new(Mutex::new(Vec::new()));
+    let reader = TransientDatalensReader::new(0, observed_ranges.clone());
     let mut runner = IndexerRunner::new(
         options,
         contexts(),
@@ -417,8 +491,8 @@ fn test_runner_keeps_transient_min_chunk_as_recoverable_pass_error() {
     );
 
     let error = runner
-        .run_to_target(100)
-        .expect_err("min chunk transient remains a pass error");
+        .run_to_target(1)
+        .expect_err("single-block transient remains a pass error");
 
     assert!(error.to_string().contains("502"));
     assert_eq!(
@@ -428,7 +502,7 @@ fn test_runner_keeps_transient_min_chunk_as_recoverable_pass_error() {
     assert_eq!(runner.store().commit_count(), 0);
     assert_eq!(
         *observed_ranges.lock().expect("observed ranges"),
-        vec![(1, 100)]
+        vec![(1, 1)]
     );
 }
 


### PR DESCRIPTION
## Summary
- Add a dedicated transient query failure split floor with default 1 block.
- Keep provider-limit and normal adaptive shrink behavior on the existing adaptive min chunk size.
- Cover below-normal-min transient recovery, 2-block to 1-block splitting, single-block transient failure, and provider-limit regression behavior.

## Validation
- cargo test -p degov-datalens-indexer --test indexer_runner
- cargo test -p degov-datalens-indexer --test datalens_client
- git diff --check

Plane: HBX-432