### PR TITLE
perf(indexer): index contributor metric aggregates

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -909,6 +909,8 @@ CREATE TABLE IF NOT EXISTS contributor (
 
 CREATE INDEX IF NOT EXISTS contributor_lookup_idx
   ON contributor (chain_id, contract_set_id, governor_address, id);
+CREATE INDEX IF NOT EXISTS contributor_data_metric_scope_idx
+  ON contributor (contract_set_id, chain_id, governor_address, dao_code) INCLUDE (power, balance);
 
 CREATE TABLE IF NOT EXISTS delegate_mapping (
   id TEXT NOT NULL,

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -70,5 +70,14 @@ async fn ensure_runtime_indexes(pool: &PgPool) -> Result<()> {
     .await
     .context("ensure delegate rolling metadata preload index")?;
 
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_data_metric_scope_idx
+         ON contributor (contract_set_id, chain_id, governor_address, dao_code)
+         INCLUDE (power, balance)",
+    )
+    .execute(pool)
+    .await
+    .context("ensure contributor data metric scope index")?;
+
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -145,6 +145,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
         "delegate_rolling_metadata_preload_idx",
     )
     .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "contributor_data_metric_scope_idx",
+    )
+    .await?;
     assert_removed_processor_status_table_absent(&database.pool).await?;
     assert_table_exists(&database.pool, &database.schema, "_sqlx_migrations").await?;
 
@@ -284,6 +290,18 @@ fn test_fresh_init_declares_split_data_metric_counts() {
             "expected data_metric count column {column_name}"
         );
     }
+}
+
+#[test]
+fn test_fresh_init_declares_contributor_data_metric_scope_index() {
+    let init_migration = include_str!("../migrations/0001_init.sql");
+
+    assert!(init_migration.contains("contributor_data_metric_scope_idx"));
+    assert!(
+        init_migration
+            .contains("ON contributor (contract_set_id, chain_id, governor_address, dao_code)")
+    );
+    assert!(init_migration.contains("INCLUDE (power, balance)"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `contributor_data_metric_scope_idx` for `data_metric` aggregate refreshes.
- Ensure existing databases receive the index through runtime migration with `CREATE INDEX CONCURRENTLY IF NOT EXISTS`.
- Add migration schema coverage for the new index.

## Why
Staging logs showed slow `INSERT INTO data_metric ... SELECT sum/count FROM contributor ...` statements. That query filters by contributor scope and aggregates `power`/`balance`; the existing contributor lookup index does not cover `dao_code`, `power`, or `balance`, so metric refreshes can spend several seconds scanning contributor rows.

## Verification
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --locked test_fresh_init_declares_contributor_data_metric_scope_index`
- `cargo test -p degov-datalens-indexer --locked --lib`