### PR TITLE
fix(indexer): reset requeued refresh attempts

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -651,23 +651,33 @@ where
             "SELECT count(*)::BIGINT AS task_count
              FROM onchain_refresh_task
              WHERE (
-                status IN ('pending', 'failed')
+                status = 'pending'
+                OR (
+                    status = 'failed'
+                    AND attempts < ",
+        );
+        query.push_bind(self.config.max_attempts).push(
+            "
+                )
                 OR (
                     status = 'processing'
                     AND locked_at IS NOT NULL
                     AND locked_at <= ",
         );
+        query.push_bind(stale_before.to_string()).push(
+            "::NUMERIC(78, 0)
+                    AND attempts < ",
+        );
         query
-            .push_bind(stale_before.to_string())
+            .push_bind(self.config.max_attempts)
             .push(
-                "::NUMERIC(78, 0)
+                "
                 )
              )
              AND next_run_at <= ",
             )
             .push_bind(now_ms.to_string())
-            .push("::NUMERIC(78, 0) AND attempts < ")
-            .push_bind(self.config.max_attempts);
+            .push("::NUMERIC(78, 0)");
         push_onchain_refresh_scope_filter(&mut query, scope);
         let row = query.build().fetch_one(&self.pool).await?;
 
@@ -691,23 +701,33 @@ where
                 SELECT id
                 FROM onchain_refresh_task
                 WHERE (
-                    status IN ('pending', 'failed')
+                    status = 'pending'
+                    OR (
+                        status = 'failed'
+                        AND attempts < ",
+        );
+        query.push_bind(self.config.max_attempts).push(
+            "
+                    )
                     OR (
                         status = 'processing'
                         AND locked_at IS NOT NULL
                         AND locked_at <= ",
         );
+        query.push_bind(stale_before.to_string()).push(
+            "::NUMERIC(78, 0)
+                        AND attempts < ",
+        );
         query
-            .push_bind(stale_before.to_string())
+            .push_bind(self.config.max_attempts)
             .push(
-                "::NUMERIC(78, 0)
+                "
                     )
                 )
                 AND next_run_at <= ",
             )
             .push_bind(now_ms.to_string())
-            .push("::NUMERIC(78, 0) AND attempts < ")
-            .push_bind(self.config.max_attempts);
+            .push("::NUMERIC(78, 0)");
         push_onchain_refresh_scope_filter(&mut query, scope);
         query
             .push(
@@ -2772,6 +2792,7 @@ async fn complete_tasks(
         "UPDATE onchain_refresh_task
          SET status = CASE WHEN pending_after_lock THEN 'pending' ELSE 'completed' END,
              next_run_at = CASE WHEN pending_after_lock THEN $2::NUMERIC(78, 0) ELSE next_run_at END,
+             attempts = CASE WHEN pending_after_lock THEN 0 ELSE attempts END,
              locked_at = NULL,
              locked_by = NULL,
              processed_at = CASE WHEN pending_after_lock THEN processed_at ELSE $3::NUMERIC(78, 0) END,

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -905,6 +905,55 @@ async fn test_onchain_refresh_worker_failed_task_uses_attempt_backoff() -> Resul
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_claims_pending_task_at_max_attempts()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        3,
+        false,
+        true,
+    )
+    .await?;
+
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::ZERO,
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::new([(
+            "task-one",
+            OnchainRefreshReadValue {
+                task_id: "task-one".to_owned(),
+                balance: None,
+                power: Some("11".to_owned()),
+            },
+        )]),
+    );
+
+    assert_eq!(worker.ready_backlog().await?, 1);
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.claimed, 1);
+    assert_eq!(report.completed, 1);
+    assert_completed_task(&database.pool, "task-one", 4).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_rolls_back_when_apply_fails() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_task(
@@ -1229,6 +1278,78 @@ async fn test_onchain_refresh_worker_reschedules_pending_after_lock_with_debounc
     assert_eq!(row.get::<String, _>("last_seen_block_timestamp"), "13000");
     assert_eq!(row.get::<String, _>("last_seen_transaction_hash"), "0xnew");
     assert!(!row.get::<bool, _>("pending_after_lock"));
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_resets_attempts_for_pending_after_lock()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        2,
+        false,
+        true,
+    )
+    .await?;
+    sqlx::query(
+        "UPDATE onchain_refresh_task
+         SET pending_after_lock = TRUE,
+             pending_after_lock_block_number = 13::NUMERIC(78, 0),
+             pending_after_lock_block_timestamp = 13000::NUMERIC(78, 0),
+             pending_after_lock_transaction_hash = '0xnew'
+         WHERE id = 'task-one'",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::ZERO,
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::new([(
+            "task-one",
+            OnchainRefreshReadValue {
+                task_id: "task-one".to_owned(),
+                balance: None,
+                power: Some("11".to_owned()),
+            },
+        )]),
+    );
+
+    let first_report = worker.run_once().await?;
+
+    assert_eq!(first_report.completed, 0);
+    assert_eq!(first_report.debounced_tasks, 1);
+    let row = sqlx::query(
+        "SELECT status, attempts
+         FROM onchain_refresh_task
+         WHERE id = 'task-one'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(row.get::<String, _>("status"), "pending");
+    assert_eq!(row.get::<i32, _>("attempts"), 0);
+
+    let second_report = worker.run_once().await?;
+
+    assert_eq!(second_report.claimed, 1);
+    assert_eq!(second_report.completed, 1);
+    assert_completed_task(&database.pool, "task-one", 1).await?;
 
     database.cleanup().await?;
 


### PR DESCRIPTION
## Summary
- Reset `onchain_refresh_task.attempts` to `0` when `complete_tasks()` requeues a row because `pending_after_lock` is set.
- Allow `pending` tasks to be claimed even when their previous `attempts` value has reached `DEGOV_ONCHAIN_REFRESH_MAX_ATTEMPTS`; keep the max-attempt guard for `failed` retries and stale `processing` retries.
- Add regression coverage for both future requeues and existing pending-at-max-attempts rows.

## Root Cause
`complete_tasks()` moved `pending_after_lock` tasks back to `pending`, but preserved their attempt count. If the successful claim had incremented `attempts` to `max_attempts`, the requeued pending row could not be claimed again because `claim_tasks()` filtered the whole pending/failed/processing candidate group with `attempts < max_attempts`.

This could also leave already-materialized rows in a pending-but-unclaimable state after a deploy, so the claim predicate now treats `pending` as new work and applies the max-attempt guard only to retry states.

## Validation
- `cargo fmt --check -p degov-datalens-indexer`
- `cargo test -p degov-datalens-indexer --test onchain_refresh_worker test_onchain_refresh_worker_resets_attempts_for_pending_after_lock`
- `cargo test -p degov-datalens-indexer --test onchain_refresh_worker`
