### PR TITLE
test(web): cover localized delegates count route

### DIFF
--- a/apps/web/scripts/delegates-count-source.test.ts
+++ b/apps/web/scripts/delegates-count-source.test.ts
@@ -6,6 +6,10 @@ const delegatesPageSource = readFileSync(
   new URL("../src/app/delegates/page.tsx", import.meta.url),
   "utf8"
 );
+const localeDelegatesPageSource = readFileSync(
+  new URL("../src/app/[locale]/delegates/page.tsx", import.meta.url),
+  "utf8"
+);
 const contributorQueriesSource = readFileSync(
   new URL("../src/services/graphql/queries/contributors.ts", import.meta.url),
   "utf8"
@@ -16,6 +20,10 @@ const graphqlServiceSource = readFileSync(
 );
 
 test("delegates page title uses contributors with delegators count", () => {
+  assert.match(
+    localeDelegatesPageSource,
+    /export\s+\{\s*default\s*\}\s+from\s+"..\/..\/delegates\/page"/
+  );
   assert.match(contributorQueriesSource, /contributorsPage\s*\(/);
   assert.match(contributorQueriesSource, /totalCount/);
   assert.match(graphqlServiceSource, /getContributorsPage/);


### PR DESCRIPTION
## Summary
- add coverage that the localized delegates route uses the corrected delegates page
- protects the delegates count display from regressing when /delegates is rewritten to /en/delegates

## Tests
- node --experimental-strip-types apps/web/scripts/delegates-count-source.test.ts
- node --experimental-strip-types apps/web/scripts/delegates-default-sort.test.ts
- node --experimental-strip-types apps/web/scripts/delegates-display-format.test.ts
- node --experimental-strip-types apps/web/scripts/governance-counts.test.ts
- pnpm --filter @degov/web build