### PR TITLE
perf(indexer): add onchain refresh claim indexes

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -75,6 +75,15 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .context("ensure onchain refresh claim queue index")?;
 
     sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_pending_status_claim_idx
+         ON onchain_refresh_task (status, next_run_at, updated_at, id)
+         WHERE status = 'pending'",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure pending onchain refresh status claim index")?;
+
+    sqlx::query(
         "CREATE INDEX IF NOT EXISTS onchain_refresh_task_scope_claim_queue_idx
          ON onchain_refresh_task (
             chain_id, contract_set_id, dao_code, status, next_run_at, updated_at, id
@@ -110,6 +119,15 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .execute(&mut *connection)
     .await
     .context("ensure failed onchain refresh ready retry index")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_failed_ready_status_retry_idx
+         ON onchain_refresh_task (status, next_run_at, updated_at, id)
+         WHERE status = 'failed' AND attempts < 3",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure failed onchain refresh ready status retry index")?;
 
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_processing_retry_idx

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -178,7 +178,19 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "onchain_refresh_task_pending_status_claim_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "onchain_refresh_task_failed_ready_retry_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_failed_ready_status_retry_idx",
     )
     .await?;
     assert_index_exists(


### PR DESCRIPTION
## Summary
- add a pending-claim partial index for onchain refresh tasks
- add a failed-ready retry partial index with `status` as the leading key
- cover both runtime indexes in the migration schema test

## Why
Staging showed the failed retry claim query using the broad `onchain_refresh_task_status_idx`, filtering ~158k exhausted failed rows before returning 1000 ready retry rows. `ANALYZE` did not change the plan. The new failed-ready index changed the same query from ~98s to ~0.4s in staging.

The pending claim query also chose the broad status index. The new pending partial index changed the test query from ~1.2s to <1ms in staging.

## Validation
- `cargo fmt --all --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_health_test cargo test --locked -p degov-datalens-indexer --test migration_schema test_migration_applies_required_schema_to_clean_postgres`
- staging `EXPLAIN (ANALYZE, BUFFERS)` for failed retry claim: ~98s before, ~0.4s after `onchain_refresh_task_failed_ready_status_retry_idx`
- staging `EXPLAIN (ANALYZE, BUFFERS)` for pending claim: ~1.2s before, <1ms after `onchain_refresh_task_pending_status_claim_idx`
