### PR TITLE
perf(indexer): dedupe onchain refresh metric updates

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -232,6 +232,22 @@ CREATE INDEX IF NOT EXISTS onchain_refresh_task_ready_claim_idx
   ON onchain_refresh_task (next_run_at, updated_at, id)
   WHERE status IN ('pending', 'failed');
 
+CREATE TABLE IF NOT EXISTS onchain_refresh_data_metric_task (
+  id TEXT PRIMARY KEY,
+  contract_set_id TEXT NOT NULL,
+  chain_id INTEGER NOT NULL,
+  dao_code TEXT,
+  governor_address TEXT NOT NULL,
+  token_address TEXT NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  created_at NUMERIC(78, 0) NOT NULL,
+  updated_at NUMERIC(78, 0) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS onchain_refresh_data_metric_task_ready_idx
+  ON onchain_refresh_data_metric_task (updated_at, id);
+
 CREATE TABLE IF NOT EXISTS onchain_refresh_deferred_candidate (
   id TEXT PRIMARY KEY,
   contract_set_id TEXT NOT NULL,

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -32,6 +32,7 @@ pub const MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE: usize = 1_000;
 const DEFAULT_ONCHAIN_REFRESH_MAX_ATTEMPTS: i32 = 3;
 const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE;
 const MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS: i64 = 200;
+const MAX_ONCHAIN_REFRESH_DATA_METRIC_REFRESH_ROWS: usize = 200;
 const ONCHAIN_REFRESH_APPLY_MAX_ATTEMPTS: usize = 3;
 const ONCHAIN_REFRESH_APPLY_RETRY_BASE_DELAY_MS: u64 = 50;
 const MULTICALL3_ADDRESS: &str = "0xca11bde05977b3631167028862be2a173976ca11";
@@ -527,7 +528,11 @@ where
         }
         let tasks = self.claim_tasks(now_ms, batch_size, scope).await?;
         if tasks.is_empty() {
-            return Ok(OnchainRefreshRunReport::default());
+            let data_metric_refreshes = self.drain_data_metric_refresh_tasks(now_ms).await?;
+            return Ok(OnchainRefreshRunReport {
+                data_metric_refreshes,
+                ..OnchainRefreshRunReport::default()
+            });
         }
 
         let mut report = OnchainRefreshRunReport {
@@ -610,7 +615,6 @@ where
                             report.completed += batch_report.completed;
                             report.debounced_tasks += batch_report.debounced_tasks;
                             report.skipped_tasks += batch_report.debounced_tasks;
-                            report.data_metric_refreshes += batch_report.data_metric_refreshes;
                         }
                         Err(error) => {
                             let message = error.to_string();
@@ -626,6 +630,7 @@ where
                     }
                 }
             }
+            report.data_metric_refreshes += self.drain_data_metric_refresh_tasks(now_ms).await?;
         }
 
         report.duration_ms = started_at.elapsed().as_millis();
@@ -699,6 +704,74 @@ where
         }
 
         Ok(drained_total)
+    }
+
+    async fn drain_data_metric_refresh_tasks(
+        &self,
+        now_ms: i64,
+    ) -> Result<usize, OnchainRefreshWorkerError> {
+        let mut refreshed_total = 0usize;
+        let mut attempted_ids = BTreeSet::<String>::new();
+        for _ in 0..MAX_ONCHAIN_REFRESH_DATA_METRIC_REFRESH_ROWS {
+            let mut transaction = self.pool.begin().await?;
+            let skipped_ids = attempted_ids.iter().cloned().collect::<Vec<_>>();
+            let row = sqlx::query(
+                "SELECT id, contract_set_id, chain_id, dao_code, governor_address, token_address
+                 FROM onchain_refresh_data_metric_task
+                 WHERE NOT (id = ANY($1::TEXT[]))
+                 ORDER BY updated_at ASC, id ASC
+                 LIMIT 1
+                 FOR UPDATE SKIP LOCKED",
+            )
+            .bind(&skipped_ids)
+            .fetch_optional(&mut *transaction)
+            .await?;
+            let Some(row) = row else {
+                transaction.commit().await?;
+                break;
+            };
+
+            let id: String = row.get("id");
+            attempted_ids.insert(id.clone());
+            let scope = DataMetricRefreshScope {
+                contract_set_id: row.get("contract_set_id"),
+                chain_id: row.get("chain_id"),
+                dao_code: row.get("dao_code"),
+                governor_address: row.get("governor_address"),
+                token_address: row.get("token_address"),
+            };
+
+            if let Err(error) = refresh_data_metric_scope(&mut transaction, &scope).await {
+                sqlx::query(
+                    "UPDATE onchain_refresh_data_metric_task
+                     SET attempts = attempts + 1,
+                         last_error = $2,
+                         updated_at = $3::NUMERIC(78, 0)
+                     WHERE id = $1",
+                )
+                .bind(&id)
+                .bind(truncate_error(&error.to_string()))
+                .bind(now_ms.to_string())
+                .execute(&mut *transaction)
+                .await?;
+                transaction.commit().await?;
+                log::warn!(
+                    "onchain refresh data metric refresh failed id={} error={}",
+                    id,
+                    error
+                );
+                continue;
+            }
+
+            sqlx::query("DELETE FROM onchain_refresh_data_metric_task WHERE id = $1")
+                .bind(&id)
+                .execute(&mut *transaction)
+                .await?;
+            transaction.commit().await?;
+            refreshed_total += 1;
+        }
+
+        Ok(refreshed_total)
     }
 
     pub async fn ready_backlog(&self) -> Result<u64, OnchainRefreshWorkerError> {
@@ -935,8 +1008,8 @@ where
                 self.current_power_method,
             )
             .await?;
-            let data_metric_refreshes =
-                refresh_data_metric_scopes(&mut transaction, data_metric_scopes).await?;
+            enqueue_data_metric_refresh_scopes(&mut transaction, data_metric_scopes, now_ms)
+                .await?;
             let debounced_tasks = complete_tasks(
                 &mut transaction,
                 successes,
@@ -946,10 +1019,10 @@ where
             )
             .await?;
 
-            Ok::<_, OnchainRefreshWorkerError>((data_metric_refreshes, debounced_tasks))
+            Ok::<_, OnchainRefreshWorkerError>(debounced_tasks)
         }
         .await;
-        let (data_metric_refreshes, debounced_tasks) = match result {
+        let debounced_tasks = match result {
             Ok(report) => report,
             Err(error) => {
                 if let Err(rollback_error) = transaction.rollback().await {
@@ -972,7 +1045,7 @@ where
         Ok(OnchainRefreshApplyBatchReport {
             completed: successes.len().saturating_sub(debounced_tasks),
             debounced_tasks,
-            data_metric_refreshes,
+            data_metric_refreshes: 0,
         })
     }
 
@@ -3128,19 +3201,42 @@ struct DataMetricRefreshScope {
     token_address: String,
 }
 
-async fn refresh_data_metric_scopes(
+async fn enqueue_data_metric_refresh_scopes(
     transaction: &mut Transaction<'_, Postgres>,
     scopes: &BTreeSet<DataMetricRefreshScope>,
-) -> Result<usize, sqlx::Error> {
+    now_ms: i64,
+) -> Result<(), sqlx::Error> {
     if scopes.is_empty() {
-        return Ok(0);
+        return Ok(());
     }
 
-    for scope in scopes {
-        refresh_data_metric_scope(transaction, scope).await?;
-    }
+    let mut query = QueryBuilder::<Postgres>::new(
+        "INSERT INTO onchain_refresh_data_metric_task (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            created_at, updated_at
+         ) ",
+    );
+    query.push_values(scopes, |mut values, scope| {
+        values
+            .push_bind(data_metric_refresh_task_id(scope))
+            .push_bind(&scope.contract_set_id)
+            .push_bind(scope.chain_id)
+            .push_bind(&scope.dao_code)
+            .push_bind(&scope.governor_address)
+            .push_bind(&scope.token_address)
+            .push_bind(now_ms.to_string())
+            .push_unseparated("::NUMERIC(78, 0)")
+            .push_bind(now_ms.to_string())
+            .push_unseparated("::NUMERIC(78, 0)");
+    });
+    query.push(
+        " ON CONFLICT (id) DO UPDATE
+          SET token_address = EXCLUDED.token_address,
+              updated_at = EXCLUDED.updated_at",
+    );
+    query.build().execute(&mut **transaction).await?;
 
-    Ok(scopes.len())
+    Ok(())
 }
 
 fn data_metric_refresh_scopes_for_chunk(
@@ -3160,6 +3256,16 @@ fn data_metric_refresh_scope(task: &OnchainRefreshTask) -> DataMetricRefreshScop
         governor_address: task.governor_address.clone(),
         token_address: task.token_address.clone(),
     }
+}
+
+fn data_metric_refresh_task_id(scope: &DataMetricRefreshScope) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        scope.contract_set_id,
+        scope.chain_id,
+        scope.dao_code.as_deref().unwrap_or(""),
+        scope.governor_address
+    )
 }
 
 async fn refresh_data_metric_scope(

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -248,6 +248,32 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .context("ensure contributor data metric scope index")?;
 
     sqlx::query(
+        "CREATE TABLE IF NOT EXISTS onchain_refresh_data_metric_task (
+            id TEXT PRIMARY KEY,
+            contract_set_id TEXT NOT NULL,
+            chain_id INTEGER NOT NULL,
+            dao_code TEXT,
+            governor_address TEXT NOT NULL,
+            token_address TEXT NOT NULL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            created_at NUMERIC(78, 0) NOT NULL,
+            updated_at NUMERIC(78, 0) NOT NULL
+         )",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure onchain refresh data metric task table")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_data_metric_task_ready_idx
+         ON onchain_refresh_data_metric_task (updated_at, id)",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure onchain refresh data metric task ready index")?;
+
+    sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_graphql_scope_power_idx
          ON contributor (chain_id, governor_address, dao_code, power DESC, id)
          INCLUDE (

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -173,6 +173,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "onchain_refresh_data_metric_task_ready_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "onchain_refresh_task_failed_retry_idx",
     )
     .await?;

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -481,7 +481,7 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     assert_eq!(report.unique_accounts, 2);
     assert_eq!(report.apply_chunks, 2);
     assert_eq!(report.apply_batch_size, 1);
-    assert_eq!(report.data_metric_refreshes, 2);
+    assert_eq!(report.data_metric_refreshes, 1);
     assert_eq!(
         contributor_values(&database.pool, ACCOUNT_ONE).await?,
         ("11".to_owned(), Some("17".to_owned()))


### PR DESCRIPTION
Refresh each onchain data metric scope only on its final successful apply chunk within a worker run.

Why:
- After #907 and #908, staging worker passes improved to ~143s/1000 tasks with `db_update_failures=0`, but slow logs still showed repeated `data_metric` full-scope aggregation, including 10s+ scans on large DAO scopes such as ENS.
- A run can process many tasks for the same DAO over many apply chunks; refreshing the same scope after every 20-row chunk repeatedly scans the same contributor scope.

Change:
- Pre-count data metric scope appearances across apply chunks.
- Pass a scope to `apply_success_batch` only for the final chunk that contains that scope.
- Existing worker test with two same-scope chunks now expects one metric refresh while still asserting final aggregate correctness.

Verification:
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_power_fallback_test cargo test --locked -p degov-datalens-indexer --test onchain_refresh_worker -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`

Review note: please pay special attention to the behavior when a final chunk for a scope fails after earlier chunks for that same scope have completed.