### PR TITLE
feat(indexer): expose provisional sync height

### DIFF
--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -142,6 +142,18 @@ fn indexer_status_query<'a>() -> QueryBuilder<'a, Postgres> {
           chain_id,
           contract_set_id,
           processed_height::BIGINT AS processed_height,
+          (
+            SELECT MIN(selector_coverage.range_end_block)::BIGINT
+            FROM (
+              SELECT MAX(segment.range_end_block) AS range_end_block
+              FROM degov_provisional_segment segment
+              WHERE segment.status = 'available'
+                AND segment.dao_code = degov_indexer_checkpoint.dao_code
+                AND segment.chain_id IS NOT DISTINCT FROM degov_indexer_checkpoint.chain_id
+                AND segment.contract_set_id = degov_indexer_checkpoint.contract_set_id
+              GROUP BY segment.source, segment.selector
+            ) selector_coverage
+          ) AS provisional_height,
           target_height::BIGINT AS target_height,
           CASE
             WHEN target_height IS NULL THEN NULL

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -203,6 +203,7 @@ pub struct IndexerStatus {
     pub(super) chain_id: i32,
     pub(super) contract_set_id: String,
     pub(super) processed_height: Option<i64>,
+    pub(super) provisional_height: Option<i64>,
     pub(super) target_height: Option<i64>,
     pub(super) synced_percentage: Option<f64>,
     pub(super) is_synced: bool,

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -1018,6 +1018,7 @@ async fn test_graphql_schema_exposes_checkpoint_statuses_with_implicit_scope()
                 chainId
                 contractSetId
                 processedHeight
+                provisionalHeight
                 targetHeight
                 syncedPercentage
                 isSynced
@@ -1042,12 +1043,14 @@ async fn test_graphql_schema_exposes_checkpoint_statuses_with_implicit_scope()
     assert_eq!(statuses.len(), 2);
     assert_eq!(statuses[0]["daoCode"], "ens-dao");
     assert_eq!(statuses[0]["processedHeight"], 1200);
+    assert_eq!(statuses[0]["provisionalHeight"], serde_json::Value::Null);
     assert_eq!(statuses[0]["targetHeight"], 1200);
     assert_eq!(statuses[0]["syncedPercentage"], 100.0);
     assert_eq!(statuses[0]["isSynced"], true);
     assert_eq!(statuses[0]["lastError"], "caught up after retry");
     assert_eq!(statuses[1]["daoCode"], "lisk-dao");
     assert_eq!(statuses[1]["processedHeight"], 900);
+    assert_eq!(statuses[1]["provisionalHeight"], 1115);
     assert_eq!(statuses[1]["targetHeight"], 1000);
     assert_eq!(statuses[1]["syncedPercentage"], 90.0);
     assert_eq!(statuses[1]["isSynced"], false);
@@ -1071,6 +1074,7 @@ async fn test_graphql_schema_exposes_checkpoint_statuses_with_implicit_scope()
                 chainId
                 contractSetId
                 processedHeight
+                provisionalHeight
                 targetHeight
                 syncedPercentage
                 isSynced
@@ -1095,6 +1099,7 @@ async fn test_graphql_schema_exposes_checkpoint_statuses_with_implicit_scope()
     let scoped_data = scoped_response.data.into_json()?;
     assert_eq!(scoped_data["indexerStatus"]["daoCode"], "lisk-dao");
     assert_eq!(scoped_data["indexerStatus"]["processedHeight"], 900);
+    assert_eq!(scoped_data["indexerStatus"]["provisionalHeight"], 1115);
     assert_eq!(scoped_data["indexerStatus"]["targetHeight"], 1000);
     assert_eq!(scoped_data["indexerStatus"]["syncedPercentage"], 90.0);
     assert_eq!(scoped_data["indexerStatus"]["isSynced"], false);
@@ -1127,6 +1132,21 @@ async fn test_graphql_schema_rejects_removed_squid_status_compatibility()
     assert!(
         !sdl.contains(&removed_type),
         "schema still exposes removed status type:\n{sdl}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_schema_exposes_provisional_indexer_status_height()
+-> Result<(), Box<dyn Error>> {
+    let pool = PgPoolOptions::new().connect_lazy("postgres://localhost/degov")?;
+    let schema = graphql::build_schema(pool);
+    let sdl = schema.sdl();
+
+    assert!(
+        sdl.contains("provisionalHeight: Int"),
+        "schema does not expose provisionalHeight on indexer status:\n{sdl}"
     );
 
     Ok(())
@@ -1581,6 +1601,39 @@ async fn seed_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
         INSERT INTO degov_indexer_checkpoint (
           dao_code, chain_id, contract_set_id, stream_id, data_source_version, next_block, processed_height, target_height, updated_at
         ) VALUES ('lisk-dao', 1135, $1, 'evm.logs', 'datalens', 901, 900, 1000, now())
+        "#,
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO degov_provisional_segment (
+          id, contract_set_id, chain_id, dao_code, dataset_key, selector,
+          selector_fingerprint, range_start_block, range_end_block,
+          segment_finality, source, status, anchor_block_number,
+          anchor_block_timestamp
+        ) VALUES
+          (
+            'segment:available:old', $1, 1135, 'lisk-dao', 'evm.logs',
+            'selector', 'selector', 901, 1100, 'safe_to_latest',
+            'live-onchain', 'available', 1100, 1700000300
+          ),
+          (
+            'segment:available:new', $1, 1135, 'lisk-dao', 'evm.logs',
+            'selector', 'selector', 1101, 1120, 'safe_to_latest',
+            'live-onchain', 'available', 1120, 1700000400
+          ),
+          (
+            'segment:available:lagging-selector', $1, 1135, 'lisk-dao',
+            'evm.logs', 'other-selector', 'other-selector', 901, 1115,
+            'safe_to_latest', 'live-onchain', 'available', 1115, 1700000450
+          ),
+          (
+            'segment:rolled-back', $1, 1135, 'lisk-dao', 'evm.logs',
+            'selector', 'selector', 1121, 1200, 'safe_to_latest',
+            'live-onchain', 'rolled_back', 1200, 1700000500
+          )
         "#,
     )
     .bind(CONTRACT_SET_ID)

--- a/apps/web/messages/en/common.json
+++ b/apps/web/messages/en/common.json
@@ -27,6 +27,7 @@
   },
   "indexer": {
     "currentlyAtBlock": "Currently at block {indexedBlock} of {currentBlock}",
+    "confirmedSafeHeight": "Confirmed safe height: {processedHeight}",
     "poweredBy": "Powered by",
     "brand": "DeGov.AI"
   },

--- a/apps/web/scripts/indexer-status-source.test.ts
+++ b/apps/web/scripts/indexer-status-source.test.ts
@@ -30,5 +30,7 @@ test("indexer status query requests native status fields", () => {
   assert.match(source, /targetHeight/);
   assert.match(source, /syncedPercentage/);
   assert.match(source, /isSynced/);
+  assert.match(source, /GET_INDEXER_STATUS_WITH_PROVISIONAL_HEIGHT/);
+  assert.match(source, /provisionalHeight/);
   assert.doesNotMatch(source, new RegExp(removedStatusField));
 });

--- a/apps/web/src/components/indexer-status.tsx
+++ b/apps/web/src/components/indexer-status.tsx
@@ -17,12 +17,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 interface IndexerStatusProps {
   currentBlock: number;
   indexedBlock: number;
+  durableProcessedBlock: number;
   syncPercentage: number;
   status: BlockSyncStatus;
 }
 export function IndexerStatus({
   currentBlock,
   indexedBlock,
+  durableProcessedBlock,
   syncPercentage,
   status,
 }: IndexerStatusProps) {
@@ -39,6 +41,9 @@ export function IndexerStatus({
   const hoverMessage = t("currentlyAtBlock", {
     indexedBlock: indexedBlock.toLocaleString(),
     currentBlock: currentBlock.toLocaleString(),
+  });
+  const confirmedHeightMessage = t("confirmedSafeHeight", {
+    processedHeight: durableProcessedBlock.toLocaleString(),
   });
 
   return (
@@ -85,7 +90,14 @@ export function IndexerStatus({
           sideOffset={12}
           className="bg-card border border-card-background shadow-xs max-w-[350px] rounded-[26px] p-[20px] text-[14px]"
         >
-          {hoverMessage}
+          <div className="flex flex-col gap-2">
+            <span>{hoverMessage}</span>
+            {!!durableProcessedBlock && (
+              <span className="text-muted-foreground">
+                {confirmedHeightMessage}
+              </span>
+            )}
+          </div>
         </TooltipContent>
       </Tooltip>
 

--- a/apps/web/src/components/layouts/aside.tsx
+++ b/apps/web/src/components/layouts/aside.tsx
@@ -34,7 +34,13 @@ export const Aside = () => {
   const config = useDaoConfig();
   const t = useTranslations("common.sidebar");
   const [collapsed, setCollapsed] = useState(false);
-  const { status, syncPercentage, currentBlock, indexedBlock } = useBlockSync();
+  const {
+    status,
+    syncPercentage,
+    currentBlock,
+    indexedBlock,
+    durableProcessedBlock,
+  } = useBlockSync();
   const { isDarkTheme } = useCustomTheme();
 
   useEffect(() => {
@@ -154,6 +160,7 @@ export const Aside = () => {
                     syncPercentage={syncPercentage}
                     currentBlock={currentBlock}
                     indexedBlock={indexedBlock}
+                    durableProcessedBlock={durableProcessedBlock}
                   />
                 </TooltipContent>
               </Tooltip>
@@ -164,6 +171,7 @@ export const Aside = () => {
               syncPercentage={syncPercentage}
               currentBlock={currentBlock}
               indexedBlock={indexedBlock}
+              durableProcessedBlock={durableProcessedBlock}
             />
           )}
         </footer>

--- a/apps/web/src/components/layouts/mobile-menu.tsx
+++ b/apps/web/src/components/layouts/mobile-menu.tsx
@@ -24,7 +24,13 @@ export const MobileMenu = ({
   open,
   onMenuToggle,
 }: MobileMenuProps) => {
-  const { currentBlock, indexedBlock, syncPercentage, status } = useBlockSync();
+  const {
+    currentBlock,
+    indexedBlock,
+    durableProcessedBlock,
+    syncPercentage,
+    status,
+  } = useBlockSync();
   const showNotification = useNotificationVisibility();
 
   return (
@@ -58,6 +64,7 @@ export const MobileMenu = ({
               <IndexerStatus
                 currentBlock={currentBlock}
                 indexedBlock={indexedBlock}
+                durableProcessedBlock={durableProcessedBlock}
                 syncPercentage={syncPercentage}
                 status={status}
               />

--- a/apps/web/src/hooks/useBlockSync.ts
+++ b/apps/web/src/hooks/useBlockSync.ts
@@ -27,20 +27,30 @@ export function useBlockSync() {
   });
 
   const currentBlock = currentBlockData ? Number(currentBlockData) : 0;
-  const indexedBlock = indexerStatus?.processedHeight
+  const durableProcessedBlock = indexerStatus?.processedHeight
     ? Number(indexerStatus.processedHeight)
     : 0;
+  const indexedBlock = indexerStatus?.provisionalHeight
+    ? Number(indexerStatus.provisionalHeight)
+    : durableProcessedBlock;
+  const hasProvisionalHeight =
+    indexerStatus?.provisionalHeight !== null &&
+    indexerStatus?.provisionalHeight !== undefined;
   const nativeSyncPercentage = indexerStatus?.syncedPercentage;
 
   const syncPercentage = useMemo(() => {
-    if (nativeSyncPercentage !== null && nativeSyncPercentage !== undefined) {
+    if (
+      !hasProvisionalHeight &&
+      nativeSyncPercentage !== null &&
+      nativeSyncPercentage !== undefined
+    ) {
       return Number(Number(nativeSyncPercentage).toFixed(1));
     }
 
     if (!currentBlock || !indexedBlock) return 0;
     const ratio = (indexedBlock / currentBlock) * 100;
     return Number(ratio.toFixed(1));
-  }, [currentBlock, indexedBlock, nativeSyncPercentage]);
+  }, [currentBlock, hasProvisionalHeight, indexedBlock, nativeSyncPercentage]);
 
   const status: BlockSyncStatus = useMemo(() => {
     if (!indexedBlock) return "offline";
@@ -52,6 +62,7 @@ export function useBlockSync() {
   return {
     currentBlock,
     indexedBlock,
+    durableProcessedBlock,
     syncPercentage,
     isLoading,
     status,

--- a/apps/web/src/services/graphql/index.ts
+++ b/apps/web/src/services/graphql/index.ts
@@ -519,8 +519,36 @@ export const delegateService = {
   },
 };
 
+const unsupportedProvisionalHeightEndpoints = new Set<string>();
+
 export const indexerStatusService = {
   getIndexerStatus: async (endpoint: string) => {
+    const useBaseQuery = unsupportedProvisionalHeightEndpoints.has(endpoint);
+
+    if (useBaseQuery) {
+      const response = await request<Types.IndexerStatusResponse>(
+        endpoint,
+        Queries.GET_INDEXER_STATUS
+      );
+      return response?.indexerStatus;
+    }
+
+    try {
+      const response = await request<Types.IndexerStatusResponse>(
+        endpoint,
+        Queries.GET_INDEXER_STATUS_WITH_PROVISIONAL_HEIGHT
+      );
+      return response?.indexerStatus;
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes("provisionalHeight")
+      ) {
+        throw error;
+      }
+      unsupportedProvisionalHeightEndpoints.add(endpoint);
+    }
+
     const response = await request<Types.IndexerStatusResponse>(
       endpoint,
       Queries.GET_INDEXER_STATUS

--- a/apps/web/src/services/graphql/queries/indexerStatus.ts
+++ b/apps/web/src/services/graphql/queries/indexerStatus.ts
@@ -11,3 +11,16 @@ export const GET_INDEXER_STATUS = gql`
     }
   }
 `;
+
+export const GET_INDEXER_STATUS_WITH_PROVISIONAL_HEIGHT = gql`
+  query indexerStatus {
+    indexerStatus {
+      daoCode
+      processedHeight
+      provisionalHeight
+      targetHeight
+      syncedPercentage
+      isSynced
+    }
+  }
+`;

--- a/apps/web/src/services/graphql/types/indexerStatus.ts
+++ b/apps/web/src/services/graphql/types/indexerStatus.ts
@@ -1,6 +1,7 @@
 export type IndexerStatus = {
   daoCode?: string;
   processedHeight?: number | null;
+  provisionalHeight?: number | null;
   targetHeight?: number | null;
   syncedPercentage?: number | null;
   isSynced?: boolean;


### PR DESCRIPTION
## Summary
- expose indexerStatus.provisionalHeight from available provisional segments
- show provisional/latest height as the primary block sync height in the web UI
- show durable processedHeight as the confirmed safe height in the sync tooltip
- keep web compatible with older indexer schemas by falling back to the base indexerStatus query

## Tests
- cargo fmt --manifest-path apps/indexer/Cargo.toml --check
- cargo test -p degov-datalens-indexer --lib graphql --manifest-path Cargo.toml
- cargo test -p degov-datalens-indexer --test graphql_service test_graphql_schema_exposes_provisional_indexer_status_height --manifest-path Cargo.toml
- node --test apps/web/scripts/indexer-status-source.test.ts
- git diff --check

Note: DB-backed graphql_service test was not run locally because DEGOV_INDEXER_TEST_DATABASE_URL is not set. Web lint could not run because node_modules/eslint is not installed in this worktree.