### PR TITLE
Add playground governor deployment script

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -1,7 +1,11 @@
 .PHONY: all fmt clean test
 .PHONY: tools foundry sync
+.PHONY: deploy dry-run deploy-playground dry-run-playground deploy-playground-skip-simulation
 
 -include .env
+
+chain-id ?= 46
+rpc-url ?= darwinia
 
 all    :; @forge build
 fmt    :; @forge fmt
@@ -9,6 +13,9 @@ clean  :; @forge clean
 test   :; @forge test
 deploy :; @forge script script/Deploy.s.sol:Deploy --chain ${chain-id} --broadcast --verify --verifier blockscout --legacy
 dry-run:; @forge script script/Deploy.s.sol:Deploy --chain ${chain-id}
+deploy-playground :; @forge script script/Playground.s.sol:DeployPlayground --chain ${chain-id} --rpc-url ${rpc-url} --broadcast --verify --verifier blockscout --legacy
+dry-run-playground:; @forge script script/Playground.s.sol:DeployPlayground --chain ${chain-id} --rpc-url ${rpc-url} --skip-simulation
+deploy-playground-skip-simulation :; @forge script script/Playground.s.sol:DeployPlayground --chain ${chain-id} --rpc-url ${rpc-url} --broadcast --skip-simulation --verify --verifier blockscout --legacy
 
 sync   :; @git submodule update --recursive
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -14,9 +14,7 @@ extra_output_files = ["metadata"]
 eth_rpc_url  = "https://erpc.ringdao.com/main/evm/46"
 
 [rpc_endpoints]
-crab = "https://crab-rpc.darwinia.network"
 darwinia = "https://rpc.darwinia.network"
 
 [etherscan]
-crab = { key = "xxx", url = "https://crab-scan.darwinia.network/api", chain = 44 }
 darwinia = { key = "xxx", url = "https://explorer.darwinia.network/api", chain = 46 }

--- a/contracts/script/Playground.s.sol
+++ b/contracts/script/Playground.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// File overview: Deploy the playground Timelock and DGovernor around the existing Darwinia governance token.
+pragma solidity ^0.8.0;
+
+import {Script} from "forge-std/Script.sol";
+import {safeconsole} from "forge-std/safeconsole.sol";
+import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import {DGovernor} from "../src/DGovernor.sol";
+import {Timelock} from "../src/Timelock.sol";
+
+contract DeployPlayground is Script {
+    uint256 internal constant DARWINIA_CHAIN_ID = 46;
+    address internal constant DEFAULT_DEPLOYER = 0x0f14341A7f464320319025540E8Fe48Ad0fe5aec;
+    address internal constant GTP = 0xbC9f58566810F7e853e1eef1b9957ac82F9971df;
+    uint256 internal constant MIN_DELAY = 3 minutes;
+
+    function run() public {
+        require(block.chainid == DARWINIA_CHAIN_ID, "playground deploy must run on Darwinia");
+        require(GTP.code.length > 0, "playground GTP has no code");
+        IERC6372(GTP).clock();
+
+        address deployer = vm.envOr("PLAYGROUND_DEPLOYER", DEFAULT_DEPLOYER);
+
+        safeconsole.log("Chain Id: ", block.chainid);
+        safeconsole.log("deployer: ", deployer);
+        safeconsole.log("gtp: ", GTP);
+
+        vm.startBroadcast(deployer);
+
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        Timelock timelock = new Timelock(MIN_DELAY, proposers, executors, deployer);
+        safeconsole.log("timelock: ", address(timelock));
+
+        DGovernor governor = new DGovernor(IVotes(GTP), timelock);
+        safeconsole.log("dgov: ", address(governor));
+
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(governor));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(governor));
+        timelock.grantRole(timelock.DEFAULT_ADMIN_ROLE(), address(governor));
+        timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), deployer);
+
+        require(timelock.hasRole(timelock.PROPOSER_ROLE(), address(governor)), "governor missing proposer role");
+        require(timelock.hasRole(timelock.CANCELLER_ROLE(), address(governor)), "governor missing canceller role");
+        require(timelock.hasRole(timelock.EXECUTOR_ROLE(), address(governor)), "governor missing executor role");
+        require(timelock.hasRole(timelock.DEFAULT_ADMIN_ROLE(), address(governor)), "governor missing admin role");
+        require(!timelock.hasRole(timelock.DEFAULT_ADMIN_ROLE(), deployer), "deployer still has admin role");
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/script/Playground.s.sol
+++ b/contracts/script/Playground.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// File overview: Deploy the playground Timelock and DGovernor around the existing Darwinia governance token.
+// File overview: Deploy the playground Timelock and DGovernor around the existing Darwinia GTK token.
 pragma solidity ^0.8.0;
 
 import {Script} from "forge-std/Script.sol";
@@ -12,19 +12,19 @@ import {Timelock} from "../src/Timelock.sol";
 contract DeployPlayground is Script {
     uint256 internal constant DARWINIA_CHAIN_ID = 46;
     address internal constant DEFAULT_DEPLOYER = 0x0f14341A7f464320319025540E8Fe48Ad0fe5aec;
-    address internal constant GTP = 0xbC9f58566810F7e853e1eef1b9957ac82F9971df;
+    address internal constant GTK = 0xbC9f58566810F7e853e1eef1b9957ac82F9971df;
     uint256 internal constant MIN_DELAY = 3 minutes;
 
     function run() public {
         require(block.chainid == DARWINIA_CHAIN_ID, "playground deploy must run on Darwinia");
-        require(GTP.code.length > 0, "playground GTP has no code");
-        IERC6372(GTP).clock();
+        require(GTK.code.length > 0, "playground GTK has no code");
+        IERC6372(GTK).clock();
 
         address deployer = vm.envOr("PLAYGROUND_DEPLOYER", DEFAULT_DEPLOYER);
 
         safeconsole.log("Chain Id: ", block.chainid);
         safeconsole.log("deployer: ", deployer);
-        safeconsole.log("gtp: ", GTP);
+        safeconsole.log("gtk: ", GTK);
 
         vm.startBroadcast(deployer);
 
@@ -33,7 +33,7 @@ contract DeployPlayground is Script {
         Timelock timelock = new Timelock(MIN_DELAY, proposers, executors, deployer);
         safeconsole.log("timelock: ", address(timelock));
 
-        DGovernor governor = new DGovernor(IVotes(GTP), timelock);
+        DGovernor governor = new DGovernor(IVotes(GTK), timelock);
         safeconsole.log("dgov: ", address(governor));
 
         timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));


### PR DESCRIPTION
## Summary
- add a dedicated Foundry script for deploying the playground Timelock and DGovernor around the existing GTK token on Darwinia
- add Makefile targets for playground dry-runs and deployment
- add chain/token sanity checks and hand over Timelock roles to the deployed governor

## Verification
- forge fmt
- forge build
- make dry-run-playground
- git diff --check

Note: forge test currently reports no tests found in contracts.