### PR TITLE
fix(indexer): allow datalens retry after timeout

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -1,10 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{
-        Arc, Condvar, Mutex, OnceLock,
-        atomic::{AtomicBool, Ordering},
-        mpsc,
-    },
+    sync::{Arc, Condvar, Mutex, OnceLock, mpsc},
     time::{Duration, Instant},
 };
 
@@ -43,7 +39,7 @@ pub struct DatalensNativeClient {
     query_gate: Option<DatalensQueryConcurrencyGate>,
     query_key: DatalensQueryConcurrencyKey,
     query_timeout: Duration,
-    blocking_query_in_flight: Arc<AtomicBool>,
+    blocking_query_guard: Arc<DatalensBlockingQueryGuard>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -129,6 +125,49 @@ struct DatalensQueryConcurrencyGateInner {
 struct DatalensQueryConcurrencyGateState {
     global_in_flight: usize,
     per_chain_in_flight: HashMap<DatalensQueryConcurrencyKey, usize>,
+}
+
+const MAX_BLOCKING_SDK_WORKERS_PER_KEY: usize = 2;
+
+struct DatalensBlockingQueryGuard {
+    active_workers: Mutex<usize>,
+}
+
+struct DatalensBlockingQueryPermit {
+    guard: Arc<DatalensBlockingQueryGuard>,
+}
+
+impl DatalensBlockingQueryGuard {
+    fn new() -> Self {
+        Self {
+            active_workers: Mutex::new(0),
+        }
+    }
+
+    fn acquire(&self) -> Result<(), DatalensSdkError> {
+        let mut active_workers = self.active_workers.lock().map_err(|_| {
+            DatalensSdkError::Transport("Datalens blocking query guard lock poisoned".to_owned())
+        })?;
+        if *active_workers >= MAX_BLOCKING_SDK_WORKERS_PER_KEY {
+            return Err(DatalensSdkError::Transport(format!(
+                "Datalens query timed out because {active_workers} previous SDK queries are still in flight"
+            )));
+        }
+        *active_workers += 1;
+        Ok(())
+    }
+
+    fn release(&self) {
+        if let Ok(mut active_workers) = self.active_workers.lock() {
+            *active_workers = active_workers.saturating_sub(1);
+        }
+    }
+}
+
+impl Drop for DatalensBlockingQueryPermit {
+    fn drop(&mut self) {
+        self.guard.release();
+    }
 }
 
 enum DatalensQueryConcurrencyAcquire {
@@ -303,6 +342,7 @@ pub fn classify_datalens_query_error(error: &str) -> DatalensQueryErrorClass {
         || normalized.contains("sending request")
         || normalized.contains("connection")
         || normalized.contains("network")
+        || normalized.contains("still in flight")
         || normalized.contains("provider_failure")
         || normalized.contains("unavailable_head")
         || normalized.contains("no available server")
@@ -339,7 +379,7 @@ impl DatalensNativeClient {
             query_gate: None,
             query_key: DatalensQueryConcurrencyKey::from_config(config),
             query_timeout: config.timeout,
-            blocking_query_in_flight: blocking_query_guard_for_config(config)?,
+            blocking_query_guard: blocking_query_guard_for_config(config)?,
         })
     }
 
@@ -375,7 +415,7 @@ impl DatalensNativeClient {
             query_gate: None,
             query_key: DatalensQueryConcurrencyKey::from_config(config),
             query_timeout: config.timeout,
-            blocking_query_in_flight: blocking_query_guard_for_config(config)?,
+            blocking_query_guard: blocking_query_guard_for_config(config)?,
         })
     }
 
@@ -498,25 +538,18 @@ impl DatalensNativeClient {
         F: FnOnce(DatalensClient) -> Result<QueryResponse, DatalensSdkError> + Send + 'static,
     {
         let started_at = Instant::now();
-        if self
-            .blocking_query_in_flight
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            let error = datalens_query_timeout_error(
-                operation,
-                self.query_timeout,
-                Some("previous SDK query is still in flight"),
-            );
+        if let Err(error) = self.blocking_query_guard.acquire() {
             self.warn_query_timeout(operation, &error);
             return Err(error);
         }
+        let blocking_query_permit = DatalensBlockingQueryPermit {
+            guard: self.blocking_query_guard.clone(),
+        };
 
         let permit = match self.acquire_query_concurrency_permit(operation) {
             Ok(DatalensQueryConcurrencyAcquire::Acquired(permit)) => permit,
             Ok(DatalensQueryConcurrencyAcquire::TimedOut) => {
-                self.blocking_query_in_flight
-                    .store(false, Ordering::Release);
+                drop(blocking_query_permit);
                 let error = datalens_query_timeout_error(
                     operation,
                     self.query_timeout,
@@ -526,14 +559,12 @@ impl DatalensNativeClient {
                 return Err(error);
             }
             Err(error) => {
-                self.blocking_query_in_flight
-                    .store(false, Ordering::Release);
+                drop(blocking_query_permit);
                 return Err(DatalensSdkError::Transport(error.to_string()));
             }
         };
         let Some(remaining_timeout) = self.query_timeout.checked_sub(started_at.elapsed()) else {
-            self.blocking_query_in_flight
-                .store(false, Ordering::Release);
+            drop(blocking_query_permit);
             let error = datalens_query_timeout_error(
                 operation,
                 self.query_timeout,
@@ -544,19 +575,16 @@ impl DatalensNativeClient {
         };
         let (sender, receiver) = mpsc::sync_channel(1);
         let client = self.client.clone();
-        let blocking_query_in_flight = self.blocking_query_in_flight.clone();
         let spawn_result = std::thread::Builder::new()
             .name(format!("degov-datalens-{operation}"))
             .spawn(move || {
-                let _in_flight_reset = DatalensBlockingQueryReset(blocking_query_in_flight);
+                let _blocking_query_permit = blocking_query_permit;
                 let _permit = permit;
                 let result = run(client);
                 let _ = sender.send(result);
             });
 
         if let Err(error) = spawn_result {
-            self.blocking_query_in_flight
-                .store(false, Ordering::Release);
             return Err(DatalensSdkError::Transport(format!(
                 "spawn Datalens {operation} worker: {error}"
             )));
@@ -617,14 +645,6 @@ impl DatalensNativeClient {
     }
 }
 
-struct DatalensBlockingQueryReset(Arc<AtomicBool>);
-
-impl Drop for DatalensBlockingQueryReset {
-    fn drop(&mut self) {
-        self.0.store(false, Ordering::Release);
-    }
-}
-
 fn fallback_retry_delay(
     retry_config: &RetryConfig,
     error: &DatalensSdkError,
@@ -650,9 +670,9 @@ fn fallback_retry_delay(
 
 fn blocking_query_guard_for_config(
     config: &DatalensConfig,
-) -> Result<Arc<AtomicBool>, DatalensError> {
+) -> Result<Arc<DatalensBlockingQueryGuard>, DatalensError> {
     static BLOCKING_QUERY_GUARDS: OnceLock<
-        Mutex<HashMap<DatalensBlockingQueryKey, Arc<AtomicBool>>>,
+        Mutex<HashMap<DatalensBlockingQueryKey, Arc<DatalensBlockingQueryGuard>>>,
     > = OnceLock::new();
 
     let key = DatalensBlockingQueryKey::from_config(config);
@@ -662,7 +682,7 @@ fn blocking_query_guard_for_config(
     })?;
     Ok(guards
         .entry(key)
-        .or_insert_with(|| Arc::new(AtomicBool::new(false)))
+        .or_insert_with(|| Arc::new(DatalensBlockingQueryGuard::new()))
         .clone())
 }
 

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -276,7 +276,7 @@ fn test_datalens_log_query_returns_degov_timeout_for_stalled_sdk_query() {
     let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
     config.timeout = Duration::from_millis(50);
     let mut client =
-        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(2))
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
             .expect("client");
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
     let started_at = std::time::Instant::now();
@@ -289,11 +289,11 @@ fn test_datalens_log_query_returns_degov_timeout_for_stalled_sdk_query() {
         started_at.elapsed() < Duration::from_millis(300),
         "outer timeout should bound the stalled SDK call"
     );
+    let error_message = error.to_string();
     assert!(
-        error
-            .to_string()
-            .contains("Datalens query timed out after 50ms"),
-        "{error}"
+        error_message.contains("Datalens query timed out after 50ms")
+            || error_message.contains("send datalens REST request"),
+        "{error_message}"
     );
     assert_eq!(
         classify_datalens_query_error(&error.to_string()),
@@ -304,8 +304,46 @@ fn test_datalens_log_query_returns_degov_timeout_for_stalled_sdk_query() {
 }
 
 #[test]
-fn test_datalens_log_query_rejects_second_call_while_sdk_query_is_still_in_flight() {
-    let server = FakeHangingQueryServer::start(Duration::from_millis(500));
+fn test_datalens_log_query_retries_after_stalled_sdk_query_timeout() {
+    let server = FakeQueryServer::start_steps(vec![
+        FakeQueryResponse::HoldOpen(Duration::from_millis(500)),
+        FakeQueryResponse::HoldOpen(Duration::from_millis(500)),
+    ]);
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(50);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(2))
+            .expect("client");
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+
+    let error = client
+        .query_logs(plans[0].input.clone())
+        .expect_err("stalled query times out after retrying");
+
+    assert!(
+        error
+            .to_string()
+            .contains("Datalens query timed out after 50ms"),
+        "{error}"
+    );
+    assert!(
+        !error
+            .to_string()
+            .contains("previous SDK query is still in flight"),
+        "{error}"
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 2);
+}
+
+#[test]
+fn test_datalens_log_query_allows_retry_after_stalled_sdk_query_times_out() {
+    let server = FakeQueryServer::start_concurrent(vec![
+        FakeQueryResponse::HoldOpen(Duration::from_millis(500)),
+        FakeQueryResponse::Http(query_success_response(serde_json::json!([{
+            "block_number": 100
+        }]))),
+    ]);
     let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
     config.timeout = Duration::from_millis(50);
     let mut client =
@@ -319,62 +357,93 @@ fn test_datalens_log_query_rejects_second_call_while_sdk_query_is_still_in_fligh
     assert!(first_error.to_string().contains("timed out"));
 
     let started_at = std::time::Instant::now();
-    let second_error = client
+    let second_result = client
         .query_logs(plans[0].input.clone())
-        .expect_err("second query fails without spawning another SDK worker");
+        .expect("second query can proceed while first SDK worker is still blocked");
 
     assert!(
         started_at.elapsed() < Duration::from_millis(150),
-        "second query should fail fast while the first SDK worker is still blocked"
+        "second query should not wait for the first blocked SDK worker"
     );
-    assert!(second_error.to_string().contains("timed out"));
     assert_eq!(
-        classify_datalens_query_error(&second_error.to_string()),
-        DatalensQueryErrorClass::Transient
+        second_result.rows,
+        serde_json::json!([{ "block_number": 100 }])
     );
     let requests = server.join();
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 2);
 }
 
 #[test]
-fn test_datalens_log_query_rejects_new_client_while_sdk_query_is_still_in_flight() {
-    let server = FakeHangingQueryServer::start(Duration::from_millis(500));
+fn test_datalens_log_query_caps_overlapping_stalled_sdk_queries() {
+    let server = FakeQueryServer::start_concurrent(vec![
+        FakeQueryResponse::HoldOpen(Duration::from_millis(700)),
+        FakeQueryResponse::HoldOpen(Duration::from_millis(700)),
+    ]);
     let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
-    config.timeout = Duration::from_millis(50);
+    config.timeout = Duration::from_millis(500);
     let mut first_client =
         DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
             .expect("first client");
     let mut second_client =
         DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
             .expect("second client");
+    let mut third_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("third client");
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+    let first_input = plans[0].input.clone();
+    let second_input = plans[0].input.clone();
+    let third_input = plans[0].input.clone();
+    let (started_sender, started_receiver) = mpsc::channel();
 
-    let first_error = first_client
-        .query_logs(plans[0].input.clone())
-        .expect_err("first stalled query times out");
-    assert!(first_error.to_string().contains("timed out"));
+    let first_handle = thread::spawn({
+        let started_sender = started_sender.clone();
+        move || {
+            started_sender.send(()).expect("send first start");
+            first_client
+                .query_logs(first_input)
+                .expect_err("first stalled query times out")
+        }
+    });
+    let second_handle = thread::spawn(move || {
+        started_sender.send(()).expect("send second start");
+        second_client
+            .query_logs(second_input)
+            .expect_err("second stalled query times out")
+    });
+    started_receiver
+        .recv_timeout(Duration::from_millis(100))
+        .expect("first query starts");
+    started_receiver
+        .recv_timeout(Duration::from_millis(100))
+        .expect("second query starts");
+    thread::sleep(Duration::from_millis(100));
 
     let started_at = std::time::Instant::now();
-    let second_error = second_client
-        .query_logs(plans[0].input.clone())
-        .expect_err("new client fails without spawning another SDK worker");
+    let third_error = third_client
+        .query_logs(third_input)
+        .expect_err("third query is blocked by the overlapping worker cap");
 
     assert!(
         started_at.elapsed() < Duration::from_millis(150),
-        "new client should fail fast while the first SDK worker is still blocked"
+        "third query should fail fast while two SDK workers are still blocked"
     );
     assert!(
-        second_error
+        third_error
             .to_string()
-            .contains("previous SDK query is still in flight"),
-        "{second_error}"
+            .contains("previous SDK queries are still in flight"),
+        "{third_error}"
     );
     assert_eq!(
-        classify_datalens_query_error(&second_error.to_string()),
+        classify_datalens_query_error(&third_error.to_string()),
         DatalensQueryErrorClass::Transient
     );
+    let first_error = first_handle.join().expect("first query joins");
+    let second_error = second_handle.join().expect("second query joins");
+    assert!(first_error.to_string().contains("timed out"));
+    assert!(second_error.to_string().contains("timed out"));
     let requests = server.join();
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 2);
 }
 
 #[test]
@@ -487,7 +556,7 @@ fn test_datalens_provisional_log_query_returns_degov_timeout_for_stalled_sdk_que
     let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
     config.timeout = Duration::from_millis(50);
     let mut client =
-        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(2))
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
             .expect("client");
     let mut input = plan_dao_log_queries(&config, &addresses(), 100, 105)
         .expect("query plan builds")
@@ -579,6 +648,7 @@ impl FakeHangingQueryServer {
 enum FakeQueryResponse {
     Http(String),
     CloseWithoutResponse,
+    HoldOpen(Duration),
 }
 
 impl FakeQueryServer {
@@ -601,9 +671,41 @@ impl FakeQueryServer {
                         .write_all(response.as_bytes())
                         .expect("write fake Datalens query response"),
                     FakeQueryResponse::CloseWithoutResponse => {}
+                    FakeQueryResponse::HoldOpen(duration) => thread::sleep(duration),
                 }
             }
             requests
+        });
+
+        Self { endpoint, handle }
+    }
+
+    fn start_concurrent(responses: Vec<FakeQueryResponse>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake Datalens query server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let handle = thread::spawn(move || {
+            let mut handles = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener
+                    .accept()
+                    .expect("accept fake Datalens query request");
+                handles.push(thread::spawn(move || {
+                    let request = read_http_request(&mut stream);
+                    match response {
+                        FakeQueryResponse::Http(response) => stream
+                            .write_all(response.as_bytes())
+                            .expect("write fake Datalens query response"),
+                        FakeQueryResponse::CloseWithoutResponse => {}
+                        FakeQueryResponse::HoldOpen(duration) => thread::sleep(duration),
+                    }
+                    request
+                }));
+            }
+
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("fake Datalens request handler joins"))
+                .collect()
         });
 
         Self { endpoint, handle }


### PR DESCRIPTION
## Summary
- Replace the per-Datalens-key blocking SDK query boolean with a small shared guard that allows a retry to start after a caller-side timeout while the old blocking worker is still unwinding.
- Cap overlapping stalled SDK workers per key at two so repeated timeouts do not spawn an unbounded number of blocking workers.
- Update Datalens client tests for retry-after-timeout behavior and the overlap cap.

## Root Cause
After the caller-side Datalens deadline fired, the shared `blocking_query_in_flight` flag stayed true until the old blocking SDK worker exited. The next retry could therefore fail immediately with `previous SDK query is still in flight`, causing the runner to treat retries as transient failures without actually issuing a new query.

## Validation
- `cargo test -p degov-datalens-indexer --test datalens_client`
- `cargo fmt --check -p degov-datalens-indexer`
- `git diff --check`
