### PR TITLE
perf(indexer): index ready failed refresh retries

### DIFF
--- a/apps/indexer/migrations/0005_onchain_refresh_failed_ready_retry_index.sql
+++ b/apps/indexer/migrations/0005_onchain_refresh_failed_ready_retry_index.sql
@@ -1,0 +1,3 @@
+-- Runtime indexes are created by the application with CREATE INDEX CONCURRENTLY.
+-- This marker records that onchain_refresh_task_failed_ready_retry_idx is part of
+-- the expected runtime schema without blocking fresh migrations on index builds.

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 
 pub const DEFAULT_ONCHAIN_REFRESH_APPLY_BATCH_SIZE: usize = 1_000;
+const DEFAULT_ONCHAIN_REFRESH_MAX_ATTEMPTS: i32 = 3;
 const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = DEFAULT_ONCHAIN_REFRESH_APPLY_BATCH_SIZE;
 const MULTICALL3_ADDRESS: &str = "0xca11bde05977b3631167028862be2a173976ca11";
 
@@ -753,18 +754,16 @@ where
                 query.push_bind("pending");
             }
             OnchainRefreshClaimQueue::FailedRetry => {
-                query
-                    .push_bind("failed")
-                    .push(" AND attempts < ")
-                    .push_bind(self.config.max_attempts);
+                query.push_bind("failed").push(" AND attempts < ");
+                push_attempt_limit(&mut query, self.config.max_attempts);
             }
             OnchainRefreshClaimQueue::StaleProcessing => {
                 query
                     .push_bind("processing")
                     .push(" AND locked_at IS NOT NULL AND locked_at <= ")
                     .push_bind(stale_before.to_string())
-                    .push("::NUMERIC(78, 0) AND attempts < ")
-                    .push_bind(self.config.max_attempts);
+                    .push("::NUMERIC(78, 0) AND attempts < ");
+                push_attempt_limit(&mut query, self.config.max_attempts);
             }
         }
         query
@@ -969,6 +968,14 @@ fn onchain_refresh_retry_backoff_delay(base_delay: Duration, attempts: i32) -> D
     let multiplier = 1u32.checked_shl(exponent).unwrap_or(32);
 
     base_delay.saturating_mul(multiplier)
+}
+
+fn push_attempt_limit(query: &mut QueryBuilder<'_, Postgres>, max_attempts: i32) {
+    if max_attempts == DEFAULT_ONCHAIN_REFRESH_MAX_ATTEMPTS {
+        query.push(DEFAULT_ONCHAIN_REFRESH_MAX_ATTEMPTS);
+    } else {
+        query.push_bind(max_attempts);
+    }
 }
 
 fn push_onchain_refresh_scope_filter<'args>(

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -103,6 +103,15 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .context("ensure failed onchain refresh attempt retry index")?;
 
     sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_failed_ready_retry_idx
+         ON onchain_refresh_task (next_run_at, updated_at, id)
+         WHERE status = 'failed' AND attempts < 3",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure failed onchain refresh ready retry index")?;
+
+    sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_processing_retry_idx
          ON onchain_refresh_task (next_run_at, updated_at, id)
          INCLUDE (locked_at, attempts)

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -178,6 +178,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "onchain_refresh_task_failed_ready_retry_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "onchain_refresh_task_processing_lock_retry_idx",
     )
     .await?;
@@ -246,7 +252,8 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
             "0001_init.sql",
             "0002_hot_path_runtime_indexes.sql",
             "0003_onchain_refresh_runtime_indexes.sql",
-            "0004_onchain_refresh_claim_retry_indexes.sql"
+            "0004_onchain_refresh_claim_retry_indexes.sql",
+            "0005_onchain_refresh_failed_ready_retry_index.sql"
         ]
     );
 


### PR DESCRIPTION
## Summary
- add a partial ready failed-retry index for the default onchain refresh max attempts
- emit the default attempts limit as a literal so PostgreSQL can match the partial index
- record the runtime schema marker and test expectation

## Tests
- cargo fmt --check
- cargo test -p degov-datalens-indexer --locked --test migration_schema test_indexer_keeps_init_migration_stable_and_appends_runtime_markers
- cargo test -p degov-datalens-indexer --locked --lib onchain_refresh

Note: full onchain_refresh_worker integration tests require DEGOV_INDEXER_TEST_DATABASE_URL, which is not configured in this workspace.