### PR TITLE
fix(indexer): support scoped shared GraphQL routes

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -177,5 +177,40 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure contributor data metric scope index")?;
 
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_graphql_scope_power_idx
+         ON contributor (chain_id, governor_address, dao_code, power DESC, id)
+         INCLUDE (
+            contract_set_id, token_address, block_number, block_timestamp,
+            transaction_hash, last_vote_timestamp, balance, delegates_count_all
+         )",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure contributor GraphQL scope power index")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_scope_power_idx
+         ON degov_provisional_contributor_power_overlay (
+            chain_id, governor_address, dao_code, power DESC, account,
+            contract_set_id, token_address
+         )
+         WHERE source = 'live-onchain' AND status = 'available'",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure live contributor overlay scope power index")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_account_lookup_idx
+         ON degov_provisional_contributor_power_overlay (
+            contract_set_id, account, chain_id, dao_code, governor_address, token_address
+         )
+         WHERE source = 'live-onchain' AND status = 'available'",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure live contributor overlay account lookup index")?;
+
     Ok(())
 }

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -95,8 +95,10 @@ fn graphql_paths(endpoint: Option<&str>, configured_path: Option<&str>) -> Resul
     if let Some(path) = endpoint.and_then(endpoint_graphql_path) {
         push_graphql_path(&mut paths, &path)?;
     }
-    if let Some(path) = configured_path {
-        push_graphql_path(&mut paths, path)?;
+    if let Some(paths_config) = configured_path {
+        for path in paths_config.split([',', '\n', '\r', '\t', ' ']) {
+            push_graphql_path(&mut paths, path)?;
+        }
     }
     Ok(paths)
 }

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -266,6 +266,32 @@ fn test_graphql_runtime_config_keeps_public_endpoint_separate_from_bind_address(
 }
 
 #[test]
+fn test_graphql_runtime_config_accepts_multiple_paths() {
+    with_env_vars!(
+        [
+            (
+                "DEGOV_INDEXER_GRAPHQL_PATH",
+                Some("/ens-dao/graphql,/lisk-dao/graphql\n/rn-dao/graphql"),
+            ),
+            ("DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS", Some("0.0.0.0:4350")),
+        ],
+        || {
+            let config = GraphqlRuntimeConfig::from_env().expect("graphql config parses");
+
+            assert_eq!(
+                config.paths,
+                vec![
+                    "/graphql".to_owned(),
+                    "/ens-dao/graphql".to_owned(),
+                    "/lisk-dao/graphql".to_owned(),
+                    "/rn-dao/graphql".to_owned(),
+                ]
+            );
+        },
+    );
+}
+
+#[test]
 fn test_graphql_runtime_config_accepts_legacy_bind_endpoint() {
     with_env_vars!(
         [


### PR DESCRIPTION
## Summary
- allow DEGOV_INDEXER_GRAPHQL_PATH to register multiple scoped GraphQL paths
- add a narrow live-overlay power fast path for scoped contributors queries
- add runtime indexes for contributor power and live overlay lookups

## Tests
- cargo fmt --check
- cargo test -p degov-datalens-indexer --test cli_runtime_config test_graphql_runtime_config -- --nocapture
- cargo check -p degov-datalens-indexer

GraphQL integration tests were compiled but not executed locally because DEGOV_INDEXER_TEST_DATABASE_URL is not configured.