### PR TITLE
fix(indexer): repair invalid runtime indexes on startup

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -76,7 +76,9 @@ pub async fn apply_migrations(pool: &PgPool) -> Result<()> {
             .run(&mut *connection)
             .await
             .context("apply Datalens-native DeGov indexer init migration")?;
+        drop_invalid_runtime_indexes_for_connection(&mut connection).await?;
         ensure_runtime_indexes(&mut connection).await?;
+        drop_obsolete_runtime_indexes_for_connection(&mut connection).await?;
 
         Ok(())
     }
@@ -401,6 +403,23 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
 async fn repair_invalid_runtime_indexes_for_connection(
     connection: &mut PgConnection,
 ) -> Result<()> {
+    drop_invalid_runtime_indexes_for_connection(connection).await?;
+    ensure_runtime_indexes(connection).await?;
+    drop_obsolete_runtime_indexes_for_connection(connection).await?;
+
+    Ok(())
+}
+
+async fn drop_obsolete_runtime_indexes_for_connection(connection: &mut PgConnection) -> Result<()> {
+    sqlx::query("DROP INDEX CONCURRENTLY IF EXISTS onchain_refresh_task_status_idx")
+        .execute(connection)
+        .await
+        .context("drop obsolete onchain refresh status index")?;
+
+    Ok(())
+}
+
+async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnection) -> Result<()> {
     drop_invalid_runtime_index(connection, "onchain_refresh_task_pending_status_claim_idx").await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_pending_ready_claim_idx").await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_retry_idx").await?;
@@ -421,6 +440,7 @@ async fn repair_invalid_runtime_indexes_for_connection(
     drop_invalid_runtime_index(connection, "delegate_mapping_effective_count_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_mapping_positive_count_idx").await?;
     drop_invalid_runtime_index(connection, "contributor_data_metric_scope_idx").await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_data_metric_task_ready_idx").await?;
     drop_invalid_runtime_index(connection, "contributor_graphql_scope_power_idx").await?;
     drop_invalid_runtime_index(connection, "provisional_contributor_live_scope_power_idx").await?;
     drop_invalid_runtime_index(
@@ -428,7 +448,6 @@ async fn repair_invalid_runtime_indexes_for_connection(
         "provisional_contributor_live_account_lookup_idx",
     )
     .await?;
-    ensure_runtime_indexes(connection).await?;
 
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -233,6 +233,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
         ],
     )
     .await?;
+    assert_index_absent(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_status_idx",
+    )
+    .await?;
     assert_index_exists(
         &database.pool,
         &database.schema,
@@ -352,7 +358,7 @@ async fn test_migration_repairs_invalid_runtime_index() -> Result<(), Box<dyn Er
     .await?;
 
     apply_migrations(&database.pool).await?;
-    assert_index_is_invalid(
+    assert_index_is_valid(
         &database.pool,
         &database.schema,
         "contributor_data_metric_scope_idx",
@@ -568,6 +574,31 @@ async fn assert_index_exists(
     Ok(())
 }
 
+async fn assert_index_absent(
+    pool: &PgPool,
+    schema: &str,
+    index_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    let exists: bool = sqlx::query_scalar(
+        r#"
+        SELECT EXISTS (
+          SELECT 1
+          FROM pg_indexes
+          WHERE schemaname = $1
+            AND indexname = $2
+        )
+        "#,
+    )
+    .bind(schema)
+    .bind(index_name)
+    .fetch_one(pool)
+    .await?;
+
+    assert!(!exists, "expected index {schema}.{index_name} to be absent");
+
+    Ok(())
+}
+
 async fn assert_index_definition_contains(
     pool: &PgPool,
     schema: &str,
@@ -648,34 +679,6 @@ async fn assert_table_reloptions_contains(
             "expected table {table_name} reloptions to contain {expected_option}, got {reloptions:?}"
         );
     }
-
-    Ok(())
-}
-
-async fn assert_index_is_invalid(
-    pool: &PgPool,
-    schema: &str,
-    index_name: &str,
-) -> Result<(), Box<dyn Error>> {
-    let is_valid: bool = sqlx::query_scalar(
-        r#"
-        SELECT pg_index.indisvalid
-        FROM pg_class index_class
-        JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
-        JOIN pg_index ON pg_index.indexrelid = index_class.oid
-        WHERE index_namespace.nspname = $1
-          AND index_class.relname = $2
-        "#,
-    )
-    .bind(schema)
-    .bind(index_name)
-    .fetch_one(pool)
-    .await?;
-
-    assert!(
-        !is_valid,
-        "expected index {schema}.{index_name} to be invalid"
-    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- run runtime invalid-index cleanup during normal startup migrations before ensuring runtime indexes
- drop obsolete `onchain_refresh_task_status_idx` after the fuller pending/claim indexes are ensured
- keep the explicit repair command behavior by sharing the same drop-and-ensure path
- update migration regression tests for startup self-healing and obsolete index removal

## Why
`CREATE INDEX CONCURRENTLY IF NOT EXISTS` skips an existing invalid index. Staging hit this with `onchain_refresh_task_pending_ready_claim_idx`: the index existed but `indisvalid=false`, so deploy logs said it already existed while PostgreSQL could not use it.

After manually repairing the invalid index, PostgreSQL still preferred the older `(status, next_run_at)` index. A transaction-only EXPLAIN showed that dropping `onchain_refresh_task_status_idx` lets the planner use `onchain_refresh_task_pending_ready_claim_idx` and reduce the candidate claim path from ~400ms to ~85ms. The broader runtime indexes cover the old index use case.

## Testing
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55436/degov_indexer_test cargo test -p degov-datalens-indexer --test migration_schema test_migration_applies_required_schema_to_clean_postgres -- --exact`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55437/degov_indexer_test cargo test -p degov-datalens-indexer --test migration_schema test_migration_repairs_invalid_runtime_index -- --exact`
- `cargo test -p degov-datalens-indexer --test migration_schema test_indexer_keeps_init_migration_stable_and_appends_runtime_markers -- --exact`
- `cargo fmt --all --check`
- `git diff --check`
