### PR TITLE
perf(indexer): split onchain refresh claim queues

### DIFF
--- a/apps/indexer/migrations/0003_onchain_refresh_runtime_indexes.sql
+++ b/apps/indexer/migrations/0003_onchain_refresh_runtime_indexes.sql
@@ -1,0 +1,5 @@
+-- Onchain refresh runtime index marker.
+--
+-- The actual index creation is performed by runtime startup with
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS so existing staging databases keep
+-- accepting writes while the hot-path indexes are built.

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -69,6 +69,13 @@ pub struct OnchainRefreshTaskScope {
     pub dao_code: String,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OnchainRefreshClaimQueue {
+    Pending,
+    FailedRetry,
+    StaleProcessing,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OnchainRefreshTickConfig {
     pub enabled: bool,
@@ -439,7 +446,8 @@ where
     }
 
     pub async fn run_once(&self) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size(self.config.batch_size).await
+        self.run_once_with_batch_size_and_scope(self.config.batch_size, None, false)
+            .await
     }
 
     pub async fn run_once_with_batch_size(
@@ -704,6 +712,32 @@ where
         batch_size: usize,
         scope: Option<&OnchainRefreshTaskScope>,
     ) -> Result<Vec<OnchainRefreshTask>, OnchainRefreshWorkerError> {
+        let mut tasks = Vec::new();
+        for queue in [
+            OnchainRefreshClaimQueue::Pending,
+            OnchainRefreshClaimQueue::FailedRetry,
+            OnchainRefreshClaimQueue::StaleProcessing,
+        ] {
+            if tasks.len() >= batch_size {
+                break;
+            }
+            let remaining_batch_size = batch_size - tasks.len();
+            tasks.extend(
+                self.claim_tasks_from_queue(now_ms, remaining_batch_size, scope, queue)
+                    .await?,
+            );
+        }
+
+        Ok(tasks)
+    }
+
+    async fn claim_tasks_from_queue(
+        &self,
+        now_ms: i64,
+        batch_size: usize,
+        scope: Option<&OnchainRefreshTaskScope>,
+        queue: OnchainRefreshClaimQueue,
+    ) -> Result<Vec<OnchainRefreshTask>, OnchainRefreshWorkerError> {
         let stale_before = now_ms.saturating_sub(duration_millis_i64(self.config.lock_ttl));
         let batch_size =
             i64::try_from(batch_size).map_err(|_| OnchainRefreshWorkerError::BatchSizeOverflow)?;
@@ -712,32 +746,29 @@ where
             "WITH candidates AS (
                 SELECT id
                 FROM onchain_refresh_task
-                WHERE (
-                    status = 'pending'
-                    OR (
-                        status = 'failed'
-                        AND attempts < ",
+                WHERE status = ",
         );
-        query.push_bind(self.config.max_attempts).push(
-            "
-                    )
-                    OR (
-                        status = 'processing'
-                        AND locked_at IS NOT NULL
-                        AND locked_at <= ",
-        );
-        query.push_bind(stale_before.to_string()).push(
-            "::NUMERIC(78, 0)
-                        AND attempts < ",
-        );
+        match queue {
+            OnchainRefreshClaimQueue::Pending => {
+                query.push_bind("pending");
+            }
+            OnchainRefreshClaimQueue::FailedRetry => {
+                query
+                    .push_bind("failed")
+                    .push(" AND attempts < ")
+                    .push_bind(self.config.max_attempts);
+            }
+            OnchainRefreshClaimQueue::StaleProcessing => {
+                query
+                    .push_bind("processing")
+                    .push(" AND locked_at IS NOT NULL AND locked_at <= ")
+                    .push_bind(stale_before.to_string())
+                    .push("::NUMERIC(78, 0) AND attempts < ")
+                    .push_bind(self.config.max_attempts);
+            }
+        }
         query
-            .push_bind(self.config.max_attempts)
-            .push(
-                "
-                    )
-                )
-                AND next_run_at <= ",
-            )
+            .push(" AND next_run_at <= ")
             .push_bind(now_ms.to_string())
             .push("::NUMERIC(78, 0)");
         push_onchain_refresh_scope_filter(&mut query, scope);

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -51,6 +51,26 @@ async fn ensure_runtime_indexes(pool: &PgPool) -> Result<()> {
     .context("ensure scoped onchain refresh claim queue index")?;
 
     sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_failed_retry_idx
+         ON onchain_refresh_task (next_run_at, updated_at, id)
+         INCLUDE (attempts)
+         WHERE status = 'failed'",
+    )
+    .execute(pool)
+    .await
+    .context("ensure failed onchain refresh retry index")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_processing_retry_idx
+         ON onchain_refresh_task (next_run_at, updated_at, id)
+         INCLUDE (locked_at, attempts)
+         WHERE status = 'processing'",
+    )
+    .execute(pool)
+    .await
+    .context("ensure processing onchain refresh retry index")?;
+
+    sqlx::query(
         "CREATE INDEX IF NOT EXISTS onchain_refresh_deferred_candidate_scope_drain_idx
          ON onchain_refresh_deferred_candidate (
             chain_id, contract_set_id, dao_code, next_run_at, updated_at, id
@@ -69,6 +89,16 @@ async fn ensure_runtime_indexes(pool: &PgPool) -> Result<()> {
     .execute(pool)
     .await
     .context("ensure delegate rolling metadata preload index")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_current_from_scope_idx
+         ON delegate (contract_set_id, chain_id, dao_code, governor_address, from_delegate)
+         INCLUDE (token_address, to_delegate, is_current)
+         WHERE is_current = TRUE",
+    )
+    .execute(pool)
+    .await
+    .context("ensure current delegate scope lookup index")?;
 
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_to_lookup_idx

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -157,6 +157,24 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
         "contributor_data_metric_scope_idx",
     )
     .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_failed_retry_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_processing_retry_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "delegate_current_from_scope_idx",
+    )
+    .await?;
     assert_removed_processor_status_table_absent(&database.pool).await?;
     assert_table_exists(&database.pool, &database.schema, "_sqlx_migrations").await?;
 
@@ -212,7 +230,11 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
 
     assert_eq!(
         migration_files,
-        ["0001_init.sql", "0002_hot_path_runtime_indexes.sql"]
+        [
+            "0001_init.sql",
+            "0002_hot_path_runtime_indexes.sql",
+            "0003_onchain_refresh_runtime_indexes.sql"
+        ]
     );
 
     let init_migration = include_str!("../migrations/0001_init.sql");


### PR DESCRIPTION
## Summary
- split onchain refresh task claiming by ready queue so PostgreSQL can use status-specific index scans instead of a single OR-driven sequential scan
- skip global backlog count in the standalone onchain worker hot path
- add runtime-created retry/delegate lookup indexes and a lightweight migration marker

## Evidence
- Before change, production EXPLAIN for claim used Seq Scan on onchain_refresh_task with OR filters.
- After splitting to an equivalent single-status query shape, EXPLAIN uses onchain_refresh_task_status_idx; deployed runtime indexes should reduce heap/filter cost further.

## Tests
- cargo fmt --check
- cargo test -p degov-datalens-indexer --locked --lib onchain_refresh
- cargo test -p degov-datalens-indexer --locked --test migration_schema test_indexer_keeps_init_migration_stable_and_appends_runtime_markers
- cargo test -p degov-datalens-indexer --locked --lib
