### PR TITLE
perf(indexer): add pending onchain refresh claim index

### DIFF
--- a/apps/indexer/migrations/0006_onchain_refresh_pending_ready_claim_index.sql
+++ b/apps/indexer/migrations/0006_onchain_refresh_pending_ready_claim_index.sql
@@ -1,0 +1,3 @@
+-- Runtime indexes are created by the application with CREATE INDEX CONCURRENTLY.
+-- This marker records that onchain_refresh_task_pending_ready_claim_idx is part of
+-- the expected runtime schema without blocking fresh migrations on index builds.

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -163,6 +163,15 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .context("ensure pending onchain refresh status claim index")?;
 
     sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_pending_ready_claim_idx
+         ON onchain_refresh_task (next_run_at, updated_at, id)
+         WHERE status = 'pending'",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure pending onchain refresh ready claim index")?;
+
+    sqlx::query(
         "CREATE INDEX IF NOT EXISTS onchain_refresh_task_scope_claim_queue_idx
          ON onchain_refresh_task (
             chain_id, contract_set_id, dao_code, status, next_run_at, updated_at, id
@@ -393,6 +402,7 @@ async fn repair_invalid_runtime_indexes_for_connection(
     connection: &mut PgConnection,
 ) -> Result<()> {
     drop_invalid_runtime_index(connection, "onchain_refresh_task_pending_status_claim_idx").await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_pending_ready_claim_idx").await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_retry_idx").await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_attempt_retry_idx").await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_ready_retry_idx").await?;

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -220,6 +220,22 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "onchain_refresh_task_pending_ready_claim_idx",
+    )
+    .await?;
+    assert_index_definition_contains(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_pending_ready_claim_idx",
+        &[
+            "USING btree (next_run_at, updated_at, id)",
+            "WHERE (status = 'pending'::text)",
+        ],
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "onchain_refresh_task_failed_ready_retry_idx",
     )
     .await?;
@@ -387,7 +403,8 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
             "0002_hot_path_runtime_indexes.sql",
             "0003_onchain_refresh_runtime_indexes.sql",
             "0004_onchain_refresh_claim_retry_indexes.sql",
-            "0005_onchain_refresh_failed_ready_retry_index.sql"
+            "0005_onchain_refresh_failed_ready_retry_index.sql",
+            "0006_onchain_refresh_pending_ready_claim_index.sql"
         ]
     );
 
@@ -406,6 +423,9 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("delegate_mapping_positive_count_idx"));
     assert!(runtime_migration.contains("WHERE power > 0"));
     assert!(runtime_migration.contains("onchain_refresh_data_metric_task"));
+    assert!(runtime_migration.contains("onchain_refresh_task_pending_ready_claim_idx"));
+    assert!(runtime_migration.contains("ON onchain_refresh_task (next_run_at, updated_at, id)"));
+    assert!(runtime_migration.contains("WHERE status = 'pending'"));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a runtime-created partial pending claim index for onchain refresh tasks
- add a marker migration so fresh schemas track the runtime index contract
- extend migration schema tests for the index shape and marker ordering

## Why
Staging onchain refresh still showed slow pending claim scans after the UNNEST upsert fix. The pending claim query filters by pending status and orders by next_run_at, updated_at, id. This narrower partial index lets PostgreSQL satisfy that path without relying on broader overlapping indexes.

## Testing
- cargo test -p degov-datalens-indexer --test migration_schema test_indexer_keeps_init_migration_stable_and_appends_runtime_markers -- --exact
- cargo test -p degov-datalens-indexer onchain_refresh --lib
- cargo test -p degov-datalens-indexer --test onchain_refresh_worker test_onchain_refresh_tick
- DEGOV_INDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55433/degov_indexer_test cargo test -p degov-datalens-indexer --test migration_schema test_migration_applies_required_schema_to_clean_postgres -- --exact
- cargo fmt --all --check
- git diff --check