### PR TITLE
fix(indexer): timeout datalens head queries

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -555,13 +555,14 @@ impl DatalensNativeClient {
         })
     }
 
-    fn run_query_with_deadline<F>(
+    fn run_query_with_deadline<F, R>(
         &self,
         operation: &'static str,
         run: F,
-    ) -> Result<QueryResponse, DatalensSdkError>
+    ) -> Result<R, DatalensSdkError>
     where
-        F: FnOnce(DatalensClient) -> Result<QueryResponse, DatalensSdkError> + Send + 'static,
+        F: FnOnce(DatalensClient) -> Result<R, DatalensSdkError> + Send + 'static,
+        R: Send + 'static,
     {
         let started_at = Instant::now();
         let permit = match self.acquire_query_concurrency_permit(operation) {
@@ -812,10 +813,11 @@ impl DatalensNativeClient {
         config: &DatalensConfig,
         finality: ChainHeadFinalityInput,
     ) -> Result<i64, DatalensError> {
+        let chain_name = config.chain.configured_name.clone();
         let response = self
-            .client
-            .native()
-            .chain_head(&config.chain.configured_name, Some(finality))
+            .run_query_with_deadline("head", move |client| {
+                client.native().chain_head(&chain_name, Some(finality))
+            })
             .map_err(|error| DatalensError::Query(error.to_string()))?;
 
         i64::try_from(response.height).map_err(|_| {

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -217,6 +217,38 @@ fn test_datalens_durable_head_reader_uses_sdk_chain_head_latest_finality() {
 }
 
 #[test]
+fn test_datalens_head_reader_returns_degov_timeout_for_stalled_sdk_head() {
+    let server = FakeHangingQueryServer::start(Duration::from_millis(500));
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(50);
+    let mut client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("client");
+    let started_at = std::time::Instant::now();
+
+    let error = client
+        .durable_head_height(&config)
+        .expect_err("stalled head request times out");
+
+    assert!(
+        started_at.elapsed() < Duration::from_millis(300),
+        "outer timeout should bound the stalled SDK head call"
+    );
+    let error_message = error.to_string();
+    assert!(
+        error_message.contains("Datalens head timed out after 50ms")
+            || error_message.contains("send datalens REST request"),
+        "{error_message}"
+    );
+    assert_eq!(
+        classify_datalens_query_error(&error.to_string()),
+        DatalensQueryErrorClass::Transient
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+}
+
+#[test]
 fn test_datalens_log_query_retries_retryable_rate_limit_before_success() {
     let server = FakeQueryServer::start(vec![
         api_error_response(429, "rate_limited", Some("request_rate_limit")),


### PR DESCRIPTION
## Summary
- apply the existing Datalens deadline/concurrency wrapper to chain head reads
- make stalled head reads fail as transient timeout errors instead of blocking a DAO before pass startup
- add a regression test for stalled SDK head reads

## Tests
- cargo fmt -p degov-datalens-indexer --check
- cargo test -p degov-datalens-indexer --locked --test datalens_client test_datalens_head_reader_returns_degov_timeout_for_stalled_sdk_head -- --nocapture
- cargo test -p degov-datalens-indexer --locked --lib