### PR TITLE
fix(indexer): isolate datalens head workers

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -41,6 +41,7 @@ pub struct DatalensNativeClient {
     query_key: DatalensQueryConcurrencyKey,
     query_timeout: Duration,
     blocking_query_guard: Arc<DatalensBlockingQueryGuard>,
+    blocking_head_guard: Arc<DatalensBlockingQueryGuard>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -99,14 +100,16 @@ struct DatalensBlockingQueryKey {
     endpoint: String,
     application: String,
     query_key: DatalensQueryConcurrencyKey,
+    operation: &'static str,
 }
 
 impl DatalensBlockingQueryKey {
-    fn from_config(config: &DatalensConfig) -> Self {
+    fn from_config(config: &DatalensConfig, operation: &'static str) -> Self {
         Self {
             endpoint: config.endpoint.clone(),
             application: config.application.clone(),
             query_key: DatalensQueryConcurrencyKey::from_config(config),
+            operation,
         }
     }
 }
@@ -153,15 +156,23 @@ impl DatalensBlockingQueryGuard {
         }
     }
 
-    fn acquire(&self) -> Result<(), DatalensSdkError> {
+    fn acquire(&self, operation: &str) -> Result<(), DatalensSdkError> {
         let mut state = self.state.lock().map_err(|_| {
             DatalensSdkError::Transport("Datalens blocking query guard lock poisoned".to_owned())
         })?;
         if state.active_workers >= state.max_workers {
-            return Err(DatalensSdkError::Transport(format!(
-                "Datalens query timed out because {} previous SDK queries are still in flight",
-                state.active_workers
-            )));
+            let message = if operation == "query" {
+                format!(
+                    "Datalens query timed out because {} previous SDK queries are still in flight",
+                    state.active_workers
+                )
+            } else {
+                format!(
+                    "Datalens {operation} timed out because {} previous SDK {operation} workers are still in flight",
+                    state.active_workers
+                )
+            };
+            return Err(DatalensSdkError::Transport(message));
         }
         state.active_workers += 1;
         Ok(())
@@ -402,7 +413,8 @@ impl DatalensNativeClient {
             query_gate: None,
             query_key: DatalensQueryConcurrencyKey::from_config(config),
             query_timeout: config.timeout,
-            blocking_query_guard: blocking_query_guard_for_config(config)?,
+            blocking_query_guard: blocking_query_guard_for_config(config, "query")?,
+            blocking_head_guard: blocking_query_guard_for_config(config, "head")?,
         })
     }
 
@@ -438,7 +450,8 @@ impl DatalensNativeClient {
             query_gate: None,
             query_key: DatalensQueryConcurrencyKey::from_config(config),
             query_timeout: config.timeout,
-            blocking_query_guard: blocking_query_guard_for_config(config)?,
+            blocking_query_guard: blocking_query_guard_for_config(config, "query")?,
+            blocking_head_guard: blocking_query_guard_for_config(config, "head")?,
         })
     }
 
@@ -589,12 +602,13 @@ impl DatalensNativeClient {
             self.warn_query_timeout(operation, &error);
             return Err(error);
         };
-        if let Err(error) = self.blocking_query_guard.acquire() {
+        let blocking_guard = self.blocking_guard_for_operation(operation);
+        if let Err(error) = blocking_guard.acquire(operation) {
             self.warn_query_timeout(operation, &error);
             return Err(error);
         }
         let blocking_query_permit = DatalensBlockingQueryPermit {
-            guard: self.blocking_query_guard.clone(),
+            guard: blocking_guard,
         };
         let (sender, receiver) = mpsc::sync_channel(1);
         let client = self.client.clone();
@@ -630,6 +644,10 @@ impl DatalensNativeClient {
         &self,
         operation: &str,
     ) -> Result<DatalensQueryConcurrencyAcquire, DatalensError> {
+        if operation == "head" {
+            return Ok(DatalensQueryConcurrencyAcquire::Acquired(None));
+        }
+
         let Some(gate) = self.query_gate.as_ref() else {
             return Ok(DatalensQueryConcurrencyAcquire::Acquired(None));
         };
@@ -666,6 +684,14 @@ impl DatalensNativeClient {
             error
         );
     }
+
+    fn blocking_guard_for_operation(&self, operation: &str) -> Arc<DatalensBlockingQueryGuard> {
+        if operation == "head" {
+            self.blocking_head_guard.clone()
+        } else {
+            self.blocking_query_guard.clone()
+        }
+    }
 }
 
 fn fallback_retry_delay(
@@ -693,12 +719,13 @@ fn fallback_retry_delay(
 
 fn blocking_query_guard_for_config(
     config: &DatalensConfig,
+    operation: &'static str,
 ) -> Result<Arc<DatalensBlockingQueryGuard>, DatalensError> {
     static BLOCKING_QUERY_GUARDS: OnceLock<
         Mutex<HashMap<DatalensBlockingQueryKey, Arc<DatalensBlockingQueryGuard>>>,
     > = OnceLock::new();
 
-    let key = DatalensBlockingQueryKey::from_config(config);
+    let key = DatalensBlockingQueryKey::from_config(config, operation);
     let guards = BLOCKING_QUERY_GUARDS.get_or_init(|| Mutex::new(HashMap::new()));
     let mut guards = guards.lock().map_err(|_| {
         DatalensError::Query("Datalens blocking query guard lock poisoned".to_owned())

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -249,6 +249,87 @@ fn test_datalens_head_reader_returns_degov_timeout_for_stalled_sdk_head() {
 }
 
 #[test]
+fn test_datalens_head_reader_uses_separate_worker_guard_from_log_queries() {
+    let server = FakeQueryServer::start_concurrent(vec![
+        FakeQueryResponse::HoldOpen(Duration::from_millis(300)),
+        FakeQueryResponse::HoldOpen(Duration::from_millis(300)),
+        FakeQueryResponse::Http(head_success_response(568901, "safe")),
+    ]);
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(120);
+    let gate = DatalensQueryConcurrencyGate::new(DatalensQueryConcurrencyConfig {
+        global_max_in_flight: Some(2),
+        per_chain_max_in_flight: Some(2),
+    })
+    .expect("gate");
+    let mut first_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("first client")
+            .with_query_concurrency_gate(gate.clone());
+    let mut second_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("second client")
+            .with_query_concurrency_gate(gate.clone());
+    let mut head_client =
+        DatalensNativeClient::from_config_with_retry_config(&config, retry_config_with_attempts(1))
+            .expect("head client")
+            .with_query_concurrency_gate(gate);
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("query plan builds");
+    let first_input = plans[0].input.clone();
+    let second_input = plans[0].input.clone();
+    let (started_sender, started_receiver) = mpsc::channel();
+
+    let first_handle = thread::spawn({
+        let started_sender = started_sender.clone();
+        move || {
+            started_sender.send(()).expect("send first start");
+            first_client
+                .query_logs(first_input)
+                .expect_err("first stalled query times out")
+        }
+    });
+    let second_handle = thread::spawn(move || {
+        started_sender.send(()).expect("send second start");
+        second_client
+            .query_logs(second_input)
+            .expect_err("second stalled query times out")
+    });
+    started_receiver
+        .recv_timeout(Duration::from_millis(100))
+        .expect("first query starts");
+    started_receiver
+        .recv_timeout(Duration::from_millis(100))
+        .expect("second query starts");
+    thread::sleep(Duration::from_millis(50));
+
+    let height = head_client
+        .durable_head_height(&config)
+        .expect("head uses a separate blocking worker guard");
+
+    assert_eq!(height, 568901);
+    let first_error = first_handle.join().expect("first query joins");
+    let second_error = second_handle.join().expect("second query joins");
+    assert_eq!(
+        classify_datalens_query_error(&first_error.to_string()),
+        DatalensQueryErrorClass::Transient,
+        "{first_error}"
+    );
+    assert_eq!(
+        classify_datalens_query_error(&second_error.to_string()),
+        DatalensQueryErrorClass::Transient,
+        "{second_error}"
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 3);
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.starts_with("GET /v1/chains/ethereum/head?finality=safe ")),
+        "{requests:?}"
+    );
+}
+
+#[test]
 fn test_datalens_log_query_retries_retryable_rate_limit_before_success() {
     let server = FakeQueryServer::start(vec![
         api_error_response(429, "rate_limited", Some("request_rate_limit")),
@@ -872,6 +953,15 @@ impl FakeQueryServer {
 
 fn handle_head_request(mut stream: TcpStream, height: u64, finality: &'static str) -> String {
     let request = read_http_request(&mut stream);
+    let response = head_success_response(height, finality);
+    stream
+        .write_all(response.as_bytes())
+        .expect("write fake Datalens head response");
+
+    request
+}
+
+fn head_success_response(height: u64, finality: &'static str) -> String {
     let body = serde_json::json!({
         "chain": {
             "configured_name": "ethereum"
@@ -886,11 +976,7 @@ fn handle_head_request(mut stream: TcpStream, height: u64, finality: &'static st
         body.len(),
         body
     );
-    stream
-        .write_all(response.as_bytes())
-        .expect("write fake Datalens head response");
-
-    request
+    response
 }
 
 fn query_success_response(rows: serde_json::Value) -> String {


### PR DESCRIPTION
## Summary
- separate Datalens head blocking worker guards from log query worker guards
- prevent durable/latest head reads from being rejected when long-running getLogs SDK workers saturate a chain
- add a regression test covering head reads while log query workers are saturated

## Tests
- cargo fmt -p degov-datalens-indexer --check
- cargo test -p degov-datalens-indexer --locked --test datalens_client -- --nocapture
- cargo test -p degov-datalens-indexer --locked --lib