### PR TITLE
perf(indexer): inline refresh claim queue status

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -751,15 +751,15 @@ where
         );
         match queue {
             OnchainRefreshClaimQueue::Pending => {
-                query.push_bind("pending");
+                query.push("'pending'");
             }
             OnchainRefreshClaimQueue::FailedRetry => {
-                query.push_bind("failed").push(" AND attempts < ");
+                query.push("'failed' AND attempts < ");
                 push_attempt_limit(&mut query, self.config.max_attempts);
             }
             OnchainRefreshClaimQueue::StaleProcessing => {
                 query
-                    .push_bind("processing")
+                    .push("'processing'")
                     .push(" AND locked_at IS NOT NULL AND locked_at <= ")
                     .push_bind(stale_before.to_string())
                     .push("::NUMERIC(78, 0) AND attempts < ");


### PR DESCRIPTION
## Summary
- inline fixed onchain refresh claim queue statuses so PostgreSQL can match partial queue indexes
- keep non-default max-attempts behavior parameterized

## Tests
- cargo fmt --check
- cargo test -p degov-datalens-indexer --locked --lib onchain_refresh