### PR TITLE
fix(indexer): gate invalid index repair behind cli

### DIFF
--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use degov_datalens_indexer::runtime::{
-    migrate, refresh_proposal_reference_fields, refresh_proposal_titles, run_graphql, run_indexer,
-    run_worker, smoke_datalens,
+    migrate, refresh_proposal_reference_fields, refresh_proposal_titles,
+    repair_invalid_runtime_indexes, run_graphql, run_indexer, run_worker, smoke_datalens,
 };
 
 #[derive(Debug, Parser)]
@@ -17,6 +17,7 @@ enum Command {
     Run,
     Worker,
     Migrate,
+    RepairInvalidIndexes,
     Graphql,
     SmokeDatalens,
     RefreshProposalTitles {
@@ -40,6 +41,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Run => run_indexer().await,
         Command::Worker => run_worker().await,
         Command::Migrate => migrate().await,
+        Command::RepairInvalidIndexes => repair_invalid_runtime_indexes().await,
         Command::Graphql => run_graphql().await,
         Command::SmokeDatalens => smoke_datalens().await,
         Command::RefreshProposalTitles { dao_code } => {

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -21,6 +21,50 @@ pub async fn migrate() -> Result<()> {
     Ok(())
 }
 
+pub async fn repair_invalid_runtime_indexes() -> Result<()> {
+    let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await
+        .context("connect to DeGov indexer Postgres")?;
+
+    let mut connection = pool
+        .acquire()
+        .await
+        .context("acquire DeGov indexer invalid index repair connection")?;
+
+    sqlx::query("SELECT pg_advisory_lock(hashtext('degov_indexer_runtime_migration'))")
+        .execute(&mut *connection)
+        .await
+        .context("acquire DeGov indexer runtime migration lock")?;
+
+    let result = repair_invalid_runtime_indexes_for_connection(&mut connection).await;
+
+    let unlock_result = sqlx::query_scalar::<_, bool>(
+        "SELECT pg_advisory_unlock(hashtext('degov_indexer_runtime_migration'))",
+    )
+    .fetch_one(&mut *connection)
+    .await
+    .context("release DeGov indexer runtime migration lock")
+    .and_then(|unlocked| {
+        if unlocked {
+            Ok(())
+        } else {
+            Err(runtime_anyhow::Error::msg(
+                "DeGov indexer runtime migration lock was not held",
+            ))
+        }
+    });
+
+    result?;
+    unlock_result?;
+
+    log::info!("Datalens-native DeGov indexer invalid runtime indexes repaired");
+
+    Ok(())
+}
+
 pub async fn apply_migrations(pool: &PgPool) -> Result<()> {
     let mut connection = pool
         .acquire()
@@ -74,7 +118,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure onchain refresh claim queue index")?;
 
-    drop_invalid_runtime_index(connection, "onchain_refresh_task_pending_status_claim_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_pending_status_claim_idx
          ON onchain_refresh_task (status, next_run_at, updated_at, id)
@@ -94,7 +137,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure scoped onchain refresh claim queue index")?;
 
-    drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_retry_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_failed_retry_idx
          ON onchain_refresh_task (next_run_at, updated_at, id)
@@ -105,7 +147,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure failed onchain refresh retry index")?;
 
-    drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_attempt_retry_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_failed_attempt_retry_idx
          ON onchain_refresh_task (status, attempts, next_run_at, updated_at, id)",
@@ -114,7 +155,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure failed onchain refresh attempt retry index")?;
 
-    drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_ready_retry_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_failed_ready_retry_idx
          ON onchain_refresh_task (next_run_at, updated_at, id)
@@ -124,11 +164,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure failed onchain refresh ready retry index")?;
 
-    drop_invalid_runtime_index(
-        connection,
-        "onchain_refresh_task_failed_ready_status_retry_idx",
-    )
-    .await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_failed_ready_status_retry_idx
          ON onchain_refresh_task (status, next_run_at, updated_at, id)
@@ -138,7 +173,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure failed onchain refresh ready status retry index")?;
 
-    drop_invalid_runtime_index(connection, "onchain_refresh_task_processing_retry_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_processing_retry_idx
          ON onchain_refresh_task (next_run_at, updated_at, id)
@@ -149,8 +183,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure processing onchain refresh retry index")?;
 
-    drop_invalid_runtime_index(connection, "onchain_refresh_task_processing_lock_retry_idx")
-        .await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_processing_lock_retry_idx
          ON onchain_refresh_task (status, attempts, locked_at, next_run_at, updated_at, id)
@@ -170,7 +202,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure scoped onchain refresh deferred drain index")?;
 
-    drop_invalid_runtime_index(connection, "delegate_rolling_metadata_preload_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_rolling_metadata_preload_idx
          ON delegate_rolling (contract_set_id, transaction_hash, log_index DESC)
@@ -181,7 +212,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure delegate rolling metadata preload index")?;
 
-    drop_invalid_runtime_index(connection, "delegate_current_from_scope_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_current_from_scope_idx
          ON delegate (contract_set_id, chain_id, dao_code, governor_address, from_delegate)
@@ -192,7 +222,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure current delegate scope lookup index")?;
 
-    drop_invalid_runtime_index(connection, "delegate_mapping_to_lookup_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_to_lookup_idx
          ON delegate_mapping (contract_set_id, \"to\") INCLUDE (id, power)",
@@ -201,7 +230,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure delegate mapping target lookup index")?;
 
-    drop_invalid_runtime_index(connection, "delegate_mapping_effective_count_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_effective_count_idx
          ON delegate_mapping (contract_set_id, \"to\", \"from\") INCLUDE (id, power)",
@@ -210,7 +238,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure delegate mapping effective count index")?;
 
-    drop_invalid_runtime_index(connection, "contributor_data_metric_scope_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_data_metric_scope_idx
          ON contributor (contract_set_id, chain_id, governor_address, dao_code)
@@ -220,7 +247,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure contributor data metric scope index")?;
 
-    drop_invalid_runtime_index(connection, "contributor_graphql_scope_power_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_graphql_scope_power_idx
          ON contributor (chain_id, governor_address, dao_code, power DESC, id)
@@ -233,7 +259,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure contributor GraphQL scope power index")?;
 
-    drop_invalid_runtime_index(connection, "provisional_contributor_live_scope_power_idx").await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_scope_power_idx
          ON degov_provisional_contributor_power_overlay (
@@ -246,11 +271,6 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure live contributor overlay scope power index")?;
 
-    drop_invalid_runtime_index(
-        connection,
-        "provisional_contributor_live_account_lookup_idx",
-    )
-    .await?;
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_account_lookup_idx
          ON degov_provisional_contributor_power_overlay (
@@ -261,6 +281,38 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .execute(&mut *connection)
     .await
     .context("ensure live contributor overlay account lookup index")?;
+
+    Ok(())
+}
+
+async fn repair_invalid_runtime_indexes_for_connection(
+    connection: &mut PgConnection,
+) -> Result<()> {
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_pending_status_claim_idx").await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_retry_idx").await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_attempt_retry_idx").await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_ready_retry_idx").await?;
+    drop_invalid_runtime_index(
+        connection,
+        "onchain_refresh_task_failed_ready_status_retry_idx",
+    )
+    .await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_processing_retry_idx").await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_processing_lock_retry_idx")
+        .await?;
+    drop_invalid_runtime_index(connection, "delegate_rolling_metadata_preload_idx").await?;
+    drop_invalid_runtime_index(connection, "delegate_current_from_scope_idx").await?;
+    drop_invalid_runtime_index(connection, "delegate_mapping_to_lookup_idx").await?;
+    drop_invalid_runtime_index(connection, "delegate_mapping_effective_count_idx").await?;
+    drop_invalid_runtime_index(connection, "contributor_data_metric_scope_idx").await?;
+    drop_invalid_runtime_index(connection, "contributor_graphql_scope_power_idx").await?;
+    drop_invalid_runtime_index(connection, "provisional_contributor_live_scope_power_idx").await?;
+    drop_invalid_runtime_index(
+        connection,
+        "provisional_contributor_live_account_lookup_idx",
+    )
+    .await?;
+    ensure_runtime_indexes(connection).await?;
 
     Ok(())
 }

--- a/apps/indexer/src/runtime/mod.rs
+++ b/apps/indexer/src/runtime/mod.rs
@@ -9,7 +9,7 @@ pub mod worker;
 pub use datalens::smoke_datalens;
 pub use graphql::run_graphql;
 pub use indexer::run_indexer;
-pub use migrate::{apply_migrations, migrate};
+pub use migrate::{apply_migrations, migrate, repair_invalid_runtime_indexes};
 pub use proposal_reference_fields::refresh_proposal_reference_fields;
 pub use proposal_title_refresh::refresh_proposal_titles;
 pub use worker::run_worker;

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -7,7 +7,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use degov_datalens_indexer::runtime::apply_migrations;
+use degov_datalens_indexer::runtime::{apply_migrations, repair_invalid_runtime_indexes};
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
 
@@ -62,6 +62,7 @@ struct TestDatabase {
     _guard: MutexGuard<'static, ()>,
     pool: PgPool,
     schema: String,
+    database_url: String,
 }
 
 impl TestDatabase {
@@ -83,16 +84,22 @@ impl TestDatabase {
             .await?;
         setup_pool.close().await;
 
+        let database_url = database_url_with_search_path(&database_url, &schema);
         let pool = PgPoolOptions::new()
             .max_connections(1)
-            .connect(&database_url_with_search_path(&database_url, &schema))
+            .connect(&database_url)
             .await?;
 
         Ok(Self {
             _guard: guard,
             pool,
             schema,
+            database_url,
         })
+    }
+
+    fn database_url(&self) -> &str {
+        &self.database_url
     }
 
     async fn cleanup(&self) -> Result<(), sqlx::Error> {
@@ -276,6 +283,26 @@ async fn test_migration_repairs_invalid_runtime_index() -> Result<(), Box<dyn Er
     .await?;
 
     apply_migrations(&database.pool).await?;
+    assert_index_is_invalid(
+        &database.pool,
+        &database.schema,
+        "contributor_data_metric_scope_idx",
+    )
+    .await?;
+
+    let previous_database_url = env::var("DEGOV_INDEXER_DATABASE_URL").ok();
+    // These migration tests are serialized by DATABASE_TEST_LOCK.
+    unsafe {
+        env::set_var("DEGOV_INDEXER_DATABASE_URL", database.database_url());
+    }
+    let repair_result = repair_invalid_runtime_indexes().await;
+    unsafe {
+        match previous_database_url {
+            Some(value) => env::set_var("DEGOV_INDEXER_DATABASE_URL", value),
+            None => env::remove_var("DEGOV_INDEXER_DATABASE_URL"),
+        }
+    }
+    repair_result?;
 
     assert_index_is_valid(
         &database.pool,
@@ -485,6 +512,34 @@ async fn assert_index_is_valid(
     .await?;
 
     assert!(is_valid, "expected index {schema}.{index_name} to be valid");
+
+    Ok(())
+}
+
+async fn assert_index_is_invalid(
+    pool: &PgPool,
+    schema: &str,
+    index_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    let is_valid: bool = sqlx::query_scalar(
+        r#"
+        SELECT pg_index.indisvalid
+        FROM pg_class index_class
+        JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
+        JOIN pg_index ON pg_index.indexrelid = index_class.oid
+        WHERE index_namespace.nspname = $1
+          AND index_class.relname = $2
+        "#,
+    )
+    .bind(schema)
+    .bind(index_name)
+    .fetch_one(pool)
+    .await?;
+
+    assert!(
+        !is_valid,
+        "expected index {schema}.{index_name} to be invalid"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- keep runtime startup migrations from dropping/recreating invalid concurrent indexes
- add explicit `repair-invalid-indexes` CLI for one-shot invalid runtime index maintenance
- update migration schema test to prove default startup leaves invalid indexes alone and explicit repair fixes them

## Test
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_partial_test cargo test --locked -p degov-datalens-indexer --test migration_schema`

## Staging note
- #903 was rolled back from staging after startup repair hit `CREATE INDEX CONCURRENTLY` deadlocks and crash-looped the indexer pod.
