### PR TITLE
perf(indexer): add delegate mapping count index

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -178,6 +178,8 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure current delegate scope lookup index")?;
 
+    drop_invalid_index_if_exists(connection, "delegate_mapping_to_lookup_idx").await?;
+
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_to_lookup_idx
          ON delegate_mapping (contract_set_id, \"to\") INCLUDE (id, power)",
@@ -185,6 +187,14 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .execute(&mut *connection)
     .await
     .context("ensure delegate mapping target lookup index")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_effective_count_idx
+         ON delegate_mapping (contract_set_id, \"to\", \"from\") INCLUDE (id, power)",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure delegate mapping effective count index")?;
 
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_data_metric_scope_idx
@@ -229,6 +239,37 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .execute(&mut *connection)
     .await
     .context("ensure live contributor overlay account lookup index")?;
+
+    Ok(())
+}
+
+async fn drop_invalid_index_if_exists(
+    connection: &mut PgConnection,
+    index_name: &str,
+) -> Result<()> {
+    let invalid_index_exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM pg_class index_class
+            JOIN pg_index ON pg_index.indexrelid = index_class.oid
+            JOIN pg_namespace ON pg_namespace.oid = index_class.relnamespace
+            WHERE pg_namespace.nspname = current_schema()
+              AND index_class.relname = $1
+              AND pg_index.indisvalid = FALSE
+         )",
+    )
+    .bind(index_name)
+    .fetch_one(&mut *connection)
+    .await
+    .with_context(|| format!("check invalid runtime index {index_name}"))?;
+
+    if invalid_index_exists {
+        let query = format!("DROP INDEX CONCURRENTLY IF EXISTS \"{index_name}\"");
+        sqlx::query(&query)
+            .execute(&mut *connection)
+            .await
+            .with_context(|| format!("drop invalid runtime index {index_name}"))?;
+    }
 
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -154,6 +154,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "delegate_mapping_effective_count_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "contributor_data_metric_scope_idx",
     )
     .await?;
@@ -277,6 +283,10 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     let hot_path_migration = include_str!("../migrations/0002_hot_path_runtime_indexes.sql");
     assert!(hot_path_migration.contains("CREATE INDEX CONCURRENTLY IF NOT EXISTS"));
     assert!(hot_path_migration.contains("sqlx migration history"));
+
+    let runtime_migration = include_str!("../src/runtime/migrate.rs");
+    assert!(runtime_migration.contains("drop_invalid_index_if_exists"));
+    assert!(runtime_migration.contains("delegate_mapping_effective_count_idx"));
 
     Ok(())
 }


### PR DESCRIPTION
## What
- Add `delegate_mapping_effective_count_idx` for effective delegate-count recalculation.
- Drop and recreate `delegate_mapping_to_lookup_idx` if runtime migration finds the existing index is invalid.

## Why
Staging had `delegate_mapping_to_lookup_idx` present but `indisvalid=false`, so Postgres skipped it and effective-count refreshes scanned `delegate_mapping` by `contract_set_id`, filtering tens of thousands of rows per affected delegate. This kept onchain refresh apply chunks slow even after limiting recomputation to changed rows.

## Staging evidence
- Existing `delegate_mapping_to_lookup_idx`: `indisvalid=false`.
- Simple delegate mapping count used `delegate_mapping_pkey` and took about 12.5s before the new index.
- After creating `delegate_mapping_effective_count_idx`, the point count used an index-only scan and the indexed portion took about 100ms.
- Onchain refresh `WITH refreshed` slow logs dropped into low single-digit seconds for common chunks after the staging index was created, though concurrent all-mode `data_metric` writes can still create occasional slow chunks.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_partial_test cargo test --locked -p degov-datalens-indexer --test migration_schema`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_partial_test cargo test --locked -p degov-datalens-indexer --test onchain_refresh_worker`