### PR TITLE
fix(indexer): support GraphQL CORS

### DIFF
--- a/apps/indexer/src/graphql/router.rs
+++ b/apps/indexer/src/graphql/router.rs
@@ -3,8 +3,11 @@ use async_graphql::{EmptyMutation, EmptySubscription, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
     Router,
+    body::Body,
     extract::State,
-    response::{Html, IntoResponse},
+    http::{HeaderValue, Request, StatusCode, header},
+    middleware::{self, Next},
+    response::{Html, IntoResponse, Response},
     routing::{get, post},
 };
 
@@ -60,7 +63,8 @@ where
                         let scope = scope.clone();
                         async move { graphql_handler(schema, request, scope).await }
                     }
-                }),
+                })
+                .options(cors_preflight),
             )
             .route(
                 &graphiql_path,
@@ -70,7 +74,9 @@ where
                 }),
             );
     }
-    router.with_state(schema)
+    router
+        .layer(middleware::from_fn(add_cors_headers))
+        .with_state(schema)
 }
 
 async fn graphql_handler(
@@ -93,6 +99,28 @@ async fn graphql_graphiql(endpoint: String) -> impl IntoResponse {
             .plugins(&[graphiql_explorer_plugin()])
             .finish(),
     )
+}
+
+async fn cors_preflight() -> StatusCode {
+    StatusCode::OK
+}
+
+async fn add_cors_headers(request: Request<Body>, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        header::ACCESS_CONTROL_ALLOW_ORIGIN,
+        HeaderValue::from_static("*"),
+    );
+    headers.insert(
+        header::ACCESS_CONTROL_ALLOW_METHODS,
+        HeaderValue::from_static("GET,POST,OPTIONS"),
+    );
+    headers.insert(
+        header::ACCESS_CONTROL_ALLOW_HEADERS,
+        HeaderValue::from_static("*"),
+    );
+    response
 }
 
 fn graphiql_explorer_plugin<'a>() -> GraphiQLPlugin<'a> {

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -1157,6 +1157,97 @@ async fn test_graphql_http_endpoint_serves_configured_dao_path() -> Result<(), B
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_http_endpoint_serves_cors_preflight_on_configured_dao_path()
+-> Result<(), Box<dyn Error>> {
+    let pool = PgPoolOptions::new().connect_lazy("postgres://localhost/degov")?;
+    let schema = graphql::build_schema(pool);
+    let app = graphql::build_router_with_paths(schema, ["/ens-dao/graphql".to_owned()]);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("http://{}/ens-dao/graphql", listener.local_addr()?);
+    let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let response = timeout(
+        Duration::from_secs(5),
+        Client::new()
+            .request(reqwest::Method::OPTIONS, endpoint)
+            .header("origin", "https://ens.next.degov.ai")
+            .header("access-control-request-method", "POST")
+            .header("access-control-request-headers", "content-type")
+            .send(),
+    )
+    .await??;
+
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(
+        response
+            .headers()
+            .get("access-control-allow-origin")
+            .expect("allow origin")
+            .to_str()?,
+        "*"
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("access-control-allow-methods")
+            .expect("allow methods")
+            .to_str()?,
+        "GET,POST,OPTIONS"
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("access-control-allow-headers")
+            .expect("allow headers")
+            .to_str()?,
+        "*"
+    );
+
+    server.abort();
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_http_endpoint_adds_cors_header_to_configured_dao_post_response()
+-> Result<(), Box<dyn Error>> {
+    let pool = PgPoolOptions::new().connect_lazy("postgres://localhost/degov")?;
+    let schema = graphql::build_schema(pool);
+    let app = graphql::build_router_with_paths(schema, ["/ens-dao/graphql".to_owned()]);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("http://{}/ens-dao/graphql", listener.local_addr()?);
+    let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let response = timeout(
+        Duration::from_secs(5),
+        Client::new()
+            .post(endpoint)
+            .header("origin", "https://ens.next.degov.ai")
+            .json(&json!({
+                "query": "query { __typename }"
+            }))
+            .send(),
+    )
+    .await??;
+
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(
+        response
+            .headers()
+            .get("access-control-allow-origin")
+            .expect("allow origin")
+            .to_str()?,
+        "*"
+    );
+    let body: serde_json::Value = response.json().await?;
+    assert_eq!(body["data"]["__typename"], "QueryRoot");
+
+    server.abort();
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_http_endpoint_serves_configured_dao_graphiql_path()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;


### PR DESCRIPTION
## Summary
- handle OPTIONS preflight on configured GraphQL routes
- add CORS headers to GraphQL/GraphiQL HTTP responses
- cover preflight and POST CORS behavior for scoped DAO GraphQL paths

## Verification
- cargo fmt --check
- cargo test -p degov-datalens-indexer test_graphql_http_endpoint_serves_cors_preflight_on_configured_dao_path --test graphql_service -- --exact --nocapture
- cargo test -p degov-datalens-indexer test_graphql_http_endpoint_adds_cors_header_to_configured_dao_post_response --test graphql_service -- --exact --nocapture
- cargo build -p degov-datalens-indexer --locked
- node ./scripts/check-rust-conventions.mjs
- node ./scripts/check-rust-conventions.test.mjs
- node ./scripts/compatibility-preflight.test.mjs

Note: local pnpm run test:indexer reaches the Postgres-backed integration tests and requires DEGOV_INDEXER_TEST_DATABASE_URL; CI provides that service.