### PR TITLE
Replace GraphQL connections with pages

### DIFF
--- a/apps/indexer/scripts/indexer-tally-onchain-e2e.mjs
+++ b/apps/indexer/scripts/indexer-tally-onchain-e2e.mjs
@@ -25,8 +25,8 @@ const PROPOSALS_QUERY = `
       chainId
       daoCode
     }
-    proposalsConnection(orderBy: [id_ASC]) { totalCount }
-    contributorsConnection(orderBy: [id_ASC]) { totalCount }
+    proposalsPage(orderBy: [id_ASC], limit: 0) { totalCount }
+    contributorsPage(orderBy: [id_ASC], limit: 0) { totalCount }
     proposals(limit: $limit, offset: $offset, orderBy: [blockNumber_DESC]) {
       proposalId
       title
@@ -295,8 +295,8 @@ export async function fetchDatalensProposals(target, limit) {
     summary: {
       indexerStatus: data.indexerStatus ?? null,
       metrics: data.dataMetrics?.[0] ?? null,
-      proposalsCount: data.proposalsConnection?.totalCount ?? null,
-      contributorsCount: data.contributorsConnection?.totalCount ?? null,
+      proposalsCount: data.proposalsPage?.totalCount ?? null,
+      contributorsCount: data.contributorsPage?.totalCount ?? null,
     },
     proposals: data.proposals ?? [],
   };

--- a/apps/indexer/src/graphql/schema.rs
+++ b/apps/indexer/src/graphql/schema.rs
@@ -8,6 +8,8 @@ use super::pagination::push_page;
 use super::query::*;
 use super::types::*;
 
+const DEFAULT_PAGE_LIMIT: i32 = 20;
+
 #[derive(Default)]
 pub struct QueryRoot;
 
@@ -182,63 +184,168 @@ impl QueryRoot {
         query_indexer_statuses(pool(ctx)?, scope(ctx)?).await
     }
 
-    async fn proposals_connection(
+    async fn proposals_page(
         &self,
         ctx: &Context<'_>,
         where_: Option<ProposalWhereInput>,
         order_by: Option<Vec<ProposalOrderByInput>>,
-    ) -> GraphqlResult<Connection> {
-        let _ = order_by;
-        Ok(Connection {
-            total_count: count_proposals(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<ProposalPage> {
+        let pool = pool(ctx)?;
+        let scope = scope(ctx)?;
+        let (offset, limit) = page_args(offset, limit);
+        let total_count = count_proposals(pool, scope, where_.as_ref()).await?;
+        let items = if limit == 0 {
+            Vec::new()
+        } else {
+            query_proposals(
+                pool,
+                scope,
+                where_.as_ref(),
+                order_by.as_deref(),
+                Some(offset),
+                Some(limit),
+            )
+            .await?
+        };
+        Ok(ProposalPage {
+            total_count,
+            offset,
+            limit,
+            items,
         })
     }
 
-    async fn contributors_connection(
+    async fn contributors_page(
         &self,
         ctx: &Context<'_>,
         where_: Option<ContributorWhereInput>,
         order_by: Option<Vec<ContributorOrderByInput>>,
-    ) -> GraphqlResult<Connection> {
-        let _ = order_by;
-        Ok(Connection {
-            total_count: count_contributors(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<ContributorPage> {
+        let pool = pool(ctx)?;
+        let scope = scope(ctx)?;
+        let (offset, limit) = page_args(offset, limit);
+        let total_count = count_contributors(pool, scope, where_.as_ref()).await?;
+        let items = if limit == 0 {
+            Vec::new()
+        } else {
+            query_contributors(
+                pool,
+                scope,
+                where_.as_ref(),
+                order_by.as_deref(),
+                Some(offset),
+                Some(limit),
+            )
+            .await?
+        };
+        Ok(ContributorPage {
+            total_count,
+            offset,
+            limit,
+            items,
         })
     }
 
-    async fn delegates_connection(
+    async fn delegates_page(
         &self,
         ctx: &Context<'_>,
         where_: Option<DelegateWhereInput>,
         order_by: Option<Vec<DelegateOrderByInput>>,
-    ) -> GraphqlResult<Connection> {
-        let _ = order_by;
-        Ok(Connection {
-            total_count: count_delegates(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<DelegatePage> {
+        let pool = pool(ctx)?;
+        let scope = scope(ctx)?;
+        let (offset, limit) = page_args(offset, limit);
+        let total_count = count_delegates(pool, scope, where_.as_ref()).await?;
+        let items = if limit == 0 {
+            Vec::new()
+        } else {
+            query_delegates(
+                pool,
+                scope,
+                where_.as_ref(),
+                order_by.as_deref(),
+                Some(offset),
+                Some(limit),
+            )
+            .await?
+        };
+        Ok(DelegatePage {
+            total_count,
+            offset,
+            limit,
+            items,
         })
     }
 
-    async fn delegate_mappings_connection(
+    async fn delegate_mappings_page(
         &self,
         ctx: &Context<'_>,
         where_: Option<DelegateMappingWhereInput>,
         order_by: Option<Vec<DelegateMappingOrderByInput>>,
-    ) -> GraphqlResult<Connection> {
-        let _ = order_by;
-        Ok(Connection {
-            total_count: count_delegate_mappings(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<DelegateMappingPage> {
+        let pool = pool(ctx)?;
+        let scope = scope(ctx)?;
+        let (offset, limit) = page_args(offset, limit);
+        let total_count = count_delegate_mappings(pool, scope, where_.as_ref()).await?;
+        let items = if limit == 0 {
+            Vec::new()
+        } else {
+            query_delegate_mappings(
+                pool,
+                scope,
+                where_.as_ref(),
+                order_by.as_deref(),
+                Some(offset),
+                Some(limit),
+            )
+            .await?
+        };
+        Ok(DelegateMappingPage {
+            total_count,
+            offset,
+            limit,
+            items,
         })
     }
 
-    async fn data_metrics_connection(
+    async fn data_metrics_page(
         &self,
         ctx: &Context<'_>,
         where_: Option<DataMetricWhereInput>,
         order_by: Option<Vec<DataMetricOrderByInput>>,
-    ) -> GraphqlResult<Connection> {
-        let _ = order_by;
-        Ok(Connection {
-            total_count: count_data_metrics(pool(ctx)?, scope(ctx)?, where_.as_ref()).await?,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<DataMetricPage> {
+        let pool = pool(ctx)?;
+        let scope = scope(ctx)?;
+        let (offset, limit) = page_args(offset, limit);
+        let total_count = count_data_metrics(pool, scope, where_.as_ref()).await?;
+        let items = if limit == 0 {
+            Vec::new()
+        } else {
+            query_data_metrics(
+                pool,
+                scope,
+                where_.as_ref(),
+                order_by.as_deref(),
+                Some(offset),
+                Some(limit),
+            )
+            .await?
+        };
+        Ok(DataMetricPage {
+            total_count,
+            offset,
+            limit,
+            items,
         })
     }
 }
@@ -303,4 +410,11 @@ fn pool<'a>(ctx: &'a Context<'_>) -> GraphqlResult<&'a sqlx::PgPool> {
 
 fn scope<'a>(ctx: &'a Context<'_>) -> GraphqlResult<&'a GraphqlScope> {
     Ok(ctx.data::<GraphqlScope>()?)
+}
+
+fn page_args(offset: Option<i32>, limit: Option<i32>) -> (i32, i32) {
+    (
+        offset.unwrap_or(0).max(0),
+        limit.unwrap_or(DEFAULT_PAGE_LIMIT).max(0),
+    )
 }

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -210,8 +210,47 @@ pub struct IndexerStatus {
 
 #[derive(Clone, Debug, SimpleObject)]
 #[graphql(rename_fields = "camelCase")]
-pub struct Connection {
+pub struct ProposalPage {
     pub(super) total_count: i64,
+    pub(super) offset: i32,
+    pub(super) limit: i32,
+    pub(super) items: Vec<Proposal>,
+}
+
+#[derive(Clone, Debug, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct ContributorPage {
+    pub(super) total_count: i64,
+    pub(super) offset: i32,
+    pub(super) limit: i32,
+    pub(super) items: Vec<Contributor>,
+}
+
+#[derive(Clone, Debug, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct DelegatePage {
+    pub(super) total_count: i64,
+    pub(super) offset: i32,
+    pub(super) limit: i32,
+    pub(super) items: Vec<Delegate>,
+}
+
+#[derive(Clone, Debug, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct DelegateMappingPage {
+    pub(super) total_count: i64,
+    pub(super) offset: i32,
+    pub(super) limit: i32,
+    pub(super) items: Vec<DelegateMapping>,
+}
+
+#[derive(Clone, Debug, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct DataMetricPage {
+    pub(super) total_count: i64,
+    pub(super) offset: i32,
+    pub(super) limit: i32,
+    pub(super) items: Vec<DataMetric>,
 }
 
 #[ComplexObject(rename_fields = "camelCase")]

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -150,7 +150,12 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
                 powerSum
                 memberCount
               }
-              dataMetricsConnection(where: { votesCount_eq: 1 }, orderBy: id_ASC) { totalCount }
+              dataMetricsPage(where: { votesCount_eq: 1 }, orderBy: id_ASC, limit: 0, offset: 2) {
+                totalCount
+                offset
+                limit
+                items { id }
+              }
               contributors(where: { OR: [{ id_eq: "0xvoter1" }, { power_lt: 50 }] }, orderBy: [power_DESC]) {
                 id
                 power
@@ -168,10 +173,30 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
                 to
                 power
               }
-              proposalsConnection(where: $where, orderBy: id_ASC) { totalCount }
-              contributorsConnection(orderBy: id_ASC) { totalCount }
-              delegatesConnection(where: { fromDelegate_eq: "0xdelegator" }, orderBy: [id_ASC]) { totalCount }
-              delegateMappingsConnection(where: { from_eq: "0xdelegator" }, orderBy: [id_ASC]) { totalCount }
+              proposalsPage(where: $where, orderBy: id_ASC, limit: 1, offset: 0) {
+                totalCount
+                offset
+                limit
+                items { id }
+              }
+              contributorsPage(orderBy: id_ASC, limit: 1, offset: 1) {
+                totalCount
+                offset
+                limit
+                items { id }
+              }
+              delegatesPage(where: { fromDelegate_eq: "0xdelegator" }, orderBy: [id_ASC], limit: 1, offset: 0) {
+                totalCount
+                offset
+                limit
+                items { id }
+              }
+              delegateMappingsPage(where: { from_eq: "0xdelegator" }, orderBy: [id_ASC], limit: 1, offset: 0) {
+                totalCount
+                offset
+                limit
+                items { id to power }
+              }
             }
             "#,
     )
@@ -221,14 +246,71 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
     );
     assert_eq!(data["proposalExecuteds"][0]["proposalId"], "0x65");
     assert_eq!(data["dataMetrics"][0]["powerSum"], "150");
-    assert_eq!(data["dataMetricsConnection"]["totalCount"], 1);
+    assert_eq!(data["dataMetricsPage"]["totalCount"], 1);
+    assert_eq!(data["dataMetricsPage"]["offset"], 2);
+    assert_eq!(data["dataMetricsPage"]["limit"], 0);
+    assert_eq!(
+        data["dataMetricsPage"]["items"]
+            .as_array()
+            .expect("items")
+            .len(),
+        0
+    );
     assert_eq!(data["contributors"][0]["id"], "0xvoter1");
     assert_eq!(data["delegates"][0]["isCurrent"], true);
     assert_eq!(data["delegateMappings"][0]["to"], "0xdelegate");
-    assert_eq!(data["proposalsConnection"]["totalCount"], 1);
-    assert_eq!(data["contributorsConnection"]["totalCount"], 2);
-    assert_eq!(data["delegatesConnection"]["totalCount"], 1);
-    assert_eq!(data["delegateMappingsConnection"]["totalCount"], 1);
+    assert_eq!(data["proposalsPage"]["totalCount"], 1);
+    assert_eq!(data["proposalsPage"]["offset"], 0);
+    assert_eq!(data["proposalsPage"]["limit"], 1);
+    assert_eq!(
+        data["proposalsPage"]["items"]
+            .as_array()
+            .expect("items")
+            .len(),
+        1
+    );
+    assert_eq!(data["contributorsPage"]["totalCount"], 2);
+    assert_eq!(data["contributorsPage"]["offset"], 1);
+    assert_eq!(data["contributorsPage"]["limit"], 1);
+    assert_eq!(
+        data["contributorsPage"]["items"]
+            .as_array()
+            .expect("items")
+            .len(),
+        1
+    );
+    assert_eq!(data["delegatesPage"]["totalCount"], 1);
+    assert_eq!(data["delegatesPage"]["offset"], 0);
+    assert_eq!(data["delegatesPage"]["limit"], 1);
+    assert_eq!(data["delegateMappingsPage"]["totalCount"], 1);
+    assert_eq!(data["delegateMappingsPage"]["offset"], 0);
+    assert_eq!(data["delegateMappingsPage"]["limit"], 1);
+    assert_eq!(data["delegateMappingsPage"]["items"][0]["to"], "0xdelegate");
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_schema_rejects_removed_connection_fields() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let schema = graphql::build_schema(database.pool.clone());
+
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query RemovedConnections {
+              proposalsConnection { totalCount }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        !response.errors.is_empty(),
+        "expected GraphQL error for removed proposalsConnection field"
+    );
 
     database.cleanup().await?;
 
@@ -326,7 +408,7 @@ async fn test_graphql_data_metrics_parity_fields_filters_and_ordering() -> Resul
                 proposalsCount
                 votesCount
               }
-              dataMetricsConnection(orderBy: id_ASC) { totalCount }
+              dataMetricsPage(orderBy: id_ASC, limit: 0) { totalCount offset limit items { id } }
             }
             "#,
         ))
@@ -339,7 +421,16 @@ async fn test_graphql_data_metrics_parity_fields_filters_and_ordering() -> Resul
     );
 
     let data = response.data.into_json()?;
-    assert_eq!(data["dataMetricsConnection"]["totalCount"], 3);
+    assert_eq!(data["dataMetricsPage"]["totalCount"], 3);
+    assert_eq!(data["dataMetricsPage"]["offset"], 0);
+    assert_eq!(data["dataMetricsPage"]["limit"], 0);
+    assert_eq!(
+        data["dataMetricsPage"]["items"]
+            .as_array()
+            .expect("items")
+            .len(),
+        0
+    );
     assert_eq!(data["dataMetrics"][0]["id"], "0000000800-proposal");
     assert_eq!(data["dataMetrics"][1]["id"], "0000000805-vote");
     assert_eq!(data["dataMetrics"][2]["id"], "global");
@@ -667,7 +758,7 @@ async fn test_graphql_proposal_fields_prefer_provisional_overlay_and_fallback_to
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_graphql_schema_applies_implicit_scope_to_queries_and_connections()
+async fn test_graphql_schema_applies_implicit_scope_to_queries_and_pages()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_other_scope_rows(&database.pool).await?;
@@ -697,11 +788,11 @@ async fn test_graphql_schema_applies_implicit_scope_to_queries_and_connections()
               contributors(orderBy: [id_ASC]) { id daoCode }
               delegates(orderBy: [id_ASC]) { id daoCode }
               delegateMappings(orderBy: [id_ASC]) { id daoCode }
-              proposalsConnection { totalCount }
-              dataMetricsConnection { totalCount }
-              contributorsConnection { totalCount }
-              delegatesConnection { totalCount }
-              delegateMappingsConnection { totalCount }
+              proposalsPage { totalCount offset limit items { id } }
+              dataMetricsPage { totalCount offset limit items { id } }
+              contributorsPage { totalCount offset limit items { id } }
+              delegatesPage { totalCount offset limit items { id } }
+              delegateMappingsPage { totalCount offset limit items { id } }
             }
             "#,
         ))
@@ -738,11 +829,20 @@ async fn test_graphql_schema_applies_implicit_scope_to_queries_and_connections()
         1
     );
     assert_eq!(data["proposalQueueds"].as_array().expect("queued").len(), 1);
-    assert_eq!(data["dataMetricsConnection"]["totalCount"], 3);
-    assert_eq!(data["contributorsConnection"]["totalCount"], 2);
-    assert_eq!(data["delegatesConnection"]["totalCount"], 1);
-    assert_eq!(data["delegateMappingsConnection"]["totalCount"], 1);
-    assert_eq!(data["proposalsConnection"]["totalCount"], 2);
+    assert_eq!(data["dataMetricsPage"]["totalCount"], 3);
+    assert_eq!(data["contributorsPage"]["totalCount"], 2);
+    assert_eq!(data["delegatesPage"]["totalCount"], 1);
+    assert_eq!(data["delegateMappingsPage"]["totalCount"], 1);
+    assert_eq!(data["proposalsPage"]["totalCount"], 2);
+    assert_eq!(data["proposalsPage"]["offset"], 0);
+    assert_eq!(data["proposalsPage"]["limit"], 20);
+    assert_eq!(
+        data["proposalsPage"]["items"]
+            .as_array()
+            .expect("items")
+            .len(),
+        2
+    );
     assert_eq!(data["dataMetrics"][0]["daoCode"], "lisk-dao");
     assert_eq!(data["contributors"][0]["daoCode"], "lisk-dao");
     assert_eq!(data["delegates"][0]["daoCode"], "lisk-dao");
@@ -909,11 +1009,11 @@ async fn test_graphql_schema_scope_conflicts_return_no_rows() -> Result<(), Box<
               contributors(where: { daoCode_eq: "ens-dao" }) { id }
               delegates(where: { daoCode_eq: "ens-dao" }) { id }
               delegateMappings(where: { daoCode_eq: "ens-dao" }) { id }
-              proposalsConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
-              dataMetricsConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
-              contributorsConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
-              delegatesConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
-              delegateMappingsConnection(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              proposalsPage(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              dataMetricsPage(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              contributorsPage(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              delegatesPage(where: { daoCode_eq: "ens-dao" }) { totalCount }
+              delegateMappingsPage(where: { daoCode_eq: "ens-dao" }) { totalCount }
             }
             "#,
         ))
@@ -939,11 +1039,11 @@ async fn test_graphql_schema_scope_conflicts_return_no_rows() -> Result<(), Box<
         assert_eq!(data[field].as_array().expect(field).len(), 0, "{field}");
     }
     for field in [
-        "proposalsConnection",
-        "dataMetricsConnection",
-        "contributorsConnection",
-        "delegatesConnection",
-        "delegateMappingsConnection",
+        "proposalsPage",
+        "dataMetricsPage",
+        "contributorsPage",
+        "delegatesPage",
+        "delegateMappingsPage",
     ] {
         assert_eq!(data[field]["totalCount"], 0, "{field}");
     }
@@ -973,7 +1073,7 @@ async fn test_graphql_http_dao_path_applies_path_scope_and_preserves_admin()
         Client::new()
             .post(admin_endpoint)
             .json(&json!({
-                "query": "query { contributorsConnection { totalCount } contributors(orderBy: [id_ASC]) { daoCode } }"
+                "query": "query { contributorsPage { totalCount } contributors(orderBy: [id_ASC]) { daoCode } }"
             }))
             .send(),
     )
@@ -985,7 +1085,7 @@ async fn test_graphql_http_dao_path_applies_path_scope_and_preserves_admin()
         Client::new()
             .post(ens_endpoint)
             .json(&json!({
-                "query": "query { contributorsConnection { totalCount } contributors(orderBy: [id_ASC]) { daoCode } }"
+                "query": "query { contributorsPage { totalCount } contributors(orderBy: [id_ASC]) { daoCode } }"
             }))
             .send(),
     )
@@ -993,14 +1093,8 @@ async fn test_graphql_http_dao_path_applies_path_scope_and_preserves_admin()
     .json()
     .await?;
 
-    assert_eq!(
-        admin_response["data"]["contributorsConnection"]["totalCount"],
-        3
-    );
-    assert_eq!(
-        ens_response["data"]["contributorsConnection"]["totalCount"],
-        1
-    );
+    assert_eq!(admin_response["data"]["contributorsPage"]["totalCount"], 3);
+    assert_eq!(ens_response["data"]["contributorsPage"]["totalCount"], 1);
     assert_eq!(
         ens_response["data"]["contributors"][0]["daoCode"],
         "ens-dao"

--- a/apps/indexer/tests/lisk_dao_golden_baseline.rs
+++ b/apps/indexer/tests/lisk_dao_golden_baseline.rs
@@ -73,7 +73,7 @@ struct BaselineCounts {
     vote_power_checkpoints: i64,
     token_balance_checkpoints: i64,
     onchain_refresh_tasks: i64,
-    data_metrics_connection_total_count: i64,
+    data_metrics_page_total_count: i64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -317,7 +317,7 @@ async fn test_lisk_dao_golden_baseline_matches_fixture_contract() -> Result<(), 
     assert_table_count(
         &database.pool,
         "data_metric",
-        baseline.counts.data_metrics_connection_total_count,
+        baseline.counts.data_metrics_page_total_count,
     )
     .await?;
 
@@ -334,9 +334,9 @@ async fn test_lisk_dao_golden_baseline_matches_fixture_contract() -> Result<(), 
                   $votedProposalWhere: ProposalWhereInput,
                   $wrongVoterProposalWhere: ProposalWhereInput
                 ) {
-                  proposalsConnection(orderBy: [id_ASC]) { totalCount }
-                  contributorsConnection(orderBy: id_ASC) { totalCount }
-                  dataMetricsConnection(orderBy: id_ASC) { totalCount }
+                  proposalsPage(orderBy: [id_ASC], limit: 0) { totalCount }
+                  contributorsPage(orderBy: id_ASC, limit: 0) { totalCount }
+                  dataMetricsPage(orderBy: id_ASC, limit: 0) { totalCount }
                   dataMetrics(where: $metricWhere) {
                     proposalsCount
                     votesCount
@@ -375,8 +375,8 @@ async fn test_lisk_dao_golden_baseline_matches_fixture_contract() -> Result<(), 
                   proposalQueueds(orderBy: [id_ASC]) { proposalId etaSeconds }
                   proposalExecuteds(orderBy: [id_ASC]) { proposalId }
                   proposalCanceleds(orderBy: [id_ASC]) { proposalId }
-                  delegatesConnection(orderBy: [id_ASC]) { totalCount }
-                  delegateMappingsConnection(orderBy: [id_ASC]) { totalCount }
+                  delegatesPage(orderBy: [id_ASC], limit: 0) { totalCount }
+                  delegateMappingsPage(orderBy: [id_ASC], limit: 0) { totalCount }
                 }
                 "#,
             )
@@ -426,12 +426,12 @@ async fn test_lisk_dao_golden_baseline_matches_fixture_contract() -> Result<(), 
     let data = response.data.into_json()?;
 
     assert_eq!(
-        data["proposalsConnection"]["totalCount"],
+        data["proposalsPage"]["totalCount"],
         baseline.counts.proposals
     );
     assert_eq!(
-        data["dataMetricsConnection"]["totalCount"],
-        baseline.counts.data_metrics_connection_total_count
+        data["dataMetricsPage"]["totalCount"],
+        baseline.counts.data_metrics_page_total_count
     );
     assert_eq!(
         data["dataMetrics"][0]["proposalsCount"],
@@ -471,7 +471,7 @@ async fn test_lisk_dao_golden_baseline_matches_fixture_contract() -> Result<(), 
     assert_eq!(data["contributors"][0]["id"], top_contributor.id);
     assert_eq!(data["contributors"][0]["power"], top_contributor.power);
     assert_eq!(
-        data["contributorsConnection"]["totalCount"],
+        data["contributorsPage"]["totalCount"],
         baseline.counts.contributors
     );
     assert_eq!(
@@ -519,11 +519,11 @@ async fn test_lisk_dao_golden_baseline_matches_fixture_contract() -> Result<(), 
         Some(baseline.counts.proposal_canceleds as usize)
     );
     assert_eq!(
-        data["delegatesConnection"]["totalCount"],
+        data["delegatesPage"]["totalCount"],
         baseline.counts.delegates
     );
     assert_eq!(
-        data["delegateMappingsConnection"]["totalCount"],
+        data["delegateMappingsPage"]["totalCount"],
         baseline.counts.delegate_mappings
     );
 
@@ -1227,7 +1227,7 @@ async fn seed_data_metrics(pool: &PgPool, baseline: &Baseline) -> Result<(), sql
     .bind(&baseline.scope.dao_code)
     .bind(&baseline.scope.governor)
     .bind(&baseline.scope.token.address)
-    .bind(baseline.counts.data_metrics_connection_total_count)
+    .bind(baseline.counts.data_metrics_page_total_count)
     .execute(pool)
     .await?;
 

--- a/apps/indexer/tests/support/fixtures/golden-baselines/lisk-dao.production.json
+++ b/apps/indexer/tests/support/fixtures/golden-baselines/lisk-dao.production.json
@@ -35,7 +35,7 @@
     "votePowerCheckpoints": 23391,
     "tokenBalanceCheckpoints": 23395,
     "onchainRefreshTasks": 14521,
-    "dataMetricsConnectionTotalCount": 3783
+    "dataMetricsPageTotalCount": 3783
   },
   "samples": {
     "latestProposal": {
@@ -61,15 +61,15 @@
     }
   },
   "queryShapes": {
-    "proposalTotal": "query { proposalsConnection(orderBy: [id_ASC]) { totalCount } }",
-    "contributorsTotal": "query { contributorsConnection(orderBy: id_ASC) { totalCount } }",
-    "dataMetricTotal": "query { dataMetricsConnection(orderBy: id_ASC) { totalCount } }",
+    "proposalTotal": "query { proposalsPage(orderBy: [id_ASC], limit: 0) { totalCount } }",
+    "contributorsTotal": "query { contributorsPage(orderBy: id_ASC, limit: 0) { totalCount } }",
+    "dataMetricTotal": "query { dataMetricsPage(orderBy: id_ASC, limit: 0) { totalCount } }",
     "globalDataMetric": "query { dataMetrics(where: { id_eq: \"global\", chainId_eq: 1135, governorAddress_eq: \"0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568\", daoCode_eq: \"lisk-dao\" }) { proposalsCount votesCount powerSum memberCount } }",
     "latestProposal": "query { proposals(orderBy: [blockTimestamp_DESC_NULLS_LAST], limit: 1) { proposalId title blockNumber metricsVotesCount metricsVotesWeightForSum metricsVotesWeightAgainstSum metricsVotesWeightAbstainSum } }",
     "topContributor": "query { contributors(orderBy: [power_DESC], limit: 1) { id power } }",
     "proposalVoters": "query { proposals(where: { proposalId_eq: \"0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878\", chainId_eq: 1135, governorAddress_eq: \"0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568\", daoCode_eq: \"lisk-dao\" }, limit: 1) { proposalId voters(orderBy: [blockTimestamp_ASC_NULLS_LAST], limit: 1) { voter support weight reason params } } }",
     "proposalsByVoter": "query { proposals(where: { proposalId_eq: \"0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878\", chainId_eq: 1135, governorAddress_eq: \"0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568\", daoCode_eq: \"lisk-dao\", voters_some: { voter_eq: \"0x439042a964a76cc3decffd4135a3d3d99d26fbb1\", support_eq: 1 } }, limit: 1) { proposalId } }",
     "proposalEvents": "query { proposalQueueds(orderBy: [id_ASC]) { proposalId etaSeconds } proposalExecuteds(orderBy: [id_ASC]) { proposalId } proposalCanceleds(orderBy: [id_ASC]) { proposalId } }",
-    "delegateTotals": "query { delegatesConnection(orderBy: [id_ASC]) { totalCount } delegateMappingsConnection(orderBy: [id_ASC]) { totalCount } }"
+    "delegateTotals": "query { delegatesPage(orderBy: [id_ASC], limit: 0) { totalCount } delegateMappingsPage(orderBy: [id_ASC], limit: 0) { totalCount } }"
   }
 }

--- a/apps/web/scripts/delegate-current-source.test.ts
+++ b/apps/web/scripts/delegate-current-source.test.ts
@@ -16,8 +16,14 @@ test("profile current delegation reads delegates with the current flag", () => {
 });
 
 test("received delegation surfaces keep the current flag on delegate reads", () => {
+  const parent = readSource(
+    "src/app/profile/_components/received-delegations.tsx"
+  );
+
+  assert.doesNotMatch(parent, /getDelegatesConnection/);
+  assert.doesNotMatch(parent, /delegatesConnection/);
+
   const files = [
-    "src/app/profile/_components/received-delegations.tsx",
     "src/components/delegation-table/index.tsx",
     "src/components/delegation-list/index.tsx",
   ];
@@ -25,8 +31,9 @@ test("received delegation surfaces keep the current flag on delegate reads", () 
   for (const file of files) {
     const source = readSource(file);
 
-    assert.match(source, /delegateService\.(getAllDelegates|getDelegatesConnection)/);
+    assert.match(source, /delegateService\.(getAllDelegates|getDelegatesPage)/);
     assert.match(source, /isCurrent_eq:\s*true/);
+    assert.doesNotMatch(source, /getDelegatesConnection/);
     assert.doesNotMatch(source, /to_eq:/);
   }
 });

--- a/apps/web/scripts/governance-counts.test.ts
+++ b/apps/web/scripts/governance-counts.test.ts
@@ -8,24 +8,25 @@ import {
 } from "../src/services/graphql/types/counts.ts";
 
 test("governance counts query requests proposal and contributor totals", () => {
-  assert.match(GET_GOVERNANCE_COUNTS, /proposalsConnection/);
-  assert.match(GET_GOVERNANCE_COUNTS, /contributorsConnection/);
+  assert.match(GET_GOVERNANCE_COUNTS, /proposalsPage/);
+  assert.match(GET_GOVERNANCE_COUNTS, /contributorsPage/);
+  assert.doesNotMatch(GET_GOVERNANCE_COUNTS, /Connection/);
   assert.match(GET_GOVERNANCE_COUNTS, /totalCount/g);
 });
 
-test("governance counts fall back to zero when connection totals are missing", () => {
+test("governance counts fall back to zero when page totals are missing", () => {
   assert.deepEqual(resolveGovernanceCounts(), {
     proposalsCount: 0,
     delegatesCount: 0,
   });
 });
 
-test("governance counts map proposal and delegate totals from connection responses", () => {
+test("governance counts map proposal and delegate totals from page responses", () => {
   const response: GovernanceCountsResponse = {
-    proposalsConnection: {
+    proposalsPage: {
       totalCount: 47,
     },
-    contributorsConnection: {
+    contributorsPage: {
       totalCount: 2516,
     },
   };

--- a/apps/web/scripts/received-delegations-source.test.ts
+++ b/apps/web/scripts/received-delegations-source.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import {
   GET_DELEGATES,
-  GET_DELEGATES_CONNECTION,
+  GET_DELEGATES_PAGE,
 } from "../src/services/graphql/queries/delegates.ts";
 
 test("received delegations list query reads current delegates", () => {
@@ -14,7 +14,13 @@ test("received delegations list query reads current delegates", () => {
   assert.match(GET_DELEGATES, /\bpower\b/);
 });
 
-test("received delegations count query matches the delegates source", () => {
-  assert.match(GET_DELEGATES_CONNECTION, /delegatesConnection\s*\(/);
-  assert.match(GET_DELEGATES_CONNECTION, /totalCount/);
+test("received delegations page query supplies count and rows from the delegates source", () => {
+  assert.match(GET_DELEGATES_PAGE, /delegatesPage\s*\(/);
+  assert.match(GET_DELEGATES_PAGE, /totalCount/);
+  assert.match(GET_DELEGATES_PAGE, /items\s*\{/);
+  assert.match(GET_DELEGATES_PAGE, /\bfromDelegate\b/);
+  assert.match(GET_DELEGATES_PAGE, /\btoDelegate\b/);
+  assert.match(GET_DELEGATES_PAGE, /\bisCurrent\b/);
+  assert.match(GET_DELEGATES_PAGE, /\bpower\b/);
+  assert.doesNotMatch(GET_DELEGATES_PAGE, /Connection/);
 });

--- a/apps/web/src/app/profile/_components/received-delegations.tsx
+++ b/apps/web/src/app/profile/_components/received-delegations.tsx
@@ -1,6 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { DelegationList } from "@/components/delegation-list";
 import { DelegationTable } from "@/components/delegation-table";
@@ -11,8 +10,6 @@ import type {
 } from "@/components/delegation-table";
 import { ResponsiveRenderer } from "@/components/responsive-renderer";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useDaoConfig } from "@/hooks/useDaoConfig";
-import { buildGovernanceScope, delegateService } from "@/services/graphql";
 
 import type { Address } from "viem";
 
@@ -41,39 +38,15 @@ const ORDER_BY_MAP: Record<
 
 export function ReceivedDelegations({ address }: ReceivedDelegationsProps) {
   const t = useTranslations("profile.receivedDelegations");
-  const daoConfig = useDaoConfig();
   const [sortState, setSortState] =
     useState<DelegationSortState>(DEFAULT_SORT_STATE);
-  const governanceScope = useMemo(
-    () => buildGovernanceScope(daoConfig),
-    [daoConfig]
-  );
+  const [totalCount, setTotalCount] = useState<number>();
 
-  // Get received delegations count
-  const { data: delegationConnection } = useQuery({
-    queryKey: [
-      "delegatesConnection",
-      address,
-      daoConfig?.indexer?.endpoint,
-      governanceScope,
-    ],
-    queryFn: () =>
-      delegateService.getDelegatesConnection(
-        daoConfig?.indexer?.endpoint as string,
-        {
-          where: {
-            ...governanceScope,
-            toDelegate_eq: address.toLowerCase(),
-            isCurrent_eq: true,
-          },
-          orderBy: ["id_ASC"],
-        }
-      ),
-    enabled: !!daoConfig?.indexer?.endpoint && !!address,
-  });
+  useEffect(() => {
+    setTotalCount(undefined);
+  }, [address]);
 
   const getDisplayTitle = () => {
-    const totalCount = delegationConnection?.totalCount;
     if (totalCount !== undefined) {
       return t("titleWithCount", { count: totalCount });
     }
@@ -112,17 +85,17 @@ export function ReceivedDelegations({ address }: ReceivedDelegationsProps) {
           <DelegationTable
             address={address}
             orderBy={orderBy}
-            totalCount={delegationConnection?.totalCount ?? 0}
             sortState={sortState}
             onDateSortChange={handleDateSortChange}
             onPowerSortChange={handlePowerSortChange}
+            onTotalCountChange={setTotalCount}
           />
         }
         mobile={
           <DelegationList
             address={address}
             orderBy={orderBy}
-            totalCount={delegationConnection?.totalCount ?? 0}
+            onTotalCountChange={setTotalCount}
           />
         }
         loadingFallback={

--- a/apps/web/src/components/delegation-list/index.tsx
+++ b/apps/web/src/components/delegation-list/index.tsx
@@ -11,7 +11,7 @@ import {
   usePaginationRange,
 } from "@/hooks/usePaginationRange";
 import { buildGovernanceScope, delegateService } from "@/services/graphql";
-import type { DelegateItem } from "@/services/graphql/types";
+import type { DelegateItem, DelegatePageItem } from "@/services/graphql/types";
 
 import { AddressAvatar } from "../address-avatar";
 import { AddressResolver } from "../address-resolver";
@@ -31,13 +31,13 @@ import type { Address } from "viem";
 interface DelegationListProps {
   address: Address;
   orderBy: string;
-  totalCount: number;
+  onTotalCountChange?: (totalCount: number) => void;
 }
 
 export function DelegationList({
   address,
   orderBy,
-  totalCount,
+  onTotalCountChange,
 }: DelegationListProps) {
   const t = useTranslations("profile.receivedDelegations");
   const formatTokenAmount = useFormatGovernanceTokenAmount();
@@ -53,21 +53,11 @@ export function DelegationList({
   }, [orderBy, address]);
 
   const pageSize = DEFAULT_PAGE_SIZE;
-  const totalPageCount = useMemo(() => {
-    return Math.max(1, Math.ceil((totalCount || 0) / pageSize));
-  }, [totalCount, pageSize]);
-
-  useEffect(() => {
-    if (currentPage > totalPageCount) {
-      setCurrentPage(totalPageCount);
-    }
-  }, [currentPage, totalPageCount]);
-
   const {
-    data: pageData = [],
+    data: page,
     isLoading,
     isFetching,
-  } = useQuery<DelegateItem[]>({
+  } = useQuery<DelegatePageItem | undefined>({
     queryKey: [
       "delegation-list",
       daoConfig?.indexer?.endpoint,
@@ -78,7 +68,7 @@ export function DelegationList({
       governanceScope,
     ],
     queryFn: () =>
-      delegateService.getAllDelegates(
+      delegateService.getDelegatesPage(
         daoConfig?.indexer?.endpoint as string,
         {
           limit: pageSize,
@@ -92,8 +82,26 @@ export function DelegationList({
         }
       ),
     enabled: !!daoConfig?.indexer?.endpoint && !!address,
-    placeholderData: (previous) => previous ?? [],
+    placeholderData: (previous) => previous,
   });
+
+  const pageData = useMemo(() => page?.items ?? [], [page?.items]);
+  const totalCount = page?.totalCount ?? 0;
+  const totalPageCount = useMemo(() => {
+    return Math.max(1, Math.ceil((totalCount || 0) / pageSize));
+  }, [totalCount, pageSize]);
+
+  useEffect(() => {
+    if (page?.totalCount !== undefined) {
+      onTotalCountChange?.(page.totalCount);
+    }
+  }, [onTotalCountChange, page?.totalCount]);
+
+  useEffect(() => {
+    if (currentPage > totalPageCount) {
+      setCurrentPage(totalPageCount);
+    }
+  }, [currentPage, totalPageCount]);
 
   const delegateAddresses = useMemo(
     () =>

--- a/apps/web/src/components/delegation-table/index.tsx
+++ b/apps/web/src/components/delegation-table/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/hooks/usePaginationRange";
 import { useCurrentVotingPower } from "@/hooks/useSmartGetVotes";
 import { buildGovernanceScope, delegateService } from "@/services/graphql";
-import type { DelegateItem } from "@/services/graphql/types";
+import type { DelegateItem, DelegatePageItem } from "@/services/graphql/types";
 import { formatTimeAgo } from "@/utils/date";
 
 import { AddressWithAvatar } from "../address-with-avatar";
@@ -40,19 +40,19 @@ export interface DelegationSortState {
 interface DelegationTableProps {
   address: Address;
   orderBy: string;
-  totalCount: number;
   sortState: DelegationSortState;
   onDateSortChange: (direction?: DelegationSortDirection) => void;
   onPowerSortChange: (direction?: DelegationSortDirection) => void;
+  onTotalCountChange?: (totalCount: number) => void;
 }
 
 export function DelegationTable({
   address,
   orderBy,
-  totalCount,
   sortState,
   onDateSortChange,
   onPowerSortChange,
+  onTotalCountChange,
 }: DelegationTableProps) {
   const t = useTranslations("profile.receivedDelegations");
   const formatTokenAmount = useFormatGovernanceTokenAmount();
@@ -70,15 +70,7 @@ export function DelegationTable({
   }, [orderBy, address]);
 
   const pageSize = DEFAULT_PAGE_SIZE;
-  const totalPageCount = Math.max(1, Math.ceil((totalCount || 0) / pageSize));
-
-  useEffect(() => {
-    if (currentPage > totalPageCount) {
-      setCurrentPage(totalPageCount);
-    }
-  }, [currentPage, totalPageCount]);
-
-  const { data: pageData = [], isFetching } = useQuery<DelegateItem[]>({
+  const { data: page, isFetching } = useQuery<DelegatePageItem | undefined>({
     queryKey: [
       "delegation-table",
       daoConfig?.indexer?.endpoint,
@@ -89,7 +81,7 @@ export function DelegationTable({
       governanceScope,
     ],
     queryFn: () =>
-      delegateService.getAllDelegates(
+      delegateService.getDelegatesPage(
         daoConfig?.indexer?.endpoint as string,
         {
           limit: pageSize,
@@ -103,8 +95,24 @@ export function DelegationTable({
         }
       ),
     enabled: !!daoConfig?.indexer?.endpoint && !!address,
-    placeholderData: (previous) => previous ?? [],
+    placeholderData: (previous) => previous,
   });
+
+  const pageData = page?.items ?? [];
+  const totalCount = page?.totalCount ?? 0;
+  const totalPageCount = Math.max(1, Math.ceil((totalCount || 0) / pageSize));
+
+  useEffect(() => {
+    if (page?.totalCount !== undefined) {
+      onTotalCountChange?.(page.totalCount);
+    }
+  }, [onTotalCountChange, page?.totalCount]);
+
+  useEffect(() => {
+    if (currentPage > totalPageCount) {
+      setCurrentPage(totalPageCount);
+    }
+  }, [currentPage, totalPageCount]);
 
   const paginationRange = usePaginationRange(currentPage, totalPageCount);
 

--- a/apps/web/src/services/graphql/index.ts
+++ b/apps/web/src/services/graphql/index.ts
@@ -443,19 +443,26 @@ export const delegateService = {
     );
     return response?.delegates ?? [];
   },
-  getDelegatesConnection: async (
+  getDelegatesPage: async (
     endpoint: string,
     options: {
+      limit?: number;
+      offset?: number;
       where: DelegateWhere;
-      orderBy: string[];
+      orderBy: string | string[];
     }
   ) => {
-    const response = await request<Types.DelegateConnectionResponse>(
+    const response = await request<Types.DelegatePageResponse>(
       endpoint,
-      Queries.GET_DELEGATES_CONNECTION,
-      options
+      Queries.GET_DELEGATES_PAGE,
+      {
+        ...options,
+        orderBy: Array.isArray(options.orderBy)
+          ? options.orderBy
+          : [options.orderBy],
+      }
     );
-    return response?.delegatesConnection;
+    return response?.delegatesPage;
   },
   getDelegateMappings: async (
     endpoint: string,
@@ -486,19 +493,26 @@ export const delegateService = {
     );
     return response?.delegateMappings ?? [];
   },
-  getDelegateMappingsConnection: async (
+  getDelegateMappingsPage: async (
     endpoint: string,
     options: {
+      limit?: number;
+      offset?: number;
       where: DelegateMappingWhere;
-      orderBy: string[];
+      orderBy: string | string[];
     }
   ) => {
-    const response = await request<Types.DelegateMappingConnectionResponse>(
+    const response = await request<Types.DelegateMappingPageResponse>(
       endpoint,
-      Queries.GET_DELEGATE_MAPPINGS_CONNECTION,
-      options
+      Queries.GET_DELEGATE_MAPPINGS_PAGE,
+      {
+        ...options,
+        orderBy: Array.isArray(options.orderBy)
+          ? options.orderBy
+          : [options.orderBy],
+      }
     );
-    return response?.delegateMappingsConnection;
+    return response?.delegateMappingsPage;
   },
 };
 

--- a/apps/web/src/services/graphql/queries/counts.ts
+++ b/apps/web/src/services/graphql/queries/counts.ts
@@ -2,10 +2,10 @@ import { gql } from "graphql-request";
 
 export const GET_GOVERNANCE_COUNTS = gql`
   query GetGovernanceCounts {
-    proposalsConnection(orderBy: id_ASC) {
+    proposalsPage(orderBy: id_ASC, limit: 0) {
       totalCount
     }
-    contributorsConnection(orderBy: id_ASC) {
+    contributorsPage(orderBy: id_ASC, limit: 0) {
       totalCount
     }
   }

--- a/apps/web/src/services/graphql/queries/delegates.ts
+++ b/apps/web/src/services/graphql/queries/delegates.ts
@@ -25,13 +25,32 @@ export const GET_DELEGATES = gql`
   }
 `;
 
-export const GET_DELEGATES_CONNECTION = gql`
-  query GetDelegatesConnection(
+export const GET_DELEGATES_PAGE = gql`
+  query GetDelegatesPage(
+    $limit: Int
+    $offset: Int
     $where: DelegateWhereInput
     $orderBy: [DelegateOrderByInput!]!
   ) {
-    delegatesConnection(where: $where, orderBy: $orderBy) {
+    delegatesPage(
+      limit: $limit
+      offset: $offset
+      where: $where
+      orderBy: $orderBy
+    ) {
       totalCount
+      offset
+      limit
+      items {
+        blockNumber
+        blockTimestamp
+        fromDelegate
+        id
+        isCurrent
+        power
+        toDelegate
+        transactionHash
+      }
     }
   }
 `;
@@ -60,13 +79,31 @@ export const GET_DELEGATE_MAPPINGS = gql`
   }
 `;
 
-export const GET_DELEGATE_MAPPINGS_CONNECTION = gql`
-  query GetDelegateMappingsConnection(
+export const GET_DELEGATE_MAPPINGS_PAGE = gql`
+  query GetDelegateMappingsPage(
+    $limit: Int
+    $offset: Int
     $where: DelegateMappingWhereInput
     $orderBy: [DelegateMappingOrderByInput!]!
   ) {
-    delegateMappingsConnection(where: $where, orderBy: $orderBy) {
+    delegateMappingsPage(
+      limit: $limit
+      offset: $offset
+      where: $where
+      orderBy: $orderBy
+    ) {
       totalCount
+      offset
+      limit
+      items {
+        blockNumber
+        blockTimestamp
+        from
+        id
+        power
+        to
+        transactionHash
+      }
     }
   }
 `;

--- a/apps/web/src/services/graphql/types/counts.ts
+++ b/apps/web/src/services/graphql/types/counts.ts
@@ -1,4 +1,4 @@
-export type CountConnectionItem = {
+export type CountPageItem = {
   totalCount: number;
 };
 
@@ -8,15 +8,15 @@ export type GovernanceCounts = {
 };
 
 export type GovernanceCountsResponse = {
-  proposalsConnection?: CountConnectionItem | null;
-  contributorsConnection?: CountConnectionItem | null;
+  proposalsPage?: CountPageItem | null;
+  contributorsPage?: CountPageItem | null;
 };
 
 export function resolveGovernanceCounts(
   response?: GovernanceCountsResponse | null
 ): GovernanceCounts {
   return {
-    proposalsCount: response?.proposalsConnection?.totalCount ?? 0,
-    delegatesCount: response?.contributorsConnection?.totalCount ?? 0,
+    proposalsCount: response?.proposalsPage?.totalCount ?? 0,
+    delegatesCount: response?.contributorsPage?.totalCount ?? 0,
   };
 }

--- a/apps/web/src/services/graphql/types/delegates.ts
+++ b/apps/web/src/services/graphql/types/delegates.ts
@@ -27,18 +27,24 @@ export type DelegateMappingResponse = {
   delegateMappings: DelegateMappingItem[];
 };
 
-export type DelegateMappingConnectionItem = {
+export type DelegateMappingPageItem = {
   totalCount: number;
+  offset: number;
+  limit: number;
+  items: DelegateMappingItem[];
 };
 
-export type DelegateMappingConnectionResponse = {
-  delegateMappingsConnection: DelegateMappingConnectionItem;
+export type DelegateMappingPageResponse = {
+  delegateMappingsPage: DelegateMappingPageItem;
 };
 
-export type DelegateConnectionItem = {
+export type DelegatePageItem = {
   totalCount: number;
+  offset: number;
+  limit: number;
+  items: DelegateItem[];
 };
 
-export type DelegateConnectionResponse = {
-  delegatesConnection: DelegateConnectionItem;
+export type DelegatePageResponse = {
+  delegatesPage: DelegatePageItem;
 };

--- a/docs/runbook/datalens-dao-migration.md
+++ b/docs/runbook/datalens-dao-migration.md
@@ -325,7 +325,7 @@ GraphQL smoke:
 ```sh
 curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
   -H "content-type: application/json" \
-  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } proposalsConnection(orderBy: [id_ASC]) { totalCount } contributorsConnection(orderBy: [id_ASC]) { totalCount } dataMetrics(where: { id_eq: \"global\" }) { proposalsCount powerSum memberCount } }"}'
+  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } proposalsPage(orderBy: [id_ASC], limit: 0) { totalCount } contributorsPage(orderBy: [id_ASC], limit: 0) { totalCount } dataMetrics(where: { id_eq: \"global\" }) { proposalsCount powerSum memberCount } }"}'
 ```
 
 Web delegates/proposals smoke:

--- a/docs/runbook/datalens-indexer-observability.md
+++ b/docs/runbook/datalens-indexer-observability.md
@@ -505,7 +505,7 @@ Run a GraphQL projection smoke against the public endpoint:
 ```sh
 curl -fsS "$DEGOV_INDEXER_GRAPHQL_ENDPOINT" \
   -H "content-type: application/json" \
-  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } proposalsConnection(orderBy: [id_ASC]) { totalCount } contributorsConnection(orderBy: [id_ASC]) { totalCount } dataMetrics(where: { id_eq: \"global\" }) { proposalsCount votesCount powerSum memberCount } }"}'
+  --data '{"query":"query { indexerStatus { processedHeight targetHeight syncedPercentage isSynced } proposalsPage(orderBy: [id_ASC], limit: 0) { totalCount } contributorsPage(orderBy: [id_ASC], limit: 0) { totalCount } dataMetrics(where: { id_eq: \"global\" }) { proposalsCount votesCount powerSum memberCount } }"}'
 ```
 
 Expected signal: GraphQL returns `indexerStatus`, proposal/contributor counts, and

--- a/docs/runbook/tally-comparison-e2e.md
+++ b/docs/runbook/tally-comparison-e2e.md
@@ -103,8 +103,8 @@ query {
     chainId
     daoCode
   }
-  proposalsConnection(orderBy: [id_ASC]) { totalCount }
-  contributorsConnection(orderBy: [id_ASC]) { totalCount }
+  proposalsPage(orderBy: [id_ASC], limit: 0) { totalCount }
+  contributorsPage(orderBy: [id_ASC], limit: 0) { totalCount }
 }
 ```
 

--- a/docs/spec/20260327__indexer_schema_reference.md
+++ b/docs/spec/20260327__indexer_schema_reference.md
@@ -28,7 +28,7 @@ query with a power-bearing projection query:
 For Seamless DAO received delegations, the correct source of truth is:
 
 - received delegation count: `Contributor.delegatesCountAll`
-- received delegation list: `delegateMappings` / `delegateMappingsConnection`
+- received delegation list: `delegateMappings` / `delegateMappingsPage`
 - historical delegation changes: `DelegateChanged` and `DelegateRolling`
 - effective power-bearing delegate edges: `delegates` / `Delegate`
 
@@ -122,7 +122,7 @@ For delegation-specific reads:
   delegate, even if some mappings do not currently contribute non-zero power.
 - `delegatesCountEffective` tracks how many effective non-zero `Delegate` edges
   currently point at this delegate.
-- `delegateMappingsConnection.totalCount` should match
+- `delegateMappingsPage.totalCount` should match
   `Contributor.delegatesCountAll` for the same delegate.
-- `delegatesConnection.totalCount` is expected to diverge when some active
+- `delegatesPage.totalCount` is expected to diverge when some active
   delegators have zero effective delegated power.


### PR DESCRIPTION
## Summary
- replace DeGov GraphQL root *Connection fields with explicit *Page fields
- update web count/delegation queries to consume Page results
- update GraphQL/web tests and required query references

## Validation
- cargo test -p degov-datalens-indexer --locked --test graphql_service
- cargo test -p degov-datalens-indexer --locked --test lisk_dao_golden_baseline
- pnpm --filter @degov/web exec node --experimental-strip-types scripts/governance-counts.test.ts
- pnpm --filter @degov/web exec node --experimental-strip-types scripts/received-delegations-source.test.ts
- pnpm --filter @degov/web exec node --experimental-strip-types scripts/delegate-current-source.test.ts
- pnpm --filter @degov/web exec tsc --noEmit
- pnpm --filter @degov/web lint (passes with existing unrelated import-order warning in src/app/_server/config-remote.ts)
- node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs