### PR TITLE
perf(indexer): add hot-path database indexes

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -909,6 +909,8 @@ CREATE TABLE IF NOT EXISTS contributor (
 
 CREATE INDEX IF NOT EXISTS contributor_lookup_idx
   ON contributor (chain_id, contract_set_id, governor_address, id);
+CREATE INDEX IF NOT EXISTS contributor_data_metric_scope_idx
+  ON contributor (contract_set_id, chain_id, governor_address, dao_code) INCLUDE (power, balance);
 
 CREATE TABLE IF NOT EXISTS delegate_mapping (
   id TEXT NOT NULL,

--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -931,6 +931,8 @@ CREATE TABLE IF NOT EXISTS delegate_mapping (
 
 CREATE INDEX IF NOT EXISTS delegate_mapping_lookup_idx
   ON delegate_mapping (chain_id, contract_set_id, governor_address, "from");
+CREATE INDEX IF NOT EXISTS delegate_mapping_to_lookup_idx
+  ON delegate_mapping (contract_set_id, "to") INCLUDE (id, power);
 
 CREATE TABLE IF NOT EXISTS degov_provisional_segment (
   id TEXT PRIMARY KEY,

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -70,5 +70,13 @@ async fn ensure_runtime_indexes(pool: &PgPool) -> Result<()> {
     .await
     .context("ensure delegate rolling metadata preload index")?;
 
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_to_lookup_idx
+         ON delegate_mapping (contract_set_id, \"to\") INCLUDE (id, power)",
+    )
+    .execute(pool)
+    .await
+    .context("ensure delegate mapping target lookup index")?;
+
     Ok(())
 }

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -78,5 +78,14 @@ async fn ensure_runtime_indexes(pool: &PgPool) -> Result<()> {
     .await
     .context("ensure delegate mapping target lookup index")?;
 
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_data_metric_scope_idx
+         ON contributor (contract_set_id, chain_id, governor_address, dao_code)
+         INCLUDE (power, balance)",
+    )
+    .execute(pool)
+    .await
+    .context("ensure contributor data metric scope index")?;
+
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -145,6 +145,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
         "delegate_rolling_metadata_preload_idx",
     )
     .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "delegate_mapping_to_lookup_idx",
+    )
+    .await?;
     assert_removed_processor_status_table_absent(&database.pool).await?;
     assert_table_exists(&database.pool, &database.schema, "_sqlx_migrations").await?;
 
@@ -293,6 +299,15 @@ fn test_fresh_init_declares_onchain_refresh_ready_claim_index() {
     assert!(init_migration.contains("onchain_refresh_task_ready_claim_idx"));
     assert!(init_migration.contains("ON onchain_refresh_task (next_run_at, updated_at, id)"));
     assert!(init_migration.contains("WHERE status IN ('pending', 'failed')"));
+}
+
+#[test]
+fn test_fresh_init_declares_delegate_mapping_target_lookup_index() {
+    let init_migration = include_str!("../migrations/0001_init.sql");
+
+    assert!(init_migration.contains("delegate_mapping_to_lookup_idx"));
+    assert!(init_migration.contains("ON delegate_mapping (contract_set_id, \"to\")"));
+    assert!(init_migration.contains("INCLUDE (id, power)"));
 }
 
 async fn assert_table_exists(

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -151,6 +151,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
         "delegate_mapping_to_lookup_idx",
     )
     .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "contributor_data_metric_scope_idx",
+    )
+    .await?;
     assert_removed_processor_status_table_absent(&database.pool).await?;
     assert_table_exists(&database.pool, &database.schema, "_sqlx_migrations").await?;
 
@@ -290,6 +296,18 @@ fn test_fresh_init_declares_split_data_metric_counts() {
             "expected data_metric count column {column_name}"
         );
     }
+}
+
+#[test]
+fn test_fresh_init_declares_contributor_data_metric_scope_index() {
+    let init_migration = include_str!("../migrations/0001_init.sql");
+
+    assert!(init_migration.contains("contributor_data_metric_scope_idx"));
+    assert!(
+        init_migration
+            .contains("ON contributor (contract_set_id, chain_id, governor_address, dao_code)")
+    );
+    assert!(init_migration.contains("INCLUDE (power, balance)"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `delegate_mapping_to_lookup_idx` on `(contract_set_id, "to") INCLUDE (id, power)` for inbound delegation count queries.
- Add `contributor_data_metric_scope_idx` on contributor metric scope with `power`/`balance` included for aggregate refreshes.
- Ensure existing databases receive both indexes through runtime migration with `CREATE INDEX CONCURRENTLY IF NOT EXISTS`.
- Add migration schema coverage for both indexes.

## Why
Staging indexer logs showed multiple DB hot-path slow statements:
- onchain refresh / delegate effective-count work joining `delegate_mapping` by `contract_set_id` + `"to"` without a target-direction index.
- `INSERT INTO data_metric ... SELECT sum/count FROM contributor ...` taking several seconds while filtering contributor rows by metric scope.

Both issues are indexer-side database access problems and can be addressed without changing Datalens.

## Verification
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --locked --test migration_schema fresh_init_declares`
- `cargo test -p degov-datalens-indexer --locked --lib`

`cargo test -p degov-datalens-indexer --locked --test migration_schema` was also attempted; the DB-backed cases require `DEGOV_INDEXER_TEST_DATABASE_URL` in this environment.