### PR TITLE
fix(delegates): count historical delegate profiles

### DIFF
--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -446,6 +446,48 @@ pub(super) async fn count_delegates(
     Ok(total)
 }
 
+pub(super) async fn count_delegate_profiles(
+    pool: &PgPool,
+    implicit_scope: &GraphqlScope,
+    where_: Option<&DelegateWhereInput>,
+) -> GraphqlResult<i64> {
+    // TODO: switch this realtime count to dataMetrics/materialized metrics.
+    let mut query = QueryBuilder::<Postgres>::new(
+        r#"
+        SELECT COUNT(DISTINCT lower(to_delegate))::int8 AS total
+        FROM (
+          SELECT delegate.id, delegate.contract_set_id, delegate.chain_id,
+            delegate.dao_code, delegate.governor_address, delegate.from_delegate,
+            delegate.to_delegate, delegate.is_current,
+            COALESCE(delegate_power_overlay.power, delegate.power) AS power
+          FROM delegate
+          LEFT JOIN degov_provisional_delegate_power_overlay delegate_power_overlay
+            ON delegate_power_overlay.contract_set_id = delegate.contract_set_id
+           AND delegate_power_overlay.chain_id IS NOT DISTINCT FROM delegate.chain_id
+           AND delegate_power_overlay.dao_code IS NOT DISTINCT FROM delegate.dao_code
+           AND delegate_power_overlay.governor_address IS NOT DISTINCT FROM delegate.governor_address
+           AND (
+             delegate_power_overlay.token_address IS NOT DISTINCT FROM delegate.token_address
+             OR delegate.token_address IS NULL
+           )
+           AND delegate_power_overlay.delegator = delegate.from_delegate
+           AND delegate_power_overlay.delegate = delegate.to_delegate
+           AND delegate_power_overlay.source = 'live-onchain'
+           AND delegate_power_overlay.status = 'available'
+        ) delegate
+        "#,
+    );
+    push_delegate_where(&mut query, implicit_scope, where_);
+    if !implicit_scope.is_empty() || where_.is_some() {
+        query.push(" AND ");
+    } else {
+        query.push(" WHERE ");
+    }
+    query.push("lower(to_delegate) <> '0x0000000000000000000000000000000000000000'");
+    let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
+    Ok(total)
+}
+
 pub(super) async fn count_delegate_mappings(
     pool: &PgPool,
     implicit_scope: &GraphqlScope,

--- a/apps/indexer/src/graphql/schema.rs
+++ b/apps/indexer/src/graphql/schema.rs
@@ -283,6 +283,14 @@ impl QueryRoot {
         })
     }
 
+    async fn delegate_profiles_count(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<DelegateWhereInput>,
+    ) -> GraphqlResult<i64> {
+        count_delegate_profiles(pool(ctx)?, scope(ctx)?, where_.as_ref()).await
+    }
+
     async fn delegate_mappings_page(
         &self,
         ctx: &Context<'_>,

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -204,6 +204,7 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
                 limit
                 items { id }
               }
+              delegateProfilesCount
               delegateMappingsPage(where: { from_eq: "0xdelegator" }, orderBy: [id_ASC], limit: 1, offset: 0) {
                 totalCount
                 offset
@@ -309,6 +310,7 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
     assert_eq!(data["delegatesPage"]["totalCount"], 1);
     assert_eq!(data["delegatesPage"]["offset"], 0);
     assert_eq!(data["delegatesPage"]["limit"], 1);
+    assert_eq!(data["delegateProfilesCount"], 2);
     assert_eq!(data["delegateMappingsPage"]["totalCount"], 1);
     assert_eq!(data["delegateMappingsPage"]["offset"], 0);
     assert_eq!(data["delegateMappingsPage"]["limit"], 1);
@@ -832,7 +834,7 @@ async fn test_graphql_schema_applies_implicit_scope_to_queries_and_pages()
               proposalsPage { totalCount offset limit items { id } }
               dataMetricsPage { totalCount offset limit items { id } }
               contributorsPage { totalCount offset limit items { id } }
-              delegatesPage { totalCount offset limit items { id } }
+              delegatesPage(where: { isCurrent_eq: true }) { totalCount offset limit items { id } }
               delegateMappingsPage { totalCount offset limit items { id } }
             }
             "#,
@@ -1448,7 +1450,10 @@ async fn seed_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
         INSERT INTO delegate (
           id, contract_set_id, chain_id, dao_code, governor_address, from_delegate, to_delegate, block_number,
           block_timestamp, transaction_hash, is_current, power
-        ) VALUES ('0xdelegator_0xdelegate', $1, 1135, 'lisk-dao', '0xgovernor', '0xdelegator', '0xdelegate', 807, 1700000125, '0xdelegate', TRUE, 75)
+        ) VALUES
+          ('0xdelegator_0xdelegate', $1, 1135, 'lisk-dao', '0xgovernor', '0xdelegator', '0xdelegate', 807, 1700000125, '0xdelegate', TRUE, 75),
+          ('0xolddelegator_0xformer', $1, 1135, 'lisk-dao', '0xgovernor', '0xolddelegator', '0xformer', 808, 1700000126, '0xformer', FALSE, 0),
+          ('0xotherdelegator_0xformer', $1, 1135, 'lisk-dao', '0xgovernor', '0xotherdelegator', '0xformer', 809, 1700000127, '0xformer2', FALSE, 0)
         "#,
     )
     .bind(CONTRACT_SET_ID)

--- a/apps/web/scripts/delegates-count-source.test.ts
+++ b/apps/web/scripts/delegates-count-source.test.ts
@@ -19,17 +19,19 @@ const graphqlServiceSource = readFileSync(
   "utf8"
 );
 
-test("delegates page title uses contributors with delegators count", () => {
+test("delegates page title uses delegate profile count", () => {
   assert.match(
     localeDelegatesPageSource,
     /export\s+\{\s*default\s*\}\s+from\s+"..\/..\/delegates\/page"/
   );
-  assert.match(contributorQueriesSource, /contributorsPage\s*\(/);
-  assert.match(contributorQueriesSource, /totalCount/);
-  assert.match(graphqlServiceSource, /getContributorsPage/);
-  assert.match(delegatesPageSource, /contributorService\.getContributorsPage/);
-  assert.match(delegatesPageSource, /delegatesCountAll_gt:\s*0/);
-  assert.match(delegatesPageSource, /delegatesCountPage\?\.totalCount/);
+  assert.match(contributorQueriesSource, /delegateProfilesCount\s*\(/);
+  assert.match(graphqlServiceSource, /getDelegateProfilesCount/);
+  assert.match(
+    delegatesPageSource,
+    /contributorService\.getDelegateProfilesCount/
+  );
+  assert.match(delegatesPageSource, /delegateProfilesCount/);
+  assert.doesNotMatch(delegatesPageSource, /delegatesCountAll_gt:\s*0/);
   assert.doesNotMatch(
     delegatesPageSource,
     /dataMetrics\?\.holdersCount\s*\?\?\s*dataMetrics\?\.memberCount/

--- a/apps/web/src/app/delegates/page.tsx
+++ b/apps/web/src/app/delegates/page.tsx
@@ -88,19 +88,13 @@ export default function Members() {
     [searchTerm]
   );
 
-  const { data: delegatesCountPage } = useQuery({
+  const { data: delegateProfilesCount } = useQuery({
     queryKey: ["delegates-count", daoConfig?.indexer?.endpoint, governanceScope],
     queryFn: () =>
-      contributorService.getContributorsPage(
+      contributorService.getDelegateProfilesCount(
         daoConfig?.indexer?.endpoint as string,
         {
-          limit: 0,
-          offset: 0,
-          orderBy: "id_ASC",
-          where: {
-            ...governanceScope,
-            delegatesCountAll_gt: 0,
-          },
+          where: governanceScope,
         }
       ),
     enabled: !!daoConfig?.indexer?.endpoint,
@@ -158,9 +152,8 @@ export default function Members() {
     applySortState("delegators", direction);
 
   const getDisplayTitle = () => {
-    const totalCount = delegatesCountPage?.totalCount;
-    if (totalCount != null) {
-      return t("titleWithCount", { count: totalCount });
+    if (delegateProfilesCount != null) {
+      return t("titleWithCount", { count: delegateProfilesCount });
     }
     return t("title");
   };

--- a/apps/web/src/services/graphql/index.ts
+++ b/apps/web/src/services/graphql/index.ts
@@ -547,6 +547,21 @@ export const treasuryService = {
 };
 
 export const contributorService = {
+  getDelegateProfilesCount: async (
+    endpoint: string,
+    options: {
+      where?: DelegateWhere;
+    } = {}
+  ) => {
+    const response = await request<Types.DelegateProfilesCountResponse>(
+      endpoint,
+      Queries.GET_DELEGATE_PROFILES_COUNT,
+      {
+        where: options.where,
+      }
+    );
+    return response?.delegateProfilesCount ?? 0;
+  },
   getContributorsPage: async (
     endpoint: string,
     options: {

--- a/apps/web/src/services/graphql/queries/contributors.ts
+++ b/apps/web/src/services/graphql/queries/contributors.ts
@@ -57,3 +57,9 @@ export const GET_CONTRIBUTORS_PAGE = gql`
     }
   }
 `;
+
+export const GET_DELEGATE_PROFILES_COUNT = gql`
+  query GetDelegateProfilesCount($where: DelegateWhereInput) {
+    delegateProfilesCount(where: $where)
+  }
+`;

--- a/apps/web/src/services/graphql/types/contributors.ts
+++ b/apps/web/src/services/graphql/types/contributors.ts
@@ -22,3 +22,7 @@ export type ContributorPageItem = {
 export type ContributorPageResponse = {
   contributorsPage: ContributorPageItem;
 };
+
+export type DelegateProfilesCountResponse = {
+  delegateProfilesCount: number;
+};


### PR DESCRIPTION
## Summary

- add `delegateProfilesCount(where: DelegateWhereInput)` to the indexer GraphQL API
- count distinct historical delegate `to_delegate` addresses, scoped by the existing delegate filters and excluding the zero address
- use the new count for the web delegates page title instead of `contributorsPage(where: { delegatesCountAll_gt: 0 })`
- leave a TODO to switch this realtime count to dataMetrics/materialized metrics later

## Context

- Tally ENS full delegates API unique addresses: 37,551
- Current DeGov contributors where `delegates_count_all > 0`: 36,762
- Onchain historical distinct `delegate.to_delegate` count: 37,531
- Remaining 20 Tally-only addresses have `votes=0` and `delegators=0`, likely offchain Tally delegate profiles
- ENS query timing observed before this PR: cold-ish `EXPLAIN ANALYZE` around 4.6s, cached direct `SELECT` around 1.8s; future dataMetrics materialization/indexing is desired

## Verification

- `cargo fmt --check`
- `cargo build -p degov-datalens-indexer --locked`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/degov_indexer_test cargo test -p degov-datalens-indexer --test graphql_service --locked`
- `node --test apps/web/scripts/*.test.ts`
- `pnpm --filter @degov/web build`
