### PR TITLE
fix(indexer): split Datalens log selectors

### DIFF
--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -185,31 +185,29 @@ fn query_plans(
     from_block: i32,
     to_block: i32,
 ) -> Vec<DaoLogQueryPlan> {
-    let mut plans = vec![
-        query_plan(
-            config,
-            DaoLogAddressSource {
-                address: addresses.governor.clone(),
-                source: DaoLogSource::Governor,
-            },
-            GOVERNOR_TOPIC0_FILTERS,
-            from_block,
-            to_block,
-        ),
-        query_plan(
-            config,
-            DaoLogAddressSource {
-                address: addresses.governor_token.clone(),
-                source: DaoLogSource::GovernorToken,
-            },
-            GOVERNOR_TOKEN_TOPIC0_FILTERS,
-            from_block,
-            to_block,
-        ),
-    ];
+    let mut plans = split_topic_query_plans(
+        config,
+        DaoLogAddressSource {
+            address: addresses.governor.clone(),
+            source: DaoLogSource::Governor,
+        },
+        GOVERNOR_TOPIC0_FILTERS,
+        from_block,
+        to_block,
+    );
+    plans.extend(split_topic_query_plans(
+        config,
+        DaoLogAddressSource {
+            address: addresses.governor_token.clone(),
+            source: DaoLogSource::GovernorToken,
+        },
+        GOVERNOR_TOKEN_TOPIC0_FILTERS,
+        from_block,
+        to_block,
+    ));
 
     if let Some(timelock) = &addresses.timelock {
-        plans.push(query_plan(
+        plans.extend(split_topic_query_plans(
             config,
             DaoLogAddressSource {
                 address: timelock.clone(),
@@ -222,6 +220,19 @@ fn query_plans(
     }
 
     plans
+}
+
+fn split_topic_query_plans(
+    config: &DatalensConfig,
+    source: DaoLogAddressSource,
+    topic0_filters: &[&str],
+    from_block: i32,
+    to_block: i32,
+) -> Vec<DaoLogQueryPlan> {
+    topic0_filters
+        .iter()
+        .map(|topic| query_plan(config, source.clone(), &[*topic], from_block, to_block))
+        .collect()
 }
 
 fn query_plan(

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -1604,13 +1604,14 @@ mod tests {
 
         assert_eq!(result, Some(1));
         assert_eq!(reader.latest_head_calls, 1);
-        assert_eq!(reader.ranges, vec![(21, 25), (21, 25)]);
-        assert_eq!(
-            reader.finalities,
-            vec![
-                Some("safe_to_latest".to_owned()),
-                Some("safe_to_latest".to_owned())
-            ]
+        assert_eq!(reader.ranges.len(), 16);
+        assert!(reader.ranges.iter().all(|range| *range == (21, 25)));
+        assert_eq!(reader.finalities.len(), 16);
+        assert!(
+            reader
+                .finalities
+                .iter()
+                .all(|finality| finality.as_deref() == Some("safe_to_latest"))
         );
         assert_eq!(store.writes.len(), 1);
         assert_eq!(store.writes[0].segment_finality, "safe_to_latest");

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -12,65 +12,38 @@ use degov_datalens_indexer::{
 #[test]
 fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelock() {
     let config = config(1_000, DatalensFinality::DurableOnly);
-    let plans = plan_dao_log_queries(&config, &addresses(), 100, 199).expect("plans");
+    let addresses = addresses();
+    let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 3);
-    assert_query(
-        &plans[0],
-        &[DaoLogAddressSource {
-            address: "0x1111111111111111111111111111111111111111".to_owned(),
-            source: DaoLogSource::Governor,
-        }],
-        &[
-            "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0",
-            "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892",
-            "0x541f725fb9f7c98a30cc9c0ff32fbb14358cd7159c847a3aa20a2bdc442ba511",
-            "0x712ae1383f79ac853f8d882153778e0260ef8f03b504e2866e0593e04d2b291f",
-            "0x789cf55be980739dad1d0699b93b58e806b51c9d96619bfa8fe0a28abaa7b30c",
-            "0xc565b045403dc03c2eea82b81a0465edad9e2e7fc4d97e11421c209da93d7a93",
-            "0x7e3f7f0708a84de9203036abaa450dccc85ad5ff52f78c170f3edb55cf5e8828",
-            "0xccb45da8d5717e6c4544694297c4ba5cf151d455c9bb0ed4fc7a38411bc05461",
-            "0x0553476bf02ef2726e8ce5ced78d63e26e602e4a2257b1f559418e24b4633997",
-            "0x7ca4ac117ed3cdce75c1161d8207c440389b1a15d69d096831664657c07dafc2",
-            "0x08f74ea46ef7894f65eabfb5e6e695de773a000b47c529ab559178069b226401",
-            "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4",
-            "0xe2babfbac5889a709b63bb7f598b324e08bc5a4fb9ec647fb3cbc9ec07eb8712",
-        ],
+    assert_eq!(
+        plans.len(),
+        GOVERNOR_TOPIC0_VALUES.len()
+            + GOVERNOR_TOKEN_TOPIC0_VALUES.len()
+            + TIMELOCK_TOPIC0_VALUES.len()
+    );
+    assert_source_queries(
+        &plans,
+        DaoLogSource::Governor,
+        &addresses.governor,
+        GOVERNOR_TOPIC0_VALUES,
         100,
         199,
         "durable_only",
     );
-    assert_query(
-        &plans[1],
-        &[DaoLogAddressSource {
-            address: "0x2222222222222222222222222222222222222222".to_owned(),
-            source: DaoLogSource::GovernorToken,
-        }],
-        &[
-            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f",
-            "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
-        ],
+    assert_source_queries(
+        &plans,
+        DaoLogSource::GovernorToken,
+        &addresses.governor_token,
+        GOVERNOR_TOKEN_TOPIC0_VALUES,
         100,
         199,
         "durable_only",
     );
-    assert_query(
-        &plans[2],
-        &[DaoLogAddressSource {
-            address: "0x3333333333333333333333333333333333333333".to_owned(),
-            source: DaoLogSource::Timelock,
-        }],
-        &[
-            "0x4cf4410cc57040e44862ef0f45f3dd5a5e02db8eb8add648d4b0e236f1d07dca",
-            "0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58",
-            "0x20fda5fd27a1ea7bf5b9567f143ac5470bb059374a27e8f67cb44f946f6d0387",
-            "0xbaa1eb22f2a492ba1a5fea61b8df4d27c6c8b5f3971e63bb58fa14ff72eedb70",
-            "0x11c24f4ead16507c69ac467fbd5e4eed5fb5c699626d2cc6d66421df253886d5",
-            "0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d",
-            "0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b",
-            "0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff",
-        ],
+    assert_source_queries(
+        &plans,
+        DaoLogSource::Timelock,
+        addresses.timelock.as_ref().expect("timelock"),
+        TIMELOCK_TOPIC0_VALUES,
         100,
         199,
         "durable_only",
@@ -85,9 +58,29 @@ fn test_plan_dao_log_queries_skips_timelock_when_not_configured() {
 
     let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 2);
-    assert_eq!(plans[0].sources[0].source, DaoLogSource::Governor);
-    assert_eq!(plans[1].sources[0].source, DaoLogSource::GovernorToken);
+    assert_eq!(
+        plans.len(),
+        GOVERNOR_TOPIC0_VALUES.len() + GOVERNOR_TOKEN_TOPIC0_VALUES.len()
+    );
+    assert_eq!(
+        plans
+            .iter()
+            .filter(|plan| plan.sources[0].source == DaoLogSource::Governor)
+            .count(),
+        GOVERNOR_TOPIC0_VALUES.len()
+    );
+    assert_eq!(
+        plans
+            .iter()
+            .filter(|plan| plan.sources[0].source == DaoLogSource::GovernorToken)
+            .count(),
+        GOVERNOR_TOKEN_TOPIC0_VALUES.len()
+    );
+    assert!(
+        plans
+            .iter()
+            .all(|plan| plan.sources[0].source != DaoLogSource::Timelock)
+    );
 }
 
 #[test]
@@ -99,19 +92,22 @@ fn test_plan_dao_log_queries_chunks_ranges_by_config_limit() {
         .map(|plan| (plan.from_block, plan.to_block))
         .collect::<Vec<_>>();
 
+    let plans_per_chunk = GOVERNOR_TOPIC0_VALUES.len()
+        + GOVERNOR_TOKEN_TOPIC0_VALUES.len()
+        + TIMELOCK_TOPIC0_VALUES.len();
+
+    assert_eq!(ranges.len(), plans_per_chunk * 3);
     assert_eq!(
-        ranges,
-        vec![
-            (100, 149),
-            (100, 149),
-            (100, 149),
-            (150, 199),
-            (150, 199),
-            (150, 199),
-            (200, 220),
-            (200, 220),
-            (200, 220),
-        ]
+        ranges.iter().filter(|range| **range == (100, 149)).count(),
+        plans_per_chunk
+    );
+    assert_eq!(
+        ranges.iter().filter(|range| **range == (150, 199)).count(),
+        plans_per_chunk
+    );
+    assert_eq!(
+        ranges.iter().filter(|range| **range == (200, 220)).count(),
+        plans_per_chunk
     );
 }
 
@@ -210,6 +206,36 @@ fn test_fetch_dao_log_pages_stops_without_later_pages_on_reader_error() {
     assert_eq!(reader.calls.len(), 1);
 }
 
+fn assert_source_queries(
+    plans: &[DaoLogQueryPlan],
+    source: DaoLogSource,
+    address: &str,
+    topic0_values: &[&str],
+    from_block: i32,
+    to_block: i32,
+    finality: &str,
+) {
+    let source_plans = plans
+        .iter()
+        .filter(|plan| plan.sources[0].source == source)
+        .collect::<Vec<_>>();
+
+    assert_eq!(source_plans.len(), topic0_values.len());
+    for (plan, topic0) in source_plans.into_iter().zip(topic0_values) {
+        assert_query(
+            plan,
+            &[DaoLogAddressSource {
+                address: address.to_owned(),
+                source,
+            }],
+            &[*topic0],
+            from_block,
+            to_block,
+            finality,
+        );
+    }
+}
+
 fn assert_query(
     plan: &DaoLogQueryPlan,
     sources: &[DaoLogAddressSource],
@@ -280,6 +306,39 @@ fn addresses() -> DaoContractAddresses {
         timelock: Some("0x3333333333333333333333333333333333333333".to_owned()),
     }
 }
+
+const GOVERNOR_TOPIC0_VALUES: &[&str] = &[
+    "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0",
+    "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892",
+    "0x541f725fb9f7c98a30cc9c0ff32fbb14358cd7159c847a3aa20a2bdc442ba511",
+    "0x712ae1383f79ac853f8d882153778e0260ef8f03b504e2866e0593e04d2b291f",
+    "0x789cf55be980739dad1d0699b93b58e806b51c9d96619bfa8fe0a28abaa7b30c",
+    "0xc565b045403dc03c2eea82b81a0465edad9e2e7fc4d97e11421c209da93d7a93",
+    "0x7e3f7f0708a84de9203036abaa450dccc85ad5ff52f78c170f3edb55cf5e8828",
+    "0xccb45da8d5717e6c4544694297c4ba5cf151d455c9bb0ed4fc7a38411bc05461",
+    "0x0553476bf02ef2726e8ce5ced78d63e26e602e4a2257b1f559418e24b4633997",
+    "0x7ca4ac117ed3cdce75c1161d8207c440389b1a15d69d096831664657c07dafc2",
+    "0x08f74ea46ef7894f65eabfb5e6e695de773a000b47c529ab559178069b226401",
+    "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4",
+    "0xe2babfbac5889a709b63bb7f598b324e08bc5a4fb9ec647fb3cbc9ec07eb8712",
+];
+
+const GOVERNOR_TOKEN_TOPIC0_VALUES: &[&str] = &[
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+    "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f",
+    "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
+];
+
+const TIMELOCK_TOPIC0_VALUES: &[&str] = &[
+    "0x4cf4410cc57040e44862ef0f45f3dd5a5e02db8eb8add648d4b0e236f1d07dca",
+    "0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58",
+    "0x20fda5fd27a1ea7bf5b9567f143ac5470bb059374a27e8f67cb44f946f6d0387",
+    "0xbaa1eb22f2a492ba1a5fea61b8df4d27c6c8b5f3971e63bb58fa14ff72eedb70",
+    "0x11c24f4ead16507c69ac467fbd5e4eed5fb5c699626d2cc6d66421df253886d5",
+    "0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d",
+    "0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b",
+    "0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff",
+];
 
 struct MockLogReader {
     calls: Vec<QueryInput>,

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -32,19 +32,32 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
         outcome,
         DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.requests.len(), 3);
-    let selector_addresses: Vec<_> = ensurer
+    assert_eq!(ensurer.requests.len(), 24);
+    let selector_addresses = ensurer
         .requests
         .iter()
         .map(|request| request.selector.addresses.clone())
-        .collect();
+        .collect::<Vec<_>>();
     assert_eq!(
-        selector_addresses,
-        vec![
-            vec!["0x1111111111111111111111111111111111111111".to_owned()],
-            vec!["0x2222222222222222222222222222222222222222".to_owned()],
-            vec!["0x3333333333333333333333333333333333333333".to_owned()],
-        ]
+        selector_addresses
+            .iter()
+            .filter(|addresses| addresses[0] == "0x1111111111111111111111111111111111111111")
+            .count(),
+        13
+    );
+    assert_eq!(
+        selector_addresses
+            .iter()
+            .filter(|addresses| addresses[0] == "0x2222222222222222222222222222222222222222")
+            .count(),
+        3
+    );
+    assert_eq!(
+        selector_addresses
+            .iter()
+            .filter(|addresses| addresses[0] == "0x3333333333333333333333333333333333333333")
+            .count(),
+        8
     );
     for request in &ensurer.requests {
         assert_eq!(request.chain.configured_name, "ethereum");
@@ -55,6 +68,7 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
         assert_eq!(request.end, None);
         assert_eq!(request.mode, "follow_query");
         assert_eq!(request.selector.topics.len(), 1);
+        assert_eq!(request.selector.topics[0].len(), 1);
     }
 }
 
@@ -76,7 +90,7 @@ fn test_ensure_datalens_warmup_task_reuses_existing_matching_task() {
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 3);
+    assert_eq!(ensurer.created_tasks.len(), 24);
 }
 
 #[test]
@@ -94,7 +108,7 @@ fn test_ensure_datalens_warmup_task_submits_distinct_task_for_selector_mismatch(
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 4);
+    assert_eq!(ensurer.created_tasks.len(), 32);
 }
 
 #[test]

--- a/apps/indexer/tests/datalens_warmup_effectiveness.rs
+++ b/apps/indexer/tests/datalens_warmup_effectiveness.rs
@@ -110,23 +110,15 @@ fn test_warmup_effectiveness_aggregation_builds_operator_log_fields() {
 fn test_fetch_dao_log_pages_preserves_cache_summary() {
     let config = config();
     let plans = plan_dao_log_queries(&config, &addresses(), 100, 100).expect("plans");
-    let mut reader = MockLogReader::new(vec![
-        Ok(DatalensLogQueryResult {
-            rows: json!([]),
-            cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
-                "hit_ranges": [],
-                "missing_ranges": [{ "kind": "block", "start": 100, "end": 100 }],
-                "provider_fill_ranges": [{ "kind": "block", "start": 100, "end": 100 }]
-            })),
-        }),
-        Ok(DatalensLogQueryResult {
-            rows: json!([]),
-            cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
-                "hit_ranges": [{ "kind": "block", "start": 100, "end": 100 }],
-                "missing_ranges": [],
-                "provider_fill_ranges": []
-            })),
-        }),
+    let mut results = vec![Ok(DatalensLogQueryResult {
+        rows: json!([]),
+        cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
+            "hit_ranges": [],
+            "missing_ranges": [{ "kind": "block", "start": 100, "end": 100 }],
+            "provider_fill_ranges": [{ "kind": "block", "start": 100, "end": 100 }]
+        })),
+    })];
+    results.extend((1..plans.len()).map(|_| {
         Ok(DatalensLogQueryResult {
             rows: json!([]),
             cache: DatalensLogQueryCacheSummary::from_datalens_cache_json(&json!({
@@ -134,21 +126,19 @@ fn test_fetch_dao_log_pages_preserves_cache_summary() {
                 "missing_ranges": [],
                 "provider_fill_ranges": []
             })),
-        }),
-    ]);
+        })
+    }));
+    let mut reader = MockLogReader::new(results);
 
     let pages = fetch_dao_log_pages(&mut reader, &plans).expect("pages");
 
-    assert_eq!(pages.len(), 3);
+    assert_eq!(pages.len(), plans.len());
     assert_eq!(pages[0].cache.outcome, DatalensLogQueryCacheOutcome::Miss);
     assert_eq!(pages[0].cache.provider_fill_range_count, Some(1));
-    assert_eq!(
-        pages[1].cache.outcome,
-        DatalensLogQueryCacheOutcome::FullHit
-    );
-    assert_eq!(
-        pages[2].cache.outcome,
-        DatalensLogQueryCacheOutcome::FullHit
+    assert!(
+        pages[1..]
+            .iter()
+            .all(|page| page.cache.outcome == DatalensLogQueryCacheOutcome::FullHit)
     );
 }
 

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -375,18 +375,11 @@ fn test_runner_splits_provider_limit_range_and_advances_checkpoint_after_subrang
         1_001
     );
     assert_eq!(runner.store().commit_count(), 2);
-    assert_eq!(
-        *observed_ranges.lock().expect("observed ranges"),
-        vec![
-            (1, 1_000),
-            (1, 500),
-            (1, 500),
-            (1, 500),
-            (501, 1_000),
-            (501, 1_000),
-            (501, 1_000),
-        ]
-    );
+    let observed = observed_ranges.lock().expect("observed ranges");
+    assert_range_count(&observed, (1, 1_000), 1);
+    assert_range_count(&observed, (1, 500), ALL_SELECTOR_COUNT);
+    assert_range_count(&observed, (501, 1_000), ALL_SELECTOR_COUNT);
+    assert_eq!(observed.len(), 1 + ALL_SELECTOR_COUNT * 2);
 }
 
 #[test]
@@ -415,10 +408,10 @@ fn test_runner_splits_transient_range_and_retries_without_pass_error() {
         2_501
     );
     assert_eq!(runner.store().commit_count(), 1);
-    assert_eq!(
-        *observed_ranges.lock().expect("observed ranges"),
-        vec![(1, 5_000), (1, 2_500), (1, 2_500), (1, 2_500)]
-    );
+    let observed = observed_ranges.lock().expect("observed ranges");
+    assert_range_count(&observed, (1, 5_000), 1);
+    assert_range_count(&observed, (1, 2_500), ALL_SELECTOR_COUNT);
+    assert_eq!(observed.len(), 1 + ALL_SELECTOR_COUNT);
 }
 
 #[test]
@@ -447,20 +440,13 @@ fn test_runner_splits_transient_failure_below_normal_min_and_advances_checkpoint
         2
     );
     assert_eq!(runner.store().commit_count(), 1);
+    let observed = observed_ranges.lock().expect("observed ranges");
     assert_eq!(
-        *observed_ranges.lock().expect("observed ranges"),
-        vec![
-            (1, 101),
-            (1, 50),
-            (1, 25),
-            (1, 12),
-            (1, 6),
-            (1, 3),
-            (1, 1),
-            (1, 1),
-            (1, 1),
-        ]
+        &observed[..6],
+        &[(1, 101), (1, 50), (1, 25), (1, 12), (1, 6), (1, 3)]
     );
+    assert_range_count(&observed, (1, 1), ALL_SELECTOR_COUNT);
+    assert_eq!(observed.len(), 6 + ALL_SELECTOR_COUNT);
 }
 
 #[test]
@@ -489,10 +475,10 @@ fn test_runner_splits_two_block_transient_failure_to_single_block() {
         2
     );
     assert_eq!(runner.store().commit_count(), 1);
-    assert_eq!(
-        *observed_ranges.lock().expect("observed ranges"),
-        vec![(1, 2), (1, 1), (1, 1), (1, 1)]
-    );
+    let observed = observed_ranges.lock().expect("observed ranges");
+    assert_range_count(&observed, (1, 2), 1);
+    assert_range_count(&observed, (1, 1), ALL_SELECTOR_COUNT);
+    assert_eq!(observed.len(), 1 + ALL_SELECTOR_COUNT);
 }
 
 #[test]
@@ -918,9 +904,12 @@ fn test_runner_decodes_distinct_log_addresses_with_matching_sources() {
 
     runner.run_to_target(1).expect("runner succeeds");
 
-    assert_eq!(
-        *attempts.lock().expect("attempts"),
-        vec![DaoLogSource::Governor, DaoLogSource::GovernorToken]
+    let attempts = attempts.lock().expect("attempts");
+    assert_source_attempt_counts(
+        &attempts,
+        GOVERNOR_SELECTOR_COUNT,
+        GOVERNOR_TOKEN_SELECTOR_COUNT,
+        0,
     );
     assert_eq!(
         runner.store().vote_repository().data_metric().votes_count,
@@ -943,13 +932,12 @@ fn test_runner_decodes_duplicate_address_token_log_with_token_source() {
 
     runner.run_to_target(1).expect("runner succeeds");
 
-    assert_eq!(
-        *attempts.lock().expect("attempts"),
-        vec![
-            DaoLogSource::Governor,
-            DaoLogSource::GovernorToken,
-            DaoLogSource::Timelock
-        ]
+    let attempts = attempts.lock().expect("attempts");
+    assert_source_attempt_counts(
+        &attempts,
+        GOVERNOR_SELECTOR_COUNT,
+        GOVERNOR_TOKEN_SELECTOR_COUNT,
+        TIMELOCK_SELECTOR_COUNT,
     );
     assert_eq!(
         runner.store().token_repository().delegate_changed().len(),
@@ -968,13 +956,12 @@ fn test_runner_keeps_duplicate_address_unsupported_topic_unsupported() {
 
     runner.run_to_target(1).expect("runner succeeds");
 
-    assert_eq!(
-        *attempts.lock().expect("attempts"),
-        vec![
-            DaoLogSource::Governor,
-            DaoLogSource::GovernorToken,
-            DaoLogSource::Timelock
-        ]
+    let attempts = attempts.lock().expect("attempts");
+    assert_source_attempt_counts(
+        &attempts,
+        GOVERNOR_SELECTOR_COUNT,
+        GOVERNOR_TOKEN_SELECTOR_COUNT,
+        TIMELOCK_SELECTOR_COUNT,
     );
     assert_eq!(
         runner.store().checkpoint().expect("checkpoint").next_block,
@@ -1560,6 +1547,49 @@ fn set_block_range_limit(options: &mut IndexerRunnerOptions, block_range_limit: 
     options.adaptive_chunk_sizer = AdaptiveChunkSizerConfig::for_max_chunk_size(block_range_limit);
 }
 
+fn assert_range_count(observed: &[(u64, u64)], range: (u64, u64), expected_count: usize) {
+    assert_eq!(
+        observed
+            .iter()
+            .filter(|observed_range| **observed_range == range)
+            .count(),
+        expected_count
+    );
+}
+
+fn assert_source_attempt_counts(
+    attempts: &[DaoLogSource],
+    governor_count: usize,
+    governor_token_count: usize,
+    timelock_count: usize,
+) {
+    assert_eq!(
+        attempts
+            .iter()
+            .filter(|source| **source == DaoLogSource::Governor)
+            .count(),
+        governor_count
+    );
+    assert_eq!(
+        attempts
+            .iter()
+            .filter(|source| **source == DaoLogSource::GovernorToken)
+            .count(),
+        governor_token_count
+    );
+    assert_eq!(
+        attempts
+            .iter()
+            .filter(|source| **source == DaoLogSource::Timelock)
+            .count(),
+        timelock_count
+    );
+    assert_eq!(
+        attempts.len(),
+        governor_count + governor_token_count + timelock_count
+    );
+}
+
 fn contexts() -> IndexerRunnerContexts {
     let contracts = ChainContracts {
         governor: "0x1111111111111111111111111111111111111111".to_owned(),
@@ -1682,3 +1712,8 @@ fn row_with_removed(
 
 const GOVERNOR: &str = "0x1111111111111111111111111111111111111111";
 const TOKEN: &str = "0x2222222222222222222222222222222222222222";
+const GOVERNOR_SELECTOR_COUNT: usize = 13;
+const GOVERNOR_TOKEN_SELECTOR_COUNT: usize = 3;
+const TIMELOCK_SELECTOR_COUNT: usize = 8;
+const ALL_SELECTOR_COUNT: usize =
+    GOVERNOR_SELECTOR_COUNT + GOVERNOR_TOKEN_SELECTOR_COUNT + TIMELOCK_SELECTOR_COUNT;

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -128,7 +128,7 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
     run_indexer_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 1);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 24);
     assert_table_count(&database.pool, "proposal_created", 1).await?;
     assert_table_count(&database.pool, "proposal", 1).await?;
     assert_table_count(&database.pool, "vote_cast", 1).await?;
@@ -358,7 +358,7 @@ async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
     run_indexer_all_contract_sets_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 0);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 24);
     assert_checkpoint_scope(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_scope(&database.pool, SECOND_CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_row_count(&database.pool, 2).await?;
@@ -2842,7 +2842,7 @@ impl FakeDatalensServer {
         let server_query_count = query_count.clone();
 
         thread::spawn(move || {
-            for stream in listener.incoming().take(8).flatten() {
+            for stream in listener.incoming().take(64).flatten() {
                 handle_datalens_request(
                     stream,
                     &governor_rows,
@@ -3026,11 +3026,11 @@ fn handle_datalens_request(
         query_count.fetch_add(1, Ordering::Relaxed);
         let request_body = request.split("\r\n\r\n").nth(1).unwrap_or_default();
         let rows = if request_body.contains(GOVERNOR) || request_body.contains(SECOND_GOVERNOR) {
-            governor_rows.to_vec()
+            matching_datalens_rows(request_body, governor_rows)
         } else if request_body.contains(TOKEN) || request_body.contains(SECOND_TOKEN) {
-            token_rows.to_vec()
+            matching_datalens_rows(request_body, token_rows)
         } else if request_body.contains(TIMELOCK) || request_body.contains(SECOND_TIMELOCK) {
-            timelock_rows.to_vec()
+            matching_datalens_rows(request_body, timelock_rows)
         } else {
             Vec::new()
         };
@@ -3053,6 +3053,17 @@ fn handle_datalens_request(
     stream
         .write_all(response.as_bytes())
         .expect("write fake Datalens response");
+}
+
+fn matching_datalens_rows(request_body: &str, rows: &[Value]) -> Vec<Value> {
+    rows.iter()
+        .filter(|row| {
+            row.pointer("/topics/0")
+                .and_then(Value::as_str)
+                .is_some_and(|topic0| request_body.contains(topic0))
+        })
+        .cloned()
+        .collect()
 }
 
 fn read_http_request(stream: &mut TcpStream) -> String {

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -29,27 +29,24 @@ static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 #[test]
 fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
     let config = datalens_config();
-    let mut reader = MockProvisionalReader::new(vec![
-        Ok(DatalensProvisionalLogQueryResult {
-            rows: serde_json::json!([]),
-            segments: vec![cache_segment("provider", "latest", 100, 105)],
-        }),
-        Ok(DatalensProvisionalLogQueryResult {
-            rows: serde_json::json!([]),
-            segments: Vec::new(),
-        }),
+    let mut results = vec![Ok(DatalensProvisionalLogQueryResult {
+        rows: serde_json::json!([]),
+        segments: vec![cache_segment("provider", "latest", 100, 105)],
+    })];
+    results.extend((1..24).map(|_| {
         Ok(DatalensProvisionalLogQueryResult {
             rows: serde_json::json!([]),
             segments: Vec::new(),
-        }),
-    ]);
+        })
+    }));
+    let mut reader = MockProvisionalReader::new(results);
     let mut store = RecordingProvisionalStore::default();
     let mut worker = ProvisionalWorker::new(options(&config), &mut reader, &mut store);
 
     let report = worker.run_once().expect("worker runs once");
 
     assert_eq!(report.segments_written, 1);
-    assert_eq!(reader.calls.len(), 3);
+    assert_eq!(reader.calls.len(), 24);
     assert!(
         reader
             .calls


### PR DESCRIPTION
## Summary
- split DAO log query planning into one Datalens selector per event topic for governor, token, and timelock logs
- keep provisional safe-to-latest queries on the same planner behavior
- add planner coverage to prevent broad topic selectors from returning stale durable empty cache results

## Root cause
Lightchain v5 was missing 5 historical VoteCast rows while the old indexer had them. Direct Datalens single-topic queries and direct eRPC getLogs returned the logs, but the broad governor selector returned a durable FullHit with zero rows. Splitting by event topic avoids trusting that stale broad-selector cache fingerprint and applies the safer shape to all DAO event sources.

## Validation
- cargo test -p degov-datalens-indexer --lib
- cargo test -p degov-datalens-indexer --test chain_tool_read_plan --test checkpoint_plan

Full `cargo test -p degov-datalens-indexer` also reaches DB-backed integration tests, which require `DEGOV_INDEXER_TEST_DATABASE_URL` in this workspace.
