### PR TITLE
perf(indexer): limit refresh delegate count recompute

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -2396,12 +2396,6 @@ async fn reconcile_current_delegate_relation_power_from_balance(
                 WHERE delegate.is_current = TRUE
                 ORDER BY delegate.contract_set_id, delegate.id
              ),
-             affected_delegates AS (
-                SELECT DISTINCT
-                    contract_set_id,
-                    to_delegate
-                FROM current_edges
-             ),
              updated_delegates AS (
                 UPDATE delegate
                 SET power = current_edges.new_power
@@ -2409,7 +2403,7 @@ async fn reconcile_current_delegate_relation_power_from_balance(
                 WHERE delegate.contract_set_id = current_edges.contract_set_id
                   AND delegate.id = current_edges.id
                   AND delegate.power IS DISTINCT FROM current_edges.new_power
-                RETURNING delegate.id
+                RETURNING delegate.contract_set_id, delegate.to_delegate
              ),
              updated_delegate_mappings AS (
                 UPDATE delegate_mapping
@@ -2420,7 +2414,14 @@ async fn reconcile_current_delegate_relation_power_from_balance(
                   AND delegate_mapping.\"from\" = current_edges.from_delegate
                   AND delegate_mapping.\"to\" = current_edges.to_delegate
                   AND delegate_mapping.power IS DISTINCT FROM current_edges.new_power
-                RETURNING delegate_mapping.id
+                RETURNING delegate_mapping.contract_set_id, delegate_mapping.\"to\" AS to_delegate
+             ),
+             affected_delegates AS (
+                SELECT contract_set_id, to_delegate
+                FROM updated_delegates
+                UNION
+                SELECT contract_set_id, to_delegate
+                FROM updated_delegate_mappings
              ),
              effective_counts AS (
                 SELECT


### PR DESCRIPTION
## What
- Recompute onchain refresh effective delegate counts only for delegates touched by actual delegate/delegate_mapping updates.
- Keep stale effective-count repair behavior when a delegate power row changes, including positive-to-positive changes.

## Why
Staging onchain refresh apply batches were spending too long in the `WITH refreshed` SQL because every refreshed current edge triggered effective count aggregation, even when the row value did not change. This keeps the expensive aggregation scoped to rows that actually changed.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_partial_test cargo test --locked -p degov-datalens-indexer --test onchain_refresh_worker`