### PR TITLE
Fix ENS effective delegate count recompute

### DIFF
--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -1611,6 +1611,9 @@ impl DelegateMappingCache {
         if self.dirty.contains_key(&key) {
             return;
         }
+        if let Some(snapshot) = &snapshot {
+            self.stage_effective_count_delegate(&snapshot.common, &snapshot.to);
+        }
         self.mappings.insert(key, snapshot);
     }
 
@@ -3076,6 +3079,28 @@ mod token_store_tests {
                 .map(|mapping| (mapping.to, mapping.power)),
             Some(("0xstaged".to_owned(), "77".to_owned()))
         );
+    }
+
+    #[test]
+    fn test_delegate_mapping_cache_preloaded_hit_stages_effective_count_recompute() {
+        let common = token_common("scope", "0xtx1", 10, 5);
+        let mut cache = DelegateMappingCache::default();
+
+        cache.set_preloaded(
+            &common,
+            "0xhit",
+            Some(DelegateMappingSnapshot {
+                common: common.clone(),
+                from: "0xhit".to_owned(),
+                to: "0xdelegate".to_owned(),
+                power: "0".to_owned(),
+            }),
+        );
+
+        assert!(cache.effective_count_delegates.contains_key(&(
+            common.contract_set_id.clone(),
+            contributor_ref("0xdelegate"),
+        )));
     }
 
     #[test]

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -1423,6 +1423,81 @@ async fn test_postgres_token_power_update_recomputes_effective_delegate_count()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_noop_delegate_change_recomputes_stale_effective_count()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let initial = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("0000000001-delegate", 1, 0, 1),
+            event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: DELEGATOR.to_owned(),
+                from_delegate: ZERO_ADDRESS.to_owned(),
+                to_delegate: DELEGATE.to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("initial token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(initial),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    sqlx::query(
+        "UPDATE contributor
+         SET delegates_count_effective = 1
+         WHERE contract_set_id = $1 AND id = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .execute(&database.pool)
+    .await?;
+
+    let noop_delegate_change = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("0000000002-noop-delegate", 2, 0, 1),
+            event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: DELEGATOR.to_owned(),
+                from_delegate: DELEGATE.to_owned(),
+                to_delegate: DELEGATE.to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("noop token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(noop_delegate_change),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let delegate_counts = sqlx::query(
+        "SELECT delegates_count_all, delegates_count_effective
+         FROM contributor
+         WHERE contract_set_id = $1 AND id = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(delegate_counts.get::<i32, _>("delegates_count_all"), 1);
+    assert_eq!(
+        delegate_counts.get::<i32, _>("delegates_count_effective"),
+        0
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_token_repeated_delegate_ensure_keeps_contributor_count_once()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;


### PR DESCRIPTION
## Summary
- stage effective delegate-count recomputes when existing delegate mappings are preloaded
- add a Postgres runtime regression for stale-high effective counts after a no-op delegate change
- add a cache unit test covering preloaded mapping hits

## Root cause
Existing delegate mappings loaded by `DelegateMappingCache::set_preloaded` were cached but did not add their `to` contributor to the recompute set. If a subsequent operation used that preloaded mapping and exited without a dirty mapping write, stale `contributor.delegates_count_effective` values could remain high even though the authoritative `delegate_mapping.power > 0` count was lower.

## Verification
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer test_delegate_mapping_cache -- --nocapture`
- `cargo test -p degov-datalens-indexer --test token_projection -- --nocapture`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgres://postgres:password@localhost:5432/postgres cargo test -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token -- --nocapture`