### PR TITLE
fix(indexer): add proposal reference field refresh

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -102,8 +102,10 @@ pub use crate::store::postgres::{
     PostgresIndexerRunnerStoreError, PostgresIndexerRunnerTransaction,
     PostgresProvisionalCleanupStore, PostgresProvisionalPowerOverlayStore,
     PostgresProvisionalProposalOverlayStore, PostgresProvisionalSegmentStore,
-    ProposalTitleRefreshCandidate, ProposalTitleRefreshUpdate,
-    read_proposal_title_refresh_candidates, update_proposal_titles,
+    ProposalReferenceFieldCandidate, ProposalReferenceFieldUpdate, ProposalTitleRefreshCandidate,
+    ProposalTitleRefreshUpdate, read_proposal_reference_field_candidates,
+    read_proposal_title_refresh_candidates, update_proposal_reference_fields,
+    update_proposal_titles,
 };
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use degov_datalens_indexer::runtime::{
-    migrate, refresh_proposal_titles, run_graphql, run_indexer, run_worker, smoke_datalens,
+    migrate, refresh_proposal_reference_fields, refresh_proposal_titles, run_graphql, run_indexer,
+    run_worker, smoke_datalens,
 };
 
 #[derive(Debug, Parser)]
@@ -22,6 +23,12 @@ enum Command {
         #[arg(long)]
         dao_code: String,
     },
+    RefreshProposalReferenceFields {
+        #[arg(long)]
+        dao_code: String,
+        #[arg(long)]
+        reference_graphql_endpoint: String,
+    },
 }
 
 #[tokio::main]
@@ -41,6 +48,23 @@ async fn main() -> anyhow::Result<()> {
                 "proposal title refresh completed dao_code={} scanned={} updated={}",
                 report.dao_code,
                 report.scanned,
+                report.updated
+            );
+            Ok(())
+        }
+        Command::RefreshProposalReferenceFields {
+            dao_code,
+            reference_graphql_endpoint,
+        } => {
+            let report =
+                refresh_proposal_reference_fields(dao_code, reference_graphql_endpoint).await?;
+            log::info!(
+                "proposal reference field refresh completed dao_code={} reference_endpoint={} local_scanned={} reference_scanned={} planned={} updated={}",
+                report.dao_code,
+                report.reference_endpoint,
+                report.local_scanned,
+                report.reference_scanned,
+                report.planned,
                 report.updated
             );
             Ok(())

--- a/apps/indexer/src/runtime/mod.rs
+++ b/apps/indexer/src/runtime/mod.rs
@@ -2,6 +2,7 @@ pub mod datalens;
 pub mod graphql;
 pub mod indexer;
 pub mod migrate;
+pub mod proposal_reference_fields;
 pub mod proposal_title_refresh;
 pub mod worker;
 
@@ -9,5 +10,6 @@ pub use datalens::smoke_datalens;
 pub use graphql::run_graphql;
 pub use indexer::run_indexer;
 pub use migrate::{apply_migrations, migrate};
+pub use proposal_reference_fields::refresh_proposal_reference_fields;
 pub use proposal_title_refresh::refresh_proposal_titles;
 pub use worker::run_worker;

--- a/apps/indexer/src/runtime/proposal_reference_fields.rs
+++ b/apps/indexer/src/runtime/proposal_reference_fields.rs
@@ -1,0 +1,371 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use anyhow as runtime_anyhow;
+use runtime_anyhow::{Context, Result};
+use serde::Deserialize;
+use sqlx::postgres::PgPoolOptions;
+
+use crate::{
+    ProposalReferenceFieldCandidate, ProposalReferenceFieldUpdate,
+    read_proposal_reference_field_candidates, required_env, update_proposal_reference_fields,
+};
+
+use super::migrate::apply_migrations;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalReferenceFieldsReport {
+    pub dao_code: String,
+    pub reference_endpoint: String,
+    pub local_scanned: usize,
+    pub reference_scanned: usize,
+    pub planned: usize,
+    pub updated: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReferenceProposalFields {
+    pub proposal_id: String,
+    pub title: String,
+    pub block_interval: Option<String>,
+}
+
+pub async fn refresh_proposal_reference_fields(
+    dao_code: String,
+    reference_endpoint: String,
+) -> Result<ProposalReferenceFieldsReport> {
+    let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await
+        .context("connect to DeGov indexer Postgres")?;
+    apply_migrations(&pool).await?;
+
+    refresh_proposal_reference_fields_with_pool(&pool, dao_code, reference_endpoint).await
+}
+
+pub async fn refresh_proposal_reference_fields_with_pool(
+    pool: &sqlx::PgPool,
+    dao_code: String,
+    reference_endpoint: String,
+) -> Result<ProposalReferenceFieldsReport> {
+    validate_reference_endpoint_scope(&dao_code, &reference_endpoint)?;
+
+    let candidates = read_proposal_reference_field_candidates(pool, &dao_code)
+        .await
+        .context("read proposal reference field candidates")?;
+    let reference = fetch_reference_proposal_fields(&reference_endpoint)
+        .await
+        .context("fetch reference proposal fields")?;
+    let updates = plan_proposal_reference_field_updates(&candidates, &reference);
+    let planned = updates.len();
+    let updated = update_proposal_reference_fields(pool, &dao_code, &updates)
+        .await
+        .context("update proposal reference fields")?;
+
+    Ok(ProposalReferenceFieldsReport {
+        dao_code,
+        reference_endpoint,
+        local_scanned: candidates.len(),
+        reference_scanned: reference.len(),
+        planned,
+        updated,
+    })
+}
+
+pub fn plan_proposal_reference_field_updates(
+    candidates: &[ProposalReferenceFieldCandidate],
+    reference: &[ReferenceProposalFields],
+) -> Vec<ProposalReferenceFieldUpdate> {
+    let reference_by_proposal_id = reference
+        .iter()
+        .filter_map(|row| normalize_proposal_id(&row.proposal_id).map(|key| (key, row)))
+        .collect::<BTreeMap<_, _>>();
+
+    candidates
+        .iter()
+        .filter_map(|candidate| {
+            let key = normalize_proposal_id(&candidate.proposal_id)?;
+            let reference = reference_by_proposal_id.get(&key)?;
+            if candidate.title == reference.title
+                && candidate.block_interval == reference.block_interval
+            {
+                return None;
+            }
+
+            Some(ProposalReferenceFieldUpdate {
+                id: candidate.id.clone(),
+                previous_title: candidate.title.clone(),
+                previous_block_interval: candidate.block_interval.clone(),
+                title: reference.title.clone(),
+                block_interval: reference.block_interval.clone(),
+            })
+        })
+        .collect()
+}
+
+pub fn normalize_proposal_id(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(hex) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        let normalized = hex.trim_start_matches('0');
+        return Some(if normalized.is_empty() {
+            "0".to_owned()
+        } else {
+            normalized.to_ascii_lowercase()
+        });
+    }
+
+    let decimal = trimmed.trim_start_matches('0');
+    if decimal.is_empty() {
+        return Some("0".to_owned());
+    }
+    if !decimal.chars().all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(decimal_to_hex(decimal))
+}
+
+fn decimal_to_hex(decimal: &str) -> String {
+    let mut digits = decimal.bytes().map(|byte| byte - b'0').collect::<Vec<_>>();
+    let mut hex_digits = Vec::new();
+
+    while !digits.is_empty() {
+        let mut quotient = Vec::with_capacity(digits.len());
+        let mut remainder = 0u8;
+        for digit in digits {
+            let value = remainder * 10 + digit;
+            let next = value / 16;
+            remainder = value % 16;
+            if !quotient.is_empty() || next != 0 {
+                quotient.push(next);
+            }
+        }
+        hex_digits.push(char::from_digit(u32::from(remainder), 16).expect("hex digit"));
+        digits = quotient;
+    }
+
+    hex_digits.iter().rev().collect()
+}
+
+fn validate_reference_endpoint_scope(dao_code: &str, endpoint: &str) -> Result<()> {
+    if reference_endpoint_has_dao_path_segment(dao_code, endpoint) {
+        return Ok(());
+    }
+
+    runtime_anyhow::bail!(
+        "reference GraphQL endpoint must be scoped to dao_code={dao_code}; use a path like /{dao_code}/graphql instead of an unscoped /graphql endpoint"
+    );
+}
+
+fn reference_endpoint_has_dao_path_segment(dao_code: &str, endpoint: &str) -> bool {
+    let without_fragment = endpoint.split('#').next().unwrap_or(endpoint);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    let path = without_query
+        .split_once("://")
+        .and_then(|(_, rest)| rest.split_once('/').map(|(_, path)| path))
+        .unwrap_or(without_query);
+
+    path.split('/').any(|segment| segment == dao_code)
+}
+
+async fn fetch_reference_proposal_fields(endpoint: &str) -> Result<Vec<ReferenceProposalFields>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("build reference proposal GraphQL client")?;
+    let mut proposals = Vec::new();
+    let mut offset = 0i32;
+    const LIMIT: i32 = 100;
+
+    loop {
+        let response = client
+            .post(endpoint)
+            .json(&ReferenceGraphqlRequest {
+                query: REFERENCE_PROPOSALS_QUERY,
+                variables: ReferenceProposalVariables {
+                    limit: LIMIT,
+                    offset,
+                },
+            })
+            .send()
+            .await
+            .context("send reference proposal GraphQL request")?
+            .error_for_status()
+            .context("reference proposal GraphQL response status")?
+            .json::<ReferenceGraphqlResponse>()
+            .await
+            .context("decode reference proposal GraphQL response")?;
+
+        if let Some(errors) = response.errors.filter(|errors| !errors.is_empty()) {
+            runtime_anyhow::bail!(
+                "reference proposal GraphQL returned errors: {}",
+                serde_json::to_string(&errors).unwrap_or_else(|_| "<unserializable>".to_owned())
+            );
+        }
+
+        let rows = response
+            .data
+            .context("reference proposal GraphQL response missing data")?
+            .proposals;
+        let row_count = rows.len();
+        proposals.extend(rows.into_iter().map(|row| ReferenceProposalFields {
+            proposal_id: row.proposal_id,
+            title: row.title,
+            block_interval: row.block_interval,
+        }));
+        if row_count < LIMIT as usize {
+            return Ok(proposals);
+        }
+        offset += LIMIT;
+    }
+}
+
+const REFERENCE_PROPOSALS_QUERY: &str = r#"
+query ProposalReferenceFields($limit: Int!, $offset: Int!) {
+  proposals(orderBy: [id_ASC], limit: $limit, offset: $offset) {
+    proposalId
+    title
+    blockInterval
+  }
+}
+"#;
+
+#[derive(serde::Serialize)]
+struct ReferenceGraphqlRequest {
+    query: &'static str,
+    variables: ReferenceProposalVariables,
+}
+
+#[derive(serde::Serialize)]
+struct ReferenceProposalVariables {
+    limit: i32,
+    offset: i32,
+}
+
+#[derive(Deserialize)]
+struct ReferenceGraphqlResponse {
+    data: Option<ReferenceGraphqlData>,
+    errors: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Deserialize)]
+struct ReferenceGraphqlData {
+    proposals: Vec<ReferenceProposalRow>,
+}
+
+#[derive(Deserialize)]
+struct ReferenceProposalRow {
+    #[serde(rename = "proposalId")]
+    proposal_id: String,
+    title: String,
+    #[serde(rename = "blockInterval")]
+    block_interval: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_proposal_id_matches_decimal_and_hex_uint256_values() {
+        assert_eq!(normalize_proposal_id("0"), Some("0".to_owned()));
+        assert_eq!(normalize_proposal_id("00042"), Some("2a".to_owned()));
+        assert_eq!(normalize_proposal_id("0x00002A"), Some("2a".to_owned()));
+        assert_eq!(
+            normalize_proposal_id(
+                "115615865324623814833258987703837575663427750121726187103053182962864855260310"
+            ),
+            Some("ff9c42c3ca9b4cc32c7aee333740cdc2616718d84666a4dea7f5dc129bdd1c96".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_plan_proposal_reference_field_updates_matches_by_normalized_proposal_id() {
+        let updates = plan_proposal_reference_field_updates(
+            &[
+                ProposalReferenceFieldCandidate {
+                    id: "proposal:1".to_owned(),
+                    proposal_id: "42".to_owned(),
+                    title: "local title".to_owned(),
+                    block_interval: Some("12".to_owned()),
+                },
+                ProposalReferenceFieldCandidate {
+                    id: "proposal:2".to_owned(),
+                    proposal_id: "7".to_owned(),
+                    title: "same title".to_owned(),
+                    block_interval: None,
+                },
+            ],
+            &[
+                ReferenceProposalFields {
+                    proposal_id: "0x2a".to_owned(),
+                    title: "reference title".to_owned(),
+                    block_interval: Some("13.333333333333334".to_owned()),
+                },
+                ReferenceProposalFields {
+                    proposal_id: "0x07".to_owned(),
+                    title: "same title".to_owned(),
+                    block_interval: None,
+                },
+            ],
+        );
+
+        assert_eq!(
+            updates,
+            vec![ProposalReferenceFieldUpdate {
+                id: "proposal:1".to_owned(),
+                previous_title: "local title".to_owned(),
+                previous_block_interval: Some("12".to_owned()),
+                title: "reference title".to_owned(),
+                block_interval: Some("13.333333333333334".to_owned()),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_reference_endpoint_scope_requires_dao_path_segment() {
+        assert!(reference_endpoint_has_dao_path_segment(
+            "ens-dao",
+            "https://indexer.degov.ai/ens-dao/graphql"
+        ));
+        assert!(reference_endpoint_has_dao_path_segment(
+            "ens-dao",
+            "http://localhost:8005/ens-dao/graphql?foo=bar"
+        ));
+        assert!(!reference_endpoint_has_dao_path_segment(
+            "ens-dao",
+            "https://indexer.degov.ai/graphql?dao_code=ens-dao"
+        ));
+        assert!(!reference_endpoint_has_dao_path_segment(
+            "ens-dao",
+            "https://ens-dao.example.com/graphql"
+        ));
+    }
+
+    #[test]
+    fn test_reference_graphql_response_accepts_null_data_with_errors() {
+        let response = serde_json::from_value::<ReferenceGraphqlResponse>(serde_json::json!({
+            "data": null,
+            "errors": [
+                {
+                    "message": "bad field"
+                }
+            ]
+        }))
+        .expect("decode GraphQL error response");
+
+        assert!(response.data.is_none());
+        assert_eq!(response.errors.expect("errors").len(), 1);
+    }
+}

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -357,6 +357,23 @@ pub struct ProposalTitleRefreshUpdate {
     pub title: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalReferenceFieldCandidate {
+    pub id: String,
+    pub proposal_id: String,
+    pub title: String,
+    pub block_interval: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalReferenceFieldUpdate {
+    pub id: String,
+    pub previous_title: String,
+    pub previous_block_interval: Option<String>,
+    pub title: String,
+    pub block_interval: Option<String>,
+}
+
 pub async fn read_proposal_title_refresh_candidates(
     pool: &PgPool,
     dao_code: &str,
@@ -423,6 +440,89 @@ async fn update_proposal_title_chunk(
     );
     builder.push_bind(dao_code);
     builder.push(" AND proposal.title IS DISTINCT FROM proposal_title_refresh.title");
+
+    let result = builder.build().execute(pool).await?;
+    Ok(result.rows_affected())
+}
+
+pub async fn read_proposal_reference_field_candidates(
+    pool: &PgPool,
+    dao_code: &str,
+) -> Result<Vec<ProposalReferenceFieldCandidate>, PostgresIndexerRunnerStoreError> {
+    let rows = sqlx::query(
+        "SELECT id, proposal_id, title, block_interval
+         FROM proposal
+         WHERE dao_code = $1
+         ORDER BY block_number, transaction_index, log_index, id",
+    )
+    .bind(dao_code)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ProposalReferenceFieldCandidate {
+            id: row.get("id"),
+            proposal_id: row.get("proposal_id"),
+            title: row.get("title"),
+            block_interval: row.get("block_interval"),
+        })
+        .collect())
+}
+
+const UPDATE_PROPOSAL_REFERENCE_FIELDS_SQL_PREFIX: &str =
+    "UPDATE proposal SET title = proposal_reference_fields.title,
+         block_interval = proposal_reference_fields.block_interval
+     FROM (";
+const UPDATE_PROPOSAL_REFERENCE_FIELDS_CHUNK_SIZE: usize = 5_000;
+
+pub async fn update_proposal_reference_fields(
+    pool: &PgPool,
+    dao_code: &str,
+    updates: &[ProposalReferenceFieldUpdate],
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
+    if updates.is_empty() {
+        return Ok(0);
+    }
+
+    let mut rows_affected = 0;
+    for update_chunk in updates.chunks(UPDATE_PROPOSAL_REFERENCE_FIELDS_CHUNK_SIZE) {
+        rows_affected += update_proposal_reference_field_chunk(pool, dao_code, update_chunk).await?;
+    }
+
+    Ok(rows_affected)
+}
+
+async fn update_proposal_reference_field_chunk(
+    pool: &PgPool,
+    dao_code: &str,
+    updates: &[ProposalReferenceFieldUpdate],
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
+    let mut builder: QueryBuilder<Postgres> =
+        QueryBuilder::new(UPDATE_PROPOSAL_REFERENCE_FIELDS_SQL_PREFIX);
+    builder.push_values(updates, |mut row, update| {
+        row.push_bind(&update.id)
+            .push_bind(&update.previous_title)
+            .push_bind(&update.previous_block_interval)
+            .push_bind(&update.title)
+            .push_bind(&update.block_interval);
+    });
+    builder.push(
+        ") AS proposal_reference_fields(
+            id, previous_title, previous_block_interval, title, block_interval
+         )
+         WHERE proposal.id = proposal_reference_fields.id
+           AND proposal.title = proposal_reference_fields.previous_title
+           AND proposal.block_interval IS NOT DISTINCT FROM proposal_reference_fields.previous_block_interval
+           AND proposal.dao_code = ",
+    );
+    builder.push_bind(dao_code);
+    builder.push(
+        " AND (
+            proposal.title IS DISTINCT FROM proposal_reference_fields.title
+            OR proposal.block_interval IS DISTINCT FROM proposal_reference_fields.block_interval
+         )",
+    );
 
     let result = builder.build().execute(pool).await?;
     Ok(result.rows_affected())

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -239,6 +239,116 @@ async fn test_refresh_proposal_titles_command_updates_only_scoped_dao() -> Resul
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_refresh_proposal_reference_fields_command_updates_only_scoped_dao()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let (demo_proposal, other_proposal) =
+        temp_env::with_vars([("OPENROUTER_API_KEY", None::<&str>)], || {
+            let demo_proposal = project_proposal_events(
+                &proposal_projection_context(),
+                vec![ProposalProjectionEvent {
+                    log: normalized_log("demo-proposal", 10, 0, 0),
+                    event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                        proposal_id: "42".to_owned(),
+                        proposer: PROPOSER.to_owned(),
+                        targets: vec![TARGET.to_owned()],
+                        values: vec!["1".to_owned()],
+                        signatures: vec!["upgrade()".to_owned()],
+                        calldatas: vec!["0x1234".to_owned()],
+                        vote_start: "100".to_owned(),
+                        vote_end: "200".to_owned(),
+                        description: "# Local demo title\nBody".to_owned(),
+                    }),
+                }],
+            )
+            .map_err(|error| format!("proposal projection failed: {error:?}"))?;
+            let other_proposal = project_proposal_events(
+                &proposal_projection_context_with_scope(
+                    SECOND_CONTRACT_SET_ID,
+                    1,
+                    SECOND_GOVERNOR,
+                    SECOND_TOKEN,
+                    SECOND_TIMELOCK,
+                    "other-dao",
+                ),
+                vec![ProposalProjectionEvent {
+                    log: normalized_log_with_scope(1, "other-proposal", 11, 0, 0, SECOND_GOVERNOR),
+                    event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                        proposal_id: "42".to_owned(),
+                        proposer: PROPOSER.to_owned(),
+                        targets: vec![TARGET.to_owned()],
+                        values: vec!["1".to_owned()],
+                        signatures: vec!["upgrade()".to_owned()],
+                        calldatas: vec!["0x1234".to_owned()],
+                        vote_start: "100".to_owned(),
+                        vote_end: "200".to_owned(),
+                        description: "# Other DAO title\nBody".to_owned(),
+                    }),
+                }],
+            )
+            .map_err(|error| format!("proposal projection failed: {error:?}"))?;
+
+            Ok::<_, String>((demo_proposal, other_proposal))
+        })?;
+
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            proposal: Some(demo_proposal),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            proposal: Some(other_proposal),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+    sqlx::query("UPDATE proposal SET title = 'stale title', block_interval = '12'")
+        .execute(&database.pool)
+        .await?;
+
+    let reference = FakeReferenceGraphqlServer::start(vec![json!({
+        "proposalId": "0x2a",
+        "title": "Reference demo title",
+        "blockInterval": "13.333333333333334"
+    })]);
+
+    run_refresh_proposal_reference_fields_command(
+        &database.database_url,
+        "demo-dao",
+        &format!("{}/demo-dao/graphql", reference.endpoint),
+    )
+    .await?;
+
+    let demo_row =
+        sqlx::query("SELECT title, block_interval FROM proposal WHERE dao_code = 'demo-dao'")
+            .fetch_one(&database.pool)
+            .await?;
+    let other_row =
+        sqlx::query("SELECT title, block_interval FROM proposal WHERE dao_code = 'other-dao'")
+            .fetch_one(&database.pool)
+            .await?;
+
+    assert_eq!(demo_row.get::<String, _>("title"), "Reference demo title");
+    assert_eq!(
+        demo_row.get::<Option<String>, _>("block_interval"),
+        Some("13.333333333333334".to_owned())
+    );
+    assert_eq!(other_row.get::<String, _>("title"), "stale title");
+    assert_eq!(
+        other_row.get::<Option<String>, _>("block_interval"),
+        Some("12".to_owned())
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -1973,6 +2083,53 @@ async fn run_refresh_proposal_titles_command(
     Ok(())
 }
 
+async fn run_refresh_proposal_reference_fields_command(
+    database_url: &str,
+    dao_code: &str,
+    reference_graphql_endpoint: &str,
+) -> Result<(), Box<dyn Error>> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_degov-datalens-indexer"))
+        .arg("refresh-proposal-reference-fields")
+        .arg("--dao-code")
+        .arg(dao_code)
+        .arg("--reference-graphql-endpoint")
+        .arg(reference_graphql_endpoint)
+        .env("DEGOV_INDEXER_DATABASE_URL", database_url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let status = timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(status) = child.try_wait()? {
+                return Ok::<_, std::io::Error>(status);
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    let status = match status {
+        Ok(status) => status?,
+        Err(_) => {
+            let _ = child.kill();
+            return Err("proposal reference field refresh command timed out".into());
+        }
+    };
+    let output = child.wait_with_output()?;
+
+    if !status.success() {
+        return Err(format!(
+            "proposal reference field refresh failed with status {status}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
 async fn run_indexer_all_contract_sets_command(
     database_url: &str,
     datalens_endpoint: &str,
@@ -2096,6 +2253,26 @@ impl FakeDatalensServer {
     }
 }
 
+struct FakeReferenceGraphqlServer {
+    endpoint: String,
+}
+
+impl FakeReferenceGraphqlServer {
+    fn start(proposals: Vec<Value>) -> Self {
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("bind fake reference GraphQL server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+
+        thread::spawn(move || {
+            for stream in listener.incoming().take(4).flatten() {
+                handle_reference_graphql_request(stream, &proposals);
+            }
+        });
+
+        Self { endpoint }
+    }
+}
+
 struct FakeRpcServer {
     endpoint: String,
 }
@@ -2113,6 +2290,42 @@ impl FakeRpcServer {
 
         Self { endpoint }
     }
+}
+
+fn handle_reference_graphql_request(mut stream: TcpStream, proposals: &[Value]) {
+    let request = read_http_request(&mut stream);
+    let request_body = request.split("\r\n\r\n").nth(1).unwrap_or_default();
+    let body_json = serde_json::from_str::<Value>(request_body).unwrap_or_else(|_| json!({}));
+    let limit = body_json
+        .pointer("/variables/limit")
+        .and_then(Value::as_i64)
+        .unwrap_or(100)
+        .max(0) as usize;
+    let offset = body_json
+        .pointer("/variables/offset")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        .max(0) as usize;
+    let rows = proposals
+        .iter()
+        .skip(offset)
+        .take(limit)
+        .cloned()
+        .collect::<Vec<_>>();
+    let body = json!({
+        "data": {
+            "proposals": rows
+        }
+    })
+    .to_string();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream
+        .write_all(response.as_bytes())
+        .expect("write fake reference GraphQL response");
 }
 
 fn handle_rpc_request(mut stream: TcpStream) {


### PR DESCRIPTION
## Summary

- add a `refresh-proposal-reference-fields` indexer command that backfills proposal display/reference fields from an existing GraphQL endpoint
- match proposals by normalized `proposalId`, so decimal IDs in the new indexer can align with hex IDs from the legacy indexer
- update only `proposal.title` and `proposal.block_interval`, scoped by `dao_code` and guarded by previous local values
- add focused tests for normalized ID matching and scoped Postgres updates

## Why

ENS comparison still has proposal differences that are not onchain projection errors:

- historical AI-generated proposal titles cannot be reproduced byte-for-byte
- one legacy ENS proposal has a historical `blockInterval` display value that differs from the new deterministic value while the derived timestamps already match

This command gives us a deterministic compatibility backfill for these reference/display fields without changing the core indexing path or onchain-derived data.

## Validation

- `cargo fmt --check -p degov-datalens-indexer`
- `pnpm exec node apps/indexer/scripts/check-rust-conventions.mjs`
- `cargo test -p degov-datalens-indexer --lib proposal_reference_fields -- --nocapture`
- `DEGOV_INDEXER_TEST_DATABASE_URL=$DEGOV_INDEXER_DATABASE_URL cargo test -p degov-datalens-indexer --test postgres_runtime_run test_refresh_proposal_reference_fields_command_updates_only_scoped_dao -- --nocapture`
- `DEGOV_INDEXER_TEST_DATABASE_URL=$DEGOV_INDEXER_DATABASE_URL cargo test -p degov-datalens-indexer --test postgres_runtime_run test_refresh_proposal_titles_command_updates_only_scoped_dao -- --nocapture`
- `cargo test -p degov-datalens-indexer proposal_metadata -- --nocapture`
