### PR TITLE
perf(indexer): improve dense token sync throughput

### DIFF
--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -73,6 +73,7 @@ pub struct AdaptiveChunkSizerConfig {
     pub max_chunk_size: u32,
     pub min_chunk_size: u32,
     pub transient_query_failure_min_chunk_size: u32,
+    pub full_hit_dense_floor: u32,
     pub local_processing_shrink_threshold: Duration,
     pub fast_chunk_duration_threshold: Duration,
     pub high_query_duration_threshold: Duration,
@@ -91,6 +92,7 @@ impl AdaptiveChunkSizerConfig {
             max_chunk_size,
             min_chunk_size: 100,
             transient_query_failure_min_chunk_size: 1,
+            full_hit_dense_floor: 1_000.min(max_chunk_size),
             local_processing_shrink_threshold: Duration::from_secs(10),
             fast_chunk_duration_threshold: Duration::from_secs(1),
             high_query_duration_threshold: Duration::from_secs(10),
@@ -106,6 +108,7 @@ impl AdaptiveChunkSizerConfig {
     pub fn capped_to_block_range_limit(mut self, block_range_limit: u32) -> Self {
         self.max_chunk_size = self.max_chunk_size.min(block_range_limit);
         self.min_chunk_size = self.min_chunk_size.min(self.max_chunk_size);
+        self.full_hit_dense_floor = self.full_hit_dense_floor.min(self.max_chunk_size);
         self.transient_query_failure_min_chunk_size = self
             .transient_query_failure_min_chunk_size
             .min(self.max_chunk_size);
@@ -179,10 +182,16 @@ impl AdaptiveChunkSizer {
             || config.max_chunk_size == 0
             || config.min_chunk_size == 0
             || config.transient_query_failure_min_chunk_size == 0
+            || config.full_hit_dense_floor == 0
         {
             return Err(CheckpointError::InvalidRangeLimit);
         }
         if config.min_chunk_size > config.max_chunk_size {
+            return Err(CheckpointError::InvalidRangeLimit);
+        }
+        if config.full_hit_dense_floor < config.min_chunk_size
+            || config.full_hit_dense_floor > config.max_chunk_size
+        {
             return Err(CheckpointError::InvalidRangeLimit);
         }
         if config.transient_query_failure_min_chunk_size > config.max_chunk_size {
@@ -222,7 +231,9 @@ impl AdaptiveChunkSizer {
 
     pub fn record_chunk(&mut self, feedback: AdaptiveChunkFeedback) -> AdaptiveChunkSizingDecision {
         let previous_chunk_size = self.current_chunk_size;
-        let dense_range = feedback.returned_row_count >= self.config.dense_returned_row_threshold;
+        let full_cache_hit = feedback.has_only_full_cache_hits();
+        let dense_range = feedback.returned_row_count >= self.config.dense_returned_row_threshold
+            && !full_cache_hit;
         let slow_local_processing = feedback.local_processing_write_duration
             > self.config.local_processing_shrink_threshold;
         let high_query_duration = feedback.read_duration
@@ -243,7 +254,12 @@ impl AdaptiveChunkSizer {
         let reason = if slow_local_processing || high_query_duration || dense_range {
             self.stable_chunks = 0;
             self.unstable_chunks = 0;
-            self.shrink_current_chunk_size();
+            let shrink_floor = if slow_local_processing && !high_query_duration && full_cache_hit {
+                self.config.full_hit_dense_floor
+            } else {
+                self.config.min_chunk_size
+            };
+            self.shrink_current_chunk_size_to(shrink_floor);
             if slow_local_processing {
                 AdaptiveChunkSizingReason::SlowLocalProcessing
             } else if high_query_duration {
@@ -343,9 +359,13 @@ impl AdaptiveChunkSizer {
     }
 
     fn shrink_current_chunk_size(&mut self) {
+        self.shrink_current_chunk_size_to(self.config.min_chunk_size);
+    }
+
+    fn shrink_current_chunk_size_to(&mut self, min_chunk_size: u32) {
         self.current_chunk_size = shrink_chunk_size(
             self.current_chunk_size,
-            self.config.min_chunk_size,
+            min_chunk_size.min(self.current_chunk_size),
             self.config.shrink_factor_percent,
         );
     }
@@ -364,6 +384,12 @@ impl AdaptiveChunkFeedback {
 
     fn has_full_cache_hit(&self) -> bool {
         self.warmup_effectiveness.full_hit_count > 0 && !self.has_cache_fill()
+    }
+
+    fn has_only_full_cache_hits(&self) -> bool {
+        self.warmup_effectiveness.query_count > 0
+            && self.warmup_effectiveness.full_hit_count == self.warmup_effectiveness.query_count
+            && !self.has_cache_fill()
     }
 
     fn is_fast(&self, config: &AdaptiveChunkSizerConfig) -> bool {

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -250,6 +250,7 @@ pub struct IndexerContractSetRuntimeConfig {
 pub struct AdaptiveChunkSizerRuntimeConfig {
     pub min_chunk_size: u32,
     pub transient_query_failure_min_chunk_size: u32,
+    pub full_hit_dense_floor: u32,
     pub max_chunk_size: Option<u32>,
     pub fast_chunk_duration_threshold: Duration,
     pub high_query_duration_threshold: Duration,
@@ -264,6 +265,7 @@ impl Default for AdaptiveChunkSizerRuntimeConfig {
         Self {
             min_chunk_size: 100,
             transient_query_failure_min_chunk_size: 1,
+            full_hit_dense_floor: 1_000,
             max_chunk_size: None,
             fast_chunk_duration_threshold: Duration::from_secs(1),
             high_query_duration_threshold: Duration::from_secs(10),
@@ -281,12 +283,17 @@ impl AdaptiveChunkSizerRuntimeConfig {
             .max_chunk_size
             .unwrap_or(block_range_limit)
             .min(block_range_limit);
+        let min_chunk_size = self.min_chunk_size.min(max_chunk_size);
         AdaptiveChunkSizerConfig {
             initial_chunk_size: max_chunk_size,
             max_chunk_size,
-            min_chunk_size: self.min_chunk_size.min(max_chunk_size),
+            min_chunk_size,
             transient_query_failure_min_chunk_size: self
                 .transient_query_failure_min_chunk_size
+                .min(max_chunk_size),
+            full_hit_dense_floor: self
+                .full_hit_dense_floor
+                .max(min_chunk_size)
                 .min(max_chunk_size),
             fast_chunk_duration_threshold: self.fast_chunk_duration_threshold,
             high_query_duration_threshold: self.high_query_duration_threshold,
@@ -766,6 +773,10 @@ fn load_adaptive_chunk_sizer_runtime_config() -> Result<AdaptiveChunkSizerRuntim
         min_chunk_size: optional_env_u32("DEGOV_INDEXER_ADAPTIVE_CHUNK_MIN_BLOCKS")?
             .unwrap_or(defaults.min_chunk_size),
         transient_query_failure_min_chunk_size: defaults.transient_query_failure_min_chunk_size,
+        full_hit_dense_floor: optional_env_u32(
+            "DEGOV_INDEXER_ADAPTIVE_CHUNK_FULL_HIT_DENSE_FLOOR_BLOCKS",
+        )?
+        .unwrap_or(defaults.full_hit_dense_floor),
         max_chunk_size: optional_env_u32("DEGOV_INDEXER_ADAPTIVE_CHUNK_MAX_BLOCKS")?,
         fast_chunk_duration_threshold: Duration::from_millis(
             optional_env_u64("DEGOV_INDEXER_ADAPTIVE_CHUNK_FAST_DURATION_MS")?
@@ -797,6 +808,14 @@ fn load_adaptive_chunk_sizer_runtime_config() -> Result<AdaptiveChunkSizerRuntim
 
     if config.min_chunk_size == 0 {
         bail!("DEGOV_INDEXER_ADAPTIVE_CHUNK_MIN_BLOCKS must be greater than zero");
+    }
+    if config.full_hit_dense_floor == 0 {
+        bail!("DEGOV_INDEXER_ADAPTIVE_CHUNK_FULL_HIT_DENSE_FLOOR_BLOCKS must be greater than zero");
+    }
+    if config.full_hit_dense_floor < config.min_chunk_size {
+        bail!(
+            "DEGOV_INDEXER_ADAPTIVE_CHUNK_FULL_HIT_DENSE_FLOOR_BLOCKS must be greater than or equal to DEGOV_INDEXER_ADAPTIVE_CHUNK_MIN_BLOCKS"
+        );
     }
     if config
         .max_chunk_size

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -1,8 +1,58 @@
 // Token projection writes and delegate relation maintenance.
-const CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE: usize = 2_000;
-const TOKEN_EVENT_BULK_CHUNK_SIZE: usize = 1_000;
-const DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE: usize = 250;
-const VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE: usize = 1_000;
+const POSTGRES_BIND_PARAMETER_LIMIT: usize = 65_535;
+const CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE_DEFAULT: usize = 3_000;
+const TOKEN_EVENT_BULK_CHUNK_SIZE_DEFAULT: usize = 3_000;
+const DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE_DEFAULT: usize = 1_000;
+const VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE_DEFAULT: usize = 3_000;
+const CONTRIBUTOR_ENSURE_BULK_BINDS_PER_ROW: usize = 16;
+const TOKEN_EVENT_BULK_BINDS_PER_ROW: usize = 19;
+const DELEGATE_ROLLING_VOTE_UPDATE_BINDS_PER_ROW: usize = 6;
+const VOTE_POWER_CHECKPOINT_BULK_BINDS_PER_ROW: usize = 21;
+
+fn bulk_chunk_size_from_env(
+    env_name: &str,
+    default_size: usize,
+    binds_per_row: usize,
+) -> usize {
+    let requested_size = std::env::var(env_name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|size| *size > 0)
+        .unwrap_or(default_size);
+    requested_size.min(POSTGRES_BIND_PARAMETER_LIMIT / binds_per_row)
+}
+
+fn token_event_bulk_chunk_size() -> usize {
+    bulk_chunk_size_from_env(
+        "DEGOV_INDEXER_TOKEN_EVENT_BULK_CHUNK_SIZE",
+        TOKEN_EVENT_BULK_CHUNK_SIZE_DEFAULT,
+        TOKEN_EVENT_BULK_BINDS_PER_ROW,
+    )
+}
+
+fn contributor_ensure_bulk_chunk_size() -> usize {
+    bulk_chunk_size_from_env(
+        "DEGOV_INDEXER_CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE",
+        CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE_DEFAULT,
+        CONTRIBUTOR_ENSURE_BULK_BINDS_PER_ROW,
+    )
+}
+
+fn delegate_rolling_vote_update_chunk_size() -> usize {
+    bulk_chunk_size_from_env(
+        "DEGOV_INDEXER_DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE",
+        DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE_DEFAULT,
+        DELEGATE_ROLLING_VOTE_UPDATE_BINDS_PER_ROW,
+    )
+}
+
+fn vote_power_checkpoint_bulk_chunk_size() -> usize {
+    bulk_chunk_size_from_env(
+        "DEGOV_INDEXER_VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE",
+        VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE_DEFAULT,
+        VOTE_POWER_CHECKPOINT_BULK_BINDS_PER_ROW,
+    )
+}
 
 async fn write_token_batch_rows(
     transaction: &mut Transaction<'_, Postgres>,
@@ -66,7 +116,7 @@ async fn insert_delegate_changed_batch(
     rows: &[DelegateChangedWrite],
 ) -> Result<Vec<(String, String)>, PostgresIndexerRunnerStoreError> {
     let mut inserted = Vec::new();
-    for rows in rows.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+    for rows in rows.chunks(token_event_bulk_chunk_size()) {
         let mut query = QueryBuilder::<Postgres>::new(
             "INSERT INTO delegate_changed (
                 id, contract_set_id, chain_id, dao_code, governor_address, token_address,
@@ -130,7 +180,7 @@ async fn insert_delegate_votes_changed_batch(
     rows: &[DelegateVotesChangedWrite],
 ) -> Result<Vec<(String, String)>, PostgresIndexerRunnerStoreError> {
     let mut inserted = Vec::new();
-    for rows in rows.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+    for rows in rows.chunks(token_event_bulk_chunk_size()) {
         let mut query = QueryBuilder::<Postgres>::new(
             "INSERT INTO delegate_votes_changed (
                 id, contract_set_id, chain_id, dao_code, governor_address, token_address,
@@ -197,7 +247,7 @@ async fn insert_token_transfer_batch(
     rows: &[TokenTransferWrite],
 ) -> Result<Vec<(String, String)>, PostgresIndexerRunnerStoreError> {
     let mut inserted = Vec::new();
-    for rows in rows.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+    for rows in rows.chunks(token_event_bulk_chunk_size()) {
         let mut query = QueryBuilder::<Postgres>::new(
             "INSERT INTO token_transfer (
                 id, contract_set_id, chain_id, dao_code, governor_address, token_address,
@@ -280,7 +330,7 @@ async fn upsert_delegate_rolling_batch(
     transaction: &mut Transaction<'_, Postgres>,
     rows: &[DelegateRollingWrite],
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
-    for rows in rows.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+    for rows in rows.chunks(token_event_bulk_chunk_size()) {
         let mut query = QueryBuilder::<Postgres>::new(
             "INSERT INTO delegate_rolling (
                 id, contract_set_id, chain_id, dao_code, governor_address, token_address,
@@ -378,7 +428,7 @@ async fn insert_vote_power_checkpoint_batch(
     rows: &[DelegateVotesChangedWrite],
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     let rows = collect_vote_power_checkpoint_inserts(metadata_cache, rows)?;
-    for rows in rows.chunks(VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE) {
+    for rows in rows.chunks(vote_power_checkpoint_bulk_chunk_size()) {
         let mut query = QueryBuilder::<Postgres>::new(
             "INSERT INTO vote_power_checkpoint (
                 id, contract_set_id, chain_id, dao_code, governor_address, token_address, contract_address,
@@ -869,7 +919,7 @@ impl DelegateSnapshotCache {
             return Ok(());
         }
 
-        for rows in snapshots.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+        for rows in snapshots.chunks(token_event_bulk_chunk_size()) {
             upsert_delegate_snapshot_batch(transaction, rows).await?;
         }
 
@@ -1173,7 +1223,7 @@ impl ContributorEnsureCache {
             })
             .collect::<Result<Vec<_>, PostgresIndexerRunnerStoreError>>()?;
 
-        for rows in rows.chunks(CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE) {
+        for rows in rows.chunks(contributor_ensure_bulk_chunk_size()) {
             let mut query = QueryBuilder::<Postgres>::new(
                 "INSERT INTO contributor (
                     id, contract_set_id, chain_id, dao_code, governor_address, token_address,
@@ -1331,7 +1381,7 @@ impl ContributorEnsureCache {
             return Ok(());
         }
 
-        for rows in deltas.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+        for rows in deltas.chunks(token_event_bulk_chunk_size()) {
             let mut query = QueryBuilder::<Postgres>::new(
                 "UPDATE contributor
                  SET chain_id = delta.chain_id,
@@ -1693,7 +1743,7 @@ impl DelegateMappingCache {
             }
         }
 
-        for rows in deletes.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+        for rows in deletes.chunks(token_event_bulk_chunk_size()) {
             let mut query =
                 QueryBuilder::<Postgres>::new("DELETE FROM delegate_mapping WHERE (contract_set_id, id) IN ");
             query.push_tuples(rows, |mut tuple, (contract_set_id, id)| {
@@ -1702,7 +1752,7 @@ impl DelegateMappingCache {
             query.build().execute(&mut **transaction).await?;
         }
 
-        for rows in relation_upserts.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+        for rows in relation_upserts.chunks(token_event_bulk_chunk_size()) {
             let mut query = QueryBuilder::<Postgres>::new(
                 r#"INSERT INTO delegate_mapping (
                     id, contract_set_id, chain_id, dao_code, governor_address, token_address, contract_address,
@@ -1773,7 +1823,7 @@ impl DelegateMappingCache {
             query.build().execute(&mut **transaction).await?;
         }
 
-        for rows in power_updates.chunks(TOKEN_EVENT_BULK_CHUNK_SIZE) {
+        for rows in power_updates.chunks(token_event_bulk_chunk_size()) {
             let mut query = QueryBuilder::<Postgres>::new(
                 "UPDATE delegate_mapping AS target
                  SET power = source.power::NUMERIC(78, 0)
@@ -2045,7 +2095,7 @@ impl BatchTokenMetadataCache {
             return Ok(());
         }
 
-        for rows in updates.chunks(DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE) {
+        for rows in updates.chunks(delegate_rolling_vote_update_chunk_size()) {
             let mut query = QueryBuilder::<Postgres>::new(
                 "UPDATE delegate_rolling
                  SET from_previous_votes = COALESCE(delta.from_previous_votes, delegate_rolling.from_previous_votes),
@@ -2571,6 +2621,100 @@ mod token_store_tests {
         BatchReadPlanConfig, ChainContracts, ChainReadMethod, PowerReconcileContext,
         plan_power_reconcile,
     };
+
+    #[test]
+    fn test_bulk_chunk_size_defaults_to_preferred_values() {
+        temp_env::with_vars(
+            [
+                ("DEGOV_INDEXER_TOKEN_EVENT_BULK_CHUNK_SIZE", None::<&str>),
+                (
+                    "DEGOV_INDEXER_CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE",
+                    None::<&str>,
+                ),
+                (
+                    "DEGOV_INDEXER_DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE",
+                    None::<&str>,
+                ),
+                (
+                    "DEGOV_INDEXER_VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE",
+                    None::<&str>,
+                ),
+            ],
+            || {
+                assert_eq!(token_event_bulk_chunk_size(), 3_000);
+                assert_eq!(contributor_ensure_bulk_chunk_size(), 3_000);
+                assert_eq!(delegate_rolling_vote_update_chunk_size(), 1_000);
+                assert_eq!(vote_power_checkpoint_bulk_chunk_size(), 3_000);
+            },
+        );
+    }
+
+    #[test]
+    fn test_bulk_chunk_size_env_values_are_capped_to_postgres_bind_limit() {
+        temp_env::with_vars(
+            [
+                ("DEGOV_INDEXER_TOKEN_EVENT_BULK_CHUNK_SIZE", Some("100000")),
+                (
+                    "DEGOV_INDEXER_CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE",
+                    Some("100000"),
+                ),
+                (
+                    "DEGOV_INDEXER_DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE",
+                    Some("100000"),
+                ),
+                (
+                    "DEGOV_INDEXER_VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE",
+                    Some("100000"),
+                ),
+            ],
+            || {
+                assert_eq!(
+                    token_event_bulk_chunk_size(),
+                    POSTGRES_BIND_PARAMETER_LIMIT / TOKEN_EVENT_BULK_BINDS_PER_ROW
+                );
+                assert_eq!(
+                    contributor_ensure_bulk_chunk_size(),
+                    POSTGRES_BIND_PARAMETER_LIMIT / CONTRIBUTOR_ENSURE_BULK_BINDS_PER_ROW
+                );
+                assert_eq!(
+                    delegate_rolling_vote_update_chunk_size(),
+                    POSTGRES_BIND_PARAMETER_LIMIT
+                        / DELEGATE_ROLLING_VOTE_UPDATE_BINDS_PER_ROW
+                );
+                assert_eq!(
+                    vote_power_checkpoint_bulk_chunk_size(),
+                    POSTGRES_BIND_PARAMETER_LIMIT / VOTE_POWER_CHECKPOINT_BULK_BINDS_PER_ROW
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_bulk_chunk_size_invalid_env_values_fall_back_to_defaults() {
+        temp_env::with_vars(
+            [
+                ("DEGOV_INDEXER_TOKEN_EVENT_BULK_CHUNK_SIZE", Some("0")),
+                (
+                    "DEGOV_INDEXER_CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE",
+                    Some("not-a-number"),
+                ),
+                (
+                    "DEGOV_INDEXER_DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE",
+                    Some("0"),
+                ),
+                (
+                    "DEGOV_INDEXER_VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE",
+                    Some("not-a-number"),
+                ),
+            ],
+            || {
+                assert_eq!(token_event_bulk_chunk_size(), 3_000);
+                assert_eq!(contributor_ensure_bulk_chunk_size(), 3_000);
+                assert_eq!(delegate_rolling_vote_update_chunk_size(), 1_000);
+                assert_eq!(vote_power_checkpoint_bulk_chunk_size(), 3_000);
+            },
+        );
+    }
 
     #[test]
     fn test_collect_contributor_ensure_candidates_dedupes_delegate_changed_targets() {

--- a/apps/indexer/tests/config.rs
+++ b/apps/indexer/tests/config.rs
@@ -398,11 +398,16 @@ fn test_indexer_runtime_loads_adaptive_chunk_sizer_env_and_caps_to_block_range_l
                 "DEGOV_INDEXER_ADAPTIVE_CHUNK_SHRINK_FACTOR_PERCENT",
                 Some("75"),
             ),
+            (
+                "DEGOV_INDEXER_ADAPTIVE_CHUNK_FULL_HIT_DENSE_FLOOR_BLOCKS",
+                Some("125"),
+            ),
         ],
         || {
             let runtime = IndexerRuntimeConfig::from_env().expect("load runtime config");
 
             assert_eq!(runtime.adaptive_chunk_sizer.min_chunk_size, 25);
+            assert_eq!(runtime.adaptive_chunk_sizer.full_hit_dense_floor, 125);
             assert_eq!(runtime.adaptive_chunk_sizer.max_chunk_size, Some(400));
             assert_eq!(
                 runtime.adaptive_chunk_sizer.fast_chunk_duration_threshold,
@@ -427,6 +432,7 @@ fn test_indexer_runtime_loads_adaptive_chunk_sizer_env_and_caps_to_block_range_l
             assert_eq!(capped.initial_chunk_size, 300);
             assert_eq!(capped.max_chunk_size, 300);
             assert_eq!(capped.min_chunk_size, 25);
+            assert_eq!(capped.full_hit_dense_floor, 125);
             assert_eq!(
                 capped.cache_fill_high_duration_threshold,
                 Duration::from_millis(1250)
@@ -434,6 +440,30 @@ fn test_indexer_runtime_loads_adaptive_chunk_sizer_env_and_caps_to_block_range_l
             assert_eq!(capped.stable_chunks_to_grow, 3);
             assert_eq!(capped.unstable_chunks_to_shrink, 4);
             assert_eq!(capped.shrink_factor_percent, 75);
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_rejects_full_hit_dense_floor_below_min_chunk_size() {
+    with_datalens_env(
+        &[
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_ADAPTIVE_CHUNK_MIN_BLOCKS", Some("100")),
+            (
+                "DEGOV_INDEXER_ADAPTIVE_CHUNK_FULL_HIT_DENSE_FLOOR_BLOCKS",
+                Some("50"),
+            ),
+        ],
+        || {
+            let error =
+                IndexerRuntimeConfig::from_env().expect_err("reject full-hit floor below min");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("DEGOV_INDEXER_ADAPTIVE_CHUNK_FULL_HIT_DENSE_FLOOR_BLOCKS")
+            );
         },
     );
 }

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -685,11 +685,52 @@ fn test_adaptive_chunk_sizer_high_duration_shrinks_immediately() {
 }
 
 #[test]
-fn test_adaptive_chunk_sizer_dense_rows_shrinks_immediately() {
+fn test_adaptive_chunk_sizer_full_hit_high_duration_can_shrink_below_full_hit_floor() {
+    let mut config = adaptive_config(400, 400);
+    config.full_hit_dense_floor = 200;
+    let mut sizer = AdaptiveChunkSizer::new(config).expect("sizer");
+
+    let first = sizer.record_chunk(adaptive_feedback(
+        cache_full_hit(),
+        Duration::from_millis(1_500),
+    ));
+    let second = sizer.record_chunk(adaptive_feedback(
+        cache_full_hit(),
+        Duration::from_millis(1_500),
+    ));
+    let third = sizer.record_chunk(adaptive_feedback(
+        cache_full_hit(),
+        Duration::from_millis(1_500),
+    ));
+
+    assert_eq!(first.current_chunk_size, 200);
+    assert_eq!(first.reason, AdaptiveChunkSizingReason::HighQueryDuration);
+    assert_eq!(second.current_chunk_size, 100);
+    assert_eq!(second.reason, AdaptiveChunkSizingReason::HighQueryDuration);
+    assert_eq!(third.current_chunk_size, 50);
+    assert_eq!(third.reason, AdaptiveChunkSizingReason::HighQueryDuration);
+}
+
+#[test]
+fn test_adaptive_chunk_sizer_full_hit_dense_rows_do_not_shrink_by_row_count() {
     let mut sizer = AdaptiveChunkSizer::new(adaptive_config(100, 400)).expect("sizer");
 
     let dense = sizer.record_chunk(adaptive_feedback_with_rows(
         cache_full_hit(),
+        Duration::from_millis(50),
+        5_000,
+    ));
+
+    assert_eq!(dense.current_chunk_size, 100);
+    assert_eq!(dense.reason, AdaptiveChunkSizingReason::Hold);
+}
+
+#[test]
+fn test_adaptive_chunk_sizer_mixed_full_hit_unavailable_dense_rows_still_shrink() {
+    let mut sizer = AdaptiveChunkSizer::new(adaptive_config(100, 400)).expect("sizer");
+
+    let dense = sizer.record_chunk(adaptive_feedback_with_rows(
+        cache_full_hit_with_unavailable(),
         Duration::from_millis(50),
         5_000,
     ));
@@ -699,9 +740,52 @@ fn test_adaptive_chunk_sizer_dense_rows_shrinks_immediately() {
 }
 
 #[test]
+fn test_adaptive_chunk_sizer_dense_provider_fill_still_shrinks_by_row_count() {
+    let mut sizer = AdaptiveChunkSizer::new(adaptive_config(100, 400)).expect("sizer");
+
+    let dense = sizer.record_chunk(adaptive_feedback_with_rows(
+        cache_provider_fill(),
+        Duration::from_millis(50),
+        5_000,
+    ));
+
+    assert_eq!(dense.current_chunk_size, 50);
+    assert_eq!(dense.reason, AdaptiveChunkSizingReason::DenseReturnedRows);
+}
+
+#[test]
+fn test_adaptive_chunk_sizer_slow_full_hit_stops_at_full_hit_floor() {
+    let mut config = adaptive_config(400, 400);
+    config.full_hit_dense_floor = 200;
+    let mut sizer = AdaptiveChunkSizer::new(config).expect("sizer");
+
+    for expected in [200, 200, 200] {
+        let mut feedback =
+            adaptive_feedback_with_rows(cache_full_hit(), Duration::from_millis(50), 5_000);
+        feedback.local_processing_write_duration = Duration::from_secs(11);
+
+        let decision = sizer.record_chunk(feedback);
+
+        assert_eq!(decision.current_chunk_size, expected);
+        assert_eq!(
+            decision.reason,
+            AdaptiveChunkSizingReason::SlowLocalProcessing
+        );
+    }
+}
+
+#[test]
+fn test_adaptive_chunk_sizer_rejects_full_hit_floor_below_min_chunk_size() {
+    let mut config = adaptive_config(100, 400);
+    config.full_hit_dense_floor = 25;
+
+    assert!(AdaptiveChunkSizer::new(config).is_err());
+}
+
+#[test]
 fn test_adaptive_chunk_sizer_slow_local_processing_shrinks_immediately() {
     let mut sizer = AdaptiveChunkSizer::new(adaptive_config(100, 400)).expect("sizer");
-    let mut feedback = adaptive_feedback(cache_full_hit(), Duration::from_millis(50));
+    let mut feedback = adaptive_feedback(cache_miss(), Duration::from_millis(50));
     feedback.local_processing_write_duration = Duration::from_secs(11);
 
     let slow_local = sizer.record_chunk(feedback);
@@ -1344,6 +1428,15 @@ fn cache_provider_fill() -> DatalensWarmupEffectivenessAggregation {
 
 fn cache_unavailable() -> DatalensWarmupEffectivenessAggregation {
     cache_aggregation(DatalensLogQueryCacheSummary::unavailable())
+}
+
+fn cache_full_hit_with_unavailable() -> DatalensWarmupEffectivenessAggregation {
+    let mut aggregation = cache_full_hit();
+    aggregation.record_query(
+        DatalensLogQueryCacheSummary::unavailable(),
+        Duration::from_millis(20),
+    );
+    aggregation
 }
 
 fn cache_aggregation(


### PR DESCRIPTION
## Problem

ENS Datalens full-cache historical sync can return very dense token chunks while still reporting full cache hits. In observed chunks, local projection/write dominated runtime, for example `rows=198480`, `write=58645ms`, `local_processing=72245ms`, `total=85894ms`. The adaptive sizer then repeatedly halved the block range due to dense rows and slow local processing, even when there was no provider fill or miss, which hurt full-hit throughput.

## Root cause

The adaptive chunk strategy treated dense returned rows and slow local write time as instability for every chunk shape. That is right for provider fill/miss and high query duration paths, but too aggressive for pure Datalens full-hit historical reads where the remote cache is healthy and the local write path is the bottleneck. Token write batches also used small hardcoded chunk sizes, increasing round-trip/write overhead in dense token ranges.

## Implementation

- Added `full_hit_dense_floor` to adaptive chunk config, with env knob `DEGOV_INDEXER_ADAPTIVE_CHUNK_FULL_HIT_DENSE_FLOOR_BLOCKS` defaulting to `1000`.
- Pure full-cache-hit chunks no longer shrink only because returned rows exceed the dense threshold.
- Slow local processing on pure full-hit chunks shrinks only down to the configured full-hit floor, while high query duration, provider fill/miss, provider limits, and transient query failures can still shrink below it.
- Tightened pure full-hit detection so mixed unavailable/empty metadata does not suppress dense-row shrinking.
- Made token bulk write chunk sizes env-driven with larger defaults and PostgreSQL bind-parameter caps:
  - `DEGOV_INDEXER_TOKEN_EVENT_BULK_CHUNK_SIZE` default `3000`
  - `DEGOV_INDEXER_CONTRIBUTOR_ENSURE_BULK_CHUNK_SIZE` default `3000`
  - `DEGOV_INDEXER_DELEGATE_ROLLING_VOTE_UPDATE_CHUNK_SIZE` default `1000`
  - `DEGOV_INDEXER_VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE` default `3000`
- Added targeted regression coverage for full-hit dense rows, slow local full-hit floor behavior, provider/high-duration shrink safety, env parsing, and bind-limit caps.

## Risk

- Larger SQL batches may increase per-query memory or latency in some deployments; each configured value is capped against the PostgreSQL bind parameter limit for its query shape.
- Invalid token bulk chunk env values fall back to defaults rather than failing startup. Zero and oversized values are not used directly.
- Full database-backed package tests were not run locally because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set.

## Test plan

- `cargo fmt` - passed
- `cargo test -p degov-datalens-indexer --locked adaptive` - passed; includes 16 adaptive indexer runner tests plus filtered adaptive/runtime tests
- `cargo test -p degov-datalens-indexer --locked bulk_chunk_size` - passed; 3 token bulk chunk tests
- `cargo test -p degov-datalens-indexer --locked test_indexer_runtime` - passed; includes adaptive runtime load/rejection tests
- `git diff --check` - passed
- `DEGOV_INDEXER_TEST_DATABASE_URL` check - not set, so full DB-backed package test run was skipped
