### PR TITLE
perf(indexer): use positive delegate count index

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -284,6 +284,15 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .context("ensure delegate mapping effective count index")?;
 
     sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_positive_count_idx
+         ON delegate_mapping (contract_set_id, \"to\") INCLUDE (id)
+         WHERE power > 0",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure positive delegate mapping count index")?;
+
+    sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_data_metric_scope_idx
          ON contributor (contract_set_id, chain_id, governor_address, dao_code)
          INCLUDE (power, balance)",
@@ -376,6 +385,7 @@ async fn repair_invalid_runtime_indexes_for_connection(
     drop_invalid_runtime_index(connection, "delegate_current_power_refresh_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_mapping_to_lookup_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_mapping_effective_count_idx").await?;
+    drop_invalid_runtime_index(connection, "delegate_mapping_positive_count_idx").await?;
     drop_invalid_runtime_index(connection, "contributor_data_metric_scope_idx").await?;
     drop_invalid_runtime_index(connection, "contributor_graphql_scope_power_idx").await?;
     drop_invalid_runtime_index(connection, "provisional_contributor_live_scope_power_idx").await?;

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -1893,7 +1893,7 @@ async fn recompute_delegate_count_effective(
              FROM (
                 SELECT affected.contract_set_id,
                        affected.id,
-                       COUNT(delegate_mapping.id) FILTER (WHERE delegate_mapping.power > 0)::INT AS positive_count
+                       COUNT(delegate_mapping.id)::INT AS positive_count
                 FROM (VALUES ",
         );
         for (index, (contract_set_id, id)) in rows.iter().enumerate() {
@@ -1912,6 +1912,7 @@ async fn recompute_delegate_count_effective(
                 LEFT JOIN delegate_mapping
                   ON delegate_mapping.contract_set_id = affected.contract_set_id
                  AND delegate_mapping."to" = affected.id
+                 AND delegate_mapping.power > 0
                 GROUP BY affected.contract_set_id, affected.id
              ) AS counts
              WHERE contributor.contract_set_id = counts.contract_set_id

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -161,6 +161,23 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "delegate_mapping_positive_count_idx",
+    )
+    .await?;
+    assert_index_definition_contains(
+        &database.pool,
+        &database.schema,
+        "delegate_mapping_positive_count_idx",
+        &[
+            "USING btree (contract_set_id, \"to\")",
+            "INCLUDE (id)",
+            "WHERE (power >",
+        ],
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "delegate_mapping_effective_count_idx",
     )
     .await?;
@@ -362,6 +379,8 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
 
     let runtime_migration = include_str!("../src/runtime/migrate.rs");
     assert!(runtime_migration.contains("delegate_mapping_effective_count_idx"));
+    assert!(runtime_migration.contains("delegate_mapping_positive_count_idx"));
+    assert!(runtime_migration.contains("WHERE power > 0"));
     assert!(runtime_migration.contains("onchain_refresh_data_metric_task"));
 
     Ok(())
@@ -501,6 +520,35 @@ async fn assert_index_exists(
     .await?;
 
     assert!(exists, "expected index {schema}.{index_name} to exist");
+
+    Ok(())
+}
+
+async fn assert_index_definition_contains(
+    pool: &PgPool,
+    schema: &str,
+    index_name: &str,
+    expected_fragments: &[&str],
+) -> Result<(), Box<dyn Error>> {
+    let indexdef: String = sqlx::query_scalar(
+        r#"
+        SELECT indexdef
+        FROM pg_indexes
+        WHERE schemaname = $1
+          AND indexname = $2
+        "#,
+    )
+    .bind(schema)
+    .bind(index_name)
+    .fetch_one(pool)
+    .await?;
+
+    for fragment in expected_fragments {
+        assert!(
+            indexdef.contains(fragment),
+            "expected index {schema}.{index_name} definition to contain {fragment:?}; got {indexdef}"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a runtime partial index for positive delegate mapping counts
- count only positive delegate mappings in the JOIN condition so recompute can use the partial index
- cover the new runtime index in migration schema tests

## Tests
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:15433/postgres cargo test --locked -p degov-datalens-indexer --test migration_schema -- --nocapture
- cargo test --locked -p degov-datalens-indexer store::postgres::token_store_tests -- --nocapture
- cargo fmt --all --check
- git diff --check