### PR TITLE
perf(indexer): avoid dense token transfer index writes

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -412,9 +412,17 @@ async fn repair_invalid_runtime_indexes_for_connection(
 
 async fn drop_obsolete_runtime_indexes_for_connection(connection: &mut PgConnection) -> Result<()> {
     sqlx::query("DROP INDEX CONCURRENTLY IF EXISTS onchain_refresh_task_status_idx")
-        .execute(connection)
+        .execute(&mut *connection)
         .await
         .context("drop obsolete onchain refresh status index")?;
+    sqlx::query("DROP INDEX CONCURRENTLY IF EXISTS token_transfer_transaction_hash_idx")
+        .execute(&mut *connection)
+        .await
+        .context("drop obsolete token transfer transaction hash index")?;
+    sqlx::query("DROP INDEX CONCURRENTLY IF EXISTS token_transfer_chain_governor_token_idx")
+        .execute(&mut *connection)
+        .await
+        .context("drop obsolete token transfer chain governor token index")?;
 
     Ok(())
 }

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -2141,7 +2141,7 @@ impl BatchTokenMetadataCache {
     ) -> Result<Self, PostgresIndexerRunnerStoreError> {
         let keys = collect_transaction_metadata_keys(batch);
         let mut cache = Self::default();
-        cache.preload_transfer_counts(transaction, &keys).await?;
+        cache.preload_transfer_counts(batch, &keys);
         cache.preload_rollings(transaction, &keys).await?;
         Ok(cache)
     }
@@ -2326,36 +2326,21 @@ impl BatchTokenMetadataCache {
         Ok(())
     }
 
-    async fn preload_transfer_counts(
+    fn preload_transfer_counts(
         &mut self,
-        transaction: &mut Transaction<'_, Postgres>,
+        batch: &TokenProjectionBatch,
         keys: &[TransactionMetadataKey],
-    ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    ) {
         for key in keys {
             self.transfer_counts.entry(key.clone()).or_default();
         }
-        for (contract_set_id, transaction_hashes) in group_transaction_hashes_by_contract_set(keys) {
-            let rows = sqlx::query(
-                "SELECT transaction_hash, count(*)::BIGINT AS transfer_count
-                 FROM token_transfer
-                 WHERE contract_set_id = $1 AND transaction_hash = ANY($2)
-                 GROUP BY transaction_hash",
-            )
-            .bind(&contract_set_id)
-            .bind(&transaction_hashes)
-            .fetch_all(&mut **transaction)
-            .await?;
-            for row in rows {
-                self.transfer_counts.insert(
-                    TransactionMetadataKey {
-                        contract_set_id: contract_set_id.clone(),
-                        transaction_hash: row.get("transaction_hash"),
-                    },
-                    row.get("transfer_count"),
-                );
-            }
+        for row in &batch.token_transfers {
+            let key = TransactionMetadataKey::new(&row.common);
+            let Some(count) = self.transfer_counts.get_mut(&key) else {
+                continue;
+            };
+            *count += 1;
         }
-        Ok(())
     }
 
     async fn preload_rollings(

--- a/apps/indexer/src/store/postgres/token_store_tests.rs
+++ b/apps/indexer/src/store/postgres/token_store_tests.rs
@@ -330,6 +330,42 @@ fn test_batch_token_metadata_cache_uses_delegate_specific_rolling_candidates() {
 }
 
 #[test]
+fn test_batch_token_metadata_cache_counts_transfers_from_current_batch() {
+    let common = token_common("scope", "0xtx1", 10, 1);
+    let other_transaction = token_common("scope", "0xtx2", 10, 2);
+    let untracked_scope = token_common("untracked-scope", "0xtx1", 10, 3);
+    let batch = TokenProjectionBatch {
+        event_order: Vec::new(),
+        delegate_changed: Vec::new(),
+        delegate_votes_changed: vec![
+            delegate_votes_changed("votes-1", common.clone(), "0xdelegate1", "0", "1"),
+            delegate_votes_changed(
+                "votes-2",
+                other_transaction.clone(),
+                "0xdelegate2",
+                "1",
+                "2",
+            ),
+        ],
+        token_transfers: vec![
+            token_transfer("transfer-1", common.clone(), "0xfrom1", "0xto1", "10"),
+            token_transfer("transfer-2", common.clone(), "0xfrom2", "0xto2", "20"),
+            token_transfer("transfer-3", untracked_scope, "0xfrom3", "0xto3", "30"),
+        ],
+        delegate_rollings: Vec::new(),
+        operations: Vec::new(),
+        reconcile_plan: empty_reconcile_plan(),
+    };
+    let keys = collect_transaction_metadata_keys(&batch);
+    let mut cache = BatchTokenMetadataCache::default();
+
+    cache.preload_transfer_counts(&batch, &keys);
+
+    assert_eq!(cache.transfer_count(&common), 2);
+    assert_eq!(cache.transfer_count(&other_transaction), 0);
+}
+
+#[test]
 fn test_delegate_mapping_cache_keeps_only_final_dirty_state_per_account() {
     let common = token_common("scope", "0xtx1", 10, 5);
     let mut cache = DelegateMappingCache::default();
@@ -692,6 +728,23 @@ fn delegate_votes_changed(
         delegate: delegate.to_owned(),
         previous_votes: previous_votes.to_owned(),
         new_votes: new_votes.to_owned(),
+    }
+}
+
+fn token_transfer(
+    id: &str,
+    common: TokenEventCommon,
+    from: &str,
+    to: &str,
+    value: &str,
+) -> TokenTransferWrite {
+    TokenTransferWrite {
+        id: id.to_owned(),
+        common,
+        from: from.to_owned(),
+        to: to.to_owned(),
+        value: value.to_owned(),
+        standard: "erc20".to_owned(),
     }
 }
 

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -432,6 +432,14 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("onchain_refresh_task_pending_ready_claim_idx"));
     assert!(runtime_migration.contains("ON onchain_refresh_task (next_run_at, updated_at, id)"));
     assert!(runtime_migration.contains("WHERE status = 'pending'"));
+    assert!(
+        runtime_migration
+            .contains("DROP INDEX CONCURRENTLY IF EXISTS token_transfer_transaction_hash_idx")
+    );
+    assert!(
+        runtime_migration
+            .contains("DROP INDEX CONCURRENTLY IF EXISTS token_transfer_chain_governor_token_idx")
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Count token transfers for vote-power checkpoint metadata from the current projected batch instead of re-querying `token_transfer` by transaction hash.
- Drop the now-obsolete token transfer transaction/hash indexes at runtime to reduce write amplification on dense DAO sync.
- This targets DeGov local write overhead after Datalens cache hits; it does not introduce selector splitting.

## Evidence
- Staging chunks were Datalens FullHit with provider fill 0, while dense DAO write time was dominated by token transfer DB work.
- `token_transfer` has millions of rows and the removed transaction-hash preload query was on the hot path for vote-power checkpoint metadata.

## Tests
- `cargo fmt --all --check`
- `cargo test -p degov-datalens-indexer store::postgres::runner_store::token_store_tests`
- `cargo test -p degov-datalens-indexer --test migration_schema test_indexer_keeps_init_migration_stable_and_appends_runtime_markers -- --exact`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55440/postgres cargo test -p degov-datalens-indexer --test migration_schema test_migration_applies_required_schema_to_clean_postgres -- --exact`
