### PR TITLE
fix(indexer): add proposal title refresh command

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -102,6 +102,8 @@ pub use crate::store::postgres::{
     PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
     PostgresProvisionalCleanupStore, PostgresProvisionalPowerOverlayStore,
     PostgresProvisionalProposalOverlayStore, PostgresProvisionalSegmentStore,
+    ProposalTitleRefreshCandidate, ProposalTitleRefreshUpdate,
+    read_proposal_title_refresh_candidates, update_proposal_titles,
 };
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use degov_datalens_indexer::runtime::{
-    migrate, run_graphql, run_indexer, run_worker, smoke_datalens,
+    migrate, refresh_proposal_titles, run_graphql, run_indexer, run_worker, smoke_datalens,
 };
 
 #[derive(Debug, Parser)]
@@ -18,6 +18,10 @@ enum Command {
     Migrate,
     Graphql,
     SmokeDatalens,
+    RefreshProposalTitles {
+        #[arg(long)]
+        dao_code: String,
+    },
 }
 
 #[tokio::main]
@@ -31,6 +35,16 @@ async fn main() -> anyhow::Result<()> {
         Command::Migrate => migrate().await,
         Command::Graphql => run_graphql().await,
         Command::SmokeDatalens => smoke_datalens().await,
+        Command::RefreshProposalTitles { dao_code } => {
+            let report = refresh_proposal_titles(dao_code).await?;
+            log::info!(
+                "proposal title refresh completed dao_code={} scanned={} updated={}",
+                report.dao_code,
+                report.scanned,
+                report.updated
+            );
+            Ok(())
+        }
     }
 }
 

--- a/apps/indexer/src/runtime/mod.rs
+++ b/apps/indexer/src/runtime/mod.rs
@@ -2,10 +2,12 @@ pub mod datalens;
 pub mod graphql;
 pub mod indexer;
 pub mod migrate;
+pub mod proposal_title_refresh;
 pub mod worker;
 
 pub use datalens::smoke_datalens;
 pub use graphql::run_graphql;
 pub use indexer::run_indexer;
 pub use migrate::{apply_migrations, migrate};
+pub use proposal_title_refresh::refresh_proposal_titles;
 pub use worker::run_worker;

--- a/apps/indexer/src/runtime/proposal_title_refresh.rs
+++ b/apps/indexer/src/runtime/proposal_title_refresh.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use anyhow as runtime_anyhow;
+use runtime_anyhow::{Context, Result};
 use sqlx::postgres::PgPoolOptions;
 
 use crate::{

--- a/apps/indexer/src/runtime/proposal_title_refresh.rs
+++ b/apps/indexer/src/runtime/proposal_title_refresh.rs
@@ -3,9 +3,11 @@ use runtime_anyhow::{Context, Result};
 use sqlx::postgres::PgPoolOptions;
 
 use crate::{
-    ProposalTitleRefreshCandidate, ProposalTitleRefreshUpdate, derive_proposal_metadata,
+    ProposalTitleRefreshCandidate, ProposalTitleRefreshUpdate,
+    projection::proposal_metadata::OpenRouterProposalTitleExtractor,
     read_proposal_title_refresh_candidates, required_env, update_proposal_titles,
 };
+use crate::{derive_proposal_metadata, derive_proposal_metadata_with_title_extractor};
 
 use super::migrate::apply_migrations;
 
@@ -53,9 +55,15 @@ pub async fn refresh_proposal_titles_with_pool(
 pub fn plan_proposal_title_refreshes(
     candidates: &[ProposalTitleRefreshCandidate],
 ) -> Vec<ProposalTitleRefreshUpdate> {
-    plan_proposal_title_refreshes_with(candidates, |description| {
-        derive_proposal_metadata(description).title
-    })
+    if let Some(title_extractor) = OpenRouterProposalTitleExtractor::from_env() {
+        plan_proposal_title_refreshes_with(candidates, |description| {
+            derive_proposal_metadata_with_title_extractor(description, &title_extractor).title
+        })
+    } else {
+        plan_proposal_title_refreshes_with(candidates, |description| {
+            derive_proposal_metadata(description).title
+        })
+    }
 }
 
 fn plan_proposal_title_refreshes_with(
@@ -71,6 +79,8 @@ fn plan_proposal_title_refreshes_with(
             } else {
                 Some(ProposalTitleRefreshUpdate {
                     id: candidate.id.clone(),
+                    description: candidate.description.clone(),
+                    previous_title: candidate.title.clone(),
                     title,
                 })
             }
@@ -111,6 +121,8 @@ mod tests {
             updates,
             vec![ProposalTitleRefreshUpdate {
                 id: "proposal:1".to_owned(),
+                description: "# Fresh title\nBody".to_owned(),
+                previous_title: "stale".to_owned(),
                 title: "Fresh title".to_owned(),
             }]
         );

--- a/apps/indexer/src/runtime/proposal_title_refresh.rs
+++ b/apps/indexer/src/runtime/proposal_title_refresh.rs
@@ -1,0 +1,117 @@
+use anyhow::{Context, Result};
+use sqlx::postgres::PgPoolOptions;
+
+use crate::{
+    ProposalTitleRefreshCandidate, ProposalTitleRefreshUpdate, derive_proposal_metadata,
+    read_proposal_title_refresh_candidates, required_env, update_proposal_titles,
+};
+
+use super::migrate::apply_migrations;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalTitleRefreshReport {
+    pub dao_code: String,
+    pub scanned: usize,
+    pub updated: u64,
+}
+
+pub async fn refresh_proposal_titles(dao_code: String) -> Result<ProposalTitleRefreshReport> {
+    let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await
+        .context("connect to DeGov indexer Postgres")?;
+    apply_migrations(&pool).await?;
+
+    refresh_proposal_titles_with_pool(&pool, dao_code).await
+}
+
+pub async fn refresh_proposal_titles_with_pool(
+    pool: &sqlx::PgPool,
+    dao_code: String,
+) -> Result<ProposalTitleRefreshReport> {
+    let candidates = read_proposal_title_refresh_candidates(pool, &dao_code)
+        .await
+        .context("read proposal title refresh candidates")?;
+    let scanned = candidates.len();
+    let updates = tokio::task::spawn_blocking(move || plan_proposal_title_refreshes(&candidates))
+        .await
+        .context("derive proposal title refreshes")?;
+    let updated = update_proposal_titles(pool, &dao_code, &updates)
+        .await
+        .context("update proposal titles")?;
+
+    Ok(ProposalTitleRefreshReport {
+        dao_code,
+        scanned,
+        updated,
+    })
+}
+
+pub fn plan_proposal_title_refreshes(
+    candidates: &[ProposalTitleRefreshCandidate],
+) -> Vec<ProposalTitleRefreshUpdate> {
+    plan_proposal_title_refreshes_with(candidates, |description| {
+        derive_proposal_metadata(description).title
+    })
+}
+
+fn plan_proposal_title_refreshes_with(
+    candidates: &[ProposalTitleRefreshCandidate],
+    derive_title: impl Fn(&str) -> String,
+) -> Vec<ProposalTitleRefreshUpdate> {
+    candidates
+        .iter()
+        .filter_map(|candidate| {
+            let title = derive_title(&candidate.description);
+            if title == candidate.title {
+                None
+            } else {
+                Some(ProposalTitleRefreshUpdate {
+                    id: candidate.id.clone(),
+                    title,
+                })
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plan_proposal_title_refreshes_updates_only_changed_titles() {
+        let updates = plan_proposal_title_refreshes_with(
+            &[
+                ProposalTitleRefreshCandidate {
+                    id: "proposal:1".to_owned(),
+                    description: "# Fresh title\nBody".to_owned(),
+                    title: "stale".to_owned(),
+                },
+                ProposalTitleRefreshCandidate {
+                    id: "proposal:2".to_owned(),
+                    description: "# Already fresh\nBody".to_owned(),
+                    title: "Already fresh".to_owned(),
+                },
+            ],
+            |description| {
+                description
+                    .lines()
+                    .next()
+                    .expect("test description has a first line")
+                    .trim_start_matches("# ")
+                    .to_owned()
+            },
+        );
+
+        assert_eq!(
+            updates,
+            vec![ProposalTitleRefreshUpdate {
+                id: "proposal:1".to_owned(),
+                title: "Fresh title".to_owned(),
+            }]
+        );
+    }
+}

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -342,6 +342,71 @@ async fn relink_existing_proposal_to_raw_id(
     Ok(())
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalTitleRefreshCandidate {
+    pub id: String,
+    pub description: String,
+    pub title: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalTitleRefreshUpdate {
+    pub id: String,
+    pub title: String,
+}
+
+pub async fn read_proposal_title_refresh_candidates(
+    pool: &PgPool,
+    dao_code: &str,
+) -> Result<Vec<ProposalTitleRefreshCandidate>, PostgresIndexerRunnerStoreError> {
+    let rows = sqlx::query(
+        "SELECT id, description, title
+         FROM proposal
+         WHERE dao_code = $1
+         ORDER BY block_number, transaction_index, log_index, id",
+    )
+    .bind(dao_code)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ProposalTitleRefreshCandidate {
+            id: row.get("id"),
+            description: row.get("description"),
+            title: row.get("title"),
+        })
+        .collect())
+}
+
+const UPDATE_PROPOSAL_TITLES_SQL_PREFIX: &str =
+    "UPDATE proposal SET title = proposal_title_refresh.title FROM (";
+
+pub async fn update_proposal_titles(
+    pool: &PgPool,
+    dao_code: &str,
+    updates: &[ProposalTitleRefreshUpdate],
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
+    if updates.is_empty() {
+        return Ok(0);
+    }
+
+    let mut builder: QueryBuilder<Postgres> = QueryBuilder::new(UPDATE_PROPOSAL_TITLES_SQL_PREFIX);
+    builder.push_values(updates, |mut row, update| {
+        row.push_bind(&update.id).push_bind(&update.title);
+    });
+    builder.push(
+        ") AS proposal_title_refresh(id, title)
+         WHERE proposal.id = proposal_title_refresh.id
+           AND proposal.dao_code = ",
+    );
+    builder.push_bind(dao_code);
+    builder.push(" AND proposal.title IS DISTINCT FROM proposal_title_refresh.title");
+
+    let result = builder.build().execute(pool).await?;
+    Ok(result.rows_affected())
+}
+
 async fn insert_proposal_action(
     transaction: &mut Transaction<'_, Postgres>,
     row: &ProposalActionWrite,
@@ -491,5 +556,11 @@ mod proposal_tests {
         assert!(UPSERT_PROPOSAL_SQL.contains(
             "decimals = CASE WHEN EXCLUDED.decimals = 0::NUMERIC(78, 0) THEN proposal.decimals ELSE EXCLUDED.decimals END"
         ));
+    }
+
+    #[test]
+    fn test_update_proposal_titles_is_scoped_to_dao_and_title_only() {
+        assert!(UPDATE_PROPOSAL_TITLES_SQL_PREFIX.contains("UPDATE proposal SET title"));
+        assert!(UPDATE_PROPOSAL_TITLES_SQL_PREFIX.contains("FROM ("));
     }
 }

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -352,6 +352,8 @@ pub struct ProposalTitleRefreshCandidate {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProposalTitleRefreshUpdate {
     pub id: String,
+    pub description: String,
+    pub previous_title: String,
     pub title: String,
 }
 
@@ -381,6 +383,7 @@ pub async fn read_proposal_title_refresh_candidates(
 
 const UPDATE_PROPOSAL_TITLES_SQL_PREFIX: &str =
     "UPDATE proposal SET title = proposal_title_refresh.title FROM (";
+const UPDATE_PROPOSAL_TITLES_CHUNK_SIZE: usize = 5_000;
 
 pub async fn update_proposal_titles(
     pool: &PgPool,
@@ -391,13 +394,31 @@ pub async fn update_proposal_titles(
         return Ok(0);
     }
 
+    let mut rows_affected = 0;
+    for update_chunk in updates.chunks(UPDATE_PROPOSAL_TITLES_CHUNK_SIZE) {
+        rows_affected += update_proposal_title_chunk(pool, dao_code, update_chunk).await?;
+    }
+
+    Ok(rows_affected)
+}
+
+async fn update_proposal_title_chunk(
+    pool: &PgPool,
+    dao_code: &str,
+    updates: &[ProposalTitleRefreshUpdate],
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
     let mut builder: QueryBuilder<Postgres> = QueryBuilder::new(UPDATE_PROPOSAL_TITLES_SQL_PREFIX);
     builder.push_values(updates, |mut row, update| {
-        row.push_bind(&update.id).push_bind(&update.title);
+        row.push_bind(&update.id)
+            .push_bind(&update.description)
+            .push_bind(&update.previous_title)
+            .push_bind(&update.title);
     });
     builder.push(
-        ") AS proposal_title_refresh(id, title)
+        ") AS proposal_title_refresh(id, description, previous_title, title)
          WHERE proposal.id = proposal_title_refresh.id
+           AND proposal.description = proposal_title_refresh.description
+           AND proposal.title = proposal_title_refresh.previous_title
            AND proposal.dao_code = ",
     );
     builder.push_bind(dao_code);

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -148,6 +148,97 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_refresh_proposal_titles_command_updates_only_scoped_dao() -> Result<(), Box<dyn Error>>
+{
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let (demo_proposal, other_proposal) =
+        temp_env::with_vars([("OPENROUTER_API_KEY", None::<&str>)], || {
+            let demo_proposal = project_proposal_events(
+                &proposal_projection_context(),
+                vec![ProposalProjectionEvent {
+                    log: normalized_log("demo-proposal", 10, 0, 0),
+                    event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                        proposal_id: "42".to_owned(),
+                        proposer: PROPOSER.to_owned(),
+                        targets: vec![TARGET.to_owned()],
+                        values: vec!["1".to_owned()],
+                        signatures: vec!["upgrade()".to_owned()],
+                        calldatas: vec!["0x1234".to_owned()],
+                        vote_start: "100".to_owned(),
+                        vote_end: "200".to_owned(),
+                        description: "# Fresh demo title\nBody".to_owned(),
+                    }),
+                }],
+            )
+            .map_err(|error| format!("proposal projection failed: {error:?}"))?;
+            let other_proposal = project_proposal_events(
+                &proposal_projection_context_with_scope(
+                    SECOND_CONTRACT_SET_ID,
+                    1,
+                    SECOND_GOVERNOR,
+                    SECOND_TOKEN,
+                    SECOND_TIMELOCK,
+                    "other-dao",
+                ),
+                vec![ProposalProjectionEvent {
+                    log: normalized_log_with_scope(1, "other-proposal", 11, 0, 0, SECOND_GOVERNOR),
+                    event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                        proposal_id: "42".to_owned(),
+                        proposer: PROPOSER.to_owned(),
+                        targets: vec![TARGET.to_owned()],
+                        values: vec!["1".to_owned()],
+                        signatures: vec!["upgrade()".to_owned()],
+                        calldatas: vec!["0x1234".to_owned()],
+                        vote_start: "100".to_owned(),
+                        vote_end: "200".to_owned(),
+                        description: "# Other DAO title\nBody".to_owned(),
+                    }),
+                }],
+            )
+            .map_err(|error| format!("proposal projection failed: {error:?}"))?;
+
+            Ok::<_, String>((demo_proposal, other_proposal))
+        })?;
+
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            proposal: Some(demo_proposal),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            proposal: Some(other_proposal),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+    sqlx::query("UPDATE proposal SET title = 'stale title'")
+        .execute(&database.pool)
+        .await?;
+
+    run_refresh_proposal_titles_command(&database.database_url, "demo-dao").await?;
+
+    let demo_title: String =
+        sqlx::query_scalar("SELECT title FROM proposal WHERE dao_code = 'demo-dao'")
+            .fetch_one(&database.pool)
+            .await?;
+    let other_title: String =
+        sqlx::query_scalar("SELECT title FROM proposal WHERE dao_code = 'other-dao'")
+            .fetch_one(&database.pool)
+            .await?;
+
+    assert_eq!(demo_title, "Fresh demo title");
+    assert_eq!(other_title, "stale title");
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -1828,6 +1919,51 @@ async fn run_indexer_command(
     if !status.success() {
         return Err(format!(
             "indexer run failed with status {status}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn run_refresh_proposal_titles_command(
+    database_url: &str,
+    dao_code: &str,
+) -> Result<(), Box<dyn Error>> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_degov-datalens-indexer"))
+        .arg("refresh-proposal-titles")
+        .arg("--dao-code")
+        .arg(dao_code)
+        .env("DEGOV_INDEXER_DATABASE_URL", database_url)
+        .env_remove("OPENROUTER_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let status = timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(status) = child.try_wait()? {
+                return Ok::<_, std::io::Error>(status);
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    let status = match status {
+        Ok(status) => status?,
+        Err(_) => {
+            let _ = child.kill();
+            return Err("proposal title refresh command timed out".into());
+        }
+    };
+    let output = child.wait_with_output()?;
+
+    if !status.success() {
+        return Err(format!(
+            "proposal title refresh failed with status {status}\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         )


### PR DESCRIPTION
## Summary
- add `refresh-proposal-titles --dao-code <dao>` to refresh existing proposal titles for one DAO without a full reindex
- reuse the existing proposal metadata extraction path, including OpenRouter when `OPENROUTER_API_KEY` is configured and deterministic fallback otherwise
- update only `proposal.title` for rows matching the requested `dao_code`; primary keys, FKs, and all other proposal fields are preserved

## Context
Local ENS validation rows were first indexed without `OPENROUTER_API_KEY`, leaving proposal title parity diffs after #861 aligned the OpenRouter prompt. Re-running ENS from scratch is too slow, so this adds a bounded backfill command for existing rows.

## Verification
- `cargo fmt --check -p degov-datalens-indexer`
- `cargo test -p degov-datalens-indexer --lib proposal_title_refresh`
- `cargo test -p degov-datalens-indexer --test proposal_metadata`
- `cargo test -p degov-datalens-indexer --test postgres_runtime_run test_refresh_proposal_titles_command_updates_only_scoped_dao` compiled, then failed at setup because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set locally

## Local runner usage
With the validation DB and OpenRouter configured, run:

```sh
DEGOV_INDEXER_DATABASE_URL=... OPENROUTER_API_KEY=... cargo run -p degov-datalens-indexer -- refresh-proposal-titles --dao-code ens-dao
```
