### PR TITLE
fix(indexer): normalize bracket proposal titles

### DIFF
--- a/apps/indexer/src/projection/proposal_metadata.rs
+++ b/apps/indexer/src/projection/proposal_metadata.rs
@@ -269,7 +269,24 @@ fn clean_fullback_line(line: &str) -> String {
         without_prefix
     };
 
-    strip_blockquote_prefix(without_rule).to_owned()
+    normalize_bracket_prefix(strip_blockquote_prefix(without_rule))
+}
+
+fn normalize_bracket_prefix(line: &str) -> String {
+    let trimmed = line.trim_start();
+    let Some(rest) = trimmed.strip_prefix('[') else {
+        return line.to_owned();
+    };
+    let Some(close_index) = rest.find(']') else {
+        return line.to_owned();
+    };
+    let label = rest[..close_index].trim();
+    let suffix = rest[close_index + 1..].trim_start();
+    if label.is_empty() || suffix.is_empty() {
+        return line.to_owned();
+    }
+
+    format!("{label}: {suffix}")
 }
 
 fn strip_heading_prefix(line: &str) -> Option<&str> {

--- a/apps/indexer/tests/proposal_metadata.rs
+++ b/apps/indexer/tests/proposal_metadata.rs
@@ -88,6 +88,8 @@ fn test_derive_proposal_metadata_preserves_textplus_fallback_compatibility() {
     let list_marker = derive_proposal_metadata_without_ai("- Proposal title\nBody");
     let markdown_link =
         derive_proposal_metadata_without_ai("[Proposal title](https://example.com)\nBody");
+    let bracket_prefix =
+        derive_proposal_metadata_without_ai("[EP2] Retrospective Airdrop \nEnacts EP2");
     let blockquote = derive_proposal_metadata_without_ai("> Proposal title\nBody");
     let compact_heading = derive_proposal_metadata_without_ai("#Title\nBody");
     let nested_hash_heading = derive_proposal_metadata_without_ai("## Title\nBody");
@@ -99,6 +101,8 @@ fn test_derive_proposal_metadata_preserves_textplus_fallback_compatibility() {
     assert_eq!(list_marker.description_body, "Body");
     assert_eq!(markdown_link.title, "Proposal title");
     assert_eq!(markdown_link.description_body, "Body");
+    assert_eq!(bracket_prefix.title, "EP2: Retrospective Airdrop");
+    assert_eq!(bracket_prefix.description_body, "Enacts EP2");
     assert_eq!(blockquote.title, "Proposal title");
     assert_eq!(blockquote.description_body, "Body");
     assert_eq!(compact_heading.title, "#Title");


### PR DESCRIPTION
## Summary\n- normalize bracket-prefixed proposal title fallback like `[EP2] Retrospective Airdrop` to `EP2: Retrospective Airdrop`\n- preserve existing markdown link fallback behavior\n- add regression coverage for ENS EP2-style descriptions\n\n## Why\nDuring ENS new-vs-old indexer comparison, the first indexed proposal matched most projection fields, but the local title fallback produced `[EP2] Retrospective Airdrop` while the legacy indexer exposes `EP2: Retrospective Airdrop`. This keeps the new Rust indexer compatible with the legacy no-AI fallback output.\n\n## Test Plan\n- `cargo test -p degov-datalens-indexer --test proposal_metadata test_derive_proposal_metadata_preserves_textplus_fallback_compatibility`\n- `cargo test -p degov-datalens-indexer --test proposal_metadata`\n- `cargo fmt --check -p degov-datalens-indexer`