### PR TITLE
fix(indexer): keep init migration checksum stable

### DIFF
--- a/apps/indexer/migrations/0001_init.sql
+++ b/apps/indexer/migrations/0001_init.sql
@@ -232,22 +232,6 @@ CREATE INDEX IF NOT EXISTS onchain_refresh_task_ready_claim_idx
   ON onchain_refresh_task (next_run_at, updated_at, id)
   WHERE status IN ('pending', 'failed');
 
-CREATE TABLE IF NOT EXISTS onchain_refresh_data_metric_task (
-  id TEXT PRIMARY KEY,
-  contract_set_id TEXT NOT NULL,
-  chain_id INTEGER NOT NULL,
-  dao_code TEXT,
-  governor_address TEXT NOT NULL,
-  token_address TEXT NOT NULL,
-  attempts INTEGER NOT NULL DEFAULT 0,
-  last_error TEXT,
-  created_at NUMERIC(78, 0) NOT NULL,
-  updated_at NUMERIC(78, 0) NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS onchain_refresh_data_metric_task_ready_idx
-  ON onchain_refresh_data_metric_task (updated_at, id);
-
 CREATE TABLE IF NOT EXISTS onchain_refresh_deferred_candidate (
   id TEXT PRIMARY KEY,
   contract_set_id TEXT NOT NULL,

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -348,6 +348,7 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(init_migration.contains("fresh index initialization"));
     assert!(init_migration.contains("No historical in-place migration"));
     assert!(init_migration.contains("reset or recreate"));
+    assert!(!init_migration.contains("onchain_refresh_data_metric_task"));
 
     let hot_path_migration = include_str!("../migrations/0002_hot_path_runtime_indexes.sql");
     assert!(hot_path_migration.contains("CREATE INDEX CONCURRENTLY IF NOT EXISTS"));
@@ -355,6 +356,7 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
 
     let runtime_migration = include_str!("../src/runtime/migrate.rs");
     assert!(runtime_migration.contains("delegate_mapping_effective_count_idx"));
+    assert!(runtime_migration.contains("onchain_refresh_data_metric_task"));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary\n- remove the #909 dirty metric queue table from the historical 0001 init migration\n- keep the dirty metric queue table covered by runtime migration instead\n- add a regression assertion so runtime-only onchain refresh tables are not added to 0001_init.sql\n\n## Why\nExisting staging databases reject sha-1e7d2c9 at startup because sqlx detects that migration 1 was previously applied but has been modified.\n\n## Verification\n- cargo test --locked -p degov-datalens-indexer --test migration_schema test_indexer_keeps_init_migration_stable_and_appends_runtime_markers -- --nocapture\n- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_power_fallback_test cargo test --locked -p degov-datalens-indexer --test migration_schema -- --nocapture\n- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5434/degov_onchain_refresh_power_fallback_test cargo test --locked -p degov-datalens-indexer --test onchain_refresh_worker -- --nocapture\n- cargo fmt --all --check\n- git diff --check