### PR TITLE
perf(indexer): align datalens sdk worker cap

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -130,7 +130,12 @@ struct DatalensQueryConcurrencyGateState {
 const MAX_BLOCKING_SDK_WORKERS_PER_KEY: usize = 2;
 
 struct DatalensBlockingQueryGuard {
-    active_workers: Mutex<usize>,
+    state: Mutex<DatalensBlockingQueryGuardState>,
+}
+
+struct DatalensBlockingQueryGuardState {
+    active_workers: usize,
+    max_workers: usize,
 }
 
 struct DatalensBlockingQueryPermit {
@@ -140,26 +145,36 @@ struct DatalensBlockingQueryPermit {
 impl DatalensBlockingQueryGuard {
     fn new() -> Self {
         Self {
-            active_workers: Mutex::new(0),
+            state: Mutex::new(DatalensBlockingQueryGuardState {
+                active_workers: 0,
+                max_workers: MAX_BLOCKING_SDK_WORKERS_PER_KEY,
+            }),
         }
     }
 
     fn acquire(&self) -> Result<(), DatalensSdkError> {
-        let mut active_workers = self.active_workers.lock().map_err(|_| {
+        let mut state = self.state.lock().map_err(|_| {
             DatalensSdkError::Transport("Datalens blocking query guard lock poisoned".to_owned())
         })?;
-        if *active_workers >= MAX_BLOCKING_SDK_WORKERS_PER_KEY {
+        if state.active_workers >= state.max_workers {
             return Err(DatalensSdkError::Transport(format!(
-                "Datalens query timed out because {active_workers} previous SDK queries are still in flight"
+                "Datalens query timed out because {} previous SDK queries are still in flight",
+                state.active_workers
             )));
         }
-        *active_workers += 1;
+        state.active_workers += 1;
         Ok(())
     }
 
     fn release(&self) {
-        if let Ok(mut active_workers) = self.active_workers.lock() {
-            *active_workers = active_workers.saturating_sub(1);
+        if let Ok(mut state) = self.state.lock() {
+            state.active_workers = state.active_workers.saturating_sub(1);
+        }
+    }
+
+    fn set_max_workers(&self, max_workers: usize) {
+        if let Ok(mut state) = self.state.lock() {
+            state.max_workers = max_workers.max(1);
         }
     }
 }
@@ -293,6 +308,13 @@ impl DatalensQueryConcurrencyGate {
                         >= limit
                 })
     }
+
+    fn blocking_query_worker_limit(&self) -> Option<usize> {
+        self.inner
+            .config
+            .per_chain_max_in_flight
+            .or(self.inner.config.global_max_in_flight)
+    }
 }
 
 impl Drop for DatalensQueryConcurrencyPermit {
@@ -420,6 +442,9 @@ impl DatalensNativeClient {
     }
 
     pub fn with_query_concurrency_gate(mut self, gate: DatalensQueryConcurrencyGate) -> Self {
+        if let Some(max_workers) = gate.blocking_query_worker_limit() {
+            self.blocking_query_guard.set_max_workers(max_workers);
+        }
         self.query_gate = Some(gate);
         self
     }
@@ -538,18 +563,9 @@ impl DatalensNativeClient {
         F: FnOnce(DatalensClient) -> Result<QueryResponse, DatalensSdkError> + Send + 'static,
     {
         let started_at = Instant::now();
-        if let Err(error) = self.blocking_query_guard.acquire() {
-            self.warn_query_timeout(operation, &error);
-            return Err(error);
-        }
-        let blocking_query_permit = DatalensBlockingQueryPermit {
-            guard: self.blocking_query_guard.clone(),
-        };
-
         let permit = match self.acquire_query_concurrency_permit(operation) {
             Ok(DatalensQueryConcurrencyAcquire::Acquired(permit)) => permit,
             Ok(DatalensQueryConcurrencyAcquire::TimedOut) => {
-                drop(blocking_query_permit);
                 let error = datalens_query_timeout_error(
                     operation,
                     self.query_timeout,
@@ -559,12 +575,10 @@ impl DatalensNativeClient {
                 return Err(error);
             }
             Err(error) => {
-                drop(blocking_query_permit);
                 return Err(DatalensSdkError::Transport(error.to_string()));
             }
         };
         let Some(remaining_timeout) = self.query_timeout.checked_sub(started_at.elapsed()) else {
-            drop(blocking_query_permit);
             let error = datalens_query_timeout_error(
                 operation,
                 self.query_timeout,
@@ -572,6 +586,13 @@ impl DatalensNativeClient {
             );
             self.warn_query_timeout(operation, &error);
             return Err(error);
+        };
+        if let Err(error) = self.blocking_query_guard.acquire() {
+            self.warn_query_timeout(operation, &error);
+            return Err(error);
+        }
+        let blocking_query_permit = DatalensBlockingQueryPermit {
+            guard: self.blocking_query_guard.clone(),
         };
         let (sender, receiver) = mpsc::sync_channel(1);
         let client = self.client.clone();

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -458,6 +458,97 @@ fn test_datalens_log_query_caps_overlapping_stalled_sdk_queries() {
 }
 
 #[test]
+fn test_datalens_log_query_uses_configured_gate_for_overlapping_sdk_cap() {
+    let server = FakeQueryServer::start_concurrent(vec![
+        FakeQueryResponse::HoldOpen(Duration::from_millis(300)),
+        FakeQueryResponse::HoldOpen(Duration::from_millis(300)),
+        FakeQueryResponse::HoldOpen(Duration::from_millis(300)),
+    ]);
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(120);
+    let gate = DatalensQueryConcurrencyGate::new(DatalensQueryConcurrencyConfig {
+        global_max_in_flight: Some(4),
+        per_chain_max_in_flight: Some(4),
+    })
+    .expect("gate");
+    let mut first_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("first client")
+            .with_query_concurrency_gate(gate.clone());
+    let mut second_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("second client")
+            .with_query_concurrency_gate(gate.clone());
+    let mut third_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("third client")
+            .with_query_concurrency_gate(gate);
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+    let first_input = plans[0].input.clone();
+    let second_input = plans[0].input.clone();
+    let third_input = plans[0].input.clone();
+    let (started_sender, started_receiver) = mpsc::channel();
+
+    let first_handle = thread::spawn({
+        let started_sender = started_sender.clone();
+        move || {
+            started_sender.send(()).expect("send first start");
+            first_client
+                .query_logs(first_input)
+                .expect_err("first stalled query times out")
+        }
+    });
+    let second_handle = thread::spawn(move || {
+        started_sender.send(()).expect("send second start");
+        second_client
+            .query_logs(second_input)
+            .expect_err("second stalled query times out")
+    });
+    started_receiver
+        .recv_timeout(Duration::from_millis(100))
+        .expect("first query starts");
+    started_receiver
+        .recv_timeout(Duration::from_millis(100))
+        .expect("second query starts");
+    thread::sleep(Duration::from_millis(50));
+
+    let started_at = std::time::Instant::now();
+    let third_error = third_client
+        .query_logs(third_input)
+        .expect_err("third query times out through configured gate");
+
+    assert!(
+        started_at.elapsed() >= Duration::from_millis(100),
+        "third query should use the configured worker cap instead of failing immediately"
+    );
+    assert!(
+        !third_error
+            .to_string()
+            .contains("previous SDK queries are still in flight"),
+        "{third_error}"
+    );
+    let first_error = first_handle.join().expect("first query joins");
+    let second_error = second_handle.join().expect("second query joins");
+    assert_eq!(
+        classify_datalens_query_error(&first_error.to_string()),
+        DatalensQueryErrorClass::Transient,
+        "{first_error}"
+    );
+    assert_eq!(
+        classify_datalens_query_error(&second_error.to_string()),
+        DatalensQueryErrorClass::Transient,
+        "{second_error}"
+    );
+    assert_eq!(
+        classify_datalens_query_error(&third_error.to_string()),
+        DatalensQueryErrorClass::Transient,
+        "{third_error}"
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 3);
+}
+
+#[test]
 fn test_datalens_log_query_times_out_while_waiting_for_query_gate() {
     let mut config = datalens_config("http://127.0.0.1:9", DatalensFinality::DurableOnly);
     config.timeout = Duration::from_millis(50);


### PR DESCRIPTION
## Summary
- Make the blocking Datalens SDK worker guard honor the configured process-local query gate limit.
- Acquire the query concurrency permit before counting a request as an active blocking SDK worker.
- Add regression coverage for configured per-chain concurrency above the default stalled-worker cap.

## Why
Staging is configured with `DEGOV_INDEXER_DATALENS_QUERY_PER_CHAIN_MAX_IN_FLIGHT=4`, but the blocking SDK guard was still capped at 2 workers per Datalens key. The third overlapping request failed immediately with `previous SDK queries are still in flight`, causing retries and chunk splits instead of using the configured concurrency policy.

## Verification
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --locked --test datalens_client`
- `cargo test -p degov-datalens-indexer --locked --lib`