### PR TITLE
fix(indexer): update OpenRouter default model

### DIFF
--- a/apps/indexer/src/projection/proposal_metadata.rs
+++ b/apps/indexer/src/projection/proposal_metadata.rs
@@ -4,7 +4,7 @@ use sha3::{Digest, Keccak256};
 use std::time::Duration;
 
 const OPENROUTER_CHAT_COMPLETIONS_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
-const OPENROUTER_DEFAULT_MODEL: &str = "google/gemini-2.5-flash-preview";
+const OPENROUTER_DEFAULT_MODEL: &str = "google/gemini-2.5-flash";
 
 pub trait ProposalTitleExtractor {
     fn extract_title(


### PR DESCRIPTION
## Summary\n- Update the default OpenRouter model from the retired `google/gemini-2.5-flash-preview` id to the current `google/gemini-2.5-flash` id.\n- This restores proposal title extraction/backfill when `OPENROUTER_DEFAULT_MODEL` is not explicitly configured.\n\n## Verification\n- `cargo fmt --check -p degov-datalens-indexer`\n- `cargo test -p degov-datalens-indexer --test proposal_metadata`\n- `pnpm exec node apps/indexer/scripts/check-rust-conventions.mjs`\n- OpenRouter smoke request with local token returned HTTP 200 using `google/gemini-2.5-flash`.