### PR TITLE
perf(indexer): speed up delegate rolling preload

### DIFF
--- a/.local/run-indexer-and-graphql.sh
+++ b/.local/run-indexer-and-graphql.sh
@@ -29,7 +29,7 @@ fi
 : "${DEGOV_INDEXER_TARGET_HEIGHT:=latest}"
 : "${DEGOV_INDEXER_RUN_ONCE:=false}"
 : "${DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED:=true}"
-: "${DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED:=true}"
+: "${DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED:=false}"
 : "${RUST_LOG:=info}"
 export DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS
 export DEGOV_INDEXER_GRAPHQL_ENDPOINT
@@ -54,18 +54,29 @@ cleanup() {
   echo "combined runner stopping at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$LOG_DIR/indexer-combined-main.log"
   [[ -n "${GRAPHQL_PID:-}" ]] && kill "$GRAPHQL_PID" 2>/dev/null || true
   [[ -n "${INDEXER_PID:-}" ]] && kill "$INDEXER_PID" 2>/dev/null || true
+  [[ -n "${WORKER_PID:-}" ]] && kill "$WORKER_PID" 2>/dev/null || true
   wait "$GRAPHQL_PID" 2>/dev/null || true
   wait "$INDEXER_PID" 2>/dev/null || true
+  [[ -n "${WORKER_PID:-}" ]] && wait "$WORKER_PID" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 cargo run -p degov-datalens-indexer --locked -- graphql >> "$LOG_DIR/indexer-graphql-main.log" 2>&1 &
 GRAPHQL_PID=$!
 echo "graphql pid=$GRAPHQL_PID" >> "$LOG_DIR/indexer-combined-main.log"
 sleep 3
+if [[ "${DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED}" == "true" && "${DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED}" != "true" ]]; then
+  cargo run -p degov-datalens-indexer --locked -- worker >> "$LOG_DIR/indexer-worker-main.log" 2>&1 &
+  WORKER_PID=$!
+  echo "worker pid=$WORKER_PID" >> "$LOG_DIR/indexer-combined-main.log"
+fi
 cargo run -p degov-datalens-indexer --locked -- run >> "$LOG_DIR/indexer-sync-main.log" 2>&1 &
 INDEXER_PID=$!
 echo "indexer pid=$INDEXER_PID" >> "$LOG_DIR/indexer-combined-main.log"
-wait -n "$GRAPHQL_PID" "$INDEXER_PID"
+if [[ -n "${WORKER_PID:-}" ]]; then
+  wait -n "$GRAPHQL_PID" "$INDEXER_PID" "$WORKER_PID"
+else
+  wait -n "$GRAPHQL_PID" "$INDEXER_PID"
+fi
 status=$?
-echo "combined runner child exited at $(date -u +%Y-%m-%dT%H:%M:%SZ) status=$status graphql_pid=$GRAPHQL_PID indexer_pid=$INDEXER_PID" >> "$LOG_DIR/indexer-combined-main.log"
+echo "combined runner child exited at $(date -u +%Y-%m-%dT%H:%M:%SZ) status=$status graphql_pid=$GRAPHQL_PID indexer_pid=$INDEXER_PID worker_pid=${WORKER_PID:-}" >> "$LOG_DIR/indexer-combined-main.log"
 exit "$status"

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -60,5 +60,15 @@ async fn ensure_runtime_indexes(pool: &PgPool) -> Result<()> {
     .await
     .context("ensure scoped onchain refresh deferred drain index")?;
 
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_rolling_metadata_preload_idx
+         ON delegate_rolling (contract_set_id, transaction_hash, log_index DESC)
+         INCLUDE (id, delegator, from_delegate, to_delegate, from_new_votes, to_new_votes)
+         WHERE from_delegate <> to_delegate",
+    )
+    .execute(pool)
+    .await
+    .context("ensure delegate rolling metadata preload index")?;
+
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -139,6 +139,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     for table_name in REQUIRED_TABLES {
         assert_table_exists(&database.pool, &database.schema, table_name).await?;
     }
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "delegate_rolling_metadata_preload_idx",
+    )
+    .await?;
     assert_removed_processor_status_table_absent(&database.pool).await?;
     assert_table_exists(&database.pool, &database.schema, "_sqlx_migrations").await?;
 
@@ -294,6 +300,31 @@ async fn assert_table_exists(
     .await?;
 
     assert!(exists, "expected table {schema}.{table_name} to exist");
+
+    Ok(())
+}
+
+async fn assert_index_exists(
+    pool: &PgPool,
+    schema: &str,
+    index_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    let exists: bool = sqlx::query_scalar(
+        r#"
+        SELECT EXISTS (
+          SELECT 1
+          FROM pg_indexes
+          WHERE schemaname = $1
+            AND indexname = $2
+        )
+        "#,
+    )
+    .bind(schema)
+    .bind(index_name)
+    .fetch_one(pool)
+    .await?;
+
+    assert!(exists, "expected index {schema}.{index_name} to exist");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add a covering partial index for delegate rolling metadata preload queries used during dense token projection.
- Ensure the index is created both by the fresh init migration and by runtime startup index checks for existing local/staging databases.
- Keep the combined local GraphQL+sync runner from running inline onchain refresh ticks by default; onchain refresh should run as its own worker so sync progress is not blocked by power refresh RPC work.

## Evidence

ENS dense window 13578418-13583417 exposed repeated slow preload queries against delegate_rolling while processing nearly 200k token events. The query shape filters by contract_set_id, transaction_hash ANY, excludes no-op delegate rows, and orders by transaction_hash plus log_index descending; the new index matches that access pattern and supports index-only reads for the preload columns.

Runtime observation after separating sync from onchain refresh showed ENS progress improved once inline refresh was disabled: the sync process no longer waits for 10s refresh ticks, while the standalone worker drains onchain refresh backlog independently.

## Tests

- cargo fmt --check -p degov-datalens-indexer
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@localhost:7432/postgres cargo test -p degov-datalens-indexer --test migration_schema
- cargo test -p degov-datalens-indexer --lib token_store_tests
- cargo test -p degov-datalens-indexer --test token_projection
