### PR TITLE
perf(indexer): bound onchain refresh drain writes

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -488,26 +488,15 @@ where
         let started_at = Instant::now();
         let now_ms = unix_time_millis();
         let deferred_drain_started_at = Instant::now();
-        let deferred_drain_batch_size =
-            worker_deferred_drain_batch_size(self.config.deferred_drain_batch_size, batch_size);
+        let deferred_drain_target =
+            worker_deferred_drain_target(self.config.deferred_drain_batch_size, batch_size);
         self.archive_exhausted_failed_tasks(now_ms).await?;
-        let deferred_drain_count = match scope {
-            Some(scope) => {
-                drain_deferred_onchain_refresh_tasks_for_scope(
-                    &self.pool,
-                    deferred_drain_batch_size,
-                    scope,
-                )
-                .await
-            }
-            None => {
-                drain_deferred_onchain_refresh_tasks(&self.pool, deferred_drain_batch_size).await
-            }
-        }
-        .map_err(|error| OnchainRefreshWorkerError::DeferredDrain(error.to_string()))?;
+        let deferred_drain_count = self
+            .drain_deferred_onchain_refresh_backlog(deferred_drain_target, scope)
+            .await?;
         if deferred_drain_count > 0 {
             log::info!(
-                "onchain refresh worker materialized deferred tasks dao_code={} chain_id={} contract_set_id={} deferred_drain_count={} deferred_drain_batch_size={} deferred_drain_duration_ms={}",
+                "onchain refresh worker materialized deferred tasks dao_code={} chain_id={} contract_set_id={} deferred_drain_count={} deferred_drain_batch_size={} deferred_drain_target={} deferred_drain_duration_ms={}",
                 scope
                     .map(|scope| scope.dao_code.as_str())
                     .unwrap_or("global"),
@@ -518,7 +507,8 @@ where
                     .map(|scope| scope.contract_set_id.as_str())
                     .unwrap_or("global"),
                 deferred_drain_count,
-                deferred_drain_batch_size,
+                self.config.deferred_drain_batch_size,
+                deferred_drain_target,
                 deferred_drain_started_at.elapsed().as_millis()
             );
         }
@@ -652,6 +642,35 @@ where
         );
 
         Ok(report)
+    }
+
+    async fn drain_deferred_onchain_refresh_backlog(
+        &self,
+        target_rows: usize,
+        scope: Option<&OnchainRefreshTaskScope>,
+    ) -> Result<usize, OnchainRefreshWorkerError> {
+        let mut drained_total = 0usize;
+        while drained_total < target_rows {
+            let batch_size = self
+                .config
+                .deferred_drain_batch_size
+                .min(target_rows - drained_total);
+            let drained = match scope {
+                Some(scope) => {
+                    drain_deferred_onchain_refresh_tasks_for_scope(&self.pool, batch_size, scope)
+                        .await
+                }
+                None => drain_deferred_onchain_refresh_tasks(&self.pool, batch_size).await,
+            }
+            .map_err(|error| OnchainRefreshWorkerError::DeferredDrain(error.to_string()))?;
+
+            drained_total += drained;
+            if drained < batch_size {
+                break;
+            }
+        }
+
+        Ok(drained_total)
     }
 
     pub async fn ready_backlog(&self) -> Result<u64, OnchainRefreshWorkerError> {
@@ -996,10 +1015,7 @@ where
     }
 }
 
-fn worker_deferred_drain_batch_size(
-    configured_batch_size: usize,
-    claim_batch_size: usize,
-) -> usize {
+fn worker_deferred_drain_target(configured_batch_size: usize, claim_batch_size: usize) -> usize {
     configured_batch_size.max(claim_batch_size)
 }
 
@@ -3522,9 +3538,9 @@ mod tests {
     }
 
     #[test]
-    fn test_worker_deferred_drain_batch_size_tracks_claim_budget() {
-        assert_eq!(worker_deferred_drain_batch_size(100, 1_000), 1_000);
-        assert_eq!(worker_deferred_drain_batch_size(2_000, 1_000), 2_000);
+    fn test_worker_deferred_drain_target_tracks_claim_budget() {
+        assert_eq!(worker_deferred_drain_target(100, 1_000), 1_000);
+        assert_eq!(worker_deferred_drain_target(2_000, 1_000), 2_000);
     }
 
     #[test]

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -29,7 +29,7 @@ pub const DEFAULT_ONCHAIN_REFRESH_APPLY_BATCH_SIZE: usize = 200;
 pub const MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE: usize = 1_000;
 const DEFAULT_ONCHAIN_REFRESH_MAX_ATTEMPTS: i32 = 3;
 const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE;
-const MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS: i64 = 5_000;
+const MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS: i64 = 500;
 const MULTICALL3_ADDRESS: &str = "0xca11bde05977b3631167028862be2a173976ca11";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -974,7 +974,6 @@ where
                 FROM onchain_refresh_task
                 WHERE status = 'failed'
                   AND attempts >= $1
-                ORDER BY updated_at ASC, id ASC
                 LIMIT $2
                 FOR UPDATE SKIP LOCKED
              )
@@ -3531,6 +3530,11 @@ mod tests {
     #[test]
     fn test_default_onchain_refresh_apply_batch_size_keeps_transactions_small() {
         assert_eq!(DEFAULT_ONCHAIN_REFRESH_APPLY_BATCH_SIZE, 200);
+    }
+
+    #[test]
+    fn test_exhausted_archive_batch_size_keeps_cleanup_transactions_small() {
+        assert_eq!(MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS, 500);
     }
 
     #[test]

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -1,5 +1,5 @@
 // Onchain refresh task persistence.
-const MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS: usize = 1_000;
+const MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS: usize = 200;
 pub const DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS: usize = 100;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -699,6 +699,11 @@ mod tests {
         assert_eq!(immediate.inline_upsert_count, 0);
         assert_eq!(immediate.deferred_candidate_count, 1_205);
         assert_eq!(immediate.ready_drain_count, 1_000);
+    }
+
+    #[test]
+    fn test_onchain_refresh_task_upsert_chunk_size_keeps_writes_bounded() {
+        assert_eq!(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS, 200);
     }
 
     fn candidate(

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -1731,6 +1731,46 @@ async fn test_refresh_live_power_overlays_writes_delegate_overlay_from_current_f
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_drains_deferred_tasks_to_claim_budget_in_small_writes()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    for index in 0..10 {
+        seed_deferred_task(
+            &database.pool,
+            &format!("deferred-{index}"),
+            &format!("0x{index:040x}"),
+        )
+        .await?;
+    }
+
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 3,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::new([]),
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.claimed, 10);
+    assert_eq!(report.failed, 10);
+    assert_table_count(&database.pool, "onchain_refresh_deferred_candidate", 0).await?;
+    assert_table_count(&database.pool, "onchain_refresh_task", 10).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_fails_only_missing_rpc_chain_group()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -2285,6 +2325,35 @@ async fn seed_task_with_contract_set(
     .bind(refresh_power)
     .bind(status)
     .bind(attempts)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn seed_deferred_task(
+    pool: &PgPool,
+    task_id: &str,
+    account: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO onchain_refresh_deferred_candidate (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address, account,
+            refresh_balance, refresh_power, reason, first_seen_block_number,
+            last_seen_block_number, last_seen_block_timestamp, last_seen_transaction_hash,
+            next_run_at, created_at, updated_at
+         )
+         VALUES (
+            $1, 'demo-dao', 46, 'demo-dao', $2, $3, $4,
+            false, true, 'token-activity', 10::NUMERIC(78, 0),
+            12::NUMERIC(78, 0), 12000::NUMERIC(78, 0), '0xdeferred',
+            0::NUMERIC(78, 0), 10000::NUMERIC(78, 0), 10000::NUMERIC(78, 0)
+         )",
+    )
+    .bind(task_id)
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .bind(account)
     .execute(pool)
     .await?;
 


### PR DESCRIPTION
## Summary
- keep onchain refresh deferred drain on the configured write budget instead of expanding it to the claim batch size
- reduce each onchain refresh task upsert chunk from 1000 rows to 200 rows
- add regression checks for the drain write budget and bounded task upsert chunk size

## Why
Staging still showed slow `INSERT ... ON CONFLICT` task materialization after the exhausted-task archive fix. The worker was configured with the default deferred drain budget, but `worker_deferred_drain_batch_size()` expanded it to the claim batch size, so a 1000-task claim also forced a 1000-row materialization write.

## Validation
- `cargo fmt --all --check`
- `cargo test --locked -p degov-datalens-indexer onchain::refresh::tests::test_worker_deferred_drain_batch_size_uses_configured_write_budget`
- `cargo test --locked -p degov-datalens-indexer store::postgres::onchain_refresh::tests::test_onchain_refresh_task_upsert_chunk_size_keeps_writes_bounded`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_health_test cargo test --locked -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token_reconcile_tasks_insert_across_bulk_chunks`
