### PR TITLE
perf(indexer): unnest delegate mapping writes

### DIFF
--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -1864,59 +1864,81 @@ impl DelegateMappingCache {
         }
 
         for rows in relation_upserts.chunks(token_event_bulk_chunk_size()) {
-            let mut query = QueryBuilder::<Postgres>::new(
+            let mut ids = Vec::with_capacity(rows.len());
+            let mut contract_set_ids = Vec::with_capacity(rows.len());
+            let mut chain_ids = Vec::with_capacity(rows.len());
+            let mut dao_codes = Vec::with_capacity(rows.len());
+            let mut governor_addresses = Vec::with_capacity(rows.len());
+            let mut token_addresses = Vec::with_capacity(rows.len());
+            let mut contract_addresses = Vec::with_capacity(rows.len());
+            let mut log_indexes = Vec::with_capacity(rows.len());
+            let mut transaction_indexes = Vec::with_capacity(rows.len());
+            let mut froms = Vec::with_capacity(rows.len());
+            let mut tos = Vec::with_capacity(rows.len());
+            let mut powers = Vec::with_capacity(rows.len());
+            let mut block_numbers = Vec::with_capacity(rows.len());
+            let mut block_timestamps = Vec::with_capacity(rows.len());
+            let mut transaction_hashes = Vec::with_capacity(rows.len());
+            for row in rows {
+                let common = &row.common;
+                ids.push(delegate_mapping_ref(common, &row.from));
+                contract_set_ids.push(common.contract_set_id.clone());
+                chain_ids.push(common.chain_id);
+                dao_codes.push(common.dao_code.clone());
+                governor_addresses.push(common.governor_address.clone());
+                token_addresses.push(common.token_address.clone());
+                contract_addresses.push(common.contract_address.clone());
+                log_indexes.push(u64_to_i32(
+                    common.log_index,
+                    "delegate_mapping.log_index",
+                )?);
+                transaction_indexes.push(u64_to_i32(
+                    common.transaction_index,
+                    "delegate_mapping.transaction_index",
+                )?);
+                froms.push(row.from.clone());
+                tos.push(row.to.clone());
+                powers.push(row.power.clone());
+                block_numbers.push(common.block_number.clone());
+                block_timestamps.push(
+                    required_numeric(&common.block_timestamp, "delegate_mapping.block_timestamp")?
+                        .to_owned(),
+                );
+                transaction_hashes.push(common.transaction_hash.clone());
+            }
+            sqlx::query(
                 r#"INSERT INTO delegate_mapping (
                     id, contract_set_id, chain_id, dao_code, governor_address, token_address, contract_address,
                     log_index, transaction_index, "from", "to", power, block_number, block_timestamp,
                     transaction_hash
-                 ) VALUES "#,
-            );
-            for (index, row) in rows.iter().enumerate() {
-                if index > 0 {
-                    query.push(", ");
-                }
-                let common = &row.common;
-                query
-                    .push("(")
-                    .push_bind(delegate_mapping_ref(common, &row.from))
-                    .push(", ")
-                    .push_bind(&common.contract_set_id)
-                    .push(", ")
-                    .push_bind(common.chain_id)
-                    .push(", ")
-                    .push_bind(&common.dao_code)
-                    .push(", ")
-                    .push_bind(&common.governor_address)
-                    .push(", ")
-                    .push_bind(&common.token_address)
-                    .push(", ")
-                    .push_bind(&common.contract_address)
-                    .push(", ")
-                    .push_bind(u64_to_i32(common.log_index, "delegate_mapping.log_index")?)
-                    .push(", ")
-                    .push_bind(u64_to_i32(
-                        common.transaction_index,
-                        "delegate_mapping.transaction_index",
-                    )?)
-                    .push(", ")
-                    .push_bind(&row.from)
-                    .push(", ")
-                    .push_bind(&row.to)
-                    .push(", ")
-                    .push_bind(&row.power)
-                    .push("::NUMERIC(78, 0), ")
-                    .push_bind(&common.block_number)
-                    .push("::NUMERIC(78, 0), ")
-                    .push_bind(required_numeric(
-                        &common.block_timestamp,
-                        "delegate_mapping.block_timestamp",
-                    )?)
-                    .push("::NUMERIC(78, 0), ")
-                    .push_bind(&common.transaction_hash)
-                    .push(")");
-            }
-            query.push(
-                r#" ON CONFLICT (contract_set_id, id) DO UPDATE
+                 )
+                 SELECT
+                    id,
+                    contract_set_id,
+                    chain_id,
+                    dao_code,
+                    governor_address,
+                    token_address,
+                    contract_address,
+                    log_index,
+                    transaction_index,
+                    "from",
+                    "to",
+                    power_text::NUMERIC(78, 0),
+                    block_number_text::NUMERIC(78, 0),
+                    block_timestamp_text::NUMERIC(78, 0),
+                    transaction_hash
+                 FROM unnest(
+                    $1::TEXT[], $2::TEXT[], $3::INT4[], $4::TEXT[], $5::TEXT[],
+                    $6::TEXT[], $7::TEXT[], $8::INT4[], $9::INT4[], $10::TEXT[],
+                    $11::TEXT[], $12::TEXT[], $13::TEXT[], $14::TEXT[], $15::TEXT[]
+                 ) AS source(
+                    id, contract_set_id, chain_id, dao_code, governor_address,
+                    token_address, contract_address, log_index, transaction_index,
+                    "from", "to", power_text, block_number_text, block_timestamp_text,
+                    transaction_hash
+                 )
+                 ON CONFLICT (contract_set_id, id) DO UPDATE
                  SET chain_id = EXCLUDED.chain_id,
                      dao_code = EXCLUDED.dao_code,
                      governor_address = EXCLUDED.governor_address,
@@ -1930,35 +1952,47 @@ impl DelegateMappingCache {
                      block_number = EXCLUDED.block_number,
                      block_timestamp = EXCLUDED.block_timestamp,
                      transaction_hash = EXCLUDED.transaction_hash"#,
-            );
-            query.build().execute(&mut **transaction).await?;
+            )
+            .bind(ids)
+            .bind(contract_set_ids)
+            .bind(chain_ids)
+            .bind(dao_codes)
+            .bind(governor_addresses)
+            .bind(token_addresses)
+            .bind(contract_addresses)
+            .bind(log_indexes)
+            .bind(transaction_indexes)
+            .bind(froms)
+            .bind(tos)
+            .bind(powers)
+            .bind(block_numbers)
+            .bind(block_timestamps)
+            .bind(transaction_hashes)
+            .execute(&mut **transaction)
+            .await?;
         }
 
         for rows in power_updates.chunks(token_event_bulk_chunk_size()) {
-            let mut query = QueryBuilder::<Postgres>::new(
-                "UPDATE delegate_mapping AS target
-                 SET power = source.power::NUMERIC(78, 0)
-                 FROM (VALUES ",
-            );
-            for (index, row) in rows.iter().enumerate() {
-                if index > 0 {
-                    query.push(", ");
-                }
-                query
-                    .push("(")
-                    .push_bind(&row.common.contract_set_id)
-                    .push(", ")
-                    .push_bind(delegate_mapping_ref(&row.common, &row.from))
-                    .push(", ")
-                    .push_bind(&row.power)
-                    .push("::NUMERIC(78, 0))");
+            let mut contract_set_ids = Vec::with_capacity(rows.len());
+            let mut ids = Vec::with_capacity(rows.len());
+            let mut powers = Vec::with_capacity(rows.len());
+            for row in rows {
+                contract_set_ids.push(row.common.contract_set_id.clone());
+                ids.push(delegate_mapping_ref(&row.common, &row.from));
+                powers.push(row.power.clone());
             }
-            query.push(
-                ") AS source(contract_set_id, id, power)
+            sqlx::query(
+                "UPDATE delegate_mapping AS target
+                 SET power = source.power_text::NUMERIC(78, 0)
+                 FROM unnest($1::TEXT[], $2::TEXT[], $3::TEXT[]) AS source(contract_set_id, id, power_text)
                  WHERE target.contract_set_id = source.contract_set_id
                    AND target.id = source.id",
-            );
-            query.build().execute(&mut **transaction).await?;
+            )
+            .bind(contract_set_ids)
+            .bind(ids)
+            .bind(powers)
+            .execute(&mut **transaction)
+            .await?;
         }
 
         Ok(effective_count_delegates)
@@ -1975,28 +2009,22 @@ async fn recompute_delegate_count_effective(
 
     let chunk_size = recompute_delegate_count_effective_chunk_size();
     for rows in delegates.chunks(chunk_size) {
-        let mut query = QueryBuilder::<Postgres>::new(
-            "UPDATE contributor
+        let contract_set_ids = rows
+            .iter()
+            .map(|(contract_set_id, _id)| contract_set_id.clone())
+            .collect::<Vec<_>>();
+        let ids = rows
+            .iter()
+            .map(|(_contract_set_id, id)| id.clone())
+            .collect::<Vec<_>>();
+        sqlx::query(
+            r#"UPDATE contributor
              SET delegates_count_effective = counts.positive_count
              FROM (
                 SELECT affected.contract_set_id,
                        affected.id,
                        COUNT(delegate_mapping.id)::INT AS positive_count
-                FROM (VALUES ",
-        );
-        for (index, (contract_set_id, id)) in rows.iter().enumerate() {
-            if index > 0 {
-                query.push(", ");
-            }
-            query
-                .push("(")
-                .push_bind(contract_set_id)
-                .push(", ")
-                .push_bind(id)
-                .push(")");
-        }
-        query.push(
-            r#") AS affected(contract_set_id, id)
+                FROM unnest($1::TEXT[], $2::TEXT[]) AS affected(contract_set_id, id)
                 LEFT JOIN delegate_mapping
                   ON delegate_mapping.contract_set_id = affected.contract_set_id
                  AND delegate_mapping."to" = affected.id
@@ -2006,8 +2034,11 @@ async fn recompute_delegate_count_effective(
              WHERE contributor.contract_set_id = counts.contract_set_id
                AND contributor.id = counts.id
                AND contributor.delegates_count_effective IS DISTINCT FROM counts.positive_count"#,
-        );
-        query.build().execute(&mut **transaction).await?;
+        )
+        .bind(contract_set_ids)
+        .bind(ids)
+        .execute(&mut **transaction)
+        .await?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Replace variable-length VALUES inputs in delegate mapping relation upserts, power updates, and effective-count recomputation with fixed-shape UNNEST queries.
- Keep the existing delegate mapping semantics and conflict handling unchanged.
- Targets dense DAO local write overhead after Datalens reads are already cache hits, without introducing selector splitting.

## Tests
- cargo fmt --all --check
- cargo test -p degov-datalens-indexer --lib token -- --nocapture
- DEGOV_INDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55439/postgres cargo test -p degov-datalens-indexer --test postgres_runtime_run token_delegate_mapping -- --nocapture