### PR TITLE
fix(indexer): include migrations in docker build

### DIFF
--- a/docker/indexer.Dockerfile
+++ b/docker/indexer.Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY apps/indexer/Cargo.toml apps/indexer/Cargo.toml
 COPY apps/indexer/src apps/indexer/src
-COPY apps/indexer/schema apps/indexer/schema
+COPY apps/indexer/migrations apps/indexer/migrations
 
 RUN cargo build -p degov-datalens-indexer --locked --release
 


### PR DESCRIPTION
## Summary
- Update the indexer Dockerfile to copy apps/indexer/migrations instead of the removed apps/indexer/schema directory.
- Fixes the release image build for the Datalens-native indexer.

## Test
- cargo build -p degov-datalens-indexer --locked