### PR TITLE
ci(release): build amd64 images only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           file: docker/${{ matrix.image }}.Dockerfile
           tags: ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}/${{ matrix.image }}:sha-${{ env.SHA }}


### PR DESCRIPTION
## Summary
- Temporarily build release images for linux/amd64 only.
- Avoids blocking the staging indexer deployment on slow multi-arch arm64 builds.

## Test
- Not run; workflow-only change.