### PR TITLE
fix(indexer): coalesce datalens head reads

### DIFF
--- a/apps/indexer/src/datalens/client.rs
+++ b/apps/indexer/src/datalens/client.rs
@@ -114,6 +114,56 @@ impl DatalensBlockingQueryKey {
     }
 }
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct DatalensHeadCacheKey {
+    endpoint: String,
+    application: String,
+    query_key: DatalensQueryConcurrencyKey,
+    finality: &'static str,
+}
+
+impl DatalensHeadCacheKey {
+    fn from_config(config: &DatalensConfig, finality: ChainHeadFinalityInput) -> Self {
+        Self {
+            endpoint: config.endpoint.clone(),
+            application: config.application.clone(),
+            query_key: DatalensQueryConcurrencyKey::from_config(config),
+            finality: head_finality_cache_key(finality),
+        }
+    }
+}
+
+#[derive(Default)]
+struct DatalensHeadCacheState {
+    cached: Option<DatalensHeadCacheValue>,
+    in_flight: bool,
+}
+
+struct DatalensHeadCacheValue {
+    height: i64,
+    cached_at: Instant,
+}
+
+struct DatalensHeadCacheEntry {
+    state: Mutex<DatalensHeadCacheState>,
+    ready: Condvar,
+}
+
+impl DatalensHeadCacheEntry {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(DatalensHeadCacheState::default()),
+            ready: Condvar::new(),
+        }
+    }
+}
+
+enum DatalensHeadCacheAcquire {
+    Cached(i64),
+    Fetch,
+    TimedOut,
+}
+
 #[derive(Clone)]
 pub struct DatalensQueryConcurrencyGate {
     inner: Arc<DatalensQueryConcurrencyGateInner>,
@@ -132,6 +182,7 @@ struct DatalensQueryConcurrencyGateState {
 }
 
 const MAX_BLOCKING_SDK_WORKERS_PER_KEY: usize = 2;
+const HEAD_HEIGHT_CACHE_TTL: Duration = Duration::from_secs(2);
 
 struct DatalensBlockingQueryGuard {
     state: Mutex<DatalensBlockingQueryGuardState>,
@@ -556,14 +607,16 @@ impl DatalensNativeClient {
     }
 
     fn query_with_deadline(&self, input: QueryInput) -> Result<QueryResponse, DatalensSdkError> {
-        self.run_query_with_deadline("query", move |client| client.native().query(input))
+        self.run_query_with_deadline("query", Instant::now(), move |client| {
+            client.native().query(input)
+        })
     }
 
     fn query_provisional_with_deadline(
         &self,
         input: QueryInput,
     ) -> Result<QueryResponse, DatalensSdkError> {
-        self.run_query_with_deadline("provisional query", move |client| {
+        self.run_query_with_deadline("provisional query", Instant::now(), move |client| {
             client.native().query_provisional(input)
         })
     }
@@ -571,13 +624,13 @@ impl DatalensNativeClient {
     fn run_query_with_deadline<F, R>(
         &self,
         operation: &'static str,
+        started_at: Instant,
         run: F,
     ) -> Result<R, DatalensSdkError>
     where
         F: FnOnce(DatalensClient) -> Result<R, DatalensSdkError> + Send + 'static,
         R: Send + 'static,
     {
-        let started_at = Instant::now();
         let permit = match self.acquire_query_concurrency_permit(operation) {
             Ok(DatalensQueryConcurrencyAcquire::Acquired(permit)) => permit,
             Ok(DatalensQueryConcurrencyAcquire::TimedOut) => {
@@ -736,6 +789,82 @@ fn blocking_query_guard_for_config(
         .clone())
 }
 
+fn head_cache_entry_for_config(
+    config: &DatalensConfig,
+    finality: ChainHeadFinalityInput,
+) -> Result<Arc<DatalensHeadCacheEntry>, DatalensError> {
+    static HEAD_CACHE_ENTRIES: OnceLock<
+        Mutex<HashMap<DatalensHeadCacheKey, Arc<DatalensHeadCacheEntry>>>,
+    > = OnceLock::new();
+
+    let key = DatalensHeadCacheKey::from_config(config, finality);
+    let entries = HEAD_CACHE_ENTRIES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut entries = entries
+        .lock()
+        .map_err(|_| DatalensError::Query("Datalens head cache lock poisoned".to_owned()))?;
+    Ok(entries
+        .entry(key)
+        .or_insert_with(|| Arc::new(DatalensHeadCacheEntry::new()))
+        .clone())
+}
+
+fn acquire_head_cache(
+    entry: &DatalensHeadCacheEntry,
+    started_at: Instant,
+    timeout: Duration,
+) -> Result<DatalensHeadCacheAcquire, DatalensSdkError> {
+    let mut state = entry
+        .state
+        .lock()
+        .map_err(|_| DatalensSdkError::Transport("Datalens head cache lock poisoned".to_owned()))?;
+    let mut waited_for_in_flight = false;
+
+    loop {
+        if let Some(cached) = state.cached.as_ref()
+            && cached.cached_at.elapsed() <= HEAD_HEIGHT_CACHE_TTL
+        {
+            return Ok(DatalensHeadCacheAcquire::Cached(cached.height));
+        }
+
+        if !state.in_flight {
+            if waited_for_in_flight {
+                return Ok(DatalensHeadCacheAcquire::TimedOut);
+            }
+            state.in_flight = true;
+            return Ok(DatalensHeadCacheAcquire::Fetch);
+        }
+
+        waited_for_in_flight = true;
+        let Some(remaining) = timeout.checked_sub(started_at.elapsed()) else {
+            return Ok(DatalensHeadCacheAcquire::TimedOut);
+        };
+        if remaining.is_zero() {
+            return Ok(DatalensHeadCacheAcquire::TimedOut);
+        }
+        let (next_state, wait_result) =
+            entry.ready.wait_timeout(state, remaining).map_err(|_| {
+                DatalensSdkError::Transport("Datalens head cache lock poisoned".to_owned())
+            })?;
+        state = next_state;
+        if wait_result.timed_out() {
+            return Ok(DatalensHeadCacheAcquire::TimedOut);
+        }
+    }
+}
+
+fn finish_head_cache_fetch(entry: &DatalensHeadCacheEntry, height: Option<i64>) {
+    if let Ok(mut state) = entry.state.lock() {
+        if let Some(height) = height {
+            state.cached = Some(DatalensHeadCacheValue {
+                height,
+                cached_at: Instant::now(),
+            });
+        }
+        state.in_flight = false;
+        entry.ready.notify_all();
+    }
+}
+
 fn datalens_query_timeout_error(
     operation: &str,
     timeout: Duration,
@@ -750,6 +879,14 @@ fn datalens_query_timeout_error(
         message.push_str(context);
     }
     DatalensSdkError::Transport(message)
+}
+
+fn head_finality_cache_key(finality: ChainHeadFinalityInput) -> &'static str {
+    match finality {
+        ChainHeadFinalityInput::Safe => "safe",
+        ChainHeadFinalityInput::Latest => "latest",
+        ChainHeadFinalityInput::Finalized => "finalized",
+    }
 }
 
 fn is_transient_sdk_api_error(error: &DatalensSdkError) -> bool {
@@ -840,19 +977,43 @@ impl DatalensNativeClient {
         config: &DatalensConfig,
         finality: ChainHeadFinalityInput,
     ) -> Result<i64, DatalensError> {
+        let started_at = Instant::now();
+        let cache_entry = head_cache_entry_for_config(config, finality)?;
+        match acquire_head_cache(&cache_entry, started_at, self.query_timeout)
+            .map_err(|error| DatalensError::Query(error.to_string()))?
+        {
+            DatalensHeadCacheAcquire::Cached(height) => return Ok(height),
+            DatalensHeadCacheAcquire::Fetch => {}
+            DatalensHeadCacheAcquire::TimedOut => {
+                let error = datalens_query_timeout_error(
+                    "head",
+                    self.query_timeout,
+                    Some("waiting for head cache fill"),
+                );
+                self.warn_query_timeout("head", &error);
+                return Err(DatalensError::Query(error.to_string()));
+            }
+        }
+
         let chain_name = config.chain.configured_name.clone();
         let response = self
-            .run_query_with_deadline("head", move |client| {
+            .run_query_with_deadline("head", started_at, move |client| {
                 client.native().chain_head(&chain_name, Some(finality))
             })
-            .map_err(|error| DatalensError::Query(error.to_string()))?;
+            .map_err(|error| {
+                finish_head_cache_fetch(&cache_entry, None);
+                DatalensError::Query(error.to_string())
+            })?;
 
-        i64::try_from(response.height).map_err(|_| {
+        let height = i64::try_from(response.height).map_err(|_| {
+            finish_head_cache_fetch(&cache_entry, None);
             DatalensError::Query(format!(
                 "Datalens chain head height {} exceeds supported indexer height",
                 response.height
             ))
-        })
+        })?;
+        finish_head_cache_fetch(&cache_entry, Some(height));
+        Ok(height)
     }
 }
 

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -330,6 +330,115 @@ fn test_datalens_head_reader_uses_separate_worker_guard_from_log_queries() {
 }
 
 #[test]
+fn test_datalens_head_reader_coalesces_concurrent_same_chain_reads() {
+    let server = FakeQueryServer::start_concurrent(vec![FakeQueryResponse::DelayedHttp(
+        Duration::from_millis(100),
+        head_success_response(568902, "safe"),
+    )]);
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(500);
+    let first_config = config.clone();
+    let second_config = config.clone();
+    let (started_sender, started_receiver) = mpsc::channel();
+
+    let first_handle = thread::spawn(move || {
+        started_sender.send(()).expect("send first start");
+        let mut client = DatalensNativeClient::from_config_with_retry_config(
+            &first_config,
+            retry_config_with_attempts(1),
+        )
+        .expect("first client");
+        client
+            .durable_head_height(&first_config)
+            .expect("first durable head height")
+    });
+    started_receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("first head starts");
+    thread::sleep(Duration::from_millis(20));
+    let second_handle = thread::spawn(move || {
+        let mut client = DatalensNativeClient::from_config_with_retry_config(
+            &second_config,
+            retry_config_with_attempts(1),
+        )
+        .expect("second client");
+        client
+            .durable_head_height(&second_config)
+            .expect("second durable head height")
+    });
+
+    assert_eq!(first_handle.join().expect("first head joins"), 568902);
+    assert_eq!(second_handle.join().expect("second head joins"), 568902);
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0].starts_with("GET /v1/chains/ethereum/head?finality=safe "),
+        "{requests:?}"
+    );
+}
+
+#[test]
+fn test_datalens_head_reader_cache_wait_counts_against_deadline() {
+    let server = FakeQueryServer::start_concurrent(vec![FakeQueryResponse::HoldOpen(
+        Duration::from_millis(300),
+    )]);
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.timeout = Duration::from_millis(120);
+    let first_config = config.clone();
+    let second_config = config.clone();
+    let (started_sender, started_receiver) = mpsc::channel();
+
+    let first_handle = thread::spawn(move || {
+        started_sender.send(()).expect("send first start");
+        let mut client = DatalensNativeClient::from_config_with_retry_config(
+            &first_config,
+            retry_config_with_attempts(1),
+        )
+        .expect("first client");
+        client
+            .durable_head_height(&first_config)
+            .expect_err("first head times out")
+    });
+    started_receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("first head starts");
+    thread::sleep(Duration::from_millis(20));
+    let second_handle = thread::spawn(move || {
+        let mut client = DatalensNativeClient::from_config_with_retry_config(
+            &second_config,
+            retry_config_with_attempts(1),
+        )
+        .expect("second client");
+        let started_at = std::time::Instant::now();
+        let error = client
+            .durable_head_height(&second_config)
+            .expect_err("second head times out");
+        (started_at.elapsed(), error)
+    });
+
+    let first_error = first_handle.join().expect("first head joins");
+    let (second_elapsed, second_error) = second_handle.join().expect("second head joins");
+    assert!(
+        second_elapsed < Duration::from_millis(220),
+        "cache wait should count against the Datalens head deadline"
+    );
+    assert!(
+        first_error
+            .to_string()
+            .contains("Datalens head timed out after 120ms"),
+        "{first_error}"
+    );
+    assert!(
+        second_error
+            .to_string()
+            .contains("Datalens head timed out after 120ms"),
+        "{second_error}"
+    );
+    let requests = server.join();
+    assert_eq!(requests.len(), 1);
+}
+
+#[test]
 fn test_datalens_log_query_retries_retryable_rate_limit_before_success() {
     let server = FakeQueryServer::start(vec![
         api_error_response(429, "rate_limited", Some("request_rate_limit")),
@@ -880,6 +989,7 @@ impl FakeHangingQueryServer {
 
 enum FakeQueryResponse {
     Http(String),
+    DelayedHttp(Duration, String),
     CloseWithoutResponse,
     HoldOpen(Duration),
 }
@@ -903,6 +1013,12 @@ impl FakeQueryServer {
                     FakeQueryResponse::Http(response) => stream
                         .write_all(response.as_bytes())
                         .expect("write fake Datalens query response"),
+                    FakeQueryResponse::DelayedHttp(duration, response) => {
+                        thread::sleep(duration);
+                        stream
+                            .write_all(response.as_bytes())
+                            .expect("write fake Datalens query response");
+                    }
                     FakeQueryResponse::CloseWithoutResponse => {}
                     FakeQueryResponse::HoldOpen(duration) => thread::sleep(duration),
                 }
@@ -928,6 +1044,12 @@ impl FakeQueryServer {
                         FakeQueryResponse::Http(response) => stream
                             .write_all(response.as_bytes())
                             .expect("write fake Datalens query response"),
+                        FakeQueryResponse::DelayedHttp(duration, response) => {
+                            thread::sleep(duration);
+                            stream
+                                .write_all(response.as_bytes())
+                                .expect("write fake Datalens query response");
+                        }
                         FakeQueryResponse::CloseWithoutResponse => {}
                         FakeQueryResponse::HoldOpen(duration) => thread::sleep(duration),
                     }


### PR DESCRIPTION
## Summary
- coalesce same-chain Datalens head reads with an in-process singleflight cache
- reuse successful head heights briefly to avoid all-mode startup head request bursts
- add a regression test proving concurrent same-chain head reads issue one upstream request

## Tests
- cargo fmt -p degov-datalens-indexer --check
- cargo test -p degov-datalens-indexer --locked --test datalens_client -- --nocapture
- cargo test -p degov-datalens-indexer --locked --lib