### PR TITLE
perf(indexer): improve all-mode scheduling

### DIFF
--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -37,6 +37,7 @@ pub struct IndexerRunnerOptions {
     pub safe_height: Option<i64>,
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerConfig,
+    pub onchain_refresh_deferred_drain_enabled: bool,
     pub onchain_refresh_deferred_drain_batch_size: usize,
     pub proposal_timestamp_backfill: ProposalTimestampBackfillConfig,
 }
@@ -908,27 +909,8 @@ where
                 .commit()
                 .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
             let write_duration = write_started_at.elapsed();
-            let deferred_drain_started_at = Instant::now();
-            let deferred_drain_count = match self.store.drain_deferred_onchain_refresh_tasks(
-                self.options.onchain_refresh_deferred_drain_batch_size,
-            ) {
-                Ok(count) => count,
-                Err(error) => {
-                    warn!(
-                        "Datalens indexer deferred onchain refresh drain failed after checkpoint commit dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} from_block={} to_block={} error={}",
-                        self.options.checkpoint_identity.dao_code,
-                        self.options.checkpoint_identity.chain_id,
-                        self.options.checkpoint_identity.contract_set_id,
-                        self.options.checkpoint_identity.stream_id,
-                        self.options.checkpoint_identity.data_source_version,
-                        range.from_block,
-                        range.to_block,
-                        error
-                    );
-                    0
-                }
-            };
-            let deferred_drain_duration = deferred_drain_started_at.elapsed();
+            let (deferred_drain_count, deferred_drain_duration) =
+                self.drain_deferred_onchain_refresh_tasks(range);
             self.run_proposal_timestamp_backfill(range.to_block);
             self.run_onchain_refresh_tick(range.to_block);
 
@@ -951,7 +933,7 @@ where
                 self.options.progress_refresh_lag_blocks,
             );
             info!(
-                "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={} adaptive_cache_full_hit_count={} adaptive_cache_partial_hit_count={} adaptive_cache_miss_count={} adaptive_cache_provider_fill_range_count={} adaptive_query_duration_max_ms={} onchain_refresh_deferred_drain_batch_size={} onchain_refresh_deferred_drain_count={} onchain_refresh_deferred_drain_duration_ms={}",
+                "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={} adaptive_cache_full_hit_count={} adaptive_cache_partial_hit_count={} adaptive_cache_miss_count={} adaptive_cache_provider_fill_range_count={} adaptive_query_duration_max_ms={} onchain_refresh_deferred_drain_enabled={} onchain_refresh_deferred_drain_batch_size={} onchain_refresh_deferred_drain_count={} onchain_refresh_deferred_drain_duration_ms={}",
                 self.options.checkpoint_identity.dao_code,
                 self.options.checkpoint_identity.chain_id,
                 self.options.checkpoint_identity.contract_set_id,
@@ -999,6 +981,7 @@ where
                         .warmup_effectiveness
                         .query_duration_max_ms()
                 ),
+                self.options.onchain_refresh_deferred_drain_enabled,
                 self.options.onchain_refresh_deferred_drain_batch_size,
                 deferred_drain_count,
                 deferred_drain_duration.as_millis()
@@ -1091,6 +1074,38 @@ where
                 error
             ),
         }
+    }
+
+    fn drain_deferred_onchain_refresh_tasks(
+        &mut self,
+        range: CheckpointBlockRange,
+    ) -> (usize, Duration) {
+        if !self.options.onchain_refresh_deferred_drain_enabled {
+            return (0, Duration::ZERO);
+        }
+
+        let started_at = Instant::now();
+        let count = match self.store.drain_deferred_onchain_refresh_tasks(
+            self.options.onchain_refresh_deferred_drain_batch_size,
+        ) {
+            Ok(count) => count,
+            Err(error) => {
+                warn!(
+                    "Datalens indexer deferred onchain refresh drain failed after checkpoint commit dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} from_block={} to_block={} error={}",
+                    self.options.checkpoint_identity.dao_code,
+                    self.options.checkpoint_identity.chain_id,
+                    self.options.checkpoint_identity.contract_set_id,
+                    self.options.checkpoint_identity.stream_id,
+                    self.options.checkpoint_identity.data_source_version,
+                    range.from_block,
+                    range.to_block,
+                    error
+                );
+                0
+            }
+        };
+
+        (count, started_at.elapsed())
     }
 
     fn run_proposal_timestamp_backfill(&mut self, processed_block: i64) {

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -11,11 +11,12 @@ use crate::{
     DatalensError, DatalensNativeClient, DatalensQueryConcurrencyGate, DatalensQueryErrorClass,
     DatalensRuntimeContractSet, DatalensWarmupEnsureOutcome, EvmRpcChainTool,
     IndexerContractSetMode, IndexerContractSetRuntimeConfig, IndexerOnchainRefreshTick,
-    IndexerRunner, IndexerRunnerReport, IndexerRuntimeConfig, IndexerTargetHeight,
-    MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig, OnchainRefreshTaskScope,
-    OnchainRefreshTickReport, OnchainRefreshTickRunner, OnchainRefreshTickScheduler,
-    OnchainRefreshWorker, OnchainRefreshWorkerError, PostgresIndexerRunnerStore,
-    PostgresProvisionalCleanupStore, classify_datalens_query_error, datalens_retry_config,
+    IndexerRunner, IndexerRunnerReport, IndexerRunnerStore, IndexerRuntimeConfig,
+    IndexerTargetHeight, MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig,
+    OnchainRefreshTaskScope, OnchainRefreshTickReport, OnchainRefreshTickRunner,
+    OnchainRefreshTickScheduler, OnchainRefreshWorker, OnchainRefreshWorkerError,
+    PostgresIndexerRunnerStore, PostgresProvisionalCleanupStore,
+    checkpoint::configured_range_progress, classify_datalens_query_error, datalens_retry_config,
     ensure_datalens_warmup_task, onchain_refresh_debounce_from_env, required_env,
 };
 
@@ -205,6 +206,7 @@ async fn run_configured_contract_set_pass_result(
         Err(error) => return Err(ContractSetPassError::setup(error)),
     };
     let report = match run_contract_set_pass(
+        runtime.contract_set_mode,
         contract_runtime.clone(),
         contract_set.config.clone(),
         contract_set.addresses.clone(),
@@ -431,6 +433,33 @@ fn contains_recoverable_datalens_query_error(error: &runtime_anyhow::Error) -> b
             ),
             _ => false,
         })
+}
+
+fn resolve_contract_set_max_chunks_per_run(
+    contract_set_mode: IndexerContractSetMode,
+    runtime: &IndexerContractSetRuntimeConfig,
+    processed_height: Option<i64>,
+    target_height: i64,
+) -> Option<u64> {
+    if let Some(chunks) = runtime.max_chunks_per_run {
+        return Some(chunks);
+    }
+    if !matches!(contract_set_mode, IndexerContractSetMode::All) {
+        return None;
+    }
+
+    let remaining_blocks =
+        configured_range_progress(processed_height, runtime.start_block, target_height)
+            .remaining_blocks;
+    if remaining_blocks >= 10_000_000 {
+        Some(5)
+    } else if remaining_blocks >= 1_000_000 {
+        Some(4)
+    } else if remaining_blocks >= 100_000 {
+        Some(3)
+    } else {
+        Some(1)
+    }
 }
 
 #[derive(Debug)]
@@ -854,6 +883,7 @@ fn warmup_startup_per_chain_semaphores(
 }
 
 async fn run_contract_set_pass(
+    contract_set_mode: IndexerContractSetMode,
     runtime: IndexerContractSetRuntimeConfig,
     config: DatalensConfig,
     contracts: DaoContractAddresses,
@@ -890,7 +920,7 @@ async fn run_contract_set_pass(
         if let Some(gate) = datalens_query_gate {
             client = client.with_query_concurrency_gate(gate);
         }
-        let store = PostgresIndexerRunnerStore::new(pool)
+        let mut store = PostgresIndexerRunnerStore::new(pool)
             .with_onchain_refresh_debounce(onchain_refresh_debounce)
             .with_onchain_refresh_deferred_drain_batch_size(
                 runtime.onchain_refresh_deferred_drain_batch_size,
@@ -898,6 +928,22 @@ async fn run_contract_set_pass(
         let options = runtime
             .options(&config, &contracts)
             .map_err(ContractSetPassError::setup)?;
+        let max_chunks_per_run = if runtime.max_chunks_per_run.is_some()
+            || matches!(contract_set_mode, IndexerContractSetMode::Single)
+        {
+            runtime.max_chunks_per_run
+        } else {
+            let checkpoint = store
+                .read_or_create_checkpoint(&options.checkpoint_identity, options.start_block)
+                .context("read Datalens indexer checkpoint for chunk budget")
+                .map_err(ContractSetPassError::setup)?;
+            resolve_contract_set_max_chunks_per_run(
+                contract_set_mode,
+                &runtime,
+                checkpoint.processed_height,
+                runtime.target_height,
+            )
+        };
         let mut runner = IndexerRunner::new(
             options,
             runtime.contexts(&contracts),
@@ -911,7 +957,7 @@ async fn run_contract_set_pass(
         if let Some(chain_tool) = projection_chain_tool {
             runner = runner.with_chain_tool(chain_tool);
         }
-        if let Some(chunks) = runtime.max_chunks_per_run {
+        if let Some(chunks) = max_chunks_per_run {
             runner.request_shutdown_after_chunks(chunks);
         }
 
@@ -1102,6 +1148,78 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn test_resolve_contract_set_max_chunks_per_run_adapts_all_mode_from_remaining_blocks() {
+        let runtime = contract_runtime_for_chunk_budget(None);
+
+        assert_eq!(
+            resolve_contract_set_max_chunks_per_run(
+                IndexerContractSetMode::All,
+                &runtime,
+                Some(0),
+                10_000_000
+            ),
+            Some(5)
+        );
+        assert_eq!(
+            resolve_contract_set_max_chunks_per_run(
+                IndexerContractSetMode::All,
+                &runtime,
+                Some(0),
+                1_000_000
+            ),
+            Some(4)
+        );
+        assert_eq!(
+            resolve_contract_set_max_chunks_per_run(
+                IndexerContractSetMode::All,
+                &runtime,
+                Some(0),
+                100_000
+            ),
+            Some(3)
+        );
+        assert_eq!(
+            resolve_contract_set_max_chunks_per_run(
+                IndexerContractSetMode::All,
+                &runtime,
+                Some(0),
+                99_999
+            ),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn test_resolve_contract_set_max_chunks_per_run_uses_explicit_value() {
+        let runtime = contract_runtime_for_chunk_budget(Some(9));
+
+        assert_eq!(
+            resolve_contract_set_max_chunks_per_run(
+                IndexerContractSetMode::All,
+                &runtime,
+                Some(0),
+                10_000_000
+            ),
+            Some(9)
+        );
+    }
+
+    #[test]
+    fn test_resolve_contract_set_max_chunks_per_run_leaves_single_mode_unset_by_default() {
+        let runtime = contract_runtime_for_chunk_budget(None);
+
+        assert_eq!(
+            resolve_contract_set_max_chunks_per_run(
+                IndexerContractSetMode::Single,
+                &runtime,
+                Some(0),
+                10_000_000
+            ),
+            None
+        );
+    }
+
     #[tokio::test]
     async fn test_resolve_contract_set_target_height_keeps_fixed_numeric_target_without_datalens() {
         let runtime = IndexerRuntimeConfig {
@@ -1121,6 +1239,7 @@ mod tests {
             progress_refresh_lag_blocks: 100,
             adaptive_chunk_sizer: Default::default(),
             onchain_refresh_tick: Default::default(),
+            onchain_refresh_deferred_drain_enabled: false,
             onchain_refresh_deferred_drain_batch_size: 100,
             proposal_timestamp_backfill: Default::default(),
             provisional: ProvisionalRuntimeConfig {
@@ -1156,6 +1275,88 @@ mod tests {
             .expect("fixed target height resolves without Datalens");
 
         assert_eq!(height, 568800);
+    }
+
+    fn contract_runtime_for_chunk_budget(
+        max_chunks_per_run: Option<u64>,
+    ) -> IndexerContractSetRuntimeConfig {
+        IndexerContractSetRuntimeConfig {
+            dao_code: "demo-dao".to_owned(),
+            start_block: 0,
+            target_height: 10_000_000,
+            checkpoint_contract_set_id: "demo-dao:v1".to_owned(),
+            checkpoint_stream_id: "datalens-native".to_owned(),
+            data_source_version: "datalens-v1".to_owned(),
+            query_max_attempts: 1,
+            datalens_query_concurrency: Default::default(),
+            contract_set_max_concurrency: crate::ContractSetConcurrencyLimit::Unlimited,
+            contract_set_per_chain_max_concurrency: crate::ContractSetConcurrencyLimit::Unlimited,
+            progress_refresh_lag_blocks: 100,
+            adaptive_chunk_sizer: Default::default(),
+            max_chunks_per_run,
+            onchain_refresh_tick: Default::default(),
+            onchain_refresh_deferred_drain_enabled: false,
+            onchain_refresh_deferred_drain_batch_size: 100,
+            proposal_timestamp_backfill: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_all_mode_contract_set_runtime_preserves_enqueue_only_onchain_refresh() {
+        let runtime = runtime_for_warmup_concurrency();
+        let contract_set = crate::DatalensRuntimeContractSet {
+            dao_code: "demo-dao".to_owned(),
+            contract_set_id: "demo-dao:1:governor".to_owned(),
+            contract: crate::DatalensContractSetConfig {
+                dao_code: Some("demo-dao".to_owned()),
+                chain_id: 1,
+                network_name: "ethereum".to_owned(),
+                governor: "0x0000000000000000000000000000000000000001".to_owned(),
+                governor_token: "0x0000000000000000000000000000000000000002".to_owned(),
+                governor_token_standard: crate::GovernanceTokenStandard::Erc20,
+                timelock: None,
+                start_block: 1,
+            },
+            config: DatalensConfig {
+                endpoint: "http://127.0.0.1:1".to_owned(),
+                application: "degov-test".to_owned(),
+                bearer_token: SecretString::new("unit-test-redacted-value"),
+                timeout: Duration::from_secs(1),
+                finality: DatalensFinality::DurableOnly,
+                chain: ChainIdentityConfig {
+                    family: ChainFamily::Evm,
+                    configured_name: "ethereum".to_owned(),
+                    network_id: Some(1),
+                },
+                dataset: DatasetKeyConfig {
+                    family: "evm".to_owned(),
+                    name: "logs".to_owned(),
+                },
+                query_limits: QueryLimitConfig {
+                    block_range_limit: 1_000,
+                },
+                warmup: Default::default(),
+                dao_contracts: None,
+                chains: Vec::new(),
+            },
+            addresses: crate::DaoContractAddresses {
+                governor: "0x0000000000000000000000000000000000000001".to_owned(),
+                governor_token: "0x0000000000000000000000000000000000000002".to_owned(),
+                timelock: None,
+                governor_token_standard: crate::GovernanceTokenStandard::Erc20,
+            },
+        };
+
+        let contract_runtime = runtime
+            .for_configured_contract_set_at_target(&contract_set, 100)
+            .expect("contract runtime builds");
+        let options = contract_runtime
+            .options(&contract_set.config, &contract_set.addresses)
+            .expect("runner options build");
+
+        assert!(!contract_runtime.onchain_refresh_tick.enabled);
+        assert!(!contract_runtime.onchain_refresh_deferred_drain_enabled);
+        assert!(!options.onchain_refresh_deferred_drain_enabled);
     }
 
     #[test]
@@ -1866,6 +2067,7 @@ mod tests {
             progress_refresh_lag_blocks: 100,
             adaptive_chunk_sizer: Default::default(),
             onchain_refresh_tick: Default::default(),
+            onchain_refresh_deferred_drain_enabled: false,
             onchain_refresh_deferred_drain_batch_size: 100,
             proposal_timestamp_backfill: Default::default(),
             provisional: ProvisionalRuntimeConfig {

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -154,6 +154,7 @@ pub struct IndexerRuntimeConfig {
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
+    pub onchain_refresh_deferred_drain_enabled: bool,
     pub onchain_refresh_deferred_drain_batch_size: usize,
     pub proposal_timestamp_backfill: ProposalTimestampBackfillConfig,
     pub provisional: ProvisionalRuntimeConfig,
@@ -246,6 +247,7 @@ pub struct IndexerContractSetRuntimeConfig {
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub max_chunks_per_run: Option<u64>,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
+    pub onchain_refresh_deferred_drain_enabled: bool,
     pub onchain_refresh_deferred_drain_batch_size: usize,
     pub proposal_timestamp_backfill: ProposalTimestampBackfillConfig,
 }
@@ -335,6 +337,12 @@ impl IndexerRuntimeConfig {
         );
         let run_once = optional_env_bool("DEGOV_INDEXER_RUN_ONCE")?.unwrap_or(false);
 
+        let onchain_refresh_tick = load_onchain_refresh_tick_config()?;
+        let onchain_refresh_deferred_drain_enabled = load_onchain_refresh_deferred_drain_enabled(
+            contract_set_mode,
+            onchain_refresh_tick.enabled,
+        )?;
+
         Ok(Self {
             dao_filter,
             contract_set_mode,
@@ -358,7 +366,8 @@ impl IndexerRuntimeConfig {
             )?
             .unwrap_or(100),
             adaptive_chunk_sizer: load_adaptive_chunk_sizer_runtime_config()?,
-            onchain_refresh_tick: load_onchain_refresh_tick_config()?,
+            onchain_refresh_tick,
+            onchain_refresh_deferred_drain_enabled,
             onchain_refresh_deferred_drain_batch_size:
                 onchain_refresh_deferred_drain_batch_size_from_env()?,
             proposal_timestamp_backfill: load_proposal_timestamp_backfill_config()?,
@@ -430,6 +439,7 @@ impl IndexerRuntimeConfig {
             adaptive_chunk_sizer: self.adaptive_chunk_sizer,
             max_chunks_per_run: self.max_chunks_per_run,
             onchain_refresh_tick: self.onchain_refresh_tick.clone(),
+            onchain_refresh_deferred_drain_enabled: self.onchain_refresh_deferred_drain_enabled,
             onchain_refresh_deferred_drain_batch_size: self
                 .onchain_refresh_deferred_drain_batch_size,
             proposal_timestamp_backfill: self.proposal_timestamp_backfill,
@@ -500,6 +510,7 @@ impl IndexerContractSetRuntimeConfig {
             adaptive_chunk_sizer: self
                 .adaptive_chunk_sizer
                 .for_block_range_limit(config.query_limits.block_range_limit),
+            onchain_refresh_deferred_drain_enabled: self.onchain_refresh_deferred_drain_enabled,
             onchain_refresh_deferred_drain_batch_size: self
                 .onchain_refresh_deferred_drain_batch_size,
             proposal_timestamp_backfill: self.proposal_timestamp_backfill,
@@ -744,6 +755,21 @@ fn load_onchain_refresh_tick_config() -> Result<OnchainRefreshTickConfig> {
     }
 
     Ok(config)
+}
+
+fn load_onchain_refresh_deferred_drain_enabled(
+    contract_set_mode: IndexerContractSetMode,
+    tick_enabled: bool,
+) -> Result<bool> {
+    let default_enabled = match contract_set_mode {
+        IndexerContractSetMode::Single => true,
+        IndexerContractSetMode::All => tick_enabled,
+    };
+
+    Ok(
+        optional_env_bool("DEGOV_INDEXER_ONCHAIN_REFRESH_DEFERRED_DRAIN_ENABLED")?
+            .unwrap_or(default_enabled),
+    )
 }
 
 fn load_proposal_timestamp_backfill_config() -> Result<ProposalTimestampBackfillConfig> {

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -599,6 +599,7 @@ fn test_indexer_runtime_config_defaults_onchain_refresh_ticks_disabled_and_bound
             ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
             ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
             ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED", None),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_DEFERRED_DRAIN_ENABLED", None,),
             ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS", None),
             ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN", None),
             ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_DURATION_MS", None),
@@ -619,6 +620,26 @@ fn test_indexer_runtime_config_defaults_onchain_refresh_ticks_disabled_and_bound
                 Duration::from_millis(500)
             );
             assert_eq!(config.onchain_refresh_tick.min_blocks_between_ticks, 100);
+            assert!(config.onchain_refresh_deferred_drain_enabled);
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_all_mode_defaults_to_enqueue_only_onchain_refresh() {
+    with_env_vars!(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", None),
+            ("DEGOV_INDEXER_CONTRACT_SET_MODE", Some("all")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED", None),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_DEFERRED_DRAIN_ENABLED", None,),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert!(!config.onchain_refresh_tick.enabled);
+            assert!(!config.onchain_refresh_deferred_drain_enabled);
         },
     );
 }
@@ -630,6 +651,7 @@ fn test_indexer_runtime_config_accepts_onchain_refresh_tick_overrides() {
             ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
             ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
             ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED", Some("true")),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_DEFERRED_DRAIN_ENABLED", None,),
             ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS", Some("3")),
             (
                 "DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_MAX_TASKS_PER_RUN",
@@ -652,6 +674,29 @@ fn test_indexer_runtime_config_accepts_onchain_refresh_tick_overrides() {
                 Duration::from_millis(25)
             );
             assert_eq!(config.onchain_refresh_tick.min_blocks_between_ticks, 5);
+            assert!(config.onchain_refresh_deferred_drain_enabled);
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_all_mode_accepts_explicit_deferred_drain_enable() {
+    with_env_vars!(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", None),
+            ("DEGOV_INDEXER_CONTRACT_SET_MODE", Some("all")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_ONCHAIN_REFRESH_TICK_ENABLED", None),
+            (
+                "DEGOV_INDEXER_ONCHAIN_REFRESH_DEFERRED_DRAIN_ENABLED",
+                Some("true"),
+            ),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert!(!config.onchain_refresh_tick.enabled);
+            assert!(config.onchain_refresh_deferred_drain_enabled);
         },
     );
 }
@@ -834,6 +879,7 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        onchain_refresh_deferred_drain_enabled: false,
         onchain_refresh_deferred_drain_batch_size: 100,
         proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
         provisional: ProvisionalRuntimeConfig {
@@ -916,6 +962,7 @@ fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        onchain_refresh_deferred_drain_enabled: false,
         onchain_refresh_deferred_drain_batch_size: 100,
         proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
         provisional: ProvisionalRuntimeConfig {
@@ -958,6 +1005,7 @@ fn test_indexer_runtime_latest_target_height_does_not_skip_all_mode_contract_set
         max_chunks_per_run: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
+        onchain_refresh_deferred_drain_enabled: false,
         onchain_refresh_deferred_drain_batch_size: 100,
         proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
         provisional: ProvisionalRuntimeConfig {

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -289,12 +289,26 @@ fn test_runner_runs_onchain_refresh_tick_after_chunk_commit() {
 #[test]
 fn test_runner_drains_deferred_onchain_refresh_with_configured_budget_after_chunk_commit() {
     let mut options = options();
+    options.onchain_refresh_deferred_drain_enabled = true;
     options.onchain_refresh_deferred_drain_batch_size = 1_000;
     let mut runner = runner_with_decoder(vec![vec![row(1, 0, 0)]], ScriptedDecoder, options);
 
     runner.run_to_target(1).expect("runner succeeds");
 
     assert_eq!(runner.store().deferred_drain_requests(), &[1_000]);
+}
+
+#[test]
+fn test_runner_skips_deferred_onchain_refresh_drain_when_disabled_after_chunk_commit() {
+    let mut options = options();
+    options.onchain_refresh_deferred_drain_enabled = false;
+    options.onchain_refresh_deferred_drain_batch_size = 1_000;
+    let mut runner = runner_with_decoder(vec![vec![row(1, 0, 0)]], ScriptedDecoder, options);
+
+    runner.run_to_target(1).expect("runner succeeds");
+
+    assert_eq!(runner.store().deferred_drain_requests(), &[] as &[usize]);
+    assert_eq!(runner.store().commit_count(), 1);
 }
 
 #[test]
@@ -1434,6 +1448,7 @@ fn options() -> IndexerRunnerOptions {
         safe_height: None,
         progress_refresh_lag_blocks: 0,
         adaptive_chunk_sizer: AdaptiveChunkSizerConfig::for_max_chunk_size(1),
+        onchain_refresh_deferred_drain_enabled: true,
         onchain_refresh_deferred_drain_batch_size: 100,
         proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
     }

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -615,6 +615,7 @@ fn options() -> IndexerRunnerOptions {
         safe_height: None,
         progress_refresh_lag_blocks: 0,
         adaptive_chunk_sizer: AdaptiveChunkSizerConfig::for_max_chunk_size(10),
+        onchain_refresh_deferred_drain_enabled: true,
         onchain_refresh_deferred_drain_batch_size: 100,
         proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
     }


### PR DESCRIPTION
## Summary

- add adaptive all-mode chunk budgeting so far-behind DAO contract sets can process more chunks per pass while near-target sets yield sooner
- add `DEGOV_INDEXER_ONCHAIN_REFRESH_DEFERRED_DRAIN_ENABLED` to separate refresh enqueueing from runner-side deferred drain consumption
- keep single-mode default drain behavior compatible, while all-mode with ticks disabled defaults to enqueue-only for unified worker consumption
- include drain enabled state in chunk logs for operational visibility

## Validation

- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --locked --lib`
- `cargo test -p degov-datalens-indexer --locked --test indexer_runner --test cli_runtime_config --test native_runner_integration`

## Review

Subagent implementation and review were used:
- adaptive chunk budget worker: done
- onchain refresh drain gate worker: done
- spec compliance reviewer: passed
- code quality reviewer: found two issues; both fixed and re-reviewed approved
