### PR TITLE
fix(indexer): use Datalens warmup ensure endpoint

### DIFF
--- a/apps/indexer/src/datalens/warmup.rs
+++ b/apps/indexer/src/datalens/warmup.rs
@@ -238,30 +238,33 @@ impl DatalensWarmupEnsurer for crate::DatalensNativeClient {
         &mut self,
         request: DatalensWarmupSubmitRequest,
     ) -> Result<DatalensWarmupEnsureOutcome, DatalensError> {
-        self.submit_warmup_task(request)
+        self.ensure_warmup_task_http(request)
     }
 }
 
 impl crate::DatalensNativeClient {
-    pub(crate) fn submit_warmup_task(
+    pub(crate) fn ensure_warmup_task_http(
         &self,
         request: DatalensWarmupSubmitRequest,
     ) -> Result<DatalensWarmupEnsureOutcome, DatalensError> {
         let response = self
             .blocking_http()
-            .post(format!("{}/v1/warmup/tasks", self.service_base_endpoint()))
+            .post(format!(
+                "{}/v1/warmup/tasks/ensure",
+                self.service_base_endpoint()
+            ))
             .bearer_auth(self.bearer_token())
             .header("x-datalens-application", self.application())
             .json(&warmup_api_request(request))
             .send()
-            .map_err(|error| DatalensError::Warmup(format!("submit warmup task: {error}")))?;
+            .map_err(|error| DatalensError::Warmup(format!("ensure warmup task: {error}")))?;
         let status = response.status().as_u16();
         let body = response
             .text()
             .map_err(|error| DatalensError::Warmup(format!("read warmup response: {error}")))?;
         if !(200..300).contains(&status) {
             return Err(DatalensError::Warmup(format!(
-                "Datalens warmup submit failed with status {status}: {body}"
+                "Datalens warmup ensure failed with status {status}: {body}"
             )));
         }
         let response: WarmupSubmitResponse = serde_json::from_str(&body)

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -12,8 +12,8 @@ use degov_datalens_indexer::{
     DatalensNativeClient, DatalensNativeReader, DatalensProvisionalLogQueryReader,
     DatalensQueryConcurrencyConfig, DatalensQueryConcurrencyGate, DatalensQueryConcurrencyKey,
     DatalensQueryErrorClass, DatasetKeyConfig, GovernanceTokenStandard, QueryLimitConfig,
-    SecretString, ServiceReadiness, classify_datalens_query_error, plan_dao_log_queries,
-    verify_datalens_service,
+    SecretString, ServiceReadiness, classify_datalens_query_error, ensure_datalens_warmup_task,
+    plan_dao_log_queries, verify_datalens_service,
 };
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -214,6 +214,32 @@ fn test_datalens_durable_head_reader_uses_sdk_chain_head_latest_finality() {
         request.starts_with("GET /v1/chains/ethereum/head?finality=latest "),
         "{request}"
     );
+}
+
+#[test]
+fn test_datalens_warmup_ensurer_uses_ensure_endpoint() {
+    let response = http_response(
+        200,
+        serde_json::json!({
+            "task_id": "task-1",
+            "created": false
+        }),
+    );
+    let server = FakeQueryServer::start(vec![response.clone(), response.clone(), response]);
+    let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
+    config.warmup.enabled = true;
+    let mut client = DatalensNativeClient::from_config(&config).expect("client");
+
+    ensure_datalens_warmup_task(&mut client, &config, &addresses(), 100).expect("warmup ensured");
+
+    let requests = server.join();
+    assert_eq!(requests.len(), 3);
+    for request in requests {
+        assert!(
+            request.starts_with("POST /v1/warmup/tasks/ensure "),
+            "{request}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- route DeGov warmup registration through Datalens /v1/warmup/tasks/ensure
- rename the internal HTTP helper to match ensure semantics
- add a regression test that asserts warmup requests use the ensure endpoint

## Tests
- cargo test -p degov-datalens-indexer --test datalens_client
- cargo test -p degov-datalens-indexer --test datalens_warmup
- cargo fmt --all --check && git diff --check

## Notes
- cargo clippy -p degov-datalens-indexer --all-targets -- -D warnings currently fails on existing lint issues outside this change (graphql/onchain/store/runtime).