### PR TITLE
perf(indexer): reduce onchain refresh write amplification

### DIFF
--- a/apps/indexer/src/store/postgres/data_metric.rs
+++ b/apps/indexer/src/store/postgres/data_metric.rs
@@ -96,12 +96,17 @@ async fn write_data_metric_timeline(
     let effective_count_delegates = delegate_mapping_cache.flush(transaction).await?;
     let mapping_flush_duration = mapping_flush_started_at.elapsed();
 
-    let contributor_count_flush_started_at = std::time::Instant::now();
-    contributor_ensure_cache
+    let contributor_count_started_at = std::time::Instant::now();
+    let contributor_count_delta_flush_started_at = std::time::Instant::now();
+    let contributor_count_delta_count = contributor_ensure_cache
         .flush_contributor_count_deltas(transaction)
         .await?;
+    let contributor_count_delta_flush_duration = contributor_count_delta_flush_started_at.elapsed();
+    let contributor_count_effective_recompute_started_at = std::time::Instant::now();
     recompute_delegate_count_effective(transaction, &effective_count_delegates).await?;
-    let contributor_count_flush_duration = contributor_count_flush_started_at.elapsed();
+    let contributor_count_effective_recompute_duration =
+        contributor_count_effective_recompute_started_at.elapsed();
+    let contributor_count_flush_duration = contributor_count_started_at.elapsed();
 
     let contributor_count_metric_flush_started_at = std::time::Instant::now();
     contributor_ensure_cache
@@ -112,13 +117,18 @@ async fn write_data_metric_timeline(
 
     if let Some(token) = token {
         if let Some(common) = token_batch_common(token) {
+            let effective_recompute_chunk_size = recompute_delegate_count_effective_chunk_size();
             log::info!(
-                "Datalens indexer token timeline phases dao_code={} chain_id={} contract_set_id={} token_operation_count={} inserted_operation_count={} contributor_preload_duration_ms={} metadata_preload_duration_ms={} mapping_preload_duration_ms={} replay_duration_ms={} rolling_flush_duration_ms={} snapshot_flush_duration_ms={} mapping_flush_duration_ms={} contributor_count_flush_duration_ms={} contributor_count_metric_flush_duration_ms={} total_duration_ms={}",
+                "Datalens indexer token timeline phases dao_code={} chain_id={} contract_set_id={} token_operation_count={} inserted_operation_count={} effective_delegate_count={} effective_recompute_chunk_size={} effective_recompute_chunk_count={} contributor_count_delta_count={} contributor_preload_duration_ms={} metadata_preload_duration_ms={} mapping_preload_duration_ms={} replay_duration_ms={} rolling_flush_duration_ms={} snapshot_flush_duration_ms={} mapping_flush_duration_ms={} contributor_count_delta_flush_duration_ms={} contributor_count_effective_recompute_duration_ms={} contributor_count_flush_duration_ms={} contributor_count_metric_flush_duration_ms={} total_duration_ms={}",
                 common.dao_code,
                 common.chain_id,
                 common.contract_set_id,
                 token.operations.len(),
                 inserted_operation_keys.len(),
+                effective_count_delegates.len(),
+                effective_recompute_chunk_size,
+                chunk_count(effective_count_delegates.len(), effective_recompute_chunk_size),
+                contributor_count_delta_count,
                 contributor_preload_duration.as_millis(),
                 metadata_preload_duration.as_millis(),
                 mapping_preload_duration.as_millis(),
@@ -126,6 +136,8 @@ async fn write_data_metric_timeline(
                 rolling_flush_duration.as_millis(),
                 snapshot_flush_duration.as_millis(),
                 mapping_flush_duration.as_millis(),
+                contributor_count_delta_flush_duration.as_millis(),
+                contributor_count_effective_recompute_duration.as_millis(),
                 contributor_count_flush_duration.as_millis(),
                 contributor_count_metric_flush_duration.as_millis(),
                 total_started_at.elapsed().as_millis(),
@@ -299,9 +311,10 @@ async fn refresh_vote_data_metric(
     let Some(row) = rows.first() else {
         return Ok(());
     };
+    let started_at = std::time::Instant::now();
     let metric_id = data_metric_id(row.chain_id, &row.governor_address, &row.dao_code);
 
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO data_metric (
             id, contract_set_id, chain_id, dao_code, governor_address, votes_count, votes_with_params_count,
             votes_without_params_count, votes_weight_for_sum, votes_weight_against_sum,
@@ -332,6 +345,16 @@ async fn refresh_vote_data_metric(
     .bind(&row.governor_address)
     .execute(&mut **transaction)
     .await?;
+
+    log::info!(
+        "Datalens indexer vote data_metric refresh completed dao_code={} chain_id={} contract_set_id={} vote_signal_count={} rows_affected={} duration_ms={}",
+        row.dao_code,
+        row.chain_id,
+        row.contract_set_id,
+        rows.len(),
+        result.rows_affected(),
+        started_at.elapsed().as_millis()
+    );
 
     Ok(())
 }
@@ -364,9 +387,10 @@ async fn refresh_proposal_data_metric(
     let Some((contract_set_id, chain_id, dao_code, governor_address)) = scope else {
         return Ok(());
     };
+    let started_at = std::time::Instant::now();
     let metric_id = data_metric_id(chain_id, governor_address, dao_code);
 
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO data_metric (
             id, contract_set_id, chain_id, dao_code, governor_address, proposals_count
          )
@@ -383,6 +407,17 @@ async fn refresh_proposal_data_metric(
     .bind(governor_address)
     .execute(&mut **transaction)
     .await?;
+
+    log::info!(
+        "Datalens indexer proposal data_metric refresh completed dao_code={} chain_id={} contract_set_id={} proposal_count={} data_metric_count={} rows_affected={} duration_ms={}",
+        dao_code,
+        chain_id,
+        contract_set_id,
+        batch.proposals.len(),
+        batch.data_metrics.len(),
+        result.rows_affected(),
+        started_at.elapsed().as_millis()
+    );
 
     Ok(())
 }

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -27,17 +27,40 @@ fn plan_onchain_refresh_enqueue_with_drain_budget(
     }
 }
 
+#[cfg(test)]
+fn should_update_deferred_candidate_conflict(
+    existing_next_run_at: i64,
+    now_ms: i64,
+    existing_refresh_balance: bool,
+    incoming_refresh_balance: bool,
+    existing_refresh_power: bool,
+    incoming_refresh_power: bool,
+    existing_first_seen_block_number: u64,
+    incoming_first_seen_block_number: u64,
+    existing_last_seen_block_number: u64,
+    incoming_last_seen_block_number: u64,
+) -> bool {
+    existing_next_run_at > now_ms
+        || (incoming_refresh_balance && !existing_refresh_balance)
+        || (incoming_refresh_power && !existing_refresh_power)
+        || existing_first_seen_block_number > incoming_first_seen_block_number
+        || existing_last_seen_block_number < incoming_last_seen_block_number
+}
+
 async fn upsert_onchain_refresh_tasks(
     transaction: &mut Transaction<'_, Postgres>,
     rows: &[PowerReconcileCandidate],
     debounce: Duration,
     deferred_drain_batch_size: usize,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let total_started_at = std::time::Instant::now();
     let original_count = rows.len();
+    let dedupe_started_at = std::time::Instant::now();
     let mut rows = dedupe_onchain_refresh_tasks(rows)
         .into_iter()
         .map(OnchainRefreshTaskWrite::from)
         .collect::<Vec<_>>();
+    let dedupe_duration = dedupe_started_at.elapsed();
     let now_ms = unix_time_millis();
     let next_run_at = now_ms.saturating_add(duration_millis_i64(debounce));
     for row in &mut rows {
@@ -46,13 +69,20 @@ async fn upsert_onchain_refresh_tasks(
 
     let plan =
         plan_onchain_refresh_enqueue_with_drain_budget(rows.len(), debounce, deferred_drain_batch_size);
+    let mut deferred_candidate_write_count = 0;
+    let deferred_upsert_started_at = std::time::Instant::now();
     for chunk in rows.chunks(MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS) {
-        upsert_deferred_onchain_refresh_candidate_chunk(transaction, chunk, now_ms, next_run_at)
-            .await?;
+        deferred_candidate_write_count +=
+            upsert_deferred_onchain_refresh_candidate_chunk(transaction, chunk, now_ms, next_run_at)
+                .await?;
     }
+    let deferred_upsert_duration = deferred_upsert_started_at.elapsed();
+    let reschedule_started_at = std::time::Instant::now();
     let rescheduled_count =
         reschedule_materialized_onchain_refresh_tasks(transaction, &rows, next_run_at, now_ms)
             .await?;
+    let reschedule_duration = reschedule_started_at.elapsed();
+    let ready_drain_started_at = std::time::Instant::now();
     let drained_count = drain_deferred_onchain_refresh_tasks_in_transaction(
         transaction,
         plan.ready_drain_count,
@@ -60,18 +90,27 @@ async fn upsert_onchain_refresh_tasks(
         None,
     )
     .await?;
+    let ready_drain_duration = ready_drain_started_at.elapsed();
 
     log::info!(
-        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} deduped_duplicate_count={} inline_upsert_count={} deferred_count={} rescheduled_materialized_count={} ready_drain_batch_size={} ready_drain_count={} materialized_count={}",
+        "onchain refresh enqueue planned original_candidate_count={} deduped_unique_count={} deduped_duplicate_count={} inline_upsert_count={} deferred_count={} deferred_chunk_size={} deferred_chunk_count={} deferred_candidate_write_count={} rescheduled_materialized_count={} ready_drain_batch_size={} ready_drain_count={} materialized_count={} dedupe_duration_ms={} deferred_upsert_duration_ms={} reschedule_duration_ms={} ready_drain_duration_ms={} total_duration_ms={}",
         original_count,
         rows.len(),
         original_count.saturating_sub(rows.len()),
         plan.inline_upsert_count,
         plan.deferred_candidate_count,
+        MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS,
+        chunk_count(rows.len(), MAX_ONCHAIN_REFRESH_TASK_UPSERT_ROWS),
+        deferred_candidate_write_count,
         rescheduled_count,
         deferred_drain_batch_size,
         plan.ready_drain_count,
-        drained_count
+        drained_count,
+        dedupe_duration.as_millis(),
+        deferred_upsert_duration.as_millis(),
+        reschedule_duration.as_millis(),
+        ready_drain_duration.as_millis(),
+        total_started_at.elapsed().as_millis()
     );
 
     Ok(())
@@ -484,7 +523,7 @@ async fn upsert_deferred_onchain_refresh_candidate_chunk(
     rows: &[OnchainRefreshTaskWrite],
     now_ms: i64,
     next_run_at: i64,
-) -> Result<(), PostgresIndexerRunnerStoreError> {
+) -> Result<u64, PostgresIndexerRunnerStoreError> {
     let mut query = QueryBuilder::<Postgres>::new(
         "INSERT INTO onchain_refresh_deferred_candidate (
             id, contract_set_id, chain_id, dao_code, governor_address, token_address, account,
@@ -530,11 +569,16 @@ async fn upsert_deferred_onchain_refresh_candidate_chunk(
              last_seen_block_timestamp = GREATEST(onchain_refresh_deferred_candidate.last_seen_block_timestamp, EXCLUDED.last_seen_block_timestamp),
              last_seen_transaction_hash = EXCLUDED.last_seen_transaction_hash,
              next_run_at = GREATEST(onchain_refresh_deferred_candidate.next_run_at, EXCLUDED.next_run_at),
-             updated_at = EXCLUDED.updated_at",
+             updated_at = EXCLUDED.updated_at
+         WHERE onchain_refresh_deferred_candidate.next_run_at > EXCLUDED.updated_at
+            OR (EXCLUDED.refresh_balance AND NOT onchain_refresh_deferred_candidate.refresh_balance)
+            OR (EXCLUDED.refresh_power AND NOT onchain_refresh_deferred_candidate.refresh_power)
+            OR onchain_refresh_deferred_candidate.first_seen_block_number > EXCLUDED.first_seen_block_number
+            OR onchain_refresh_deferred_candidate.last_seen_block_number < EXCLUDED.last_seen_block_number",
     );
-    query.build().execute(&mut **transaction).await?;
+    let result = query.build().execute(&mut **transaction).await?;
 
-    Ok(())
+    Ok(result.rows_affected())
 }
 
 async fn read_deferred_onchain_refresh_candidates(
@@ -699,6 +743,32 @@ mod tests {
         assert_eq!(immediate.inline_upsert_count, 0);
         assert_eq!(immediate.deferred_candidate_count, 1_205);
         assert_eq!(immediate.ready_drain_count, 1_000);
+    }
+
+    #[test]
+    fn test_deferred_candidate_conflict_skips_ready_metadata_only_update() {
+        assert!(!should_update_deferred_candidate_conflict(
+            1_000, 1_234, true, false, true, true, 30, 31, 40, 40,
+        ));
+    }
+
+    #[test]
+    fn test_deferred_candidate_conflict_updates_behavioral_changes() {
+        assert!(should_update_deferred_candidate_conflict(
+            2_000, 1_234, true, false, true, true, 30, 31, 40, 40,
+        ));
+        assert!(should_update_deferred_candidate_conflict(
+            1_000, 1_234, false, true, true, true, 30, 31, 40, 40,
+        ));
+        assert!(should_update_deferred_candidate_conflict(
+            1_000, 1_234, true, false, false, true, 30, 31, 40, 40,
+        ));
+        assert!(should_update_deferred_candidate_conflict(
+            1_000, 1_234, true, false, true, true, 30, 29, 40, 40,
+        ));
+        assert!(should_update_deferred_candidate_conflict(
+            1_000, 1_234, true, false, true, true, 30, 31, 40, 41,
+        ));
     }
 
     #[test]

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -8,6 +8,7 @@ const CONTRIBUTOR_ENSURE_BULK_BINDS_PER_ROW: usize = 16;
 const TOKEN_EVENT_BULK_BINDS_PER_ROW: usize = 19;
 const DELEGATE_ROLLING_VOTE_UPDATE_BINDS_PER_ROW: usize = 6;
 const VOTE_POWER_CHECKPOINT_BULK_BINDS_PER_ROW: usize = 21;
+const RECOMPUTE_DELEGATE_COUNT_EFFECTIVE_BINDS_PER_ROW: usize = 2;
 
 fn bulk_chunk_size_from_env(
     env_name: &str,
@@ -54,6 +55,22 @@ fn vote_power_checkpoint_bulk_chunk_size() -> usize {
     )
 }
 
+fn recompute_delegate_count_effective_chunk_size() -> usize {
+    bulk_chunk_size_from_env(
+        "DEGOV_INDEXER_RECOMPUTE_DELEGATE_COUNT_EFFECTIVE_CHUNK_SIZE",
+        TOKEN_EVENT_BULK_CHUNK_SIZE_DEFAULT,
+        RECOMPUTE_DELEGATE_COUNT_EFFECTIVE_BINDS_PER_ROW,
+    )
+}
+
+fn chunk_count(row_count: usize, chunk_size: usize) -> usize {
+    if row_count == 0 {
+        0
+    } else {
+        (row_count - 1) / chunk_size + 1
+    }
+}
+
 async fn write_token_batch_rows(
     transaction: &mut Transaction<'_, Postgres>,
     batch: &TokenProjectionBatch,
@@ -88,15 +105,21 @@ async fn write_token_batch_rows(
     let vote_power_checkpoint_duration = vote_power_checkpoint_started_at.elapsed();
 
     if let Some(common) = token_batch_common(batch) {
+        let token_event_chunk_size = token_event_bulk_chunk_size();
         log::info!(
-            "Datalens indexer token row write phases dao_code={} chain_id={} contract_set_id={} delegate_changed_count={} delegate_votes_changed_count={} token_transfer_count={} delegate_rolling_count={} inserted_operation_count={} delegate_changed_duration_ms={} delegate_votes_changed_duration_ms={} token_transfer_duration_ms={} delegate_rolling_duration_ms={} metadata_preload_duration_ms={} vote_power_checkpoint_duration_ms={} total_duration_ms={}",
+            "Datalens indexer token row write phases dao_code={} chain_id={} contract_set_id={} token_event_chunk_size={} delegate_changed_count={} delegate_changed_chunk_count={} delegate_votes_changed_count={} delegate_votes_changed_chunk_count={} token_transfer_count={} token_transfer_chunk_count={} delegate_rolling_count={} delegate_rolling_chunk_count={} inserted_operation_count={} delegate_changed_duration_ms={} delegate_votes_changed_duration_ms={} token_transfer_duration_ms={} delegate_rolling_duration_ms={} metadata_preload_duration_ms={} vote_power_checkpoint_duration_ms={} total_duration_ms={}",
             common.dao_code,
             common.chain_id,
             common.contract_set_id,
+            token_event_chunk_size,
             batch.delegate_changed.len(),
+            chunk_count(batch.delegate_changed.len(), token_event_chunk_size),
             batch.delegate_votes_changed.len(),
+            chunk_count(batch.delegate_votes_changed.len(), token_event_chunk_size),
             batch.token_transfers.len(),
+            chunk_count(batch.token_transfers.len(), token_event_chunk_size),
             batch.delegate_rollings.len(),
+            chunk_count(batch.delegate_rollings.len(), token_event_chunk_size),
             inserted_operation_keys.len(),
             delegate_changed_duration.as_millis(),
             delegate_votes_changed_duration.as_millis(),
@@ -246,8 +269,10 @@ async fn insert_token_transfer_batch(
     transaction: &mut Transaction<'_, Postgres>,
     rows: &[TokenTransferWrite],
 ) -> Result<Vec<(String, String)>, PostgresIndexerRunnerStoreError> {
+    let started_at = std::time::Instant::now();
+    let chunk_size = token_event_bulk_chunk_size();
     let mut inserted = Vec::new();
-    for rows in rows.chunks(token_event_bulk_chunk_size()) {
+    for rows in rows.chunks(chunk_size) {
         let mut query = QueryBuilder::<Postgres>::new(
             "INSERT INTO token_transfer (
                 id, contract_set_id, chain_id, dao_code, governor_address, token_address,
@@ -303,6 +328,20 @@ async fn insert_token_transfer_batch(
         }
         query.push(" ON CONFLICT (contract_set_id, id) DO NOTHING RETURNING contract_set_id, id");
         inserted.extend(fetch_inserted_operation_keys(transaction, query).await?);
+    }
+
+    if let Some(common) = rows.first().map(|row| &row.common) {
+        log::info!(
+            "Datalens indexer token transfer row write completed dao_code={} chain_id={} contract_set_id={} row_count={} chunk_size={} chunk_count={} inserted_count={} duration_ms={}",
+            common.dao_code,
+            common.chain_id,
+            common.contract_set_id,
+            rows.len(),
+            chunk_size,
+            chunk_count(rows.len(), chunk_size),
+            inserted.len(),
+            started_at.elapsed().as_millis()
+        );
     }
 
     Ok(inserted)
@@ -1373,12 +1412,13 @@ impl ContributorEnsureCache {
     async fn flush_contributor_count_deltas(
         &mut self,
         transaction: &mut Transaction<'_, Postgres>,
-    ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    ) -> Result<usize, PostgresIndexerRunnerStoreError> {
         let deltas = std::mem::take(&mut self.contributor_count_deltas)
             .into_iter()
             .collect::<Vec<_>>();
+        let delta_count = deltas.len();
         if deltas.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         for rows in deltas.chunks(token_event_bulk_chunk_size()) {
@@ -1458,7 +1498,7 @@ impl ContributorEnsureCache {
             query.build().execute(&mut **transaction).await?;
         }
 
-        Ok(())
+        Ok(delta_count)
     }
 
     async fn flush_contributor_count_increments(
@@ -1886,7 +1926,8 @@ async fn recompute_delegate_count_effective(
         return Ok(());
     }
 
-    for rows in delegates.chunks(token_event_bulk_chunk_size()) {
+    let chunk_size = recompute_delegate_count_effective_chunk_size();
+    for rows in delegates.chunks(chunk_size) {
         let mut query = QueryBuilder::<Postgres>::new(
             "UPDATE contributor
              SET delegates_count_effective = counts.positive_count

--- a/apps/indexer/src/store/postgres/token_store_tests.rs
+++ b/apps/indexer/src/store/postgres/token_store_tests.rs
@@ -21,12 +21,17 @@ fn test_bulk_chunk_size_defaults_to_preferred_values() {
                 "DEGOV_INDEXER_VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE",
                 None::<&str>,
             ),
+            (
+                "DEGOV_INDEXER_RECOMPUTE_DELEGATE_COUNT_EFFECTIVE_CHUNK_SIZE",
+                None::<&str>,
+            ),
         ],
         || {
             assert_eq!(token_event_bulk_chunk_size(), 3_000);
             assert_eq!(contributor_ensure_bulk_chunk_size(), 3_000);
             assert_eq!(delegate_rolling_vote_update_chunk_size(), 1_000);
             assert_eq!(vote_power_checkpoint_bulk_chunk_size(), 3_000);
+            assert_eq!(recompute_delegate_count_effective_chunk_size(), 3_000);
         },
     );
 }
@@ -48,6 +53,10 @@ fn test_bulk_chunk_size_env_values_are_capped_to_postgres_bind_limit() {
                 "DEGOV_INDEXER_VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE",
                 Some("100000"),
             ),
+            (
+                "DEGOV_INDEXER_RECOMPUTE_DELEGATE_COUNT_EFFECTIVE_CHUNK_SIZE",
+                Some("100000"),
+            ),
         ],
         || {
             assert_eq!(
@@ -65,6 +74,10 @@ fn test_bulk_chunk_size_env_values_are_capped_to_postgres_bind_limit() {
             assert_eq!(
                 vote_power_checkpoint_bulk_chunk_size(),
                 POSTGRES_BIND_PARAMETER_LIMIT / VOTE_POWER_CHECKPOINT_BULK_BINDS_PER_ROW
+            );
+            assert_eq!(
+                recompute_delegate_count_effective_chunk_size(),
+                POSTGRES_BIND_PARAMETER_LIMIT / RECOMPUTE_DELEGATE_COUNT_EFFECTIVE_BINDS_PER_ROW
             );
         },
     );
@@ -87,12 +100,17 @@ fn test_bulk_chunk_size_invalid_env_values_fall_back_to_defaults() {
                 "DEGOV_INDEXER_VOTE_POWER_CHECKPOINT_BULK_CHUNK_SIZE",
                 Some("not-a-number"),
             ),
+            (
+                "DEGOV_INDEXER_RECOMPUTE_DELEGATE_COUNT_EFFECTIVE_CHUNK_SIZE",
+                Some("0"),
+            ),
         ],
         || {
             assert_eq!(token_event_bulk_chunk_size(), 3_000);
             assert_eq!(contributor_ensure_bulk_chunk_size(), 3_000);
             assert_eq!(delegate_rolling_vote_update_chunk_size(), 1_000);
             assert_eq!(vote_power_checkpoint_bulk_chunk_size(), 3_000);
+            assert_eq!(recompute_delegate_count_effective_chunk_size(), 3_000);
         },
     );
 }

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -2240,6 +2240,123 @@ async fn test_postgres_token_deferred_refresh_reschedules_ready_materialized_tas
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_deferred_refresh_skips_ready_metadata_only_conflict()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone())
+        .with_onchain_refresh_debounce(Duration::from_secs(120));
+    let first_batch = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("0000000030-ready-votes", 30, 0, 1),
+            event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                delegate: DELEGATE.to_owned(),
+                previous_votes: "0".to_owned(),
+                new_votes: "1".to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("first token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(first_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    sqlx::query(
+        "UPDATE onchain_refresh_deferred_candidate
+         SET next_run_at = 0::NUMERIC(78, 0),
+             updated_at = 1234::NUMERIC(78, 0)
+         WHERE contract_set_id = $1 AND account = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .execute(&database.pool)
+    .await?;
+
+    let second_batch = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("0000000031-ready-votes-repeat", 31, 0, 1),
+            event: DecodedTokenEvent::DelegateVotesChanged(DelegateVotesChangedEvent {
+                delegate: DELEGATE.to_owned(),
+                previous_votes: "1".to_owned(),
+                new_votes: "2".to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("repeat token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(second_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let advanced = sqlx::query(
+        "SELECT refresh_balance, refresh_power,
+                last_seen_block_number::TEXT AS last_seen_block_number,
+                next_run_at::TEXT AS next_run_at,
+                updated_at::TEXT AS updated_at
+         FROM onchain_refresh_deferred_candidate
+         WHERE contract_set_id = $1 AND account = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert!(!advanced.get::<bool, _>("refresh_balance"));
+    assert!(advanced.get::<bool, _>("refresh_power"));
+    assert_eq!(advanced.get::<String, _>("last_seen_block_number"), "31");
+    assert_ne!(advanced.get::<String, _>("updated_at"), "1234");
+    assert_ne!(advanced.get::<String, _>("next_run_at"), "0");
+
+    let flag_batch = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("0000000032-ready-transfer", 32, 0, 1),
+            event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                from: DELEGATE.to_owned(),
+                to: RECEIVER.to_owned(),
+                value: "1".to_owned(),
+                standard: GovernanceTokenStandard::Erc20,
+            }),
+        }],
+    )
+    .map_err(|error| format!("flag token projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(flag_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    let updated = sqlx::query(
+        "SELECT refresh_balance, refresh_power,
+                last_seen_block_number::TEXT AS last_seen_block_number,
+                updated_at::TEXT AS updated_at
+         FROM onchain_refresh_deferred_candidate
+         WHERE contract_set_id = $1 AND account = $2",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(DELEGATE)
+    .fetch_one(&database.pool)
+    .await?;
+    assert!(updated.get::<bool, _>("refresh_balance"));
+    assert!(updated.get::<bool, _>("refresh_power"));
+    assert_eq!(updated.get::<String, _>("last_seen_block_number"), "32");
+    assert_ne!(updated.get::<String, _>("updated_at"), "1234");
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_postgres_token_reconcile_tasks_insert_across_bulk_chunks()
 -> Result<(), Box<dyn Error>> {
     const DENSE_EVENT_COUNT: usize = 1_205;


### PR DESCRIPTION
## Summary
- skip redundant ready deferred-candidate rewrites while still advancing behavioral anchors like last_seen block
- add phase-level timing and write-count logs for onchain refresh enqueue, token timeline, token transfers, and data_metric refreshes
- add a dedicated chunk-size knob for delegate-count recompute writes

## Why
Staging indexer throughput is currently limited by DB write amplification after Datalens cache hits. This keeps the broad Datalens selector contract and fixes the DeGov write path instead of relying on selector split workarounds.

## Tests
- cargo fmt --all --check
- git diff --check
- cargo test -p degov-datalens-indexer --lib
- cargo test -p degov-datalens-indexer --test token_projection
- cargo test -p degov-datalens-indexer --test indexer_runner deferred_onchain_refresh

DB-backed postgres_runtime_run regression was added but not run locally because DEGOV_INDEXER_TEST_DATABASE_URL is not configured.