### PR TITLE
fix(indexer): read onchain refresh current values at latest

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -1395,7 +1395,7 @@ where
 
             for task in group_tasks {
                 if task.refresh_power {
-                    builder.add_account_power_refresh_with_method(
+                    builder.add_account_latest_power_refresh_with_method(
                         &task.account,
                         parse_u64(&task.last_seen_block_number)?,
                         crate::ChainReadReason::TokenActivityPowerRefresh,
@@ -1403,7 +1403,7 @@ where
                     );
                 }
                 if task.refresh_balance {
-                    builder.add_account_balance_refresh(
+                    builder.add_account_latest_balance_refresh(
                         &task.account,
                         parse_u64(&task.last_seen_block_number)?,
                         crate::ChainReadReason::TokenActivityPowerRefresh,
@@ -1463,14 +1463,13 @@ where
 
         for task in tasks {
             let mut task_failures = Vec::<String>::new();
-            let activity_block = parse_u64(&task.last_seen_block_number)?;
             let power = if task.refresh_power {
                 let key = (
                     task.chain_id,
                     normalize_identifier(&task.token_address),
                     normalize_identifier(&task.account),
                     self.current_power_method,
-                    BlockReadMode::AtBlock(activity_block),
+                    BlockReadMode::Latest,
                 );
                 match values_by_key.get(&key).cloned() {
                     Some(value) => Some(value),
@@ -1495,7 +1494,7 @@ where
                     normalize_identifier(&task.token_address),
                     normalize_identifier(&task.account),
                     ChainReadMethod::BalanceOf,
-                    BlockReadMode::AtBlock(activity_block),
+                    BlockReadMode::Latest,
                 );
                 match values_by_key.get(&key).cloned() {
                     Some(value) => Some(value),
@@ -4762,6 +4761,90 @@ mod tests {
             Some(ChainReadValue::Integer("18".to_owned()))
         );
         assert_eq!(cache.get(&quorum), None);
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturePlanChainTool {
+        reads: Arc<Mutex<Vec<ChainReadRequest>>>,
+    }
+
+    impl ChainTool for CapturePlanChainTool {
+        fn execute_read_plan(
+            &self,
+            plan: &ChainReadPlan,
+        ) -> Result<ChainReadExecutionReport, PartialChainReadFailureReport> {
+            self.reads
+                .lock()
+                .expect("read capture lock")
+                .extend(plan.reads.clone());
+            Ok(ChainReadExecutionReport {
+                metrics: ChainReadMetrics {
+                    requested_reads: plan.metrics.requested_reads,
+                    deduped_reads: plan.metrics.deduped_reads,
+                    ..ChainReadMetrics::default()
+                },
+                results: plan
+                    .reads
+                    .iter()
+                    .enumerate()
+                    .map(|(read_index, read)| ChainReadResult {
+                        read_index,
+                        key: read.key.clone(),
+                        value: ChainReadValue::Integer(match read.key.method {
+                            ChainReadMethod::BalanceOf => "100".to_owned(),
+                            ChainReadMethod::GetVotes => "50".to_owned(),
+                            _ => "0".to_owned(),
+                        }),
+                    })
+                    .collect(),
+                ..ChainReadExecutionReport::default()
+            })
+        }
+    }
+
+    #[test]
+    fn test_onchain_refresh_reader_reads_current_values_at_latest() {
+        let chain_tool = CapturePlanChainTool::default();
+        let reads = chain_tool.reads.clone();
+        let reader = ChainToolOnchainRefreshReader::new(
+            chain_tool,
+            BatchReadPlanConfig {
+                max_concurrency: 4,
+                multicall_batch_size: 10,
+            },
+            ChainReadMethod::GetVotes,
+        );
+        let task = OnchainRefreshTask {
+            id: "task-1".to_owned(),
+            contract_set_id: "contract-set-1".to_owned(),
+            chain_id: 1,
+            dao_code: Some("test-dao".to_owned()),
+            governor_address: "0x1000000000000000000000000000000000000000".to_owned(),
+            token_address: "0x2000000000000000000000000000000000000000".to_owned(),
+            account: "0x3000000000000000000000000000000000000000".to_owned(),
+            refresh_balance: true,
+            refresh_power: true,
+            last_seen_block_number: "200".to_owned(),
+            last_seen_block_timestamp: "1000".to_owned(),
+            last_seen_transaction_hash: "0xabc".to_owned(),
+            attempts: 0,
+        };
+
+        let report = reader
+            .read_tasks_with_report(&[task])
+            .expect("current refresh read succeeds");
+
+        assert_eq!(report.values.len(), 1);
+        assert_eq!(report.values[0].balance.as_deref(), Some("100"));
+        assert_eq!(report.values[0].power.as_deref(), Some("50"));
+        let reads = reads.lock().expect("read capture lock");
+        assert_eq!(reads.len(), 2);
+        assert!(
+            reads
+                .iter()
+                .all(|read| read.key.block_mode == BlockReadMode::Latest)
+        );
+        assert!(reads.iter().all(|read| read.activity_blocks == vec![200]));
     }
 
     #[derive(Clone, Default)]

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -1932,7 +1932,8 @@ fn test_multi_chain_reader_routes_tasks_to_matching_chain_tool() {
         .chain(lisk_tool.captured_plans())
     {
         for read in plan.reads {
-            assert_eq!(read.key.block_mode, BlockReadMode::AtBlock(12));
+            assert_eq!(read.key.block_mode, BlockReadMode::Latest);
+            assert_eq!(read.activity_blocks, vec![12]);
         }
     }
 }
@@ -1967,7 +1968,7 @@ fn test_chain_tool_onchain_refresh_reader_dedupes_duplicate_reads_in_one_batch()
 }
 
 #[test]
-fn test_chain_tool_onchain_refresh_reader_keeps_same_account_activity_blocks_distinct() {
+fn test_chain_tool_onchain_refresh_reader_dedupes_latest_reads_and_keeps_activity_blocks() {
     let chain_tool = BlockModeValueChainTool::new();
     let reader = degov_datalens_indexer::ChainToolOnchainRefreshReader::new(
         chain_tool.clone(),
@@ -1992,15 +1993,19 @@ fn test_chain_tool_onchain_refresh_reader_keeps_same_account_activity_blocks_dis
             .expect("earlier")
             .power
             .as_deref(),
-        Some("200")
+        Some("latest")
     );
     assert_eq!(
         values.get("task-later").expect("later").power.as_deref(),
-        Some("201")
+        Some("latest")
     );
     let plans = chain_tool.captured_plans();
     assert_eq!(plans.len(), 1);
-    assert_eq!(plans[0].reads.len(), 2);
+    assert_eq!(plans[0].metrics.requested_reads, 2);
+    assert_eq!(plans[0].metrics.deduped_reads, 1);
+    assert_eq!(plans[0].reads.len(), 1);
+    assert_eq!(plans[0].reads[0].key.block_mode, BlockReadMode::Latest);
+    assert_eq!(plans[0].reads[0].activity_blocks, vec![200, 201]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- read onchain refresh balance/power values at latest instead of the event activity block
- keep the task activity block as metadata/anchor for checkpoint and overlay semantics
- add a reader-level regression test that captures the generated read plan

## Why
The worker refreshes current contributor/delegate state. Using historical AtBlock reads for dense DAO tasks forces fallback paths when Multicall3 or upstream historical state is unavailable, producing large retry backlogs. Live overlays already use latest for this same current-value read model.

## Tests
- cargo fmt --all --check
- cargo test -p degov-datalens-indexer onchain::refresh::tests --lib -- --nocapture