### PR TITLE
fix(indexer): avoid runtime invalid index rebuild

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -178,8 +178,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure current delegate scope lookup index")?;
 
-    drop_invalid_index_if_exists(connection, "delegate_mapping_to_lookup_idx").await?;
-
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_to_lookup_idx
          ON delegate_mapping (contract_set_id, \"to\") INCLUDE (id, power)",
@@ -239,37 +237,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .execute(&mut *connection)
     .await
     .context("ensure live contributor overlay account lookup index")?;
-
-    Ok(())
-}
-
-async fn drop_invalid_index_if_exists(
-    connection: &mut PgConnection,
-    index_name: &str,
-) -> Result<()> {
-    let invalid_index_exists = sqlx::query_scalar::<_, bool>(
-        "SELECT EXISTS (
-            SELECT 1
-            FROM pg_class index_class
-            JOIN pg_index ON pg_index.indexrelid = index_class.oid
-            JOIN pg_namespace ON pg_namespace.oid = index_class.relnamespace
-            WHERE pg_namespace.nspname = current_schema()
-              AND index_class.relname = $1
-              AND pg_index.indisvalid = FALSE
-         )",
-    )
-    .bind(index_name)
-    .fetch_one(&mut *connection)
-    .await
-    .with_context(|| format!("check invalid runtime index {index_name}"))?;
-
-    if invalid_index_exists {
-        let query = format!("DROP INDEX CONCURRENTLY IF EXISTS \"{index_name}\"");
-        sqlx::query(&query)
-            .execute(&mut *connection)
-            .await
-            .with_context(|| format!("drop invalid runtime index {index_name}"))?;
-    }
 
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -285,7 +285,6 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(hot_path_migration.contains("sqlx migration history"));
 
     let runtime_migration = include_str!("../src/runtime/migrate.rs");
-    assert!(runtime_migration.contains("drop_invalid_index_if_exists"));
     assert!(runtime_migration.contains("delegate_mapping_effective_count_idx"));
 
     Ok(())


### PR DESCRIPTION
## What
- Stop dropping/rebuilding invalid `delegate_mapping_to_lookup_idx` during runtime startup.
- Keep `delegate_mapping_effective_count_idx`, which is the new valid index used by the onchain refresh effective-count path.

## Why
Rebuilding the invalid legacy index in runtime startup can deadlock with active all-mode writes to `delegate_mapping`, causing the staging indexer container to restart. The invalid legacy index should be repaired separately in an operational window, not on every app startup.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_partial_test cargo test --locked -p degov-datalens-indexer --test migration_schema`