### PR TITLE
fix(indexer): separate current onchain refresh values

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -351,11 +351,25 @@ pub struct OnchainRefreshTask {
     pub attempts: i32,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct OnchainRefreshReadValue {
     pub task_id: String,
     pub balance: Option<String>,
     pub power: Option<String>,
+    pub checkpoint_balance: Option<String>,
+    pub checkpoint_power: Option<String>,
+}
+
+impl OnchainRefreshReadValue {
+    fn balance_for_current_update(&self) -> Option<&str> {
+        self.balance
+            .as_deref()
+            .or(self.checkpoint_balance.as_deref())
+    }
+
+    fn power_for_current_update(&self) -> Option<&str> {
+        self.power.as_deref().or(self.checkpoint_power.as_deref())
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -1387,26 +1401,39 @@ where
                 chain_id,
                 ChainContracts {
                     governor: governor_address,
-                    governor_token: token_address,
+                    governor_token: token_address.clone(),
                     timelock: None,
                 },
                 self.read_plan_config,
             );
 
             for task in group_tasks {
+                let activity_block = parse_u64(&task.last_seen_block_number)?;
                 if task.refresh_power {
-                    builder.add_account_power_refresh_with_method(
+                    builder.add_account_latest_power_refresh_with_method(
                         &task.account,
-                        parse_u64(&task.last_seen_block_number)?,
+                        activity_block,
                         crate::ChainReadReason::TokenActivityPowerRefresh,
                         self.current_power_method,
                     );
+                    builder.add_optional_enrichment_read(
+                        token_address.clone(),
+                        self.current_power_method,
+                        vec![task.account.clone()],
+                        BlockReadMode::AtBlock(activity_block),
+                    );
                 }
                 if task.refresh_balance {
-                    builder.add_account_balance_refresh(
+                    builder.add_account_latest_balance_refresh(
                         &task.account,
-                        parse_u64(&task.last_seen_block_number)?,
+                        activity_block,
                         crate::ChainReadReason::TokenActivityPowerRefresh,
+                    );
+                    builder.add_optional_enrichment_read(
+                        token_address.clone(),
+                        ChainReadMethod::BalanceOf,
+                        vec![task.account.clone()],
+                        BlockReadMode::AtBlock(activity_block),
                     );
                 }
             }
@@ -1433,6 +1460,15 @@ where
                     ))
                     .or_default()
                     .push(failure.message);
+            }
+            for failure in report.partial_failures.optional_failures {
+                log::warn!(
+                    "onchain refresh optional checkpoint read failed chain_id={} method={:?} block_mode={:?} error={}",
+                    failure.key.chain_id,
+                    failure.key.method,
+                    failure.key.block_mode,
+                    failure.message
+                );
             }
 
             for result in report.results {
@@ -1470,7 +1506,7 @@ where
                     normalize_identifier(&task.token_address),
                     normalize_identifier(&task.account),
                     self.current_power_method,
-                    BlockReadMode::AtBlock(activity_block),
+                    BlockReadMode::Latest,
                 );
                 match values_by_key.get(&key).cloned() {
                     Some(value) => Some(value),
@@ -1489,13 +1525,25 @@ where
             } else {
                 None
             };
+            let checkpoint_power = if task.refresh_power {
+                let key = (
+                    task.chain_id,
+                    normalize_identifier(&task.token_address),
+                    normalize_identifier(&task.account),
+                    self.current_power_method,
+                    BlockReadMode::AtBlock(activity_block),
+                );
+                values_by_key.get(&key).cloned()
+            } else {
+                None
+            };
             let balance = if task.refresh_balance {
                 let key = (
                     task.chain_id,
                     normalize_identifier(&task.token_address),
                     normalize_identifier(&task.account),
                     ChainReadMethod::BalanceOf,
-                    BlockReadMode::AtBlock(activity_block),
+                    BlockReadMode::Latest,
                 );
                 match values_by_key.get(&key).cloned() {
                     Some(value) => Some(value),
@@ -1514,12 +1562,26 @@ where
             } else {
                 None
             };
+            let checkpoint_balance = if task.refresh_balance {
+                let key = (
+                    task.chain_id,
+                    normalize_identifier(&task.token_address),
+                    normalize_identifier(&task.account),
+                    ChainReadMethod::BalanceOf,
+                    BlockReadMode::AtBlock(activity_block),
+                );
+                values_by_key.get(&key).cloned()
+            } else {
+                None
+            };
 
             if task_failures.is_empty() {
                 read_report.values.push(OnchainRefreshReadValue {
                     task_id: task.id.clone(),
                     balance,
                     power,
+                    checkpoint_balance,
+                    checkpoint_power,
                 });
             } else {
                 read_report.failures.push(OnchainRefreshReadFailure {
@@ -2206,14 +2268,20 @@ impl EvmRpcChainTool {
                 }
             }
             Err(message) => {
+                let latest_fallback_applicable = calls.iter().all(|call| {
+                    should_try_latest_block_fallback_for_read(&call.read, call.call_key.method)
+                });
                 if should_try_latest_block_fallback_after_error(&message)
-                    && self
+                    && latest_fallback_applicable
+                {
+                    if self
                         .execute_latest_multicall_fallback(calls.clone(), &mut report)
                         .is_ok()
-                {
-                    return report;
-                }
-                if should_try_latest_block_fallback_after_error(&message) {
+                    {
+                        return report;
+                    }
+                    self.execute_multicall_fallback(calls, &mut report, message);
+                } else if should_try_latest_block_fallback_after_error(&message) {
                     self.execute_multicall_fallback(calls, &mut report, message);
                 } else {
                     fail_multicall_group(calls, &mut report, message);
@@ -2697,7 +2765,8 @@ fn should_try_latest_block_fallback_for_read(
     read: &crate::ChainReadRequest,
     method: ChainReadMethod,
 ) -> bool {
-    matches!(read.key.block_mode, BlockReadMode::AtBlock(_))
+    read.requirement == ReadRequirement::Required
+        && matches!(read.key.block_mode, BlockReadMode::AtBlock(_))
         && matches!(
             method,
             ChainReadMethod::BalanceOf | ChainReadMethod::GetVotes | ChainReadMethod::CurrentVotes
@@ -2839,12 +2908,12 @@ async fn upsert_contributor_refresh_group(
             .push("CASE WHEN ")
             .push_bind_unseparated(task.refresh_power)
             .push_unseparated(" THEN ")
-            .push_bind_unseparated(value.power.as_deref())
+            .push_bind_unseparated(value.power_for_current_update())
             .push_unseparated("::NUMERIC(78, 0) ELSE 0::NUMERIC(78, 0) END")
             .push("CASE WHEN ")
             .push_bind_unseparated(task.refresh_balance)
             .push_unseparated(" THEN ")
-            .push_bind_unseparated(value.balance.as_deref())
+            .push_bind_unseparated(value.balance_for_current_update())
             .push_unseparated("::NUMERIC(78, 0) ELSE NULL END")
             .push("0")
             .push("0");
@@ -2894,7 +2963,10 @@ async fn reconcile_current_delegate_relation_power_from_balance(
 ) -> Result<(), sqlx::Error> {
     let mut refreshes_by_key = BTreeMap::new();
     for (task, value) in successes {
-        let Some(balance) = value.balance.as_ref().filter(|_| task.refresh_balance) else {
+        let Some(balance) = value
+            .balance_for_current_update()
+            .filter(|_| task.refresh_balance)
+        else {
             continue;
         };
         let key = DelegateRelationBalanceRefreshKey {
@@ -2909,7 +2981,7 @@ async fn reconcile_current_delegate_relation_power_from_balance(
             key.clone(),
             DelegateRelationBalanceRefresh {
                 key,
-                balance: balance.clone(),
+                balance: balance.to_owned(),
             },
         );
     }
@@ -3134,7 +3206,7 @@ async fn insert_refresh_checkpoints(
 ) -> Result<(), sqlx::Error> {
     let balance_successes = successes
         .iter()
-        .filter(|(task, _value)| task.refresh_balance)
+        .filter(|(task, value)| checkpoint_balance_value(task, value).is_some())
         .collect::<Vec<_>>();
     if !balance_successes.is_empty() {
         let mut query = QueryBuilder::<Postgres>::new(
@@ -3151,7 +3223,7 @@ async fn insert_refresh_checkpoints(
                 .cloned()
                 .unwrap_or_default();
             let previous_balance = previous.balance.unwrap_or_else(|| "0".to_owned());
-            let new_balance = value.balance.as_deref().unwrap_or("0");
+            let new_balance = checkpoint_balance_value(task, value).unwrap_or("0");
             values
                 .push_bind(format!(
                     "onchain-refresh-balance-{}",
@@ -3187,7 +3259,7 @@ async fn insert_refresh_checkpoints(
 
     let power_successes = successes
         .iter()
-        .filter(|(task, _value)| task.refresh_power)
+        .filter(|(task, value)| checkpoint_power_value(task, value).is_some())
         .collect::<Vec<_>>();
     if !power_successes.is_empty() {
         let source = current_power_checkpoint_source(current_power_method);
@@ -3205,7 +3277,7 @@ async fn insert_refresh_checkpoints(
                 .cloned()
                 .unwrap_or_default();
             let previous_power = previous.power.unwrap_or_else(|| "0".to_owned());
-            let new_power = value.power.as_deref().unwrap_or("0");
+            let new_power = checkpoint_power_value(task, value).unwrap_or("0");
             values
                 .push_bind(format!(
                     "onchain-refresh-power-{}",
@@ -3245,6 +3317,24 @@ async fn insert_refresh_checkpoints(
     Ok(())
 }
 
+fn checkpoint_balance_value<'a>(
+    task: &OnchainRefreshTask,
+    value: &'a OnchainRefreshReadValue,
+) -> Option<&'a str> {
+    task.refresh_balance
+        .then_some(value.checkpoint_balance.as_deref())
+        .flatten()
+}
+
+fn checkpoint_power_value<'a>(
+    task: &OnchainRefreshTask,
+    value: &'a OnchainRefreshReadValue,
+) -> Option<&'a str> {
+    task.refresh_power
+        .then_some(value.checkpoint_power.as_deref())
+        .flatten()
+}
+
 async fn upsert_live_power_overlays(
     transaction: &mut Transaction<'_, Postgres>,
     successes: &[(OnchainRefreshTask, OnchainRefreshReadValue)],
@@ -3268,7 +3358,7 @@ fn live_contributor_power_overlay_writes(
     successes
         .iter()
         .filter_map(|(task, value)| {
-            let power = value.power.as_ref()?;
+            let power = value.power_for_current_update()?;
             task.refresh_power
                 .then(|| ProvisionalContributorPowerOverlayWrite {
                     id: provisional_contributor_power_overlay_id(task),
@@ -3280,8 +3370,8 @@ fn live_contributor_power_overlay_writes(
                     governor_address: Some(normalize_identifier(&task.governor_address)),
                     token_address: Some(normalize_identifier(&task.token_address)),
                     account: normalize_identifier(&task.account),
-                    power: power.clone(),
-                    balance: value.balance.clone(),
+                    power: power.to_owned(),
+                    balance: value.balance_for_current_update().map(str::to_owned),
                     delegates_count_all: 0,
                     delegates_count_effective: 0,
                     last_vote_block_number: None,
@@ -4472,6 +4562,45 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_refresh_checkpoints_skips_values_without_checkpoint_values() {
+        let task = OnchainRefreshTask {
+            id: "task-one".to_owned(),
+            contract_set_id: "contract-set".to_owned(),
+            chain_id: 1,
+            dao_code: Some("dao".to_owned()),
+            governor_address: "0xgovernor".to_owned(),
+            token_address: "0xtoken".to_owned(),
+            account: "0xaccount".to_owned(),
+            refresh_balance: true,
+            refresh_power: true,
+            last_seen_block_number: "12".to_owned(),
+            last_seen_block_timestamp: "12000".to_owned(),
+            last_seen_transaction_hash: "0xtask".to_owned(),
+            attempts: 0,
+        };
+        let latest_only = OnchainRefreshReadValue {
+            task_id: "task-one".to_owned(),
+            balance: Some("99".to_owned()),
+            power: Some("88".to_owned()),
+            checkpoint_balance: None,
+            checkpoint_power: None,
+        };
+        let with_checkpoints = OnchainRefreshReadValue {
+            checkpoint_balance: Some("11".to_owned()),
+            checkpoint_power: Some("22".to_owned()),
+            ..latest_only.clone()
+        };
+
+        assert_eq!(checkpoint_balance_value(&task, &latest_only), None);
+        assert_eq!(checkpoint_power_value(&task, &latest_only), None);
+        assert_eq!(
+            checkpoint_balance_value(&task, &with_checkpoints),
+            Some("11")
+        );
+        assert_eq!(checkpoint_power_value(&task, &with_checkpoints), Some("22"));
+    }
+
+    #[test]
     fn test_encode_call_data_accepts_hex_uint_arguments() {
         let decimal = encode_call_data(ChainReadMethod::State, &["42".to_owned()])
             .expect("decimal proposal id encodes");
@@ -5437,6 +5566,98 @@ mod tests {
         assert_eq!(
             *block_modes.lock().expect("block mode lock"),
             vec![BlockReadMode::AtBlock(200), BlockReadMode::Latest]
+        );
+    }
+
+    #[test]
+    fn test_evm_rpc_chain_tool_does_not_fallback_optional_historical_reads_to_latest() {
+        let block_modes = Arc::new(Mutex::new(Vec::new()));
+        let tool = EvmRpcChainTool::from_rpc_client(HistoricalStateFallbackMockEvmRpcClient {
+            block_modes: block_modes.clone(),
+            at_block_error: "historical state abc is not available",
+        });
+        let contracts = ChainContracts {
+            governor: "0x1000000000000000000000000000000000000000".to_owned(),
+            governor_token: "0x2000000000000000000000000000000000000000".to_owned(),
+            timelock: None,
+        };
+        let mut builder = ChainReadPlanBuilder::new(
+            1,
+            contracts.clone(),
+            BatchReadPlanConfig {
+                max_concurrency: 4,
+                multicall_batch_size: 10,
+            },
+        );
+        builder.add_optional_enrichment_read(
+            contracts.governor_token,
+            ChainReadMethod::BalanceOf,
+            vec!["0x0000000000000000000000000000000000000001".to_owned()],
+            BlockReadMode::AtBlock(200),
+        );
+
+        let report = tool.execute_read_plan_partial(&builder.build());
+
+        assert_eq!(report.results, vec![]);
+        assert_eq!(report.partial_failures.required_failures, vec![]);
+        assert_eq!(report.partial_failures.optional_failures.len(), 1);
+        assert_eq!(
+            *block_modes.lock().expect("block mode lock"),
+            vec![BlockReadMode::AtBlock(200), BlockReadMode::AtBlock(200)]
+        );
+    }
+
+    #[test]
+    fn test_evm_rpc_chain_tool_preserves_required_fallback_in_mixed_historical_group() {
+        let block_modes = Arc::new(Mutex::new(Vec::new()));
+        let tool = EvmRpcChainTool::from_rpc_client(HistoricalStateFallbackMockEvmRpcClient {
+            block_modes: block_modes.clone(),
+            at_block_error: "historical state abc is not available",
+        });
+        let contracts = ChainContracts {
+            governor: "0x1000000000000000000000000000000000000000".to_owned(),
+            governor_token: "0x2000000000000000000000000000000000000000".to_owned(),
+            timelock: None,
+        };
+        let mut builder = ChainReadPlanBuilder::new(
+            1,
+            contracts.clone(),
+            BatchReadPlanConfig {
+                max_concurrency: 4,
+                multicall_batch_size: 10,
+            },
+        );
+        builder.add_account_balance_refresh(
+            "0x0000000000000000000000000000000000000001",
+            200,
+            crate::ChainReadReason::TokenActivityPowerRefresh,
+        );
+        builder.add_optional_enrichment_read(
+            contracts.governor_token,
+            ChainReadMethod::BalanceOf,
+            vec!["0x0000000000000000000000000000000000000002".to_owned()],
+            BlockReadMode::AtBlock(200),
+        );
+
+        let report = tool
+            .execute_read_plan(&builder.build())
+            .expect("required read falls back when optional read cannot use latest");
+
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(
+            report.results[0].value,
+            ChainReadValue::Integer("777".to_owned())
+        );
+        assert_eq!(report.partial_failures.required_failures, vec![]);
+        assert_eq!(report.partial_failures.optional_failures.len(), 1);
+        assert_eq!(
+            *block_modes.lock().expect("block mode lock"),
+            vec![
+                BlockReadMode::AtBlock(200),
+                BlockReadMode::AtBlock(200),
+                BlockReadMode::Latest,
+                BlockReadMode::AtBlock(200)
+            ]
         );
     }
 

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -447,6 +447,9 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
                 task_id: "task-one".to_owned(),
                 balance: Some("17".to_owned()),
                 power: Some("11".to_owned()),
+                checkpoint_balance: Some("17".to_owned()),
+                checkpoint_power: Some("11".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         ),
         (
@@ -455,6 +458,8 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
                 task_id: "task-two".to_owned(),
                 balance: None,
                 power: Some("5".to_owned()),
+                checkpoint_power: Some("5".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         ),
     ]);
@@ -541,6 +546,7 @@ async fn test_onchain_refresh_worker_reconciles_current_delegate_relation_power_
             task_id: "task-one".to_owned(),
             balance: Some("32".to_owned()),
             power: Some("0".to_owned()),
+            ..OnchainRefreshReadValue::default()
         },
     )]);
     let worker = OnchainRefreshWorker::new(
@@ -626,6 +632,7 @@ async fn test_onchain_refresh_worker_preserves_effective_delegate_count_for_posi
             task_id: "task-one".to_owned(),
             balance: Some("32".to_owned()),
             power: Some("0".to_owned()),
+            ..OnchainRefreshReadValue::default()
         },
     )]);
     let worker = OnchainRefreshWorker::new(
@@ -697,6 +704,7 @@ async fn test_onchain_refresh_worker_zeros_current_delegate_relation_power_from_
             task_id: "task-one".to_owned(),
             balance: Some("0".to_owned()),
             power: Some("0".to_owned()),
+            ..OnchainRefreshReadValue::default()
         },
     )]);
     let worker = OnchainRefreshWorker::new(
@@ -757,6 +765,8 @@ async fn test_onchain_refresh_worker_uses_current_votes_checkpoint_source()
             task_id: "task-one".to_owned(),
             balance: None,
             power: Some("11".to_owned()),
+            checkpoint_power: Some("11".to_owned()),
+            ..OnchainRefreshReadValue::default()
         },
     )]);
     let worker = OnchainRefreshWorker::new(
@@ -913,6 +923,7 @@ async fn test_onchain_refresh_worker_scoped_run_claims_only_matching_contract_se
                 task_id: "lisk-task".to_owned(),
                 balance: None,
                 power: Some("13".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         )]),
     );
@@ -1174,6 +1185,7 @@ async fn test_onchain_refresh_worker_prioritizes_stale_processing_before_pending
                     task_id: "stale-task".to_owned(),
                     balance: None,
                     power: Some("11".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
             (
@@ -1182,6 +1194,7 @@ async fn test_onchain_refresh_worker_prioritizes_stale_processing_before_pending
                     task_id: "pending-task".to_owned(),
                     balance: None,
                     power: Some("17".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
         ]),
@@ -1279,6 +1292,7 @@ async fn test_onchain_refresh_worker_keeps_pending_moving_when_stale_processing_
                     task_id: "stale-task-one".to_owned(),
                     balance: None,
                     power: Some("11".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
             (
@@ -1287,6 +1301,7 @@ async fn test_onchain_refresh_worker_keeps_pending_moving_when_stale_processing_
                     task_id: "stale-task-two".to_owned(),
                     balance: None,
                     power: Some("12".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
             (
@@ -1295,6 +1310,7 @@ async fn test_onchain_refresh_worker_keeps_pending_moving_when_stale_processing_
                     task_id: "failed-task".to_owned(),
                     balance: None,
                     power: Some("13".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
             (
@@ -1303,6 +1319,7 @@ async fn test_onchain_refresh_worker_keeps_pending_moving_when_stale_processing_
                     task_id: "pending-task".to_owned(),
                     balance: None,
                     power: Some("17".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
         ]),
@@ -1401,6 +1418,7 @@ async fn test_onchain_refresh_worker_refills_unused_queue_quota_by_priority()
                     task_id: "stale-task-one".to_owned(),
                     balance: None,
                     power: Some("11".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
             (
@@ -1409,6 +1427,7 @@ async fn test_onchain_refresh_worker_refills_unused_queue_quota_by_priority()
                     task_id: "stale-task-two".to_owned(),
                     balance: None,
                     power: Some("12".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
             (
@@ -1417,6 +1436,7 @@ async fn test_onchain_refresh_worker_refills_unused_queue_quota_by_priority()
                     task_id: "pending-task-one".to_owned(),
                     balance: None,
                     power: Some("17".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
             (
@@ -1425,6 +1445,7 @@ async fn test_onchain_refresh_worker_refills_unused_queue_quota_by_priority()
                     task_id: "pending-task-two".to_owned(),
                     balance: None,
                     power: Some("19".to_owned()),
+                    ..OnchainRefreshReadValue::default()
                 },
             ),
         ]),
@@ -1477,6 +1498,7 @@ async fn test_onchain_refresh_worker_claims_pending_task_at_max_attempts()
                 task_id: "task-one".to_owned(),
                 balance: None,
                 power: Some("11".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         )]),
     );
@@ -1524,6 +1546,7 @@ async fn test_onchain_refresh_worker_rolls_back_when_apply_fails() -> Result<(),
                 task_id: "task-one".to_owned(),
                 balance: None,
                 power: Some("not-a-number".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         ),
         (
@@ -1532,6 +1555,7 @@ async fn test_onchain_refresh_worker_rolls_back_when_apply_fails() -> Result<(),
                 task_id: "task-two".to_owned(),
                 balance: None,
                 power: Some("5".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         ),
     ]);
@@ -1611,6 +1635,9 @@ async fn test_onchain_refresh_worker_checkpoint_ids_include_scope() -> Result<()
                 task_id: "task-one".to_owned(),
                 balance: Some("17".to_owned()),
                 power: Some("11".to_owned()),
+                checkpoint_balance: Some("17".to_owned()),
+                checkpoint_power: Some("11".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         ),
         (
@@ -1619,6 +1646,9 @@ async fn test_onchain_refresh_worker_checkpoint_ids_include_scope() -> Result<()
                 task_id: "task-two".to_owned(),
                 balance: Some("23".to_owned()),
                 power: Some("19".to_owned()),
+                checkpoint_balance: Some("23".to_owned()),
+                checkpoint_power: Some("19".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         ),
     ]);
@@ -1700,6 +1730,9 @@ async fn test_onchain_refresh_worker_updates_only_matching_contract_set_contribu
             task_id: "task-one".to_owned(),
             balance: Some("17".to_owned()),
             power: Some("11".to_owned()),
+            checkpoint_balance: Some("17".to_owned()),
+            checkpoint_power: Some("11".to_owned()),
+            ..OnchainRefreshReadValue::default()
         },
     )]);
     let worker = OnchainRefreshWorker::new(
@@ -1789,6 +1822,7 @@ async fn test_onchain_refresh_worker_reschedules_pending_after_lock_with_debounc
                 task_id: "task-one".to_owned(),
                 balance: None,
                 power: Some("11".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         )]),
     );
@@ -1867,6 +1901,7 @@ async fn test_onchain_refresh_worker_resets_attempts_for_pending_after_lock()
                 task_id: "task-one".to_owned(),
                 balance: None,
                 power: Some("11".to_owned()),
+                ..OnchainRefreshReadValue::default()
             },
         )]),
     );
@@ -1931,10 +1966,66 @@ fn test_multi_chain_reader_routes_tasks_to_matching_chain_tool() {
         .into_iter()
         .chain(lisk_tool.captured_plans())
     {
-        for read in plan.reads {
-            assert_eq!(read.key.block_mode, BlockReadMode::AtBlock(12));
-        }
+        let block_modes = plan
+            .reads
+            .iter()
+            .map(|read| read.key.block_mode)
+            .collect::<Vec<_>>();
+        assert!(block_modes.contains(&BlockReadMode::Latest));
+        assert!(block_modes.contains(&BlockReadMode::AtBlock(12)));
     }
+}
+
+#[test]
+fn test_chain_tool_onchain_refresh_reader_reads_current_latest_and_checkpoint_at_activity_block() {
+    let chain_tool = BlockModeValueChainTool::new();
+    let reader = degov_datalens_indexer::ChainToolOnchainRefreshReader::new(
+        chain_tool.clone(),
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+    let mut task = task_for_chain("task-one", 1, ACCOUNT_ONE);
+    task.refresh_balance = true;
+    task.refresh_power = true;
+
+    let values = reader.read_tasks(&[task]).expect("read tasks");
+
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0].power.as_deref(), Some("latest"));
+    assert_eq!(values[0].balance.as_deref(), Some("latest"));
+    assert_eq!(values[0].checkpoint_power.as_deref(), Some("12"));
+    assert_eq!(values[0].checkpoint_balance.as_deref(), Some("12"));
+
+    let plans = chain_tool.captured_plans();
+    assert_eq!(plans.len(), 1);
+    assert!(
+        plans[0]
+            .reads
+            .iter()
+            .any(|read| read.key.method == ChainReadMethod::GetVotes
+                && read.key.block_mode == BlockReadMode::Latest)
+    );
+    assert!(
+        plans[0]
+            .reads
+            .iter()
+            .any(|read| read.key.method == ChainReadMethod::GetVotes
+                && read.key.block_mode == BlockReadMode::AtBlock(12))
+    );
+    assert!(
+        plans[0]
+            .reads
+            .iter()
+            .any(|read| read.key.method == ChainReadMethod::BalanceOf
+                && read.key.block_mode == BlockReadMode::Latest)
+    );
+    assert!(
+        plans[0]
+            .reads
+            .iter()
+            .any(|read| read.key.method == ChainReadMethod::BalanceOf
+                && read.key.block_mode == BlockReadMode::AtBlock(12))
+    );
 }
 
 #[test]
@@ -1961,9 +2052,9 @@ fn test_chain_tool_onchain_refresh_reader_dedupes_duplicate_reads_in_one_batch()
     );
     let plans = chain_tool.captured_plans();
     assert_eq!(plans.len(), 1);
-    assert_eq!(plans[0].metrics.requested_reads, 2);
-    assert_eq!(plans[0].metrics.deduped_reads, 1);
-    assert_eq!(plans[0].reads.len(), 1);
+    assert_eq!(plans[0].metrics.requested_reads, 4);
+    assert_eq!(plans[0].metrics.deduped_reads, 2);
+    assert_eq!(plans[0].reads.len(), 2);
 }
 
 #[test]
@@ -1990,17 +2081,45 @@ fn test_chain_tool_onchain_refresh_reader_keeps_same_account_activity_blocks_dis
         values
             .get("task-earlier")
             .expect("earlier")
-            .power
+            .checkpoint_power
             .as_deref(),
         Some("200")
     );
     assert_eq!(
-        values.get("task-later").expect("later").power.as_deref(),
+        values
+            .get("task-later")
+            .expect("later")
+            .checkpoint_power
+            .as_deref(),
         Some("201")
     );
     let plans = chain_tool.captured_plans();
     assert_eq!(plans.len(), 1);
-    assert_eq!(plans[0].reads.len(), 2);
+    assert_eq!(plans[0].reads.len(), 3);
+}
+
+#[test]
+fn test_chain_tool_onchain_refresh_reader_keeps_current_value_when_checkpoint_read_fails() {
+    let chain_tool = HistoricalFailureChainTool;
+    let reader = degov_datalens_indexer::ChainToolOnchainRefreshReader::new(
+        chain_tool,
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+    let mut task = task_for_chain("task-one", 1, ACCOUNT_ONE);
+    task.refresh_balance = true;
+    task.refresh_power = true;
+
+    let report = reader
+        .read_tasks_with_report(&[task])
+        .expect("historical failure is optional");
+
+    assert_eq!(report.failures, vec![]);
+    assert_eq!(report.values.len(), 1);
+    assert_eq!(report.values[0].power.as_deref(), Some("latest"));
+    assert_eq!(report.values[0].balance.as_deref(), Some("latest"));
+    assert_eq!(report.values[0].checkpoint_power, None);
+    assert_eq!(report.values[0].checkpoint_balance, None);
 }
 
 #[test]
@@ -2339,6 +2458,9 @@ struct PartialFailureChainTool {
     failed_account: String,
 }
 
+#[derive(Clone, Debug)]
+struct HistoricalFailureChainTool;
+
 impl PartialFailureChainTool {
     fn new(failed_account: &str) -> Self {
         Self {
@@ -2393,6 +2515,55 @@ impl ChainTool for PartialFailureChainTool {
                 executed_rpc_calls: plan.reads.len(),
                 multicall_batch_size: plan.metrics.multicall_batch_size,
                 failures: failures.required_failures.len(),
+                ..ChainReadMetrics::default()
+            },
+            results,
+            partial_failures: failures,
+            ..ChainReadExecutionReport::default()
+        }
+    }
+}
+
+impl ChainTool for HistoricalFailureChainTool {
+    fn execute_read_plan(
+        &self,
+        plan: &ChainReadPlan,
+    ) -> Result<ChainReadExecutionReport, PartialChainReadFailureReport> {
+        Ok(self.execute_read_plan_partial(plan))
+    }
+
+    fn execute_read_plan_partial(&self, plan: &ChainReadPlan) -> ChainReadExecutionReport {
+        let mut results = Vec::new();
+        let mut failures = PartialChainReadFailureReport::default();
+
+        for (read_index, read) in plan.reads.iter().enumerate() {
+            match read.key.block_mode {
+                BlockReadMode::AtBlock(_) => {
+                    failures.optional_failures.push(ChainReadFailure {
+                        key: read.key.clone(),
+                        kind: ChainReadFailureKind::Reverted,
+                        retryable: false,
+                        message: "historical read unavailable".to_owned(),
+                    });
+                }
+                BlockReadMode::Latest => {
+                    results.push(ChainReadResult {
+                        read_index,
+                        key: read.key.clone(),
+                        value: ChainReadValue::Integer("latest".to_owned()),
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        ChainReadExecutionReport {
+            metrics: ChainReadMetrics {
+                requested_reads: plan.metrics.requested_reads,
+                deduped_reads: plan.metrics.deduped_reads,
+                executed_rpc_calls: plan.reads.len(),
+                multicall_batch_size: plan.metrics.multicall_batch_size,
+                failures: failures.optional_failures.len(),
                 ..ChainReadMetrics::default()
             },
             results,


### PR DESCRIPTION
## Summary
- read latest values for current contributor/delegate/live-overlay updates
- keep historical checkpoint values separate and only write checkpoints when AtBlock reads succeed
- prevent optional historical checkpoint reads from falling back to latest so history is not corrupted

## Tests
- cargo fmt --all --check
- cargo test -p degov-datalens-indexer onchain::refresh::tests --lib -- --nocapture
- cargo test -p degov-datalens-indexer --test onchain_refresh_worker test_chain_tool_onchain_refresh_reader -- --nocapture
- cargo test -p degov-datalens-indexer onchain::refresh::tests::test_evm_rpc_chain_tool_does_not_fallback_optional_historical_reads_to_latest --lib -- --exact --nocapture

## Notes
Replaces the unsafe approach in #944. Latest/current values must never be written as historical token balance or vote power checkpoints.