### PR TITLE
fix(indexer): recompute effective delegate counts

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -2237,21 +2237,11 @@ async fn reconcile_current_delegate_relation_power_from_balance(
                 WHERE delegate.is_current = TRUE
                 ORDER BY delegate.contract_set_id, delegate.id
              ),
-             effective_deltas AS (
-                SELECT
+             affected_delegates AS (
+                SELECT DISTINCT
                     contract_set_id,
-                    to_delegate,
-                    SUM(
-                        CASE
-                            WHEN previous_power = 0::NUMERIC(78, 0)
-                             AND new_power <> 0::NUMERIC(78, 0) THEN 1
-                            WHEN previous_power <> 0::NUMERIC(78, 0)
-                             AND new_power = 0::NUMERIC(78, 0) THEN -1
-                            ELSE 0
-                        END
-                    )::INT AS delta
+                    to_delegate
                 FROM current_edges
-                GROUP BY contract_set_id, to_delegate
              ),
              updated_delegates AS (
                 UPDATE delegate
@@ -2273,16 +2263,30 @@ async fn reconcile_current_delegate_relation_power_from_balance(
                   AND delegate_mapping.power IS DISTINCT FROM current_edges.new_power
                 RETURNING delegate_mapping.id
              ),
+             effective_counts AS (
+                SELECT
+                    affected_delegates.contract_set_id,
+                    affected_delegates.to_delegate,
+                    COUNT(delegate_mapping.id) FILTER (
+                        WHERE COALESCE(current_edges.new_power, delegate_mapping.power) > 0
+                    )::INT AS positive_count
+                FROM affected_delegates
+                LEFT JOIN delegate_mapping
+                  ON delegate_mapping.contract_set_id = affected_delegates.contract_set_id
+                 AND delegate_mapping.\"to\" = affected_delegates.to_delegate
+                LEFT JOIN current_edges
+                  ON current_edges.contract_set_id = delegate_mapping.contract_set_id
+                 AND current_edges.from_delegate = delegate_mapping.\"from\"
+                 AND current_edges.to_delegate = delegate_mapping.\"to\"
+                GROUP BY affected_delegates.contract_set_id, affected_delegates.to_delegate
+             ),
              updated_effective_counts AS (
                 UPDATE contributor
-                SET delegates_count_effective = GREATEST(
-                    0,
-                    contributor.delegates_count_effective + effective_deltas.delta
-                )
-                FROM effective_deltas
-                WHERE contributor.contract_set_id = effective_deltas.contract_set_id
-                  AND contributor.id = effective_deltas.to_delegate
-                  AND effective_deltas.delta <> 0
+                SET delegates_count_effective = effective_counts.positive_count
+                FROM effective_counts
+                WHERE contributor.contract_set_id = effective_counts.contract_set_id
+                  AND contributor.id = effective_counts.to_delegate
+                  AND contributor.delegates_count_effective IS DISTINCT FROM effective_counts.positive_count
                 RETURNING contributor.id
              )
              SELECT

--- a/apps/indexer/src/store/postgres/data_metric.rs
+++ b/apps/indexer/src/store/postgres/data_metric.rs
@@ -93,13 +93,14 @@ async fn write_data_metric_timeline(
     let snapshot_flush_duration = snapshot_flush_started_at.elapsed();
 
     let mapping_flush_started_at = std::time::Instant::now();
-    delegate_mapping_cache.flush(transaction).await?;
+    let effective_count_delegates = delegate_mapping_cache.flush(transaction).await?;
     let mapping_flush_duration = mapping_flush_started_at.elapsed();
 
     let contributor_count_flush_started_at = std::time::Instant::now();
     contributor_ensure_cache
         .flush_contributor_count_deltas(transaction)
         .await?;
+    recompute_delegate_count_effective(transaction, &effective_count_delegates).await?;
     let contributor_count_flush_duration = contributor_count_flush_started_at.elapsed();
 
     let contributor_count_metric_flush_started_at = std::time::Instant::now();

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -1573,6 +1573,7 @@ struct DelegateMappingPreloadCandidate {
 struct DelegateMappingCache {
     mappings: HashMap<(String, String), Option<DelegateMappingSnapshot>>,
     dirty: std::collections::BTreeMap<(String, String), DelegateMappingDirty>,
+    effective_count_delegates: HashMap<(String, String), TokenEventCommon>,
 }
 
 #[derive(Clone, Debug)]
@@ -1620,6 +1621,12 @@ impl DelegateMappingCache {
         snapshot: Option<DelegateMappingSnapshot>,
     ) {
         let key = self.key(common, from);
+        if let Some(Some(previous)) = self.mappings.get(&key).cloned() {
+            self.stage_effective_count_delegate(&previous.common, &previous.to);
+        }
+        if let Some(snapshot) = &snapshot {
+            self.stage_effective_count_delegate(&snapshot.common, &snapshot.to);
+        }
         self.mappings.insert(key.clone(), snapshot.clone());
         match snapshot {
             Some(snapshot) => {
@@ -1639,6 +1646,7 @@ impl DelegateMappingCache {
         snapshot: DelegateMappingSnapshot,
     ) {
         let key = self.key(common, from);
+        self.stage_effective_count_delegate(&snapshot.common, &snapshot.to);
         self.mappings.insert(key.clone(), Some(snapshot.clone()));
         match self.dirty.get_mut(&key) {
             Some(DelegateMappingDirty::Relation(previous)) => {
@@ -1652,8 +1660,18 @@ impl DelegateMappingCache {
 
     fn stage_delete(&mut self, common: &TokenEventCommon, from: &str) {
         let key = self.key(common, from);
+        if let Some(Some(previous)) = self.mappings.get(&key).cloned() {
+            self.stage_effective_count_delegate(&previous.common, &previous.to);
+        }
         self.mappings.insert(key.clone(), None);
         self.dirty.insert(key, DelegateMappingDirty::Delete);
+    }
+
+    fn stage_effective_count_delegate(&mut self, common: &TokenEventCommon, to_delegate: &str) {
+        self.effective_count_delegates.insert(
+            (common.contract_set_id.clone(), contributor_ref(to_delegate)),
+            common.clone(),
+        );
     }
 
     fn key(&self, common: &TokenEventCommon, from: &str) -> (String, String) {
@@ -1726,10 +1744,13 @@ impl DelegateMappingCache {
     async fn flush(
         &mut self,
         transaction: &mut Transaction<'_, Postgres>,
-    ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    ) -> Result<Vec<(String, String)>, PostgresIndexerRunnerStoreError> {
         let dirty = std::mem::take(&mut self.dirty);
+        let effective_count_delegates = std::mem::take(&mut self.effective_count_delegates)
+            .into_keys()
+            .collect::<Vec<_>>();
         if dirty.is_empty() {
-            return Ok(());
+            return Ok(effective_count_delegates);
         }
 
         let mut deletes = Vec::new();
@@ -1850,8 +1871,54 @@ impl DelegateMappingCache {
             query.build().execute(&mut **transaction).await?;
         }
 
-        Ok(())
+        Ok(effective_count_delegates)
     }
+}
+
+async fn recompute_delegate_count_effective(
+    transaction: &mut Transaction<'_, Postgres>,
+    delegates: &[(String, String)],
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    if delegates.is_empty() {
+        return Ok(());
+    }
+
+    for rows in delegates.chunks(token_event_bulk_chunk_size()) {
+        let mut query = QueryBuilder::<Postgres>::new(
+            "UPDATE contributor
+             SET delegates_count_effective = counts.positive_count
+             FROM (
+                SELECT affected.contract_set_id,
+                       affected.id,
+                       COUNT(delegate_mapping.id) FILTER (WHERE delegate_mapping.power > 0)::INT AS positive_count
+                FROM (VALUES ",
+        );
+        for (index, (contract_set_id, id)) in rows.iter().enumerate() {
+            if index > 0 {
+                query.push(", ");
+            }
+            query
+                .push("(")
+                .push_bind(contract_set_id)
+                .push(", ")
+                .push_bind(id)
+                .push(")");
+        }
+        query.push(
+            r#") AS affected(contract_set_id, id)
+                LEFT JOIN delegate_mapping
+                  ON delegate_mapping.contract_set_id = affected.contract_set_id
+                 AND delegate_mapping."to" = affected.id
+                GROUP BY affected.contract_set_id, affected.id
+             ) AS counts
+             WHERE contributor.contract_set_id = counts.contract_set_id
+               AND contributor.id = counts.id
+               AND contributor.delegates_count_effective IS DISTINCT FROM counts.positive_count"#,
+        );
+        query.build().execute(&mut **transaction).await?;
+    }
+
+    Ok(())
 }
 
 #[derive(Clone, Debug)]

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -579,6 +579,88 @@ async fn test_onchain_refresh_worker_reconciles_current_delegate_relation_power_
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_recomputes_effective_delegate_count_for_positive_power_refresh()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_contributor(&database.pool, ACCOUNT_ONE, "3", Some("4")).await?;
+    seed_contributor(&database.pool, ACCOUNT_TWO, "0", Some("0")).await?;
+    set_contributor_delegate_counts(&database.pool, ACCOUNT_TWO, 2, 1).await?;
+    seed_data_metric(&database.pool, "3").await?;
+    seed_final_delegate_with_scope(
+        &database.pool,
+        "demo-dao",
+        "demo-dao",
+        46,
+        ACCOUNT_ONE,
+        ACCOUNT_TWO,
+        "64",
+    )
+    .await?;
+    seed_final_delegate_with_scope(
+        &database.pool,
+        "demo-dao",
+        "demo-dao",
+        46,
+        ACCOUNT_THREE,
+        ACCOUNT_TWO,
+        "5",
+    )
+    .await?;
+    seed_final_delegate_mapping(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "64").await?;
+    seed_final_delegate_mapping(&database.pool, ACCOUNT_THREE, ACCOUNT_TWO, "5").await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        true,
+        true,
+    )
+    .await?;
+
+    let reader = MockOnchainRefreshReader::new([(
+        "task-one",
+        OnchainRefreshReadValue {
+            task_id: "task-one".to_owned(),
+            balance: Some("32".to_owned()),
+            power: Some("0".to_owned()),
+        },
+    )]);
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker.run_once().await?;
+
+    if report.failed > 0 {
+        panic!(
+            "task failed: {:?}",
+            task_error(&database.pool, "task-one").await?
+        );
+    }
+    assert_eq!(report.completed, 1, "{report:?}");
+    assert_final_delegate(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "32").await?;
+    assert_final_delegate_mapping(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "32").await?;
+    assert_contributor_delegate_counts(&database.pool, ACCOUNT_TWO, 2, 2).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_zeros_current_delegate_relation_power_from_zero_balance()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -2686,3 +2768,4 @@ const SCOPE_ONE: &str = "scope:timelock-a:erc20:dataset-a";
 const SCOPE_TWO: &str = "scope:timelock-b:erc721:dataset-b";
 const ACCOUNT_ONE: &str = "0x0000000000000000000000000000000000000001";
 const ACCOUNT_TWO: &str = "0x0000000000000000000000000000000000000002";
+const ACCOUNT_THREE: &str = "0x0000000000000000000000000000000000000003";

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -1319,6 +1319,110 @@ async fn test_postgres_token_delegate_mapping_bulk_power_only_update_preserves_r
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_power_update_recomputes_effective_delegate_count()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let initial = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000001-delegate", 1, 0, 1),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: DELEGATOR.to_owned(),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: DELEGATE.to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000002-second-delegate", 1, 0, 2),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: RECEIVER.to_owned(),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: DELEGATE.to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000003-transfer", 2, 0, 1),
+                event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                    from: ZERO_ADDRESS.to_owned(),
+                    to: DELEGATOR.to_owned(),
+                    value: "40".to_owned(),
+                    standard: GovernanceTokenStandard::Erc20,
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("0000000004-second-transfer", 2, 0, 2),
+                event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                    from: ZERO_ADDRESS.to_owned(),
+                    to: RECEIVER.to_owned(),
+                    value: "60".to_owned(),
+                    standard: GovernanceTokenStandard::Erc20,
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("initial token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(initial),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    sqlx::query(
+        "UPDATE contributor
+         SET delegates_count_effective = 1
+         WHERE contract_set_id = $1 AND id = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .execute(&database.pool)
+    .await?;
+
+    let update = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("0000000005-transfer", 3, 0, 1),
+            event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                from: ZERO_ADDRESS.to_owned(),
+                to: DELEGATOR.to_owned(),
+                value: "10".to_owned(),
+                standard: GovernanceTokenStandard::Erc20,
+            }),
+        }],
+    )
+    .map_err(|error| format!("update token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(update),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let delegate_counts = sqlx::query(
+        "SELECT delegates_count_all, delegates_count_effective
+         FROM contributor
+         WHERE contract_set_id = $1 AND id = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(delegate_counts.get::<i32, _>("delegates_count_all"), 2);
+    assert_eq!(
+        delegate_counts.get::<i32, _>("delegates_count_effective"),
+        2
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_token_repeated_delegate_ensure_keeps_contributor_count_once()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;


### PR DESCRIPTION
## Summary
- recompute `contributor.delegates_count_effective` for bounded affected delegates after delegate mapping writes
- update onchain refresh to derive effective counts from final delegate mapping power instead of accumulated deltas
- add regression coverage for event-store and onchain refresh drift cases

## Root cause
Delta-based updates could preserve existing drift when a mapping changed positive-to-positive, or when refresh ordering made the final `delegate_mapping.power` the only reliable source of truth.

## Validation
- `cargo test -p degov-datalens-indexer --test onchain_refresh_worker test_onchain_refresh_worker_recomputes_effective_delegate_count_for_positive_power_refresh -- --exact`
- `cargo test -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token_power_update_recomputes_effective_delegate_count -- --exact`
- `cargo test -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token_delegate_mapping -- --nocapture`
- `cargo test -p degov-datalens-indexer --test onchain_refresh_worker test_onchain_refresh_worker_reconciles_current_delegate_relation_power_from_balance -- --exact`
- `cargo test -p degov-datalens-indexer --test onchain_refresh_worker test_onchain_refresh_worker_zeros_current_delegate_relation_power_from_zero_balance -- --exact`
- `cargo test -p degov-datalens-indexer test_delegate_mapping_cache -- --nocapture`
