### PR TITLE
Split DataMetric member count semantics

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -812,6 +812,8 @@ CREATE TABLE IF NOT EXISTS data_metric (
   votes_weight_against_sum NUMERIC(78, 0),
   votes_weight_abstain_sum NUMERIC(78, 0),
   power_sum NUMERIC(78, 0),
+  contributor_count INTEGER,
+  holders_count INTEGER,
   member_count INTEGER,
   PRIMARY KEY (contract_set_id, id),
   CONSTRAINT data_metric_scope_unique UNIQUE NULLS NOT DISTINCT (

--- a/apps/indexer/reference/schema.graphql
+++ b/apps/indexer/reference/schema.graphql
@@ -615,6 +615,8 @@ type DataMetric @entity @index(fields: ["chainId", "governorAddress", "daoCode"]
   votesWeightAgainstSum: BigInt
   votesWeightAbstainSum: BigInt
   powerSum: BigInt
+  contributorCount: Int
+  holdersCount: Int
   memberCount: Int
 }
 

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -237,7 +237,10 @@ pub(super) async fn query_data_metrics(
           votes_without_params_count, votes_weight_for_sum::text AS votes_weight_for_sum,
           votes_weight_against_sum::text AS votes_weight_against_sum,
           votes_weight_abstain_sum::text AS votes_weight_abstain_sum,
-          power_sum::text AS power_sum, member_count
+          power_sum::text AS power_sum,
+          COALESCE(contributor_count, member_count) AS contributor_count,
+          COALESCE(holders_count, member_count) AS holders_count,
+          COALESCE(holders_count, member_count) AS member_count
         FROM data_metric
         "#,
     );

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -144,6 +144,8 @@ pub struct DataMetric {
     pub(super) votes_weight_against_sum: Option<String>,
     pub(super) votes_weight_abstain_sum: Option<String>,
     pub(super) power_sum: Option<String>,
+    pub(super) contributor_count: Option<i32>,
+    pub(super) holders_count: Option<i32>,
     pub(super) member_count: Option<i32>,
 }
 

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -2752,17 +2752,32 @@ async fn refresh_data_metric_scope(
 
     sqlx::query(
         "INSERT INTO data_metric (
-            id, contract_set_id, chain_id, dao_code, governor_address, token_address, power_sum, member_count
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            power_sum, contributor_count, holders_count, member_count
          )
          SELECT
             $1, $2, $3, $4, $5, $6,
             COALESCE(sum(power), 0)::NUMERIC(78, 0),
-            count(*)::INTEGER
+            count(*)::INTEGER,
+            (
+                CASE
+                    WHEN count(balance) > 0 THEN count(*) FILTER (WHERE balance > 0)
+                    ELSE count(*)
+                END
+            )::INTEGER,
+            (
+                CASE
+                    WHEN count(balance) > 0 THEN count(*) FILTER (WHERE balance > 0)
+                    ELSE count(*)
+                END
+            )::INTEGER
          FROM contributor
          WHERE contract_set_id = $2 AND chain_id = $3 AND governor_address = $5 AND dao_code IS NOT DISTINCT FROM $4
          ON CONFLICT ON CONSTRAINT data_metric_scope_unique DO UPDATE
          SET token_address = COALESCE(data_metric.token_address, EXCLUDED.token_address),
              power_sum = EXCLUDED.power_sum,
+             contributor_count = EXCLUDED.contributor_count,
+             holders_count = EXCLUDED.holders_count,
              member_count = EXCLUDED.member_count",
     )
     .bind(metric_id)

--- a/apps/indexer/src/projection/data_metric.rs
+++ b/apps/indexer/src/projection/data_metric.rs
@@ -18,5 +18,7 @@ pub struct DataMetricWrite {
     pub votes_weight_against_sum: Option<String>,
     pub votes_weight_abstain_sum: Option<String>,
     pub power_sum: Option<String>,
+    pub contributor_count: Option<i64>,
+    pub holders_count: Option<i64>,
     pub member_count: Option<i64>,
 }

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -854,6 +854,8 @@ fn proposal_data_metric(log_id: &str, common: &ProposalEventCommon) -> DataMetri
         votes_weight_against_sum: Some("0".to_owned()),
         votes_weight_abstain_sum: Some("0".to_owned()),
         power_sum: None,
+        contributor_count: None,
+        holders_count: None,
         member_count: None,
     }
 }

--- a/apps/indexer/src/projection/vote.rs
+++ b/apps/indexer/src/projection/vote.rs
@@ -554,6 +554,8 @@ fn vote_data_metric(log_id: &str, group: &VoteCastGroupWrite) -> DataMetricWrite
         votes_weight_against_sum: Some("0".to_owned()),
         votes_weight_abstain_sum: Some("0".to_owned()),
         power_sum: None,
+        contributor_count: None,
+        holders_count: None,
         member_count: None,
     };
     match group.kind.as_str() {

--- a/apps/indexer/src/store/postgres/data_metric.rs
+++ b/apps/indexer/src/store/postgres/data_metric.rs
@@ -74,7 +74,7 @@ async fn write_data_metric_timeline(
             }
             DataMetricTimelineItem::Proposal(row) | DataMetricTimelineItem::Vote(row) => {
                 contributor_ensure_cache
-                    .flush_member_count_increments(transaction)
+                    .flush_contributor_count_increments(transaction)
                     .await?;
                 upsert_event_data_metric(transaction, row).await?;
             }
@@ -102,14 +102,17 @@ async fn write_data_metric_timeline(
         .await?;
     let contributor_count_flush_duration = contributor_count_flush_started_at.elapsed();
 
-    let member_count_flush_started_at = std::time::Instant::now();
-    contributor_ensure_cache.flush_member_count_increments(transaction).await?;
-    let member_count_flush_duration = member_count_flush_started_at.elapsed();
+    let contributor_count_metric_flush_started_at = std::time::Instant::now();
+    contributor_ensure_cache
+        .flush_contributor_count_increments(transaction)
+        .await?;
+    let contributor_count_metric_flush_duration =
+        contributor_count_metric_flush_started_at.elapsed();
 
     if let Some(token) = token {
         if let Some(common) = token_batch_common(token) {
             log::info!(
-                "Datalens indexer token timeline phases dao_code={} chain_id={} contract_set_id={} token_operation_count={} inserted_operation_count={} contributor_preload_duration_ms={} metadata_preload_duration_ms={} mapping_preload_duration_ms={} replay_duration_ms={} rolling_flush_duration_ms={} snapshot_flush_duration_ms={} mapping_flush_duration_ms={} contributor_count_flush_duration_ms={} member_count_flush_duration_ms={} total_duration_ms={}",
+                "Datalens indexer token timeline phases dao_code={} chain_id={} contract_set_id={} token_operation_count={} inserted_operation_count={} contributor_preload_duration_ms={} metadata_preload_duration_ms={} mapping_preload_duration_ms={} replay_duration_ms={} rolling_flush_duration_ms={} snapshot_flush_duration_ms={} mapping_flush_duration_ms={} contributor_count_flush_duration_ms={} contributor_count_metric_flush_duration_ms={} total_duration_ms={}",
                 common.dao_code,
                 common.chain_id,
                 common.contract_set_id,
@@ -123,7 +126,7 @@ async fn write_data_metric_timeline(
                 snapshot_flush_duration.as_millis(),
                 mapping_flush_duration.as_millis(),
                 contributor_count_flush_duration.as_millis(),
-                member_count_flush_duration.as_millis(),
+                contributor_count_metric_flush_duration.as_millis(),
                 total_started_at.elapsed().as_millis(),
             );
         }
@@ -156,6 +159,8 @@ fn data_metric_timeline_order(item: &DataMetricTimelineItem<'_>) -> (u64, u64, u
 struct DataMetricSnapshot {
     token_address: Option<String>,
     power_sum: Option<String>,
+    contributor_count: Option<i32>,
+    holders_count: Option<i32>,
     member_count: Option<i32>,
 }
 
@@ -166,6 +171,14 @@ async fn upsert_event_data_metric(
     let snapshot = read_global_data_metric_snapshot(transaction, row).await?;
     let token_address = row.token_address.clone().or(snapshot.token_address.clone());
     let power_sum = row.power_sum.clone().or(snapshot.power_sum);
+    let contributor_count = match row.contributor_count {
+        Some(value) => Some(i64_to_i32(value, "data_metric.contributor_count")?),
+        None => snapshot.contributor_count,
+    };
+    let holders_count = match row.holders_count {
+        Some(value) => Some(i64_to_i32(value, "data_metric.holders_count")?),
+        None => snapshot.holders_count,
+    };
     let member_count = match row.member_count {
         Some(value) => Some(i64_to_i32(value, "data_metric.member_count")?),
         None => snapshot.member_count,
@@ -176,12 +189,12 @@ async fn upsert_event_data_metric(
             id, contract_set_id, chain_id, dao_code, governor_address, token_address, contract_address,
             log_index, transaction_index, proposals_count, votes_count, votes_with_params_count,
             votes_without_params_count, votes_weight_for_sum, votes_weight_against_sum,
-            votes_weight_abstain_sum, power_sum, member_count
+            votes_weight_abstain_sum, power_sum, contributor_count, holders_count, member_count
          )
          VALUES (
             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
             $14::NUMERIC(78, 0), $15::NUMERIC(78, 0), $16::NUMERIC(78, 0),
-            $17::NUMERIC(78, 0), $18
+            $17::NUMERIC(78, 0), $18, $19, $20
          )
          ON CONFLICT (contract_set_id, id) WHERE id <> 'global' DO UPDATE
          SET contract_set_id = EXCLUDED.contract_set_id,
@@ -200,6 +213,8 @@ async fn upsert_event_data_metric(
              votes_weight_against_sum = EXCLUDED.votes_weight_against_sum,
              votes_weight_abstain_sum = EXCLUDED.votes_weight_abstain_sum,
              power_sum = EXCLUDED.power_sum,
+             contributor_count = EXCLUDED.contributor_count,
+             holders_count = EXCLUDED.holders_count,
              member_count = EXCLUDED.member_count",
     )
     .bind(&row.id)
@@ -234,6 +249,8 @@ async fn upsert_event_data_metric(
     .bind(&row.votes_weight_against_sum)
     .bind(&row.votes_weight_abstain_sum)
     .bind(&power_sum)
+    .bind(contributor_count)
+    .bind(holders_count)
     .bind(member_count)
     .execute(&mut **transaction)
     .await?;
@@ -246,7 +263,8 @@ async fn read_global_data_metric_snapshot(
     row: &DataMetricWrite,
 ) -> Result<DataMetricSnapshot, PostgresIndexerRunnerStoreError> {
     let snapshot = sqlx::query(
-        "SELECT token_address, power_sum::TEXT AS power_sum, member_count
+        "SELECT token_address, power_sum::TEXT AS power_sum, contributor_count, holders_count,
+                member_count
          FROM data_metric
          WHERE id = $1 AND contract_set_id = $2 AND chain_id = $3 AND governor_address = $4 AND dao_code IS NOT DISTINCT FROM $5",
     )
@@ -266,6 +284,8 @@ async fn read_global_data_metric_snapshot(
         .map(|snapshot| DataMetricSnapshot {
             token_address: snapshot.get("token_address"),
             power_sum: snapshot.get("power_sum"),
+            contributor_count: snapshot.get("contributor_count"),
+            holders_count: snapshot.get("holders_count"),
             member_count: snapshot.get("member_count"),
         })
         .unwrap_or_default())

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -1050,7 +1050,7 @@ async fn ensure_contributor(
     .await?;
 
     if result.rows_affected() > 0 {
-        increment_member_count(transaction, common).await?;
+        increment_contributor_count(transaction, common).await?;
     }
 
     Ok(())
@@ -1075,8 +1075,9 @@ struct ContributorEnsureInsert {
 #[derive(Debug, Default)]
 struct ContributorEnsureCache {
     ensured: HashSet<(String, String)>,
-    pending_member_count_increments: HashMap<(String, String), TokenEventCommon>,
-    member_count_increments: std::collections::BTreeMap<DataMetricIncrementScope, DataMetricIncrement>,
+    pending_contributor_count_increments: HashMap<(String, String), TokenEventCommon>,
+    contributor_count_increments:
+        std::collections::BTreeMap<DataMetricIncrementScope, DataMetricIncrement>,
     contributor_count_deltas:
         std::collections::BTreeMap<ContributorCountDeltaKey, ContributorCountDelta>,
 }
@@ -1228,7 +1229,7 @@ impl ContributorEnsureCache {
                     )
                 })
                 .collect::<Vec<_>>();
-            self.stage_member_count_increments(rows, &inserted);
+            self.stage_contributor_count_increments(rows, &inserted);
         }
 
         Ok(())
@@ -1246,11 +1247,11 @@ impl ContributorEnsureCache {
             common: common.clone(),
         };
         if !self.insert_cache_key(&candidate) {
-            if let Some(common) = self.pending_member_count_increments.remove(&(
+            if let Some(common) = self.pending_contributor_count_increments.remove(&(
                 candidate.common.contract_set_id.clone(),
                 candidate.account.clone(),
             )) {
-                self.stage_member_count_increment(&common);
+                self.stage_contributor_count_increment(&common);
             }
             return Ok(());
         }
@@ -1264,7 +1265,7 @@ impl ContributorEnsureCache {
         ))
     }
 
-    fn stage_member_count_increments(
+    fn stage_contributor_count_increments(
         &mut self,
         candidates: &[ContributorEnsureInsert],
         inserted: &[(String, String)],
@@ -1276,16 +1277,16 @@ impl ContributorEnsureCache {
                 candidate.account.clone(),
             );
             if inserted.contains(&key) {
-                self.pending_member_count_increments
+                self.pending_contributor_count_increments
                     .entry(key)
                     .or_insert_with(|| candidate.common.clone());
             }
         }
     }
 
-    fn stage_member_count_increment(&mut self, common: &TokenEventCommon) {
+    fn stage_contributor_count_increment(&mut self, common: &TokenEventCommon) {
         let key = DataMetricIncrementScope::from(common);
-        self.member_count_increments
+        self.contributor_count_increments
             .entry(key)
             .and_modify(|increment| increment.count += 1)
             .or_insert_with(|| DataMetricIncrement {
@@ -1410,12 +1411,12 @@ impl ContributorEnsureCache {
         Ok(())
     }
 
-    async fn flush_member_count_increments(
+    async fn flush_contributor_count_increments(
         &mut self,
         transaction: &mut Transaction<'_, Postgres>,
     ) -> Result<(), PostgresIndexerRunnerStoreError> {
-        for (_, increment) in std::mem::take(&mut self.member_count_increments) {
-            increment_member_count_by(transaction, &increment.common, increment.count).await?;
+        for (_, increment) in std::mem::take(&mut self.contributor_count_increments) {
+            increment_contributor_count_by(transaction, &increment.common, increment.count).await?;
         }
 
         Ok(())
@@ -1452,26 +1453,26 @@ fn collect_contributor_ensure_candidates(
     candidates
 }
 
-async fn increment_member_count(
+async fn increment_contributor_count(
     transaction: &mut Transaction<'_, Postgres>,
     common: &TokenEventCommon,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
-    increment_member_count_by(transaction, common, 1).await
+    increment_contributor_count_by(transaction, common, 1).await
 }
 
-async fn increment_member_count_by(
+async fn increment_contributor_count_by(
     transaction: &mut Transaction<'_, Postgres>,
     common: &TokenEventCommon,
     increment: i32,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     sqlx::query(
         "INSERT INTO data_metric (
-            id, contract_set_id, chain_id, dao_code, governor_address, token_address, member_count
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address, contributor_count
          )
          VALUES ($1, $2, $3, $4, $5, $6, $7)
          ON CONFLICT ON CONSTRAINT data_metric_scope_unique DO UPDATE
          SET token_address = COALESCE(data_metric.token_address, EXCLUDED.token_address),
-             member_count = COALESCE(data_metric.member_count, 0) + EXCLUDED.member_count",
+             contributor_count = COALESCE(data_metric.contributor_count, 0) + EXCLUDED.contributor_count",
     )
     .bind(data_metric_id(
         common.chain_id,
@@ -3043,22 +3044,22 @@ mod token_store_tests {
     }
 
     #[test]
-    fn test_contributor_ensure_cache_accumulates_member_count_by_scope() {
+    fn test_contributor_ensure_cache_accumulates_contributor_count_by_scope() {
         let common = token_common("scope", "0xtx1", 10, 5);
         let other_common = token_common("other-scope", "0xtx2", 11, 6);
         let mut cache = ContributorEnsureCache::default();
 
-        cache.stage_member_count_increment(&common);
-        cache.stage_member_count_increment(&common);
-        cache.stage_member_count_increment(&other_common);
+        cache.stage_contributor_count_increment(&common);
+        cache.stage_contributor_count_increment(&common);
+        cache.stage_contributor_count_increment(&other_common);
 
         assert_eq!(
-            cache.member_count_increments
+            cache.contributor_count_increments
                 .get(&DataMetricIncrementScope::from(&common))
                 .map(|increment| increment.count),
             Some(2)
         );
-        assert_eq!(cache.member_count_increments.len(), 2);
+        assert_eq!(cache.contributor_count_increments.len(), 2);
     }
 
     #[test]

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -148,6 +148,8 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
                 votesCount
                 votesWeightForSum
                 powerSum
+                contributorCount
+                holdersCount
                 memberCount
               }
               dataMetricsPage(where: { votesCount_eq: 1 }, orderBy: id_ASC, limit: 0, offset: 2) {
@@ -246,6 +248,9 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
     );
     assert_eq!(data["proposalExecuteds"][0]["proposalId"], "0x65");
     assert_eq!(data["dataMetrics"][0]["powerSum"], "150");
+    assert_eq!(data["dataMetrics"][0]["contributorCount"], 3);
+    assert_eq!(data["dataMetrics"][0]["holdersCount"], 2);
+    assert_eq!(data["dataMetrics"][0]["memberCount"], 2);
     assert_eq!(data["dataMetricsPage"]["totalCount"], 1);
     assert_eq!(data["dataMetricsPage"]["offset"], 2);
     assert_eq!(data["dataMetricsPage"]["limit"], 0);
@@ -389,6 +394,8 @@ async fn test_graphql_data_metrics_parity_fields_filters_and_ordering() -> Resul
                 votesWeightAgainstSum
                 votesWeightAbstainSum
                 powerSum
+                contributorCount
+                holdersCount
                 memberCount
               }
               proposalMetrics: dataMetrics(where: { proposalsCount_eq: 1 }, orderBy: id_ASC) {
@@ -404,6 +411,8 @@ async fn test_graphql_data_metrics_parity_fields_filters_and_ordering() -> Resul
               globalMetric: dataMetrics(where: { id_eq: "global" }) {
                 id
                 powerSum
+                contributorCount
+                holdersCount
                 memberCount
                 proposalsCount
                 votesCount
@@ -443,6 +452,9 @@ async fn test_graphql_data_metrics_parity_fields_filters_and_ordering() -> Resul
     assert_eq!(data["voteMetrics"][0]["votesWithoutParamsCount"], 1);
     assert_eq!(data["globalMetric"][0]["id"], "global");
     assert_eq!(data["globalMetric"][0]["powerSum"], "150");
+    assert_eq!(data["globalMetric"][0]["contributorCount"], 3);
+    assert_eq!(data["globalMetric"][0]["holdersCount"], 2);
+    assert_eq!(data["globalMetric"][0]["memberCount"], 2);
 
     database.cleanup().await?;
 
@@ -455,9 +467,9 @@ async fn test_graphql_data_metrics_returns_scoped_global_rows() -> Result<(), Bo
     sqlx::query(
         "INSERT INTO data_metric (
             id, contract_set_id, chain_id, dao_code, governor_address, proposals_count, votes_count,
-            power_sum, member_count
+            power_sum, contributor_count, holders_count, member_count
          )
-         VALUES ('global', 'other-scope', 10, 'other-dao', '0xothergovernor', 7, 9, 700, 3)",
+         VALUES ('global', 'other-scope', 10, 'other-dao', '0xothergovernor', 7, 9, 700, 5, 3, 3)",
     )
     .execute(&database.pool)
     .await?;
@@ -476,6 +488,8 @@ async fn test_graphql_data_metrics_returns_scoped_global_rows() -> Result<(), Bo
                     proposalsCount
                     votesCount
                     powerSum
+                    contributorCount
+                    holdersCount
                     memberCount
                   }
                   other: dataMetrics(where: $other) {
@@ -486,6 +500,8 @@ async fn test_graphql_data_metrics_returns_scoped_global_rows() -> Result<(), Bo
                     proposalsCount
                     votesCount
                     powerSum
+                    contributorCount
+                    holdersCount
                     memberCount
                   }
                 }
@@ -522,6 +538,9 @@ async fn test_graphql_data_metrics_returns_scoped_global_rows() -> Result<(), Bo
     assert_eq!(data["other"][0]["daoCode"], "other-dao");
     assert_eq!(data["other"][0]["proposalsCount"], 7);
     assert_eq!(data["other"][0]["powerSum"], "700");
+    assert_eq!(data["other"][0]["contributorCount"], 5);
+    assert_eq!(data["other"][0]["holdersCount"], 3);
+    assert_eq!(data["other"][0]["memberCount"], 3);
 
     database.cleanup().await?;
 
@@ -1268,11 +1287,11 @@ async fn seed_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
         INSERT INTO data_metric (
           id, contract_set_id, chain_id, dao_code, governor_address, votes_count, votes_with_params_count,
           votes_without_params_count, votes_weight_for_sum, votes_weight_against_sum,
-          votes_weight_abstain_sum, power_sum, member_count, proposals_count
+          votes_weight_abstain_sum, power_sum, contributor_count, holders_count, member_count, proposals_count
         ) VALUES
-          ('global', $1, 1135, 'lisk-dao', '0xgovernor', 2, 1, 1, 100, 25, 0, 150, 2, 2),
-          ('0000000800-proposal', $1, 1135, 'lisk-dao', '0xgovernor', 0, 0, 0, 0, 0, 0, 150, 2, 1),
-          ('0000000805-vote', $1, 1135, 'lisk-dao', '0xgovernor', 1, 0, 1, 100, 0, 0, 150, 2, 0)
+          ('global', $1, 1135, 'lisk-dao', '0xgovernor', 2, 1, 1, 100, 25, 0, 150, 3, 2, 2, 2),
+          ('0000000800-proposal', $1, 1135, 'lisk-dao', '0xgovernor', 0, 0, 0, 0, 0, 0, 150, 3, 2, 2, 1),
+          ('0000000805-vote', $1, 1135, 'lisk-dao', '0xgovernor', 1, 0, 1, 100, 0, 0, 150, 3, 2, 2, 0)
         "#,
     )
     .bind(CONTRACT_SET_ID)
@@ -1401,8 +1420,8 @@ async fn seed_other_scope_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
         INSERT INTO data_metric (
           id, contract_set_id, chain_id, dao_code, governor_address, votes_count, votes_with_params_count,
           votes_without_params_count, votes_weight_for_sum, votes_weight_against_sum,
-          votes_weight_abstain_sum, power_sum, member_count, proposals_count
-        ) VALUES ('global', $1, 10, 'ens-dao', '0xensgovernor', 1, 0, 1, 50, 0, 0, 50, 1, 1)
+          votes_weight_abstain_sum, power_sum, contributor_count, holders_count, member_count, proposals_count
+        ) VALUES ('global', $1, 10, 'ens-dao', '0xensgovernor', 1, 0, 1, 50, 0, 0, 50, 1, 1, 1, 1)
         "#,
     )
     .bind(OTHER_CONTRACT_SET_ID)

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -271,6 +271,22 @@ fn test_fresh_init_declares_provisional_overlay_schema() {
 }
 
 #[test]
+fn test_fresh_init_declares_split_data_metric_counts() {
+    let init_migration = include_str!("../migrations/0001_init.sql");
+
+    for column_name in [
+        "contributor_count INTEGER",
+        "holders_count INTEGER",
+        "member_count INTEGER",
+    ] {
+        assert!(
+            init_migration.contains(column_name),
+            "expected data_metric count column {column_name}"
+        );
+    }
+}
+
+#[test]
 fn test_fresh_init_declares_onchain_refresh_ready_claim_index() {
     let init_migration = include_str!("../migrations/0001_init.sql");
 

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -400,6 +400,13 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_contributor(&database.pool, ACCOUNT_ONE, "3", Some("4")).await?;
+    seed_contributor(
+        &database.pool,
+        "0x0000000000000000000000000000000000000003",
+        "0",
+        Some("0"),
+    )
+    .await?;
     seed_data_metric(&database.pool, "7").await?;
     seed_final_delegate_with_scope(
         &database.pool,
@@ -484,7 +491,7 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     );
     assert_completed_task(&database.pool, "task-one", 1).await?;
     assert_completed_task(&database.pool, "task-two", 2).await?;
-    assert_data_metric(&database.pool, "16", 2, 7).await?;
+    assert_data_metric_counts(&database.pool, "16", 3, 1, 1, 7).await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_ONE, "3", "11", "8").await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_TWO, "0", "5", "5").await?;
     assert_balance_checkpoint(&database.pool, ACCOUNT_ONE, "4", "17", "13").await?;
@@ -1999,11 +2006,11 @@ async fn seed_data_metric_with_scope(
     sqlx::query(
         "INSERT INTO data_metric (
             id, contract_set_id, chain_id, dao_code, governor_address, token_address, power_sum,
-            member_count, votes_count
+            contributor_count, holders_count, member_count, votes_count
          )
          VALUES (
             'global',
-            $1, 46, 'demo-dao', $2, $3, $4::NUMERIC(78, 0), $5, $6
+            $1, 46, 'demo-dao', $2, $3, $4::NUMERIC(78, 0), $5, $5, $5, $6
          )",
     )
     .bind(contract_set_id)
@@ -2313,8 +2320,28 @@ async fn assert_data_metric(
     member_count: i32,
     votes_count: i32,
 ) -> Result<(), sqlx::Error> {
+    assert_data_metric_counts(
+        pool,
+        power_sum,
+        member_count,
+        member_count,
+        member_count,
+        votes_count,
+    )
+    .await
+}
+
+async fn assert_data_metric_counts(
+    pool: &PgPool,
+    power_sum: &str,
+    contributor_count: i32,
+    holders_count: i32,
+    member_count: i32,
+    votes_count: i32,
+) -> Result<(), sqlx::Error> {
     let row = sqlx::query(
-        "SELECT power_sum::TEXT AS power_sum, member_count, votes_count
+        "SELECT power_sum::TEXT AS power_sum, contributor_count, holders_count, member_count,
+                votes_count
          FROM data_metric
          WHERE chain_id = 46 AND governor_address = $1 AND dao_code = 'demo-dao'",
     )
@@ -2323,6 +2350,8 @@ async fn assert_data_metric(
     .await?;
 
     assert_eq!(row.get::<String, _>("power_sum"), power_sum);
+    assert_eq!(row.get::<i32, _>("contributor_count"), contributor_count);
+    assert_eq!(row.get::<i32, _>("holders_count"), holders_count);
     assert_eq!(row.get::<i32, _>("member_count"), member_count);
     assert_eq!(row.get::<i32, _>("votes_count"), votes_count);
 

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -985,7 +985,7 @@ async fn test_postgres_data_metric_event_snapshots_follow_mixed_batch_event_orde
         .map_err(|error| format!("commit transaction failed: {error}"))?;
 
     let metric = sqlx::query(
-        "SELECT power_sum::TEXT AS power_sum, member_count
+        "SELECT power_sum::TEXT AS power_sum, contributor_count, holders_count, member_count
          FROM data_metric
          WHERE id = '0000000002-proposal'",
     )
@@ -995,7 +995,9 @@ async fn test_postgres_data_metric_event_snapshots_follow_mixed_batch_event_orde
         metric.get::<Option<String>, _>("power_sum"),
         Some("0".to_owned())
     );
-    assert_eq!(metric.get::<Option<i32>, _>("member_count"), Some(1));
+    assert_eq!(metric.get::<Option<i32>, _>("contributor_count"), Some(1));
+    assert_eq!(metric.get::<Option<i32>, _>("holders_count"), Some(0));
+    assert_eq!(metric.get::<Option<i32>, _>("member_count"), Some(0));
 
     database.cleanup().await?;
 
@@ -1317,7 +1319,7 @@ async fn test_postgres_token_delegate_mapping_bulk_power_only_update_preserves_r
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_postgres_token_repeated_delegate_ensure_keeps_member_count_once()
+async fn test_postgres_token_repeated_delegate_ensure_keeps_contributor_count_once()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
@@ -1377,15 +1379,17 @@ async fn test_postgres_token_repeated_delegate_ensure_keeps_member_count_once()
         0
     );
 
-    let member_count: Option<i32> = sqlx::query_scalar(
-        "SELECT member_count
+    let counts = sqlx::query(
+        "SELECT contributor_count, holders_count, member_count
          FROM data_metric
          WHERE contract_set_id = $1 AND id = 'global'",
     )
     .bind(CONTRACT_SET_ID)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(member_count, Some(1));
+    assert_eq!(counts.get::<Option<i32>, _>("contributor_count"), Some(1));
+    assert_eq!(counts.get::<Option<i32>, _>("holders_count"), None);
+    assert_eq!(counts.get::<Option<i32>, _>("member_count"), None);
 
     database.cleanup().await?;
 
@@ -1444,15 +1448,17 @@ async fn test_postgres_token_dense_delegate_count_deltas_are_batched() -> Result
         0
     );
 
-    let member_count: Option<i32> = sqlx::query_scalar(
-        "SELECT member_count
+    let counts = sqlx::query(
+        "SELECT contributor_count, holders_count, member_count
          FROM data_metric
          WHERE contract_set_id = $1 AND id = 'global'",
     )
     .bind(CONTRACT_SET_ID)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(member_count, Some(1));
+    assert_eq!(counts.get::<Option<i32>, _>("contributor_count"), Some(1));
+    assert_eq!(counts.get::<Option<i32>, _>("holders_count"), None);
+    assert_eq!(counts.get::<Option<i32>, _>("member_count"), None);
 
     database.cleanup().await?;
 
@@ -1568,7 +1574,7 @@ async fn test_postgres_token_bulk_writes_dense_events_across_chunks() -> Result<
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_postgres_token_preload_does_not_advance_member_count_before_timeline()
+async fn test_postgres_token_preload_does_not_advance_contributor_count_before_timeline()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_global_metric(&database.pool).await?;
@@ -1622,8 +1628,8 @@ async fn test_postgres_token_preload_does_not_advance_member_count_before_timeli
         },
     )?;
 
-    let proposal_member_count: Option<i32> = sqlx::query_scalar(
-        "SELECT member_count
+    let proposal_counts = sqlx::query(
+        "SELECT contributor_count, holders_count, member_count
          FROM data_metric
          WHERE contract_set_id = $1 AND id = $2",
     )
@@ -1631,17 +1637,36 @@ async fn test_postgres_token_preload_does_not_advance_member_count_before_timeli
     .bind("0000000010-proposal-before-token")
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(proposal_member_count, Some(2));
+    assert_eq!(
+        proposal_counts.get::<Option<i32>, _>("contributor_count"),
+        Some(2)
+    );
+    assert_eq!(
+        proposal_counts.get::<Option<i32>, _>("holders_count"),
+        Some(2)
+    );
+    assert_eq!(
+        proposal_counts.get::<Option<i32>, _>("member_count"),
+        Some(2)
+    );
 
-    let global_member_count: Option<i32> = sqlx::query_scalar(
-        "SELECT member_count
+    let global_counts = sqlx::query(
+        "SELECT contributor_count, holders_count, member_count
          FROM data_metric
          WHERE contract_set_id = $1 AND id = 'global'",
     )
     .bind(CONTRACT_SET_ID)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(global_member_count, Some(3));
+    assert_eq!(
+        global_counts.get::<Option<i32>, _>("contributor_count"),
+        Some(3)
+    );
+    assert_eq!(
+        global_counts.get::<Option<i32>, _>("holders_count"),
+        Some(2)
+    );
+    assert_eq!(global_counts.get::<Option<i32>, _>("member_count"), Some(2));
 
     database.cleanup().await?;
 
@@ -3528,9 +3553,10 @@ fn token_projection_context() -> TokenProjectionContext {
 async fn seed_global_metric(pool: &PgPool) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO data_metric (
-            id, contract_set_id, chain_id, dao_code, governor_address, token_address, power_sum, member_count
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            power_sum, contributor_count, holders_count, member_count
          )
-         VALUES ('global', $1, 1, 'demo-dao', $2, $3, 150::NUMERIC(78, 0), 2)",
+         VALUES ('global', $1, 1, 'demo-dao', $2, $3, 150::NUMERIC(78, 0), 2, 2, 2)",
     )
     .bind(CONTRACT_SET_ID)
     .bind(GOVERNOR)
@@ -3544,9 +3570,10 @@ async fn seed_global_metric(pool: &PgPool) -> Result<(), sqlx::Error> {
 async fn seed_empty_global_metric(pool: &PgPool) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO data_metric (
-            id, contract_set_id, chain_id, dao_code, governor_address, token_address, power_sum, member_count
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            power_sum, contributor_count, holders_count, member_count
          )
-         VALUES ('global', $1, 1, 'demo-dao', $2, $3, 0::NUMERIC(78, 0), 0)",
+         VALUES ('global', $1, 1, 'demo-dao', $2, $3, 0::NUMERIC(78, 0), 0, 0, 0)",
     )
     .bind(CONTRACT_SET_ID)
     .bind(GOVERNOR)

--- a/apps/web/scripts/governance-counts.test.ts
+++ b/apps/web/scripts/governance-counts.test.ts
@@ -7,9 +7,12 @@ import {
   type GovernanceCountsResponse,
 } from "../src/services/graphql/types/counts.ts";
 
-test("governance counts query requests proposal and contributor totals", () => {
+test("governance counts query requests proposal totals and holder totals", () => {
   assert.match(GET_GOVERNANCE_COUNTS, /proposalsPage/);
-  assert.match(GET_GOVERNANCE_COUNTS, /contributorsPage/);
+  assert.match(GET_GOVERNANCE_COUNTS, /dataMetrics/);
+  assert.match(GET_GOVERNANCE_COUNTS, /contributorCount/);
+  assert.match(GET_GOVERNANCE_COUNTS, /holdersCount/);
+  assert.doesNotMatch(GET_GOVERNANCE_COUNTS, /contributorsPage/);
   assert.doesNotMatch(GET_GOVERNANCE_COUNTS, /Connection/);
   assert.match(GET_GOVERNANCE_COUNTS, /totalCount/g);
 });
@@ -26,13 +29,25 @@ test("governance counts map proposal and delegate totals from page responses", (
     proposalsPage: {
       totalCount: 47,
     },
-    contributorsPage: {
-      totalCount: 2516,
-    },
+    dataMetrics: [{ holdersCount: 2516 }],
   };
 
   assert.deepEqual(resolveGovernanceCounts(response), {
     proposalsCount: 47,
     delegatesCount: 2516,
+  });
+});
+
+test("governance counts fall back to contributors before holder refresh", () => {
+  const response: GovernanceCountsResponse = {
+    proposalsPage: {
+      totalCount: 47,
+    },
+    dataMetrics: [{ contributorCount: 289581, holdersCount: null }],
+  };
+
+  assert.deepEqual(resolveGovernanceCounts(response), {
+    proposalsCount: 47,
+    delegatesCount: 289581,
   });
 });

--- a/apps/web/scripts/proposal-metrics-counts.test.ts
+++ b/apps/web/scripts/proposal-metrics-counts.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { GET_PROPOSAL_METRICS } from "../src/services/graphql/queries/proposals.ts";
+
+test("proposal metrics query requests explicit contributor and holder counts", () => {
+  assert.match(GET_PROPOSAL_METRICS, /contributorCount/);
+  assert.match(GET_PROPOSAL_METRICS, /holdersCount/);
+  assert.match(GET_PROPOSAL_METRICS, /memberCount/);
+});

--- a/apps/web/src/app/delegates/page.tsx
+++ b/apps/web/src/app/delegates/page.tsx
@@ -145,8 +145,8 @@ export default function Members() {
     applySortState("delegators", direction);
 
   const getDisplayTitle = () => {
-    const totalCount = dataMetrics?.memberCount;
-    if (totalCount !== undefined) {
+    const totalCount = dataMetrics?.holdersCount ?? dataMetrics?.memberCount;
+    if (totalCount != null) {
       return t("titleWithCount", { count: totalCount });
     }
     return t("title");

--- a/apps/web/src/services/graphql/index.ts
+++ b/apps/web/src/services/graphql/index.ts
@@ -18,6 +18,8 @@ import type { ProfileData } from "./types/profile";
 import type { EvmAbiResponse, EvmAbiInput } from "./types/proposals";
 
 const emptyProposalMetrics: Types.ProposalMetricsItem = {
+  contributorCount: 0,
+  holdersCount: 0,
   memberCount: 0,
   powerSum: "0",
   proposalsCount: "0",

--- a/apps/web/src/services/graphql/queries/counts.ts
+++ b/apps/web/src/services/graphql/queries/counts.ts
@@ -5,8 +5,9 @@ export const GET_GOVERNANCE_COUNTS = gql`
     proposalsPage(orderBy: id_ASC, limit: 0) {
       totalCount
     }
-    contributorsPage(orderBy: id_ASC, limit: 0) {
-      totalCount
+    dataMetrics(where: { id_eq: "global" }) {
+      contributorCount
+      holdersCount
     }
   }
 `;

--- a/apps/web/src/services/graphql/queries/proposals.ts
+++ b/apps/web/src/services/graphql/queries/proposals.ts
@@ -166,6 +166,8 @@ export const GET_PROPOSAL_QUEUED_BY_ID = gql`
 export const GET_PROPOSAL_METRICS = gql`
   query GetProposalMetrics($where: DataMetricWhereInput) {
     dataMetrics(where: $where) {
+      contributorCount
+      holdersCount
       memberCount
       powerSum
       proposalsCount

--- a/apps/web/src/services/graphql/types/counts.ts
+++ b/apps/web/src/services/graphql/types/counts.ts
@@ -2,6 +2,11 @@ export type CountPageItem = {
   totalCount: number;
 };
 
+export type DataMetricCountItem = {
+  contributorCount?: number | null;
+  holdersCount?: number | null;
+};
+
 export type GovernanceCounts = {
   proposalsCount: number;
   delegatesCount: number;
@@ -9,7 +14,7 @@ export type GovernanceCounts = {
 
 export type GovernanceCountsResponse = {
   proposalsPage?: CountPageItem | null;
-  contributorsPage?: CountPageItem | null;
+  dataMetrics?: DataMetricCountItem[] | null;
 };
 
 export function resolveGovernanceCounts(
@@ -17,6 +22,9 @@ export function resolveGovernanceCounts(
 ): GovernanceCounts {
   return {
     proposalsCount: response?.proposalsPage?.totalCount ?? 0,
-    delegatesCount: response?.contributorsPage?.totalCount ?? 0,
+    delegatesCount:
+      response?.dataMetrics?.[0]?.holdersCount ??
+      response?.dataMetrics?.[0]?.contributorCount ??
+      0,
   };
 }

--- a/apps/web/src/services/graphql/types/proposals.ts
+++ b/apps/web/src/services/graphql/types/proposals.ts
@@ -166,7 +166,9 @@ export type ProposalQueuedByIdResponse = {
 };
 
 export type ProposalMetricsItem = {
-  memberCount: number;
+  contributorCount: number | null;
+  holdersCount: number | null;
+  memberCount: number | null;
   powerSum: string;
   proposalsCount: string;
   votesCount: string;


### PR DESCRIPTION
## Summary
- add `contributorCount` and `holdersCount` to DataMetric schema and GraphQL output
- update token contributor discovery to increment `contributor_count` only
- update onchain refresh to recompute contributor and holder counts from contributor rows and positive balances
- keep `memberCount` as a temporary compatibility alias for holder/member semantics
- update web metrics/count queries to use `holdersCount` for members/delegates totals

## Verification
- `cargo fmt`
- `cargo test -p degov-datalens-indexer --locked --no-run`
- `pnpm --dir apps/web exec tsc --noEmit`
- `node --experimental-strip-types --test apps/web/scripts/governance-counts.test.ts apps/web/scripts/proposal-metrics-counts.test.ts`
- `cargo test -p degov-datalens-indexer --locked test_contributor_ensure_cache_accumulates_contributor_count_by_scope`
- `cargo test -p degov-datalens-indexer --locked test_fresh_init_declares_split_data_metric_counts`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@127.0.0.1:7432/postgres cargo test -p degov-datalens-indexer --locked test_postgres_token_repeated_delegate_ensure_keeps_contributor_count_once`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@127.0.0.1:7432/postgres cargo test -p degov-datalens-indexer --locked test_postgres_token_preload_does_not_advance_contributor_count_before_timeline`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@127.0.0.1:7432/postgres cargo test -p degov-datalens-indexer --locked test_graphql_data_metrics_parity_fields_filters_and_ordering`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:password@127.0.0.1:7432/postgres cargo test -p degov-datalens-indexer --locked test_onchain_refresh_worker_updates_contributors_tasks_and_metrics`