### PR TITLE
fix(delegates): count active delegate profiles

### DIFF
--- a/apps/indexer/src/graphql/filters.rs
+++ b/apps/indexer/src/graphql/filters.rs
@@ -256,6 +256,11 @@ pub(super) fn push_contributor_filters<'a>(
         push_qualified_column(query, table_alias, "power");
         query.push(" < ").push_bind(power).push("::numeric");
     }
+    if let Some(count) = where_.delegates_count_all_gt {
+        push_and(query, has_condition);
+        push_qualified_column(query, table_alias, "delegates_count_all");
+        query.push(" > ").push_bind(count);
+    }
     if let Some(or) = &where_.or {
         push_or_group(query, has_condition, or, |query, has_condition, filter| {
             push_contributor_filters(query, has_condition, filter, table_alias);

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -512,6 +512,8 @@ pub struct ContributorWhereInput {
     pub(super) id_not_eq: Option<String>,
     #[graphql(name = "power_lt")]
     pub(super) power_lt: Option<i64>,
+    #[graphql(name = "delegatesCountAll_gt")]
+    pub(super) delegates_count_all_gt: Option<i32>,
     #[graphql(name = "OR")]
     pub(super) or: Option<Vec<ContributorWhereInput>>,
 }

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -187,6 +187,17 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
                 limit
                 items { id }
               }
+              contributorsWithDelegatorsPage: contributorsPage(
+                where: { delegatesCountAll_gt: 0 }
+                orderBy: id_ASC
+                limit: 1
+                offset: 0
+              ) {
+                totalCount
+                offset
+                limit
+                items { id delegatesCountAll }
+              }
               delegatesPage(where: { fromDelegate_eq: "0xdelegator" }, orderBy: [id_ASC], limit: 1, offset: 0) {
                 totalCount
                 offset
@@ -282,6 +293,17 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
             .as_array()
             .expect("items")
             .len(),
+        1
+    );
+    assert_eq!(data["contributorsWithDelegatorsPage"]["totalCount"], 1);
+    assert_eq!(data["contributorsWithDelegatorsPage"]["offset"], 0);
+    assert_eq!(data["contributorsWithDelegatorsPage"]["limit"], 1);
+    assert_eq!(
+        data["contributorsWithDelegatorsPage"]["items"][0]["id"],
+        "0xvoter1"
+    );
+    assert_eq!(
+        data["contributorsWithDelegatorsPage"]["items"][0]["delegatesCountAll"],
         1
     );
     assert_eq!(data["delegatesPage"]["totalCount"], 1);

--- a/apps/web/scripts/delegates-count-source.test.ts
+++ b/apps/web/scripts/delegates-count-source.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const delegatesPageSource = readFileSync(
+  new URL("../src/app/delegates/page.tsx", import.meta.url),
+  "utf8"
+);
+const contributorQueriesSource = readFileSync(
+  new URL("../src/services/graphql/queries/contributors.ts", import.meta.url),
+  "utf8"
+);
+const graphqlServiceSource = readFileSync(
+  new URL("../src/services/graphql/index.ts", import.meta.url),
+  "utf8"
+);
+
+test("delegates page title uses contributors with delegators count", () => {
+  assert.match(contributorQueriesSource, /contributorsPage\s*\(/);
+  assert.match(contributorQueriesSource, /totalCount/);
+  assert.match(graphqlServiceSource, /getContributorsPage/);
+  assert.match(delegatesPageSource, /contributorService\.getContributorsPage/);
+  assert.match(delegatesPageSource, /delegatesCountAll_gt:\s*0/);
+  assert.match(delegatesPageSource, /delegatesCountPage\?\.totalCount/);
+  assert.doesNotMatch(
+    delegatesPageSource,
+    /dataMetrics\?\.holdersCount\s*\?\?\s*dataMetrics\?\.memberCount/
+  );
+});

--- a/apps/web/src/app/delegates/page.tsx
+++ b/apps/web/src/app/delegates/page.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDebounce } from "react-use";
 import { useAccount } from "wagmi";
 
@@ -21,7 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WithConnect } from "@/components/with-connect";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
-import { proposalService } from "@/services/graphql";
+import { buildGovernanceScope, contributorService } from "@/services/graphql";
 import type { ContributorItem } from "@/services/graphql/types";
 
 import type { Address } from "viem";
@@ -74,6 +74,10 @@ export default function Members() {
   const [sortState, setSortState] =
     useState<MemberSortState>(DEFAULT_SORT_STATE);
   const [hasUserSorted, setHasUserSorted] = useState(false);
+  const governanceScope = useMemo(
+    () => buildGovernanceScope(daoConfig),
+    [daoConfig]
+  );
 
   // Debounce search term
   useDebounce(
@@ -84,11 +88,20 @@ export default function Members() {
     [searchTerm]
   );
 
-  const { data: dataMetrics } = useQuery({
-    queryKey: ["dataMetrics", daoConfig?.indexer?.endpoint],
+  const { data: delegatesCountPage } = useQuery({
+    queryKey: ["delegates-count", daoConfig?.indexer?.endpoint, governanceScope],
     queryFn: () =>
-      proposalService.getProposalMetrics(
-        daoConfig?.indexer?.endpoint as string
+      contributorService.getContributorsPage(
+        daoConfig?.indexer?.endpoint as string,
+        {
+          limit: 0,
+          offset: 0,
+          orderBy: "id_ASC",
+          where: {
+            ...governanceScope,
+            delegatesCountAll_gt: 0,
+          },
+        }
       ),
     enabled: !!daoConfig?.indexer?.endpoint,
   });
@@ -145,7 +158,7 @@ export default function Members() {
     applySortState("delegators", direction);
 
   const getDisplayTitle = () => {
-    const totalCount = dataMetrics?.holdersCount ?? dataMetrics?.memberCount;
+    const totalCount = delegatesCountPage?.totalCount;
     if (totalCount != null) {
       return t("titleWithCount", { count: totalCount });
     }

--- a/apps/web/src/services/graphql/index.ts
+++ b/apps/web/src/services/graphql/index.ts
@@ -72,6 +72,7 @@ type ContributorWhere = GovernanceScope & {
   id_in?: string[];
   id_not_eq?: string;
   id_eq?: string;
+  delegatesCountAll_gt?: number;
 };
 
 const normalizeScopeAddress = (address?: string | null) => {
@@ -546,6 +547,33 @@ export const treasuryService = {
 };
 
 export const contributorService = {
+  getContributorsPage: async (
+    endpoint: string,
+    options: {
+      limit: number;
+      offset: number;
+      orderBy?: string | string[];
+      where?: ContributorWhere;
+    }
+  ) => {
+    const orderByInput = Array.isArray(options?.orderBy)
+      ? options?.orderBy
+      : options?.orderBy
+      ? [options.orderBy]
+      : ["id_ASC"];
+
+    const response = await request<Types.ContributorPageResponse>(
+      endpoint,
+      Queries.GET_CONTRIBUTORS_PAGE,
+      {
+        limit: options.limit,
+        offset: options.offset,
+        orderBy: orderByInput,
+        where: options.where,
+      }
+    );
+    return response?.contributorsPage;
+  },
   getAllContributors: async (
     endpoint: string,
     options: {

--- a/apps/web/src/services/graphql/queries/contributors.ts
+++ b/apps/web/src/services/graphql/queries/contributors.ts
@@ -33,3 +33,27 @@ export const GET_CONTRIBUTORS = gql`
     }
   }
 `;
+
+export const GET_CONTRIBUTORS_PAGE = gql`
+  query GetContributorsPage(
+    $limit: Int
+    $offset: Int
+    $orderBy: [ContributorOrderByInput!]
+    $where: ContributorWhereInput
+  ) {
+    contributorsPage(
+      limit: $limit
+      offset: $offset
+      orderBy: $orderBy
+      where: $where
+    ) {
+      totalCount
+      offset
+      limit
+      items {
+        id
+        delegatesCountAll
+      }
+    }
+  }
+`;

--- a/apps/web/src/services/graphql/types/contributors.ts
+++ b/apps/web/src/services/graphql/types/contributors.ts
@@ -11,3 +11,14 @@ export type ContributorItem = {
 export type ContributorResponse = {
   contributors: ContributorItem[];
 };
+
+export type ContributorPageItem = {
+  totalCount: number;
+  offset: number;
+  limit: number;
+  items: Pick<ContributorItem, "id" | "delegatesCountAll">[];
+};
+
+export type ContributorPageResponse = {
+  contributorsPage: ContributorPageItem;
+};


### PR DESCRIPTION
## Summary
- add contributorsPage filtering by delegatesCountAll_gt in the indexer GraphQL API
- use contributorsPage(where: { delegatesCountAll_gt: 0 }).totalCount for the delegates page title
- add regression coverage for the GraphQL filter and delegates count source

## Verification
- DEGOV_INDEXER_TEST_DATABASE_URL='postgresql://postgres:postgres@localhost:55432/degov_indexer_test' cargo test -p degov-datalens-indexer --test graphql_service --locked
- cargo fmt --check
- cargo build -p degov-datalens-indexer --locked
- node --experimental-strip-types apps/web/scripts/delegates-count-source.test.ts && node --experimental-strip-types apps/web/scripts/delegates-default-sort.test.ts && node --experimental-strip-types apps/web/scripts/delegates-display-format.test.ts && node --experimental-strip-types apps/web/scripts/governance-counts.test.ts
- pnpm --filter @degov/web lint (0 errors, 1 pre-existing import/order warning)
- pnpm --filter @degov/web build