### PR TITLE
fix(indexer): grow provider-fill chunk sizes

### DIFF
--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -237,7 +237,8 @@ impl AdaptiveChunkSizer {
         let stable_growth_reason = feedback.stable_growth_reason(&self.config);
         let stable_growth_candidate = stable_growth_reason
             != AdaptiveChunkSizingReason::StableSparseRange
-            || feedback.returned_row_count <= self.config.sparse_returned_row_threshold;
+            || feedback.returned_row_count <= self.config.sparse_returned_row_threshold
+            || feedback.has_provider_fill();
 
         let reason = if slow_local_processing || high_query_duration || dense_range {
             self.stable_chunks = 0;
@@ -378,6 +379,10 @@ impl AdaptiveChunkFeedback {
         self.warmup_effectiveness.partial_hit_count > 0
             || self.warmup_effectiveness.miss_count > 0
             || self.warmup_effectiveness.provider_fill_range_count > 0
+    }
+
+    fn has_provider_fill(&self) -> bool {
+        self.warmup_effectiveness.provider_fill_range_count > 0
     }
 
     fn is_slow_cache_fill(&self, config: &AdaptiveChunkSizerConfig) -> bool {

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -647,6 +647,28 @@ fn test_adaptive_chunk_sizer_provider_fill_below_high_duration_grows() {
 }
 
 #[test]
+fn test_adaptive_chunk_sizer_provider_fill_over_sparse_threshold_grows_below_high_duration() {
+    let mut sizer = AdaptiveChunkSizer::new(adaptive_config(100, 400)).expect("sizer");
+
+    let first = sizer.record_chunk(adaptive_feedback_with_rows(
+        cache_provider_fill(),
+        Duration::from_millis(800),
+        300,
+    ));
+    let second = sizer.record_chunk(adaptive_feedback_with_rows(
+        cache_provider_fill(),
+        Duration::from_millis(800),
+        300,
+    ));
+
+    assert_eq!(first.current_chunk_size, 100);
+    assert_eq!(first.reason, AdaptiveChunkSizingReason::Hold);
+    assert_eq!(second.previous_chunk_size, 100);
+    assert_eq!(second.current_chunk_size, 200);
+    assert_eq!(second.reason, AdaptiveChunkSizingReason::StableSparseRange);
+}
+
+#[test]
 fn test_adaptive_chunk_sizer_high_duration_shrinks_immediately() {
     let mut sizer = AdaptiveChunkSizer::new(adaptive_config(100, 400)).expect("sizer");
 


### PR DESCRIPTION
## Summary
- allow provider-fill chunks below the existing high-query/dense/slow-local safety gates to count toward adaptive chunk growth even when returned rows exceed the sparse threshold
- keep true high query duration, dense returned rows, slow local processing, provider limit splits, and transient split behavior unchanged
- add a regression test for ENS-like provider-fill chunks that previously stayed at tiny sizes with `adaptive_reason=hold`

## Context
ENS runner logs showed `chunk_size=100-200` with `adaptive_reason=hold`, `miss/provider_fill=3`, and query durations often around 0.6-3s after occasional long tails. The old growth candidate logic rejected non-fast provider-fill chunks with more than `sparse_returned_row_threshold` rows, so once the sizer shrank it recovered too slowly.

## Verification
- `cargo test -p degov-datalens-indexer --test indexer_runner test_adaptive_chunk_sizer_provider_fill_over_sparse_threshold_grows_below_high_duration`
- `cargo test -p degov-datalens-indexer --test indexer_runner`
- `cargo fmt --check -p degov-datalens-indexer`
- `git diff --check`