### PR TITLE
fix(indexer): repair delegate mapping power updates

### DIFF
--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -1778,12 +1778,19 @@ impl DelegateMappingCache {
                  SET power = source.power::NUMERIC(78, 0)
                  FROM (VALUES ",
             );
-            query.push_tuples(rows, |mut tuple, row| {
-                tuple
+            for (index, row) in rows.iter().enumerate() {
+                if index > 0 {
+                    query.push(", ");
+                }
+                query
+                    .push("(")
                     .push_bind(&row.common.contract_set_id)
+                    .push(", ")
                     .push_bind(delegate_mapping_ref(&row.common, &row.from))
-                    .push_bind(&row.power);
-            });
+                    .push(", ")
+                    .push_bind(&row.power)
+                    .push("::NUMERIC(78, 0))");
+            }
             query.push(
                 ") AS source(contract_set_id, id, power)
                  WHERE target.contract_set_id = source.contract_set_id

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -971,6 +971,99 @@ async fn test_postgres_token_delegate_mapping_power_update_preserves_relation_me
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_delegate_mapping_bulk_power_only_update_preserves_relations()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let initial = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000001-delegate", 1, 0, 1),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: DELEGATOR.to_owned(),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: DELEGATE.to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000002-second-delegate", 1, 0, 2),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: RECEIVER.to_owned(),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: SECOND_DELEGATE.to_owned(),
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("initial token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(initial),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let power_only = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000003-transfer", 2, 0, 1),
+                event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                    from: ZERO_ADDRESS.to_owned(),
+                    to: DELEGATOR.to_owned(),
+                    value: "40".to_owned(),
+                    standard: GovernanceTokenStandard::Erc20,
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000004-second-transfer", 2, 0, 2),
+                event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                    from: ZERO_ADDRESS.to_owned(),
+                    to: RECEIVER.to_owned(),
+                    value: "60".to_owned(),
+                    standard: GovernanceTokenStandard::Erc20,
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("power-only token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(power_only),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let rows = sqlx::query(
+        r#"SELECT "from", "to", power::TEXT AS power, block_number::TEXT AS block_number
+           FROM delegate_mapping
+           WHERE contract_set_id = $1 AND "from" IN ($2, $3)
+           ORDER BY "from""#,
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATOR)
+    .bind(RECEIVER)
+    .fetch_all(&database.pool)
+    .await?;
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].get::<String, _>("from"), DELEGATOR);
+    assert_eq!(rows[0].get::<String, _>("to"), DELEGATE);
+    assert_eq!(rows[0].get::<String, _>("power"), "40");
+    assert_eq!(rows[0].get::<String, _>("block_number"), "1");
+    assert_eq!(rows[1].get::<String, _>("from"), RECEIVER);
+    assert_eq!(rows[1].get::<String, _>("to"), SECOND_DELEGATE);
+    assert_eq!(rows[1].get::<String, _>("power"), "60");
+    assert_eq!(rows[1].get::<String, _>("block_number"), "1");
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_token_repeated_delegate_ensure_keeps_member_count_once()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;


### PR DESCRIPTION
## Summary

- Fix the delegate_mapping power-only bulk update SQL builder so `VALUES` emits one 3-column row per update.
- Add a Postgres runtime regression that first persists delegate mappings, then applies a later transfer-only batch with two power-only mapping updates.

## Root cause

PR #865 introduced a power-only `delegate_mapping` update path that called `QueryBuilder::push_tuples` after an explicit `FROM (VALUES` prefix. `push_tuples` adds an outer tuple wrapper intended for row-value `IN` lists, so Postgres saw two composite columns instead of the aliased three scalar columns and failed with `table "source" has 2 columns available but 3 columns specified`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@localhost:7432/postgres cargo test --locked -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token_delegate_mapping_bulk_power_only_update_preserves_relations -- --exact --nocapture`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@localhost:7432/postgres cargo test --locked -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token_ -- --nocapture`
- `cd apps/indexer && node ./scripts/check-rust-conventions.mjs`
- `cd apps/indexer && node ./scripts/check-rust-conventions.test.mjs`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@localhost:7432/postgres cargo test --locked -p degov-datalens-indexer`