### PR TITLE
perf(indexer): skip hot path refresh backlog counts

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -446,7 +446,7 @@ where
         &self,
         batch_size: usize,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(batch_size, None)
+        self.run_once_with_batch_size_and_scope(batch_size, None, true)
             .await
     }
 
@@ -455,7 +455,16 @@ where
         batch_size: usize,
         scope: &OnchainRefreshTaskScope,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(batch_size, Some(scope))
+        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), true)
+            .await
+    }
+
+    pub async fn run_once_with_batch_size_for_scope_without_backlog(
+        &self,
+        batch_size: usize,
+        scope: &OnchainRefreshTaskScope,
+    ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
+        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), false)
             .await
     }
 
@@ -463,6 +472,7 @@ where
         &self,
         batch_size: usize,
         scope: Option<&OnchainRefreshTaskScope>,
+        include_backlog: bool,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
         let started_at = Instant::now();
         let now_ms = unix_time_millis();
@@ -589,10 +599,12 @@ where
         }
 
         report.duration_ms = started_at.elapsed().as_millis();
-        report.backlog = match scope {
-            Some(scope) => self.ready_backlog_for_scope(scope).await.ok(),
-            None => self.ready_backlog().await.ok(),
-        };
+        if include_backlog {
+            report.backlog = match scope {
+                Some(scope) => self.ready_backlog_for_scope(scope).await.ok(),
+                None => self.ready_backlog().await.ok(),
+            };
+        }
 
         log::info!(
             "onchain refresh batch completed dao_code={} chain_id={} contract_set_id={} claimed={} completed={} failed={} skipped_tasks={} rpc_error_failures={} validation_failures={} db_update_failures={} unique_accounts={} rpc_reads_requested={} rpc_reads_deduped={} cache_hits={} debounced_tasks={} data_metric_refreshes={} apply_chunks={} apply_batch_size={} duration_ms={} backlog={}",

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -936,14 +936,12 @@ where
     ) -> std::result::Result<crate::OnchainRefreshRunReport, Self::Error> {
         self.handle.block_on(
             self.worker
-                .run_once_with_batch_size_for_scope(max_tasks, &self.scope),
+                .run_once_with_batch_size_for_scope_without_backlog(max_tasks, &self.scope),
         )
     }
 
     fn backlog(&mut self) -> Option<u64> {
-        self.handle
-            .block_on(self.worker.ready_backlog_for_scope(&self.scope))
-            .ok()
+        None
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a scoped onchain refresh worker path that skips exact backlog counting.
- Use that path for indexer chunk-triggered onchain refresh ticks.
- Keep `ready_backlog()` and the ordinary worker `run_once()` behavior available for explicit worker/reporting use.

## Why
Staging logs showed slow `SELECT count(*) FROM onchain_refresh_task ...` statements during indexer chunk processing. The count is diagnostic/logging data, but it runs on the sync hot path against a large, high-churn task table. This avoids spending chunk time on exact backlog counts while preserving explicit backlog APIs.

## Verification
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --locked --lib`