### PR TITLE
Enable safe-to-latest provisional indexing

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -22,6 +22,7 @@ pub trait DatalensNativeReader {
 
 pub trait DatalensDurableHeadReader {
     fn durable_head_height(&mut self, config: &DatalensConfig) -> Result<i64, DatalensError>;
+    fn latest_head_height(&mut self, config: &DatalensConfig) -> Result<i64, DatalensError>;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -797,13 +798,24 @@ impl DatalensProvisionalLogQueryReader for DatalensNativeClient {
 
 impl DatalensDurableHeadReader for DatalensNativeClient {
     fn durable_head_height(&mut self, config: &DatalensConfig) -> Result<i64, DatalensError> {
+        self.head_height(config, ChainHeadFinalityInput::Safe)
+    }
+
+    fn latest_head_height(&mut self, config: &DatalensConfig) -> Result<i64, DatalensError> {
+        self.head_height(config, ChainHeadFinalityInput::Latest)
+    }
+}
+
+impl DatalensNativeClient {
+    fn head_height(
+        &mut self,
+        config: &DatalensConfig,
+        finality: ChainHeadFinalityInput,
+    ) -> Result<i64, DatalensError> {
         let response = self
             .client
             .native()
-            .chain_head(
-                &config.chain.configured_name,
-                Some(ChainHeadFinalityInput::Safe),
-            )
+            .chain_head(&config.chain.configured_name, Some(finality))
             .map_err(|error| DatalensError::Query(error.to_string()))?;
 
         i64::try_from(response.height).map_err(|_| {

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -9,16 +9,21 @@ use tokio::{runtime::Handle, sync::Semaphore, task, time::sleep};
 use crate::runner::IndexerRunnerProgress;
 use crate::{
     ChainTool, DaoContractAddresses, DaoEventDecoder, DatalensConfig, DatalensDurableHeadReader,
-    DatalensError, DatalensNativeClient, DatalensQueryConcurrencyGate, DatalensQueryErrorClass,
-    DatalensRuntimeContractSet, DatalensWarmupEnsureOutcome, EvmRpcChainTool,
-    IndexerContractSetMode, IndexerContractSetRuntimeConfig, IndexerOnchainRefreshTick,
-    IndexerRunner, IndexerRunnerReport, IndexerRunnerStore, IndexerRuntimeConfig,
-    IndexerTargetHeight, MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig,
-    OnchainRefreshTaskScope, OnchainRefreshTickReport, OnchainRefreshTickRunner,
-    OnchainRefreshTickScheduler, OnchainRefreshWorker, OnchainRefreshWorkerError,
-    PostgresIndexerRunnerStore, PostgresProvisionalCleanupStore,
-    checkpoint::configured_range_progress, classify_datalens_query_error, datalens_retry_config,
-    ensure_datalens_warmup_task, onchain_refresh_debounce_from_env, required_env,
+    DatalensError, DatalensNativeClient, DatalensProvisionalLogQueryReader,
+    DatalensQueryConcurrencyGate, DatalensQueryErrorClass, DatalensRuntimeContractSet,
+    DatalensWarmupEnsureOutcome, EvmRpcChainTool, IndexerContractSetMode,
+    IndexerContractSetRuntimeConfig, IndexerOnchainRefreshTick, IndexerRunner, IndexerRunnerReport,
+    IndexerRunnerStore, IndexerRuntimeConfig, IndexerTargetHeight,
+    MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig, OnchainRefreshTaskScope,
+    OnchainRefreshTickReport, OnchainRefreshTickRunner, OnchainRefreshTickScheduler,
+    OnchainRefreshWorker, OnchainRefreshWorkerError, PostgresIndexerRunnerStore,
+    PostgresProvisionalCleanupStore, PostgresProvisionalSegmentStore, ProvisionalWorker,
+    ProvisionalWorkerOptions,
+    checkpoint::configured_range_progress,
+    classify_datalens_query_error, datalens_retry_config, ensure_datalens_warmup_task,
+    onchain_refresh_debounce_from_env,
+    provisional::{DatalensProvisionalSegmentStore, ProvisionalWorkerError},
+    required_env,
 };
 
 use super::{datalens::verify_datalens, migrate::apply_migrations};
@@ -1000,10 +1005,10 @@ async fn run_contract_set_pass(
         )
         .context("create Datalens client")
         .map_err(ContractSetPassError::setup)?;
-        if let Some(gate) = datalens_query_gate {
+        if let Some(gate) = datalens_query_gate.clone() {
             client = client.with_query_concurrency_gate(gate);
         }
-        let mut store = PostgresIndexerRunnerStore::new(pool)
+        let mut store = PostgresIndexerRunnerStore::new(pool.clone())
             .with_onchain_refresh_debounce(onchain_refresh_debounce)
             .with_onchain_refresh_deferred_drain_batch_size(
                 runtime.onchain_refresh_deferred_drain_batch_size,
@@ -1044,10 +1049,50 @@ async fn run_contract_set_pass(
             runner.request_shutdown_after_chunks(chunks);
         }
 
-        runner
+        let report = runner
             .run_to_target(runtime.target_height)
             .context("run Datalens indexer to target height")
-            .map_err(ContractSetPassError::runner)
+            .map_err(ContractSetPassError::runner)?;
+
+        if runtime.provisional.enabled {
+            let mut provisional_client = DatalensNativeClient::from_config_with_retry_config(
+                &config,
+                datalens_retry_config(runtime.query_max_attempts),
+            )
+            .context("create Datalens provisional client")
+            .map_err(ContractSetPassError::setup)?;
+            if let Some(gate) = datalens_query_gate {
+                provisional_client = provisional_client.with_query_concurrency_gate(gate);
+            }
+            let mut provisional_store = PostgresProvisionalSegmentStore::new(pool);
+            if let Err(error) = run_provisional_worker_once(
+                &runtime,
+                &config,
+                &contracts,
+                &report,
+                &mut provisional_client,
+                &mut provisional_store,
+            )
+            .context("run Datalens provisional worker")
+            {
+                log::warn!(
+                    "Datalens provisional worker failed after durable pass dao_code={} chain_id={:?} contract_set_id={} error={:#}",
+                    runtime.dao_code,
+                    config.chain.network_id,
+                    runtime.checkpoint_contract_set_id,
+                    error
+                );
+            }
+        } else {
+            log::debug!(
+                "Datalens provisional worker disabled dao_code={} chain_id={:?} contract_set_id={}",
+                runtime.dao_code,
+                config.chain.network_id,
+                runtime.checkpoint_contract_set_id
+            );
+        }
+
+        Ok(report)
     })
     .await
     .map_err(|error| {
@@ -1055,6 +1100,102 @@ async fn run_contract_set_pass(
             runtime_anyhow::Error::new(error).context("join Datalens indexer runner task"),
         )
     })?
+}
+
+fn run_provisional_worker_once<R, S>(
+    runtime: &IndexerContractSetRuntimeConfig,
+    config: &DatalensConfig,
+    contracts: &DaoContractAddresses,
+    report: &IndexerRunnerReport,
+    reader: &mut R,
+    store: &mut S,
+) -> Result<Option<usize>>
+where
+    R: DatalensDurableHeadReader + DatalensProvisionalLogQueryReader,
+    S: DatalensProvisionalSegmentStore,
+{
+    if !runtime.provisional.enabled {
+        log::debug!(
+            "Datalens provisional worker disabled dao_code={} chain_id={:?} contract_set_id={}",
+            runtime.dao_code,
+            config.chain.network_id,
+            runtime.checkpoint_contract_set_id
+        );
+        return Ok(None);
+    }
+
+    let Some(chain_id) = config.chain.network_id else {
+        bail!(
+            "missing Datalens chain network_id for provisional worker dao_code={} contract_set_id={}",
+            runtime.dao_code,
+            runtime.checkpoint_contract_set_id
+        );
+    };
+    let latest_height = reader
+        .latest_head_height(config)
+        .context("resolve latest Datalens head height for provisional worker")?;
+    let Some((from_block, to_block)) = provisional_tail_range(runtime, report, latest_height)
+    else {
+        log::debug!(
+            "Datalens provisional worker skipped without latest tail dao_code={} chain_id={} contract_set_id={} durable_target_height={} latest_height={}",
+            runtime.dao_code,
+            chain_id,
+            runtime.checkpoint_contract_set_id,
+            runtime.target_height,
+            latest_height
+        );
+        return Ok(None);
+    };
+    let options = ProvisionalWorkerOptions {
+        datalens_config: config.clone(),
+        addresses: contracts.clone(),
+        dao_code: runtime.dao_code.clone(),
+        contract_set_id: runtime.checkpoint_contract_set_id.clone(),
+        chain_id,
+        chain_name: config.chain.configured_name.clone(),
+        finality: runtime.provisional.finality,
+        from_block,
+        to_block,
+    };
+    let mut worker = ProvisionalWorker::new(options, reader, store);
+    let report = worker
+        .run_once()
+        .map_err(provisional_worker_error_to_anyhow)?;
+
+    log::info!(
+        "Datalens provisional worker completed dao_code={} chain_id={} contract_set_id={} finality={} range_start_block={} range_end_block={} segments_written={}",
+        runtime.dao_code,
+        chain_id,
+        runtime.checkpoint_contract_set_id,
+        runtime.provisional.finality.as_datalens_value(),
+        from_block,
+        to_block,
+        report.segments_written
+    );
+
+    Ok(Some(report.segments_written))
+}
+
+fn provisional_tail_range(
+    runtime: &IndexerContractSetRuntimeConfig,
+    report: &IndexerRunnerReport,
+    latest_height: i64,
+) -> Option<(i64, i64)> {
+    if report.last_progress.remaining_blocks != 0 || latest_height <= runtime.target_height {
+        return None;
+    }
+
+    Some((
+        runtime
+            .target_height
+            .saturating_add(1)
+            .max(runtime.start_block),
+        latest_height,
+    ))
+}
+
+fn provisional_worker_error_to_anyhow(error: ProvisionalWorkerError) -> runtime_anyhow::Error {
+    runtime_anyhow::Error::new(error)
 }
 
 fn build_projection_chain_tool(
@@ -1224,9 +1365,13 @@ mod tests {
         time::Duration,
     };
 
+    use datalens_sdk::native::QueryInput;
+
     use crate::{
-        ChainFamily, ChainIdentityConfig, DatalensFinality, DatalensProvisionalFinality,
-        DatasetKeyConfig, ProvisionalRuntimeConfig, QueryLimitConfig, SecretString,
+        ChainFamily, ChainIdentityConfig, DatalensFinality, DatalensProvisionalCacheSegment,
+        DatalensProvisionalFinality, DatalensProvisionalLogQueryResult,
+        DatalensProvisionalSegmentWrite, DatasetKeyConfig, GovernanceTokenStandard,
+        ProvisionalRuntimeConfig, QueryLimitConfig, SecretString,
     };
 
     use super::*;
@@ -1399,6 +1544,108 @@ mod tests {
         assert_eq!(height, 568800);
     }
 
+    #[test]
+    fn test_provisional_worker_runtime_disabled_skips_reader_and_store() {
+        let runtime = contract_runtime(ProvisionalRuntimeConfig {
+            enabled: false,
+            finality: DatalensProvisionalFinality::SafeToLatest,
+        });
+        let config = datalens_config();
+        let contracts = dao_contracts();
+        let mut reader = RecordingProvisionalReader::default();
+        let mut store = RecordingProvisionalSegmentStore::default();
+
+        let result = run_provisional_worker_once(
+            &runtime,
+            &config,
+            &contracts,
+            &runner_report_with_remaining_blocks(0),
+            &mut reader,
+            &mut store,
+        )
+        .expect("disabled provisional worker skips cleanly");
+
+        assert_eq!(result, None);
+        assert_eq!(reader.latest_head_calls, 0);
+        assert!(reader.finalities.is_empty());
+        assert!(store.writes.is_empty());
+    }
+
+    #[test]
+    fn test_provisional_worker_runtime_enabled_runs_safe_to_latest_path() {
+        let runtime = contract_runtime(ProvisionalRuntimeConfig {
+            enabled: true,
+            finality: DatalensProvisionalFinality::SafeToLatest,
+        });
+        let config = datalens_config();
+        let contracts = dao_contracts();
+        let mut reader =
+            RecordingProvisionalReader::with_segments(vec![DatalensProvisionalCacheSegment {
+                source: "provider".to_owned(),
+                finality: "safe_to_latest".to_owned(),
+                range_start_block: 21,
+                range_end_block: 25,
+                anchor_block_number: Some(25),
+                anchor_block_hash: Some("0xanchor".to_owned()),
+                anchor_parent_hash: Some("0xparent".to_owned()),
+                anchor_block_timestamp: Some(1_700_000_000),
+            }]);
+        let mut store = RecordingProvisionalSegmentStore::default();
+
+        let result = run_provisional_worker_once(
+            &runtime,
+            &config,
+            &contracts,
+            &runner_report_with_remaining_blocks(0),
+            &mut reader,
+            &mut store,
+        )
+        .expect("enabled provisional worker runs");
+
+        assert_eq!(result, Some(1));
+        assert_eq!(reader.latest_head_calls, 1);
+        assert_eq!(reader.ranges, vec![(21, 25), (21, 25)]);
+        assert_eq!(
+            reader.finalities,
+            vec![
+                Some("safe_to_latest".to_owned()),
+                Some("safe_to_latest".to_owned())
+            ]
+        );
+        assert_eq!(store.writes.len(), 1);
+        assert_eq!(store.writes[0].segment_finality, "safe_to_latest");
+        assert_eq!(store.writes[0].range_start_block, 21);
+        assert_eq!(store.writes[0].range_end_block, 25);
+    }
+
+    #[test]
+    fn test_provisional_worker_runtime_skips_until_durable_pass_catches_up() {
+        let runtime = contract_runtime(ProvisionalRuntimeConfig {
+            enabled: true,
+            finality: DatalensProvisionalFinality::SafeToLatest,
+        });
+        let config = datalens_config();
+        let contracts = dao_contracts();
+        let mut reader = RecordingProvisionalReader::default();
+        let mut store = RecordingProvisionalSegmentStore::default();
+
+        let result = run_provisional_worker_once(
+            &runtime,
+            &config,
+            &contracts,
+            &runner_report_with_remaining_blocks(1),
+            &mut reader,
+            &mut store,
+        )
+        .expect("provisional worker skips while durable pass is behind");
+
+        assert_eq!(result, None);
+        assert_eq!(reader.latest_head_calls, 1);
+        assert!(reader.finalities.is_empty());
+        assert!(reader.ranges.is_empty());
+        assert!(store.writes.is_empty());
+    }
+
     fn contract_runtime_for_chunk_budget(
         max_chunks_per_run: Option<u64>,
     ) -> IndexerContractSetRuntimeConfig {
@@ -1420,6 +1667,33 @@ mod tests {
             onchain_refresh_deferred_drain_enabled: false,
             onchain_refresh_deferred_drain_batch_size: 100,
             proposal_timestamp_backfill: Default::default(),
+            provisional: ProvisionalRuntimeConfig {
+                enabled: false,
+                finality: DatalensProvisionalFinality::SafeToLatest,
+            },
+        }
+    }
+
+    fn contract_runtime(provisional: ProvisionalRuntimeConfig) -> IndexerContractSetRuntimeConfig {
+        IndexerContractSetRuntimeConfig {
+            dao_code: "demo-dao".to_owned(),
+            start_block: 10,
+            target_height: 20,
+            checkpoint_contract_set_id: "demo-set".to_owned(),
+            checkpoint_stream_id: "datalens-native".to_owned(),
+            data_source_version: "datalens-v1".to_owned(),
+            query_max_attempts: 1,
+            datalens_query_concurrency: Default::default(),
+            contract_set_max_concurrency: crate::ContractSetConcurrencyLimit::Unlimited,
+            contract_set_per_chain_max_concurrency: crate::ContractSetConcurrencyLimit::Unlimited,
+            progress_refresh_lag_blocks: 100,
+            adaptive_chunk_sizer: Default::default(),
+            max_chunks_per_run: None,
+            onchain_refresh_tick: Default::default(),
+            onchain_refresh_deferred_drain_enabled: false,
+            onchain_refresh_deferred_drain_batch_size: 100,
+            proposal_timestamp_backfill: Default::default(),
+            provisional,
         }
     }
 
@@ -1442,6 +1716,40 @@ mod tests {
                 eta_seconds: None,
                 onchain_refresh_allowed: true,
             },
+        }
+    }
+
+    fn datalens_config() -> DatalensConfig {
+        DatalensConfig {
+            endpoint: "http://127.0.0.1:1".to_owned(),
+            application: "degov-test".to_owned(),
+            bearer_token: SecretString::new("unit-test-redacted-value"),
+            timeout: Duration::from_secs(1),
+            finality: DatalensFinality::DurableOnly,
+            chain: ChainIdentityConfig {
+                family: ChainFamily::Evm,
+                configured_name: "ethereum".to_owned(),
+                network_id: Some(1),
+            },
+            dataset: DatasetKeyConfig {
+                family: "evm".to_owned(),
+                name: "logs".to_owned(),
+            },
+            query_limits: QueryLimitConfig {
+                block_range_limit: 1_000,
+            },
+            warmup: Default::default(),
+            dao_contracts: None,
+            chains: Vec::new(),
+        }
+    }
+
+    fn dao_contracts() -> DaoContractAddresses {
+        DaoContractAddresses {
+            governor: "0x0000000000000000000000000000000000000100".to_owned(),
+            governor_token: "0x0000000000000000000000000000000000000200".to_owned(),
+            timelock: None,
+            governor_token_standard: GovernanceTokenStandard::Erc20,
         }
     }
 
@@ -2220,6 +2528,75 @@ mod tests {
                 enabled: false,
                 finality: DatalensProvisionalFinality::SafeToLatest,
             },
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingProvisionalReader {
+        finalities: Vec<Option<String>>,
+        latest_head_calls: usize,
+        ranges: Vec<(u64, u64)>,
+        next_segments: Vec<DatalensProvisionalCacheSegment>,
+    }
+
+    impl RecordingProvisionalReader {
+        fn with_segments(next_segments: Vec<DatalensProvisionalCacheSegment>) -> Self {
+            Self {
+                finalities: Vec::new(),
+                latest_head_calls: 0,
+                ranges: Vec::new(),
+                next_segments,
+            }
+        }
+    }
+
+    impl DatalensDurableHeadReader for RecordingProvisionalReader {
+        fn durable_head_height(
+            &mut self,
+            _config: &DatalensConfig,
+        ) -> std::result::Result<i64, DatalensError> {
+            Ok(20)
+        }
+
+        fn latest_head_height(
+            &mut self,
+            _config: &DatalensConfig,
+        ) -> std::result::Result<i64, DatalensError> {
+            self.latest_head_calls += 1;
+            Ok(25)
+        }
+    }
+
+    impl DatalensProvisionalLogQueryReader for RecordingProvisionalReader {
+        fn query_provisional_logs(
+            &mut self,
+            input: QueryInput,
+        ) -> std::result::Result<DatalensProvisionalLogQueryResult, DatalensError> {
+            self.finalities.push(input.finality);
+            self.ranges.push((input.range.start, input.range.end));
+            let segments = std::mem::take(&mut self.next_segments);
+
+            Ok(DatalensProvisionalLogQueryResult {
+                rows: serde_json::json!([]),
+                segments,
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingProvisionalSegmentStore {
+        writes: Vec<DatalensProvisionalSegmentWrite>,
+    }
+
+    impl DatalensProvisionalSegmentStore for RecordingProvisionalSegmentStore {
+        type Error = String;
+
+        fn write_provisional_segments(
+            &mut self,
+            segments: &[DatalensProvisionalSegmentWrite],
+        ) -> std::result::Result<(), Self::Error> {
+            self.writes.extend_from_slice(segments);
+            Ok(())
         }
     }
 

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -251,6 +251,7 @@ pub struct IndexerContractSetRuntimeConfig {
     pub onchain_refresh_deferred_drain_enabled: bool,
     pub onchain_refresh_deferred_drain_batch_size: usize,
     pub proposal_timestamp_backfill: ProposalTimestampBackfillConfig,
+    pub provisional: ProvisionalRuntimeConfig,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -444,11 +445,22 @@ impl IndexerRuntimeConfig {
             onchain_refresh_deferred_drain_batch_size: self
                 .onchain_refresh_deferred_drain_batch_size,
             proposal_timestamp_backfill: self.proposal_timestamp_backfill,
+            provisional: self.provisional_for_target(),
         };
 
         Ok(runtime
             .with_start_block(contract_set.contract.start_block)?
             .with_contract_set_scope(contract_set.contract_set_id.clone()))
+    }
+
+    fn provisional_for_target(&self) -> ProvisionalRuntimeConfig {
+        match self.target_height {
+            IndexerTargetHeight::Latest => self.provisional.clone(),
+            IndexerTargetHeight::Fixed(_) => ProvisionalRuntimeConfig {
+                enabled: false,
+                finality: self.provisional.finality,
+            },
+        }
     }
 
     pub fn should_skip_contract_set_start_after_target(&self, start_block: i64) -> bool {

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -886,8 +886,8 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
         onchain_refresh_deferred_drain_batch_size: 100,
         proposal_timestamp_backfill: ProposalTimestampBackfillConfig::default(),
         provisional: ProvisionalRuntimeConfig {
-            enabled: false,
-            finality: DatalensProvisionalFinality::SafeToLatest,
+            enabled: true,
+            finality: DatalensProvisionalFinality::LatestOnly,
         },
     };
     let selected = config
@@ -903,6 +903,11 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
 
     assert_eq!(planned.dao_code, "lisk-dao");
     assert_eq!(planned.start_block, 568752);
+    assert!(!planned.provisional.enabled);
+    assert_eq!(
+        planned.provisional.finality,
+        DatalensProvisionalFinality::LatestOnly
+    );
     assert_eq!(options.checkpoint_identity.chain_id, 1135);
     assert_eq!(
         options.checkpoint_identity.contract_set_id,

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -199,6 +199,24 @@ fn test_datalens_durable_head_reader_uses_safe_finality_for_durable_head() {
 }
 
 #[test]
+fn test_datalens_durable_head_reader_uses_sdk_chain_head_latest_finality() {
+    let server = FakeHeadServer::start(568900, "latest");
+    let config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    let mut client = DatalensNativeClient::from_config(&config).expect("client");
+
+    let height = client
+        .latest_head_height(&config)
+        .expect("latest head height");
+
+    assert_eq!(height, 568900);
+    let request = server.join();
+    assert!(
+        request.starts_with("GET /v1/chains/ethereum/head?finality=latest "),
+        "{request}"
+    );
+}
+
+#[test]
 fn test_datalens_log_query_retries_retryable_rate_limit_before_success() {
     let server = FakeQueryServer::start(vec![
         api_error_response(429, "rate_limited", Some("request_rate_limit")),

--- a/apps/web/scripts/indexer-status-source.test.ts
+++ b/apps/web/scripts/indexer-status-source.test.ts
@@ -14,6 +14,8 @@ test("block sync hook reads native indexer status", () => {
 
   assert.match(source, /indexerStatusService\.getIndexerStatus/);
   assert.match(source, /syncedPercentage/);
+  assert.match(source, /refetchInterval:\s*CACHE_TIMES\.TWO_SECONDS/);
+  assert.doesNotMatch(source, /refetchInterval:\s*CACHE_TIMES\.THIRTY_SECONDS/);
   assert.doesNotMatch(source, new RegExp(removedStatusField));
   assert.doesNotMatch(source, new RegExp(removedStatusService));
 });

--- a/apps/web/src/hooks/useBlockSync.ts
+++ b/apps/web/src/hooks/useBlockSync.ts
@@ -23,7 +23,7 @@ export function useBlockSync() {
       return indexerStatusService.getIndexerStatus(daoConfig.indexer.endpoint);
     },
     enabled: !!daoConfig?.indexer?.endpoint,
-    refetchInterval: CACHE_TIMES.THIRTY_SECONDS,
+    refetchInterval: CACHE_TIMES.TWO_SECONDS,
   });
 
   const currentBlock = currentBlockData ? Number(currentBlockData) : 0;

--- a/apps/web/src/utils/query-config.ts
+++ b/apps/web/src/utils/query-config.ts
@@ -1,6 +1,7 @@
 import { hashFn } from "@wagmi/core/query";
 
 export const CACHE_TIMES = {
+  TWO_SECONDS: 2 * 1000,
   FIVE_SECONDS: 5 * 1000,
   TEN_SECONDS: 10 * 1000,
   THIRTY_SECONDS: 30 * 1000,


### PR DESCRIPTION
## Summary
- Run the Datalens provisional worker when `DEGOV_PROVISIONAL_WORKER_ENABLED=true`.
- Keep durable ingestion on the safe/durable path, then scan only the `safe + 1 .. latest` tail with `safe_to_latest` after the durable pass catches up.
- Add Datalens latest-head support and tests for the safe/latest head calls.
- Poll web indexer status every 2 seconds instead of every 30 seconds so users see sync/provisional progress sooner.

## Validation
- `cargo fmt -p degov-datalens-indexer`
- `git diff --check`
- `cargo test -p degov-datalens-indexer runtime::indexer::tests::test_provisional_worker_runtime --lib`
- `cargo test -p degov-datalens-indexer --test datalens_client latest_finality`
- `cargo test -p degov-datalens-indexer --test cli_runtime_config provisional`
- `cargo test -p degov-datalens-indexer --test provisional_worker test_provisional_worker_writes_segments_without_final_checkpoint_boundary`
- `cargo test -p degov-datalens-indexer --test provisional_worker test_provisional_cleanup_planner`
- `node --test apps/web/scripts/indexer-status-source.test.ts`
- `pnpm --filter @degov/web lint` (passes with existing import/order warning in `apps/web/src/app/_server/config-remote.ts`)
- `pnpm --filter @degov/web exec tsc --noEmit`
- `pnpm --filter @degov/web build` (passes with existing `ox/viem` dynamic dependency warning)

Note: `cargo test -p degov-datalens-indexer --locked` runs through non-DB tests, then local DB-backed tests fail because `DEGOV_INDEXER_TEST_DATABASE_URL` is not configured in this shell; CI provides the Postgres service/env.
