### PR TITLE
fix(indexer): backfill proposal block timestamps

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -539,6 +539,8 @@ CREATE TABLE IF NOT EXISTS proposal (
   title TEXT NOT NULL,
   vote_start_timestamp NUMERIC(78, 0) NOT NULL,
   vote_end_timestamp NUMERIC(78, 0) NOT NULL,
+  vote_start_timestamp_resolved BOOLEAN NOT NULL DEFAULT FALSE,
+  vote_end_timestamp_resolved BOOLEAN NOT NULL DEFAULT FALSE,
   block_interval TEXT,
   description_hash TEXT,
   proposal_snapshot NUMERIC(78, 0),

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -69,8 +69,9 @@ pub use crate::projection::proposal::{
     ProposalDeadlineExtensionWrite, ProposalEventCommon, ProposalExtendedWrite, ProposalIdWrite,
     ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionError,
     ProposalProjectionEvent, ProposalProjectionRepository, ProposalQueuedWrite,
-    ProposalRepositoryWriteError, ProposalStateEpochWrite, ProposalStateWriteKind, ProposalWrite,
-    project_proposal_events,
+    ProposalRepositoryWriteError, ProposalStateEpochWrite, ProposalStateWriteKind,
+    ProposalTimestampBackfillCandidate, ProposalTimestampBackfillUpdate, ProposalWrite,
+    plan_proposal_timestamp_backfill_updates, project_proposal_events,
 };
 pub use crate::projection::proposal_metadata::{
     ProposalTextMetadata, ProposalTitleExtractionError, ProposalTitleExtractor,
@@ -104,8 +105,8 @@ pub use crate::store::postgres::{
     PostgresProvisionalProposalOverlayStore, PostgresProvisionalSegmentStore,
     ProposalReferenceFieldCandidate, ProposalReferenceFieldUpdate, ProposalTitleRefreshCandidate,
     ProposalTitleRefreshUpdate, read_proposal_reference_field_candidates,
-    read_proposal_title_refresh_candidates, update_proposal_reference_fields,
-    update_proposal_titles,
+    read_proposal_timestamp_backfill_candidates, read_proposal_title_refresh_candidates,
+    update_proposal_reference_fields, update_proposal_timestamp_backfill, update_proposal_titles,
 };
 pub use checkpoint::{
     CheckpointBlockRange, CheckpointRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
@@ -138,7 +139,7 @@ pub use runner::{
     InMemoryIndexerRunnerStore, InMemoryIndexerRunnerStoreError, IndexerEventDecoder,
     IndexerOnchainRefreshTick, IndexerProjectionBatch, IndexerRunner, IndexerRunnerContexts,
     IndexerRunnerError, IndexerRunnerOptions, IndexerRunnerProgress, IndexerRunnerReport,
-    IndexerRunnerStore, IndexerRunnerTransaction, page_rows,
+    IndexerRunnerStore, IndexerRunnerTransaction, ProposalTimestampBackfillConfig, page_rows,
 };
 pub use runtime_config::{
     AdaptiveChunkSizerRuntimeConfig, ContractSetConcurrencyLimit, GraphqlRuntimeConfig,

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -210,11 +210,9 @@ pub fn plan_proposal_timestamp_backfill_updates(
         .filter_map(|candidate| {
             let vote_start_timestamp = block_timestamps
                 .get(&(candidate.chain_id, candidate.vote_start.clone()))
-                .filter(|timestamp| *timestamp != &candidate.vote_start_timestamp)
                 .cloned();
             let vote_end_timestamp = block_timestamps
                 .get(&(candidate.chain_id, candidate.vote_end.clone()))
-                .filter(|timestamp| *timestamp != &candidate.vote_end_timestamp)
                 .cloned();
 
             (vote_start_timestamp.is_some() || vote_end_timestamp.is_some()).then(|| {

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -169,6 +169,66 @@ fn apply_block_timestamps(
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalTimestampBackfillCandidate {
+    pub proposal_ref: String,
+    pub chain_id: i32,
+    pub governor_address: String,
+    pub clock_mode: String,
+    pub vote_start: String,
+    pub vote_end: String,
+    pub vote_start_timestamp: String,
+    pub vote_end_timestamp: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalTimestampBackfillUpdate {
+    pub proposal_ref: String,
+    pub vote_start_timestamp: Option<String>,
+    pub vote_end_timestamp: Option<String>,
+}
+
+pub fn plan_proposal_timestamp_backfill_updates(
+    candidates: &[ProposalTimestampBackfillCandidate],
+    report: &ChainReadExecutionReport,
+) -> Vec<ProposalTimestampBackfillUpdate> {
+    let block_timestamps = report
+        .results
+        .iter()
+        .filter_map(|result| {
+            if result.key.method != ChainReadMethod::BlockTimestamp {
+                return None;
+            }
+            let block_number = result.key.args.first()?;
+            let timestamp = chain_read_scalar(&result.value)?;
+            Some(((result.key.chain_id, block_number.clone()), timestamp))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    candidates
+        .iter()
+        .filter(|candidate| candidate.clock_mode == "blocknumber")
+        .filter_map(|candidate| {
+            let vote_start_timestamp = block_timestamps
+                .get(&(candidate.chain_id, candidate.vote_start.clone()))
+                .filter(|timestamp| *timestamp != &candidate.vote_start_timestamp)
+                .cloned();
+            let vote_end_timestamp = block_timestamps
+                .get(&(candidate.chain_id, candidate.vote_end.clone()))
+                .filter(|timestamp| *timestamp != &candidate.vote_end_timestamp)
+                .cloned();
+
+            (vote_start_timestamp.is_some() || vote_end_timestamp.is_some()).then(|| {
+                ProposalTimestampBackfillUpdate {
+                    proposal_ref: candidate.proposal_ref.clone(),
+                    vote_start_timestamp,
+                    vote_end_timestamp,
+                }
+            })
+        })
+        .collect()
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProposalProjectionError {
     MixedChainIds {
         expected: i32,

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -6,22 +6,23 @@ use log::{error, info, warn};
 use thiserror::Error;
 
 use crate::{
-    ChainReadExecutionReport, ChainReadPlan, ChainTool, CheckpointBlockRange, CheckpointError,
-    DaoContractAddresses, DaoEventDecodeError, DaoLogSource, DatalensConfig, DatalensError,
-    DatalensLogPage, DatalensLogQueryReader, DatalensQueryErrorClass,
+    ChainReadExecutionReport, ChainReadPlan, ChainReadPlanBuilder, ChainTool, CheckpointBlockRange,
+    CheckpointError, DaoContractAddresses, DaoEventDecodeError, DaoLogSource, DatalensConfig,
+    DatalensError, DatalensLogPage, DatalensLogQueryReader, DatalensQueryErrorClass,
     DatalensWarmupEffectivenessAggregation, DatalensWarmupEffectivenessLogFields, DecodedDaoEvent,
     GovernanceTokenStandard, InMemoryProposalProjectionRepository,
     InMemoryTimelockProjectionRepository, InMemoryTokenProjectionRepository,
     InMemoryVoteProjectionRepository, IndexerCheckpoint, IndexerCheckpointIdentity,
     NormalizedEvmLog, ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionEvent,
-    ProposalProjectionRepository, TimelockProjectionBatch, TimelockProjectionContext,
+    ProposalProjectionRepository, ProposalTimestampBackfillCandidate,
+    ProposalTimestampBackfillUpdate, TimelockProjectionBatch, TimelockProjectionContext,
     TimelockProjectionEvent, TimelockProjectionRepository, TimelockProposalLinkContext,
     TokenProjectionBatch, TokenProjectionContext, TokenProjectionEvent, TokenProjectionRepository,
     VoteProjectionBatch, VoteProjectionContext, VoteProjectionEvent, VoteProjectionRepository,
     classify_datalens_query_error, datalens_selector_fingerprint, decode_dao_log,
     fetch_dao_log_pages, normalize_evm_log_rows, plan_dao_log_queries, plan_next_checkpoint_range,
-    project_proposal_events, project_timelock_events_with_proposal_links, project_token_events,
-    project_vote_events,
+    plan_proposal_timestamp_backfill_updates, project_proposal_events,
+    project_timelock_events_with_proposal_links, project_token_events, project_vote_events,
 };
 
 use crate::OnchainRefreshTickReport;
@@ -37,6 +38,22 @@ pub struct IndexerRunnerOptions {
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerConfig,
     pub onchain_refresh_deferred_drain_batch_size: usize,
+    pub proposal_timestamp_backfill: ProposalTimestampBackfillConfig,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProposalTimestampBackfillConfig {
+    pub enabled: bool,
+    pub batch_size: usize,
+}
+
+impl Default for ProposalTimestampBackfillConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            batch_size: 100,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -543,6 +560,22 @@ pub trait IndexerRunnerStore {
     ) -> Result<usize, Self::Error> {
         Ok(0)
     }
+
+    fn read_proposal_timestamp_backfill_candidates(
+        &mut self,
+        _identity: &IndexerCheckpointIdentity,
+        _processed_height: i64,
+        _batch_size: usize,
+    ) -> Result<Vec<ProposalTimestampBackfillCandidate>, Self::Error> {
+        Ok(Vec::new())
+    }
+
+    fn update_proposal_timestamp_backfill(
+        &mut self,
+        _updates: &[ProposalTimestampBackfillUpdate],
+    ) -> Result<u64, Self::Error> {
+        Ok(0)
+    }
 }
 
 pub trait IndexerRunnerTransaction {
@@ -896,6 +929,7 @@ where
                 }
             };
             let deferred_drain_duration = deferred_drain_started_at.elapsed();
+            self.run_proposal_timestamp_backfill(range.to_block);
             self.run_onchain_refresh_tick(range.to_block);
 
             chunks_processed += 1;
@@ -1056,6 +1090,142 @@ where
                 processed_block,
                 error
             ),
+        }
+    }
+
+    fn run_proposal_timestamp_backfill(&mut self, processed_block: i64) {
+        let config = self.options.proposal_timestamp_backfill;
+        if !config.enabled || config.batch_size == 0 {
+            return;
+        }
+        let Some(context) = self.contexts.proposal.as_ref() else {
+            return;
+        };
+        if self.chain_tool.is_none() {
+            return;
+        }
+
+        let started_at = Instant::now();
+        let candidates = match self.store.read_proposal_timestamp_backfill_candidates(
+            &self.options.checkpoint_identity,
+            processed_block,
+            config.batch_size,
+        ) {
+            Ok(candidates) => candidates,
+            Err(error) => {
+                warn!(
+                    "Datalens indexer proposal timestamp backfill candidate read failed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} processed_block={} error={}",
+                    self.options.checkpoint_identity.dao_code,
+                    self.options.checkpoint_identity.chain_id,
+                    self.options.checkpoint_identity.contract_set_id,
+                    self.options.checkpoint_identity.stream_id,
+                    self.options.checkpoint_identity.data_source_version,
+                    processed_block,
+                    error
+                );
+                return;
+            }
+        };
+        if candidates.is_empty() {
+            return;
+        }
+
+        let mut builder = ChainReadPlanBuilder::new(
+            self.options.checkpoint_identity.chain_id,
+            context.contracts.clone(),
+            context.read_plan_config,
+        );
+        for candidate in &candidates {
+            if candidate.clock_mode != "blocknumber" {
+                continue;
+            }
+            if candidate
+                .vote_start
+                .parse::<i64>()
+                .is_ok_and(|block| block <= processed_block)
+            {
+                builder.add_optional_block_timestamp_read(&candidate.vote_start);
+            }
+            if candidate
+                .vote_end
+                .parse::<i64>()
+                .is_ok_and(|block| block <= processed_block)
+            {
+                builder.add_optional_block_timestamp_read(&candidate.vote_end);
+            }
+        }
+
+        let plan = builder.build();
+        let Some(report) = self.execute_proposal_timestamp_backfill_read_plan(&plan) else {
+            return;
+        };
+        let updates = plan_proposal_timestamp_backfill_updates(&candidates, &report);
+        let updated_rows = match self.store.update_proposal_timestamp_backfill(&updates) {
+            Ok(rows) => rows,
+            Err(error) => {
+                warn!(
+                    "Datalens indexer proposal timestamp backfill update failed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} processed_block={} candidates={} updates={} error={}",
+                    self.options.checkpoint_identity.dao_code,
+                    self.options.checkpoint_identity.chain_id,
+                    self.options.checkpoint_identity.contract_set_id,
+                    self.options.checkpoint_identity.stream_id,
+                    self.options.checkpoint_identity.data_source_version,
+                    processed_block,
+                    candidates.len(),
+                    updates.len(),
+                    error
+                );
+                return;
+            }
+        };
+
+        info!(
+            "Datalens indexer proposal timestamp backfill completed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} processed_block={} candidates={} updates={} updated_rows={} optional_failures={} duration_ms={}",
+            self.options.checkpoint_identity.dao_code,
+            self.options.checkpoint_identity.chain_id,
+            self.options.checkpoint_identity.contract_set_id,
+            self.options.checkpoint_identity.stream_id,
+            self.options.checkpoint_identity.data_source_version,
+            processed_block,
+            candidates.len(),
+            updates.len(),
+            updated_rows,
+            report.partial_failures.optional_failures.len(),
+            started_at.elapsed().as_millis()
+        );
+    }
+
+    fn execute_proposal_timestamp_backfill_read_plan(
+        &self,
+        plan: &ChainReadPlan,
+    ) -> Option<ChainReadExecutionReport> {
+        if plan.reads.is_empty() {
+            return None;
+        }
+        let Some(chain_tool) = self.chain_tool.as_ref() else {
+            return None;
+        };
+
+        match chain_tool.execute_read_plan(plan) {
+            Ok(report) => Some(report),
+            Err(failures) if failures.can_commit_projection_writes() => {
+                Some(ChainReadExecutionReport {
+                    partial_failures: failures,
+                    ..ChainReadExecutionReport::default()
+                })
+            }
+            Err(failures) => {
+                warn!(
+                    "Datalens indexer proposal timestamp backfill reads failed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} failures={:?}",
+                    self.options.checkpoint_identity.dao_code,
+                    self.options.checkpoint_identity.chain_id,
+                    self.options.checkpoint_identity.contract_set_id,
+                    self.options.checkpoint_identity.stream_id,
+                    self.options.checkpoint_identity.data_source_version,
+                    failures
+                );
+                None
+            }
         }
     }
 
@@ -1511,6 +1681,9 @@ pub struct InMemoryIndexerRunnerStore {
     commit_count: u64,
     rollback_count: u64,
     deferred_drain_requests: Vec<usize>,
+    proposal_timestamp_backfill_candidates: Vec<ProposalTimestampBackfillCandidate>,
+    proposal_timestamp_backfill_updates: Vec<ProposalTimestampBackfillUpdate>,
+    proposal_timestamp_backfill_requests: Vec<(i64, usize)>,
     apply_failures: VecDeque<String>,
     commit_failures: VecDeque<String>,
 }
@@ -1526,6 +1699,9 @@ impl InMemoryIndexerRunnerStore {
             commit_count: 0,
             rollback_count: 0,
             deferred_drain_requests: Vec::new(),
+            proposal_timestamp_backfill_candidates: Vec::new(),
+            proposal_timestamp_backfill_updates: Vec::new(),
+            proposal_timestamp_backfill_requests: Vec::new(),
             apply_failures: VecDeque::new(),
             commit_failures: VecDeque::new(),
         }
@@ -1545,6 +1721,21 @@ impl InMemoryIndexerRunnerStore {
 
     pub fn deferred_drain_requests(&self) -> &[usize] {
         &self.deferred_drain_requests
+    }
+
+    pub fn set_proposal_timestamp_backfill_candidates(
+        &mut self,
+        candidates: Vec<ProposalTimestampBackfillCandidate>,
+    ) {
+        self.proposal_timestamp_backfill_candidates = candidates;
+    }
+
+    pub fn proposal_timestamp_backfill_updates(&self) -> &[ProposalTimestampBackfillUpdate] {
+        &self.proposal_timestamp_backfill_updates
+    }
+
+    pub fn proposal_timestamp_backfill_requests(&self) -> &[(i64, usize)] {
+        &self.proposal_timestamp_backfill_requests
     }
 
     pub fn fail_next_apply(&mut self, message: impl Into<String>) {
@@ -1632,6 +1823,31 @@ impl IndexerRunnerStore for InMemoryIndexerRunnerStore {
     ) -> Result<usize, Self::Error> {
         self.deferred_drain_requests.push(max_rows);
         Ok(0)
+    }
+
+    fn read_proposal_timestamp_backfill_candidates(
+        &mut self,
+        _identity: &IndexerCheckpointIdentity,
+        processed_height: i64,
+        batch_size: usize,
+    ) -> Result<Vec<ProposalTimestampBackfillCandidate>, Self::Error> {
+        self.proposal_timestamp_backfill_requests
+            .push((processed_height, batch_size));
+        Ok(self
+            .proposal_timestamp_backfill_candidates
+            .iter()
+            .take(batch_size)
+            .cloned()
+            .collect())
+    }
+
+    fn update_proposal_timestamp_backfill(
+        &mut self,
+        updates: &[ProposalTimestampBackfillUpdate],
+    ) -> Result<u64, Self::Error> {
+        self.proposal_timestamp_backfill_updates
+            .extend_from_slice(updates);
+        Ok(updates.len() as u64)
     }
 }
 

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -1007,6 +1007,7 @@ mod tests {
             adaptive_chunk_sizer: Default::default(),
             onchain_refresh_tick: Default::default(),
             onchain_refresh_deferred_drain_batch_size: 100,
+            proposal_timestamp_backfill: Default::default(),
             provisional: ProvisionalRuntimeConfig {
                 enabled: false,
                 finality: DatalensProvisionalFinality::SafeToLatest,

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -10,8 +10,8 @@ use crate::{
     DEFAULT_ONCHAIN_REFRESH_APPLY_BATCH_SIZE, DatalensConfig, DatalensProvisionalFinality,
     DatalensQueryConcurrencyConfig, DatalensRuntimeContractSet, IndexerCheckpointIdentity,
     IndexerRunnerContexts, IndexerRunnerOptions, OnchainRefreshTickConfig,
-    OnchainRefreshWorkerConfig, ProposalProjectionContext, SecretString, TimelockProjectionContext,
-    TokenProjectionContext, VoteProjectionContext,
+    OnchainRefreshWorkerConfig, ProposalProjectionContext, ProposalTimestampBackfillConfig,
+    SecretString, TimelockProjectionContext, TokenProjectionContext, VoteProjectionContext,
     store::postgres::DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS,
 };
 
@@ -153,6 +153,7 @@ pub struct IndexerRuntimeConfig {
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
     pub onchain_refresh_deferred_drain_batch_size: usize,
+    pub proposal_timestamp_backfill: ProposalTimestampBackfillConfig,
     pub provisional: ProvisionalRuntimeConfig,
 }
 
@@ -244,6 +245,7 @@ pub struct IndexerContractSetRuntimeConfig {
     pub max_chunks_per_run: Option<u64>,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
     pub onchain_refresh_deferred_drain_batch_size: usize,
+    pub proposal_timestamp_backfill: ProposalTimestampBackfillConfig,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -357,6 +359,7 @@ impl IndexerRuntimeConfig {
             onchain_refresh_tick: load_onchain_refresh_tick_config()?,
             onchain_refresh_deferred_drain_batch_size:
                 onchain_refresh_deferred_drain_batch_size_from_env()?,
+            proposal_timestamp_backfill: load_proposal_timestamp_backfill_config()?,
             provisional: ProvisionalRuntimeConfig::from_env()?,
             poll_interval,
             run_once,
@@ -427,6 +430,7 @@ impl IndexerRuntimeConfig {
             onchain_refresh_tick: self.onchain_refresh_tick.clone(),
             onchain_refresh_deferred_drain_batch_size: self
                 .onchain_refresh_deferred_drain_batch_size,
+            proposal_timestamp_backfill: self.proposal_timestamp_backfill,
         };
 
         Ok(runtime
@@ -496,6 +500,7 @@ impl IndexerContractSetRuntimeConfig {
                 .for_block_range_limit(config.query_limits.block_range_limit),
             onchain_refresh_deferred_drain_batch_size: self
                 .onchain_refresh_deferred_drain_batch_size,
+            proposal_timestamp_backfill: self.proposal_timestamp_backfill,
         })
     }
 
@@ -732,6 +737,22 @@ fn load_onchain_refresh_tick_config() -> Result<OnchainRefreshTickConfig> {
     }
     if config.min_blocks_between_ticks < 0 {
         bail!("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MIN_BLOCKS must be zero or greater");
+    }
+
+    Ok(config)
+}
+
+fn load_proposal_timestamp_backfill_config() -> Result<ProposalTimestampBackfillConfig> {
+    let defaults = ProposalTimestampBackfillConfig::default();
+    let config = ProposalTimestampBackfillConfig {
+        enabled: optional_env_bool("DEGOV_INDEXER_PROPOSAL_TIMESTAMP_BACKFILL_ENABLED")?
+            .unwrap_or(defaults.enabled),
+        batch_size: optional_env_usize("DEGOV_INDEXER_PROPOSAL_TIMESTAMP_BACKFILL_BATCH_SIZE")?
+            .unwrap_or(defaults.batch_size),
+    };
+
+    if config.enabled && config.batch_size == 0 {
+        bail!("DEGOV_INDEXER_PROPOSAL_TIMESTAMP_BACKFILL_BATCH_SIZE must be greater than zero");
     }
 
     Ok(config)

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -14,7 +14,8 @@ use crate::{
     IndexerCheckpoint, IndexerCheckpointIdentity, IndexerProjectionBatch, IndexerRunnerStore,
     IndexerRunnerTransaction, PowerReconcileCandidate, ProposalActionWrite, ProposalCreatedWrite,
     ProposalDeadlineExtensionWrite, ProposalExtendedWrite, ProposalIdWrite,
-    ProposalProjectionBatch, ProposalQueuedWrite, ProposalStateEpochWrite, ProposalVoteTotalWrite,
+    ProposalProjectionBatch, ProposalQueuedWrite, ProposalStateEpochWrite,
+    ProposalTimestampBackfillCandidate, ProposalTimestampBackfillUpdate, ProposalVoteTotalWrite,
     ProposalWrite, ProvisionalCleanupReport, ProvisionalCleanupStore,
     ProvisionalContributorPowerOverlayWrite, ProvisionalDelegatePowerOverlayRelation,
     ProvisionalDelegatePowerOverlayWrite, ProvisionalPowerOverlayScope,
@@ -111,6 +112,27 @@ impl IndexerRunnerStore for PostgresIndexerRunnerStore {
         max_rows: usize,
     ) -> Result<usize, Self::Error> {
         block_on_runtime(drain_deferred_onchain_refresh_tasks(&self.pool, max_rows))
+    }
+
+    fn read_proposal_timestamp_backfill_candidates(
+        &mut self,
+        identity: &IndexerCheckpointIdentity,
+        processed_height: i64,
+        batch_size: usize,
+    ) -> Result<Vec<ProposalTimestampBackfillCandidate>, Self::Error> {
+        block_on_runtime(read_proposal_timestamp_backfill_candidates(
+            &self.pool,
+            identity,
+            processed_height,
+            batch_size,
+        ))
+    }
+
+    fn update_proposal_timestamp_backfill(
+        &mut self,
+        updates: &[ProposalTimestampBackfillUpdate],
+    ) -> Result<u64, Self::Error> {
+        block_on_runtime(update_proposal_timestamp_backfill(&self.pool, updates))
     }
 }
 

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -554,19 +554,11 @@ pub async fn read_proposal_timestamp_backfill_candidates(
            AND (
                 (
                     vote_start <= $4::NUMERIC(78, 0)
-                    AND vote_start_timestamp = CASE
-                        WHEN block_interval IS NOT NULL AND block_timestamp IS NOT NULL
-                            THEN block_timestamp + ((vote_start - block_number) * (block_interval::NUMERIC * 1000::NUMERIC))
-                        ELSE vote_start
-                    END
+                    AND vote_start_timestamp_resolved = FALSE
                 )
                 OR (
                     vote_end <= $4::NUMERIC(78, 0)
-                    AND vote_end_timestamp = CASE
-                        WHEN block_interval IS NOT NULL AND block_timestamp IS NOT NULL
-                            THEN block_timestamp + ((vote_end - block_number) * (block_interval::NUMERIC * 1000::NUMERIC))
-                        ELSE vote_end
-                    END
+                    AND vote_end_timestamp_resolved = FALSE
                 )
            )
          ORDER BY block_number, transaction_index, log_index, id
@@ -612,7 +604,9 @@ pub async fn update_proposal_timestamp_backfill(
 const UPDATE_PROPOSAL_TIMESTAMP_BACKFILL_SQL_PREFIX: &str =
     "UPDATE proposal SET
          vote_start_timestamp = COALESCE(proposal_timestamp_backfill.vote_start_timestamp::NUMERIC(78, 0), proposal.vote_start_timestamp),
-         vote_end_timestamp = COALESCE(proposal_timestamp_backfill.vote_end_timestamp::NUMERIC(78, 0), proposal.vote_end_timestamp)
+         vote_end_timestamp = COALESCE(proposal_timestamp_backfill.vote_end_timestamp::NUMERIC(78, 0), proposal.vote_end_timestamp),
+         vote_start_timestamp_resolved = proposal.vote_start_timestamp_resolved OR proposal_timestamp_backfill.vote_start_timestamp IS NOT NULL,
+         vote_end_timestamp_resolved = proposal.vote_end_timestamp_resolved OR proposal_timestamp_backfill.vote_end_timestamp IS NOT NULL
      FROM (";
 
 async fn update_proposal_timestamp_backfill_proposals(
@@ -632,11 +626,17 @@ async fn update_proposal_timestamp_backfill_proposals(
            AND (
                 (
                     proposal_timestamp_backfill.vote_start_timestamp IS NOT NULL
-                    AND proposal.vote_start_timestamp IS DISTINCT FROM proposal_timestamp_backfill.vote_start_timestamp::NUMERIC(78, 0)
+                    AND (
+                        proposal.vote_start_timestamp IS DISTINCT FROM proposal_timestamp_backfill.vote_start_timestamp::NUMERIC(78, 0)
+                        OR proposal.vote_start_timestamp_resolved = FALSE
+                    )
                 )
                 OR (
                     proposal_timestamp_backfill.vote_end_timestamp IS NOT NULL
-                    AND proposal.vote_end_timestamp IS DISTINCT FROM proposal_timestamp_backfill.vote_end_timestamp::NUMERIC(78, 0)
+                    AND (
+                        proposal.vote_end_timestamp IS DISTINCT FROM proposal_timestamp_backfill.vote_end_timestamp::NUMERIC(78, 0)
+                        OR proposal.vote_end_timestamp_resolved = FALSE
+                    )
                 )
            )",
     );

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -530,6 +530,180 @@ async fn update_proposal_reference_field_chunk(
     Ok(result.rows_affected())
 }
 
+pub async fn read_proposal_timestamp_backfill_candidates(
+    pool: &PgPool,
+    identity: &IndexerCheckpointIdentity,
+    processed_height: i64,
+    batch_size: usize,
+) -> Result<Vec<ProposalTimestampBackfillCandidate>, PostgresIndexerRunnerStoreError> {
+    if batch_size == 0 {
+        return Ok(Vec::new());
+    }
+
+    let rows = sqlx::query(
+        "SELECT id, chain_id, governor_address, clock_mode,
+                vote_start::TEXT AS vote_start,
+                vote_end::TEXT AS vote_end,
+                vote_start_timestamp::TEXT AS vote_start_timestamp,
+                vote_end_timestamp::TEXT AS vote_end_timestamp
+         FROM proposal
+         WHERE dao_code = $1
+           AND contract_set_id = $2
+           AND chain_id = $3
+           AND clock_mode = 'blocknumber'
+           AND (
+                (
+                    vote_start <= $4::NUMERIC(78, 0)
+                    AND vote_start_timestamp = CASE
+                        WHEN block_interval IS NOT NULL AND block_timestamp IS NOT NULL
+                            THEN block_timestamp + ((vote_start - block_number) * (block_interval::NUMERIC * 1000::NUMERIC))
+                        ELSE vote_start
+                    END
+                )
+                OR (
+                    vote_end <= $4::NUMERIC(78, 0)
+                    AND vote_end_timestamp = CASE
+                        WHEN block_interval IS NOT NULL AND block_timestamp IS NOT NULL
+                            THEN block_timestamp + ((vote_end - block_number) * (block_interval::NUMERIC * 1000::NUMERIC))
+                        ELSE vote_end
+                    END
+                )
+           )
+         ORDER BY block_number, transaction_index, log_index, id
+         LIMIT $5",
+    )
+    .bind(&identity.dao_code)
+    .bind(&identity.contract_set_id)
+    .bind(identity.chain_id)
+    .bind(processed_height.to_string())
+    .bind(i64::try_from(batch_size).unwrap_or(i64::MAX))
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ProposalTimestampBackfillCandidate {
+            proposal_ref: row.get("id"),
+            chain_id: row.get("chain_id"),
+            governor_address: row.get("governor_address"),
+            clock_mode: row.get("clock_mode"),
+            vote_start: row.get("vote_start"),
+            vote_end: row.get("vote_end"),
+            vote_start_timestamp: row.get("vote_start_timestamp"),
+            vote_end_timestamp: row.get("vote_end_timestamp"),
+        })
+        .collect())
+}
+
+pub async fn update_proposal_timestamp_backfill(
+    pool: &PgPool,
+    updates: &[ProposalTimestampBackfillUpdate],
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
+    if updates.is_empty() {
+        return Ok(0);
+    }
+
+    let proposal_rows = update_proposal_timestamp_backfill_proposals(pool, updates).await?;
+    let state_epoch_rows = update_proposal_timestamp_backfill_state_epochs(pool, updates).await?;
+
+    Ok(proposal_rows + state_epoch_rows)
+}
+
+const UPDATE_PROPOSAL_TIMESTAMP_BACKFILL_SQL_PREFIX: &str =
+    "UPDATE proposal SET
+         vote_start_timestamp = COALESCE(proposal_timestamp_backfill.vote_start_timestamp::NUMERIC(78, 0), proposal.vote_start_timestamp),
+         vote_end_timestamp = COALESCE(proposal_timestamp_backfill.vote_end_timestamp::NUMERIC(78, 0), proposal.vote_end_timestamp)
+     FROM (";
+
+async fn update_proposal_timestamp_backfill_proposals(
+    pool: &PgPool,
+    updates: &[ProposalTimestampBackfillUpdate],
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
+    let mut builder: QueryBuilder<Postgres> =
+        QueryBuilder::new(UPDATE_PROPOSAL_TIMESTAMP_BACKFILL_SQL_PREFIX);
+    builder.push_values(updates, |mut row, update| {
+        row.push_bind(&update.proposal_ref)
+            .push_bind(update.vote_start_timestamp.as_deref())
+            .push_bind(update.vote_end_timestamp.as_deref());
+    });
+    builder.push(
+        ") AS proposal_timestamp_backfill(id, vote_start_timestamp, vote_end_timestamp)
+         WHERE proposal.id = proposal_timestamp_backfill.id
+           AND (
+                (
+                    proposal_timestamp_backfill.vote_start_timestamp IS NOT NULL
+                    AND proposal.vote_start_timestamp IS DISTINCT FROM proposal_timestamp_backfill.vote_start_timestamp::NUMERIC(78, 0)
+                )
+                OR (
+                    proposal_timestamp_backfill.vote_end_timestamp IS NOT NULL
+                    AND proposal.vote_end_timestamp IS DISTINCT FROM proposal_timestamp_backfill.vote_end_timestamp::NUMERIC(78, 0)
+                )
+           )",
+    );
+
+    let result = builder.build().execute(pool).await?;
+    Ok(result.rows_affected())
+}
+
+const UPDATE_PROPOSAL_STATE_EPOCH_TIMESTAMP_BACKFILL_SQL_PREFIX: &str =
+    "UPDATE proposal_state_epoch SET
+         start_block_timestamp = CASE
+             WHEN proposal_timestamp_backfill.vote_start_timestamp IS NOT NULL
+                  AND proposal_state_epoch.start_timepoint = proposal.vote_start
+                 THEN proposal_timestamp_backfill.vote_start_timestamp::NUMERIC(78, 0)
+             WHEN proposal_timestamp_backfill.vote_end_timestamp IS NOT NULL
+                  AND proposal_state_epoch.start_timepoint = proposal.vote_end
+                 THEN proposal_timestamp_backfill.vote_end_timestamp::NUMERIC(78, 0)
+             ELSE proposal_state_epoch.start_block_timestamp
+         END,
+         end_block_timestamp = CASE
+             WHEN proposal_timestamp_backfill.vote_start_timestamp IS NOT NULL
+                  AND proposal_state_epoch.end_timepoint = proposal.vote_start
+                 THEN proposal_timestamp_backfill.vote_start_timestamp::NUMERIC(78, 0)
+             WHEN proposal_timestamp_backfill.vote_end_timestamp IS NOT NULL
+                  AND proposal_state_epoch.end_timepoint = proposal.vote_end
+                 THEN proposal_timestamp_backfill.vote_end_timestamp::NUMERIC(78, 0)
+             ELSE proposal_state_epoch.end_block_timestamp
+         END
+     FROM (";
+
+async fn update_proposal_timestamp_backfill_state_epochs(
+    pool: &PgPool,
+    updates: &[ProposalTimestampBackfillUpdate],
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
+    let mut builder: QueryBuilder<Postgres> =
+        QueryBuilder::new(UPDATE_PROPOSAL_STATE_EPOCH_TIMESTAMP_BACKFILL_SQL_PREFIX);
+    builder.push_values(updates, |mut row, update| {
+        row.push_bind(&update.proposal_ref)
+            .push_bind(update.vote_start_timestamp.as_deref())
+            .push_bind(update.vote_end_timestamp.as_deref());
+    });
+    builder.push(
+        ") AS proposal_timestamp_backfill(proposal_ref, vote_start_timestamp, vote_end_timestamp)
+         JOIN proposal ON proposal.id = proposal_timestamp_backfill.proposal_ref
+         WHERE proposal_state_epoch.proposal_ref = proposal_timestamp_backfill.proposal_ref
+           AND (
+                (
+                    proposal_timestamp_backfill.vote_start_timestamp IS NOT NULL
+                    AND (
+                        proposal_state_epoch.start_timepoint = proposal.vote_start
+                        OR proposal_state_epoch.end_timepoint = proposal.vote_start
+                    )
+                )
+                OR (
+                    proposal_timestamp_backfill.vote_end_timestamp IS NOT NULL
+                    AND (
+                        proposal_state_epoch.start_timepoint = proposal.vote_end
+                        OR proposal_state_epoch.end_timepoint = proposal.vote_end
+                    )
+                )
+           )",
+    );
+
+    let result = builder.build().execute(pool).await?;
+    Ok(result.rows_affected())
+}
+
 async fn insert_proposal_action(
     transaction: &mut Transaction<'_, Postgres>,
     row: &ProposalActionWrite,

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -4,8 +4,9 @@ use degov_datalens_indexer::{
     ContractSetConcurrencyLimit, DEFAULT_ONCHAIN_REFRESH_APPLY_BATCH_SIZE, DatalensConfig,
     DatalensProvisionalFinality, DatalensQueryConcurrencyConfig, GraphqlRuntimeConfig,
     IndexerContractSetMode, IndexerRuntimeConfig, IndexerTargetHeight, OnchainRefreshRuntimeConfig,
-    OnchainRefreshTickConfig, ProvisionalRuntimeConfig, datalens_retry_config,
-    onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value,
+    OnchainRefreshTickConfig, ProposalTimestampBackfillConfig, ProvisionalRuntimeConfig,
+    datalens_retry_config, onchain_refresh_worker_enabled, parse_bool_env_value,
+    parse_i64_env_value,
 };
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -808,6 +809,7 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
         onchain_refresh_deferred_drain_batch_size: 100,
+        proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
         provisional: ProvisionalRuntimeConfig {
             enabled: false,
             finality: DatalensProvisionalFinality::SafeToLatest,
@@ -889,6 +891,7 @@ fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
         onchain_refresh_deferred_drain_batch_size: 100,
+        proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
         provisional: ProvisionalRuntimeConfig {
             enabled: false,
             finality: DatalensProvisionalFinality::SafeToLatest,
@@ -930,6 +933,7 @@ fn test_indexer_runtime_latest_target_height_does_not_skip_all_mode_contract_set
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
         onchain_refresh_deferred_drain_batch_size: 100,
+        proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
         provisional: ProvisionalRuntimeConfig {
             enabled: false,
             finality: DatalensProvisionalFinality::SafeToLatest,

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -10,10 +10,15 @@ use degov_datalens_indexer::{
     DatalensWarmupEffectivenessAggregation, DatasetKeyConfig, DecodedDaoEvent,
     DecodedGovernorEvent, DecodedTokenEvent, GovernanceTokenStandard, InMemoryIndexerRunnerStore,
     IndexerCheckpointIdentity, IndexerEventDecoder, IndexerRunner, IndexerRunnerContexts,
-    IndexerRunnerOptions, NormalizedEvmLog, QueryLimitConfig, SecretString, TokenProjectionContext,
-    VoteCastEvent, VoteProjectionContext, page_rows,
+    IndexerRunnerOptions, NormalizedEvmLog, PartialChainReadFailureReport,
+    ProposalProjectionContext, ProposalTimestampBackfillCandidate, ProposalTimestampBackfillConfig,
+    QueryLimitConfig, SecretString, TokenProjectionContext, VoteCastEvent, VoteProjectionContext,
+    page_rows,
 };
-use degov_datalens_indexer::{IndexerOnchainRefreshTick, OnchainRefreshTickReport};
+use degov_datalens_indexer::{
+    ChainReadExecutionReport, ChainReadMethod, ChainReadResult, ChainReadValue, ChainTool,
+    IndexerOnchainRefreshTick, OnchainRefreshTickReport,
+};
 use serde_json::{Value, json};
 
 #[test]
@@ -971,6 +976,46 @@ fn test_runner_keeps_duplicate_address_unsupported_topic_unsupported() {
     );
 }
 
+#[test]
+fn test_runner_backfills_proposal_timestamp_after_chunk_commit() {
+    let mut store = InMemoryIndexerRunnerStore::new(identity(), 1);
+    store.set_proposal_timestamp_backfill_candidates(vec![ProposalTimestampBackfillCandidate {
+        proposal_ref: "proposal:ens:42".to_owned(),
+        chain_id: 1,
+        governor_address: GOVERNOR.to_owned(),
+        clock_mode: "blocknumber".to_owned(),
+        vote_start: "10".to_owned(),
+        vote_end: "20".to_owned(),
+        vote_start_timestamp: "1700000100000".to_owned(),
+        vote_end_timestamp: "1700000200000".to_owned(),
+    }]);
+    let mut options = options();
+    set_block_range_limit(&mut options, 20);
+    let mut runner = runner_with_store_and_contexts(
+        vec![vec![]],
+        ScriptedDecoder,
+        options,
+        store,
+        contexts_with_proposal(),
+    )
+    .with_chain_tool(Box::new(TimestampBackfillChainTool));
+
+    runner.run_to_target(20).expect("runner succeeds");
+
+    assert_eq!(
+        runner.store().proposal_timestamp_backfill_requests(),
+        &[(20, 100)]
+    );
+    let updates = runner.store().proposal_timestamp_backfill_updates();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].proposal_ref, "proposal:ens:42");
+    assert_eq!(updates[0].vote_start_timestamp, None);
+    assert_eq!(
+        updates[0].vote_end_timestamp.as_deref(),
+        Some("1680641927000")
+    );
+}
+
 struct ScriptedDatalensReader {
     rows: Vec<Vec<Value>>,
 }
@@ -1028,6 +1073,35 @@ impl DatalensLogQueryReader for FailingDatalensReader {
 
 struct RecordingOnchainRefreshTick {
     blocks: Arc<Mutex<Vec<i64>>>,
+}
+
+struct TimestampBackfillChainTool;
+
+impl ChainTool for TimestampBackfillChainTool {
+    fn execute_read_plan(
+        &self,
+        plan: &degov_datalens_indexer::ChainReadPlan,
+    ) -> Result<ChainReadExecutionReport, PartialChainReadFailureReport> {
+        let results = plan
+            .reads
+            .iter()
+            .enumerate()
+            .filter_map(|(read_index, read)| {
+                (read.key.method == ChainReadMethod::BlockTimestamp
+                    && read.key.args.first().map(String::as_str) == Some("20"))
+                .then(|| ChainReadResult {
+                    read_index,
+                    key: read.key.clone(),
+                    value: ChainReadValue::Integer("1680641927000".to_owned()),
+                })
+            })
+            .collect();
+
+        Ok(ChainReadExecutionReport {
+            results,
+            ..ChainReadExecutionReport::default()
+        })
+    }
 }
 
 impl IndexerOnchainRefreshTick for RecordingOnchainRefreshTick {
@@ -1311,9 +1385,19 @@ fn runner_with_store<D: IndexerEventDecoder>(
     options: IndexerRunnerOptions,
     store: InMemoryIndexerRunnerStore,
 ) -> IndexerRunner<ScriptedDatalensReader, InMemoryIndexerRunnerStore, D> {
+    runner_with_store_and_contexts(rows, decoder, options, store, contexts())
+}
+
+fn runner_with_store_and_contexts<D: IndexerEventDecoder>(
+    rows: Vec<Vec<Value>>,
+    decoder: D,
+    options: IndexerRunnerOptions,
+    store: InMemoryIndexerRunnerStore,
+    contexts: IndexerRunnerContexts,
+) -> IndexerRunner<ScriptedDatalensReader, InMemoryIndexerRunnerStore, D> {
     IndexerRunner::new(
         options,
-        contexts(),
+        contexts,
         ScriptedDatalensReader { rows },
         store,
         decoder,
@@ -1351,6 +1435,7 @@ fn options() -> IndexerRunnerOptions {
         progress_refresh_lag_blocks: 0,
         adaptive_chunk_sizer: AdaptiveChunkSizerConfig::for_max_chunk_size(1),
         onchain_refresh_deferred_drain_batch_size: 100,
+        proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
     }
 }
 
@@ -1495,6 +1580,32 @@ fn contexts() -> IndexerRunnerContexts {
         proposal: None,
         timelock: None,
     }
+}
+
+fn proposal_context() -> ProposalProjectionContext {
+    let contracts = ChainContracts {
+        governor: GOVERNOR.to_owned(),
+        governor_token: TOKEN.to_owned(),
+        timelock: "0x3333333333333333333333333333333333333333".to_owned(),
+    };
+
+    ProposalProjectionContext {
+        contract_set_id: "demo-scope".to_owned(),
+        dao_code: "demo-dao".to_owned(),
+        governor_address: contracts.governor.clone(),
+        contracts,
+        token_standard: GovernanceTokenStandard::Erc20,
+        read_plan_config: BatchReadPlanConfig {
+            max_concurrency: 10,
+            multicall_batch_size: 100,
+        },
+    }
+}
+
+fn contexts_with_proposal() -> IndexerRunnerContexts {
+    let mut contexts = contexts();
+    contexts.proposal = Some(proposal_context());
+    contexts
 }
 
 fn identity() -> IndexerCheckpointIdentity {

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -13,9 +13,10 @@ use degov_datalens_indexer::{
     IndexerProjectionBatch, IndexerRunner, IndexerRunnerContexts, IndexerRunnerOptions,
     IndexerRunnerStore, IndexerRunnerTransaction, PartialChainReadFailureReport,
     ProposalProjectionBatch, ProposalProjectionContext, ProposalProjectionRepository,
-    QueryLimitConfig, SecretString, TimelockProjectionContext, TimelockProjectionEvent,
-    TimelockProjectionRepository, TimelockProposalLinkContext, TokenProjectionContext,
-    TokenProjectionRepository, VoteProjectionContext, VoteProjectionRepository,
+    ProposalTimestampBackfillConfig, QueryLimitConfig, SecretString, TimelockProjectionContext,
+    TimelockProjectionEvent, TimelockProjectionRepository, TimelockProposalLinkContext,
+    TokenProjectionContext, TokenProjectionRepository, VoteProjectionContext,
+    VoteProjectionRepository,
 };
 use ethabi::{Token, encode};
 use serde_json::{Value, json};
@@ -615,6 +616,7 @@ fn options() -> IndexerRunnerOptions {
         progress_refresh_lag_blocks: 0,
         adaptive_chunk_sizer: AdaptiveChunkSizerConfig::for_max_chunk_size(10),
         onchain_refresh_deferred_drain_batch_size: 100,
+        proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
     }
 }
 

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -338,6 +338,51 @@ fn test_project_proposal_created_estimates_blocknumber_vote_timestamps_from_prop
 }
 
 #[test]
+fn test_project_proposal_created_preserves_fallback_when_block_timestamp_read_fails() {
+    let mut batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: production_log(
+                "0022339715-afd3c-000054",
+                22_339_715,
+                0,
+                84,
+                1_745_507_987_000,
+            ),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id:
+                    "7402631996988205717047317892914463120232263405485409023912445691668825031406"
+                        .to_owned(),
+                proposer: "0x1d5460f896521ad685ea4c3f2c679ec0b6806359".to_owned(),
+                targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "22339716".to_owned(),
+                vote_end: "22385534".to_owned(),
+                description: "ENS blocknumber proposal".to_owned(),
+            }),
+        }],
+    )
+    .expect("projection succeeds");
+    let report = ChainReadExecutionReport {
+        results: vec![read_result(
+            ChainReadMethod::ClockMode,
+            "",
+            ChainReadValue::String("mode=blocknumber&from=default".to_owned()),
+        )],
+        ..ChainReadExecutionReport::default()
+    };
+
+    batch.apply_chain_read_execution_report(&report);
+
+    let proposal = &batch.proposals[0];
+    assert_eq!(proposal.clock_mode, "blocknumber");
+    assert_eq!(proposal.vote_start_timestamp, "1745507999000");
+    assert_eq!(proposal.vote_end_timestamp, "1746057815000");
+}
+
+#[test]
 fn test_project_proposal_created_omits_block_interval_for_non_ethereum_blocknumber() {
     let mut event_log = production_log(
         "0022339715-afd3c-000054",

--- a/apps/indexer/tests/proposal_timestamp_backfill.rs
+++ b/apps/indexer/tests/proposal_timestamp_backfill.rs
@@ -1,0 +1,76 @@
+use degov_datalens_indexer::{
+    BlockReadMode, ChainReadExecutionReport, ChainReadKey, ChainReadMethod, ChainReadResult,
+    ChainReadValue, ProposalTimestampBackfillCandidate, plan_proposal_timestamp_backfill_updates,
+};
+
+#[test]
+fn test_plan_proposal_timestamp_backfill_updates_vote_end_and_state_epoch() {
+    let updates = plan_proposal_timestamp_backfill_updates(
+        &[blocknumber_candidate()],
+        &ChainReadExecutionReport {
+            results: vec![block_timestamp_result("16978023", "1680641927000")],
+            ..ChainReadExecutionReport::default()
+        },
+    );
+
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].proposal_ref, "proposal:ens:42");
+    assert_eq!(updates[0].vote_start_timestamp, None);
+    assert_eq!(
+        updates[0].vote_end_timestamp.as_deref(),
+        Some("1680641927000")
+    );
+}
+
+#[test]
+fn test_plan_proposal_timestamp_backfill_keeps_failed_reads_retryable() {
+    let updates = plan_proposal_timestamp_backfill_updates(
+        &[blocknumber_candidate()],
+        &ChainReadExecutionReport::default(),
+    );
+
+    assert!(updates.is_empty());
+}
+
+#[test]
+fn test_plan_proposal_timestamp_backfill_ignores_timestamp_clock_proposals() {
+    let mut candidate = blocknumber_candidate();
+    candidate.clock_mode = "timestamp".to_owned();
+
+    let updates = plan_proposal_timestamp_backfill_updates(
+        &[candidate],
+        &ChainReadExecutionReport {
+            results: vec![block_timestamp_result("16978023", "1680641927000")],
+            ..ChainReadExecutionReport::default()
+        },
+    );
+
+    assert!(updates.is_empty());
+}
+
+fn blocknumber_candidate() -> ProposalTimestampBackfillCandidate {
+    ProposalTimestampBackfillCandidate {
+        proposal_ref: "proposal:ens:42".to_owned(),
+        chain_id: 1,
+        governor_address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+        clock_mode: "blocknumber".to_owned(),
+        vote_start: "16948023".to_owned(),
+        vote_end: "16978023".to_owned(),
+        vote_start_timestamp: "1680281927000".to_owned(),
+        vote_end_timestamp: "1680633647000".to_owned(),
+    }
+}
+
+fn block_timestamp_result(block_number: &str, timestamp: &str) -> ChainReadResult {
+    ChainReadResult {
+        read_index: 0,
+        key: ChainReadKey {
+            chain_id: 1,
+            contract_address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+            method: ChainReadMethod::BlockTimestamp,
+            args: vec![block_number.to_owned()],
+            block_mode: BlockReadMode::AtBlock(block_number.parse().expect("block number")),
+        },
+        value: ChainReadValue::Integer(timestamp.to_owned()),
+    }
+}

--- a/apps/indexer/tests/proposal_timestamp_backfill.rs
+++ b/apps/indexer/tests/proposal_timestamp_backfill.rs
@@ -33,6 +33,23 @@ fn test_plan_proposal_timestamp_backfill_keeps_failed_reads_retryable() {
 }
 
 #[test]
+fn test_plan_proposal_timestamp_backfill_marks_exact_timestamp_read_resolved() {
+    let updates = plan_proposal_timestamp_backfill_updates(
+        &[blocknumber_candidate()],
+        &ChainReadExecutionReport {
+            results: vec![block_timestamp_result("16978023", "1680633647000")],
+            ..ChainReadExecutionReport::default()
+        },
+    );
+
+    assert_eq!(updates.len(), 1);
+    assert_eq!(
+        updates[0].vote_end_timestamp.as_deref(),
+        Some("1680633647000")
+    );
+}
+
+#[test]
 fn test_plan_proposal_timestamp_backfill_ignores_timestamp_clock_proposals() {
     let mut candidate = blocknumber_candidate();
     candidate.clock_mode = "timestamp".to_owned();


### PR DESCRIPTION
## Summary

- Add a bounded proposal timestamp backfill tick after indexer chunk commit.
- Select blocknumber proposals whose stored vote timestamps still match fallback estimates and whose vote blocks are within processed height.
- Refresh successful block timestamp reads through the existing ChainTool/RPC path and update proposal plus proposal_state_epoch timestamp fields.
- Keep failed reads non-blocking and retryable on later ticks.

## Configuration

- `DEGOV_INDEXER_PROPOSAL_TIMESTAMP_BACKFILL_ENABLED` defaults to `true`.
- `DEGOV_INDEXER_PROPOSAL_TIMESTAMP_BACKFILL_BATCH_SIZE` defaults to `100`.

## Verification

- `cargo check --locked -p degov-datalens-indexer`
- `cargo test --locked -p degov-datalens-indexer --test proposal_projection`
- `cargo test --locked -p degov-datalens-indexer --test proposal_timestamp_backfill`
- `cargo test --locked -p degov-datalens-indexer --test indexer_runner test_runner_backfills_proposal_timestamp_after_chunk_commit`
- `cargo test --locked -p degov-datalens-indexer --test native_runner_integration`

Attempted requested combined DB-backed run:

- `cargo test --locked -p degov-datalens-indexer --test proposal_projection --test postgres_runtime_run --test native_runner_integration`

`native_runner_integration` passed in that run, but `postgres_runtime_run` is blocked locally because `DEGOV_INDEXER_TEST_DATABASE_URL` is not set.
