### PR TITLE
fix(indexer): apply token delegate timeline writes

### DIFF
--- a/apps/indexer/src/store/postgres/token_store_tests.rs
+++ b/apps/indexer/src/store/postgres/token_store_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     BatchReadPlanConfig, ChainContracts, ChainReadMethod, PowerReconcileContext,
-    plan_power_reconcile,
+    plan_power_reconcile, runtime::apply_migrations,
 };
 
 #[test]
@@ -643,6 +643,149 @@ fn test_collect_vote_power_checkpoint_inserts_keeps_delegate_votes_changed_cause
     assert_eq!(rows[0].delegator, None);
     assert_eq!(rows[0].from_delegate, None);
     assert_eq!(rows[0].to_delegate, None);
+}
+
+#[tokio::test]
+async fn test_write_token_batch_rows_applies_same_tx_mint_self_delegation_vote_power() {
+    let Ok(database_url) = std::env::var("DEGOV_INDEXER_TEST_DATABASE_URL") else {
+        return;
+    };
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await
+        .expect("connect test database");
+    apply_migrations(&pool).await.expect("apply migrations");
+
+    let mut transaction = pool.begin().await.expect("begin transaction");
+    let account = "0xb00c12b64c0ad418513e9a5d934c921d86b6615";
+    let zero = "0x0000000000000000000000000000000000000000";
+    let power = "1000000000000000";
+    let base_common = TokenEventCommon {
+        contract_set_id: format!("token-timeline-regression-{}", std::process::id()),
+        chain_id: 1,
+        dao_code: "bytom-dao".to_owned(),
+        governor_address: "0xgovernor".to_owned(),
+        token_address: "0xtoken".to_owned(),
+        contract_address: "0xtoken".to_owned(),
+        log_index: 0,
+        transaction_index: 42,
+        block_number: "19624062".to_owned(),
+        block_timestamp: Some("1710000000".to_owned()),
+        transaction_hash: "0xff65c789b44935908b54018c9b7c5fd4acec93138c13a64790626d18ef03898e"
+            .to_owned(),
+    };
+    let transfer_common = TokenEventCommon {
+        log_index: 256,
+        ..base_common.clone()
+    };
+    let changed_common = TokenEventCommon {
+        log_index: 257,
+        ..base_common.clone()
+    };
+    let votes_common = TokenEventCommon {
+        log_index: 258,
+        ..base_common.clone()
+    };
+    let batch = TokenProjectionBatch {
+        event_order: vec![
+            "transfer".to_owned(),
+            "changed".to_owned(),
+            "votes".to_owned(),
+        ],
+        delegate_changed: vec![DelegateChangedWrite {
+            id: "changed".to_owned(),
+            common: changed_common.clone(),
+            delegator: account.to_owned(),
+            from_delegate: zero.to_owned(),
+            to_delegate: account.to_owned(),
+        }],
+        delegate_votes_changed: vec![delegate_votes_changed(
+            "votes",
+            votes_common.clone(),
+            account,
+            "0",
+            power,
+        )],
+        token_transfers: vec![TokenTransferWrite {
+            id: "transfer".to_owned(),
+            common: transfer_common.clone(),
+            from: zero.to_owned(),
+            to: account.to_owned(),
+            value: power.to_owned(),
+            standard: "erc20".to_owned(),
+        }],
+        delegate_rollings: vec![DelegateRollingWrite {
+            id: "changed".to_owned(),
+            common: changed_common.clone(),
+            delegator: account.to_owned(),
+            from_delegate: zero.to_owned(),
+            to_delegate: account.to_owned(),
+            from_previous_votes: None,
+            from_new_votes: None,
+            to_previous_votes: None,
+            to_new_votes: None,
+        }],
+        operations: vec![
+            TokenProjectionOperation::Transfer {
+                id: "transfer".to_owned(),
+                common: transfer_common,
+                from: zero.to_owned(),
+                to: account.to_owned(),
+                value: power.to_owned(),
+                standard: GovernanceTokenStandard::Erc20,
+            },
+            TokenProjectionOperation::DelegateChanged {
+                id: "changed".to_owned(),
+                common: changed_common,
+                delegator: account.to_owned(),
+                from_delegate: zero.to_owned(),
+                to_delegate: account.to_owned(),
+            },
+            TokenProjectionOperation::DelegateVotesChanged {
+                id: "votes".to_owned(),
+                common: votes_common,
+                delegate: account.to_owned(),
+                previous_votes: "0".to_owned(),
+                new_votes: power.to_owned(),
+            },
+        ],
+        reconcile_plan: empty_reconcile_plan(),
+    };
+
+    let inserted = write_token_batch_rows(&mut transaction, &batch)
+        .await
+        .expect("write token rows");
+    write_data_metric_timeline(&mut transaction, &inserted, None, None, Some(&batch))
+        .await
+        .expect("write token timeline");
+
+    let mapping_power = sqlx::query_scalar::<_, String>(
+        r#"SELECT power::TEXT
+           FROM delegate_mapping
+           WHERE contract_set_id = $1 AND id = $2"#,
+    )
+    .bind(&base_common.contract_set_id)
+    .bind(contributor_ref(account))
+    .fetch_one(&mut *transaction)
+    .await
+    .expect("delegate mapping power");
+    let delegate_power = sqlx::query_scalar::<_, String>(
+        r#"SELECT power::TEXT
+           FROM delegate
+           WHERE contract_set_id = $1 AND id = $2 AND is_current"#,
+    )
+    .bind(&base_common.contract_set_id)
+    .bind(delegate_ref(&base_common, account, account))
+    .fetch_one(&mut *transaction)
+    .await
+    .expect("delegate snapshot power");
+
+    assert_eq!(inserted.len(), 3);
+    assert_eq!(mapping_power, power);
+    assert_eq!(delegate_power, power);
+
+    transaction.rollback().await.expect("rollback transaction");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- apply token delegate timeline state updates after inserting token events
- update delegate mappings/snapshots from same-transaction DelegateVotesChanged rolling metadata
- add regression coverage for mint -> self-delegate -> vote power in one transaction

## Validation
- cargo fmt --check
- cargo test -p degov-datalens-indexer test_write_token_batch_rows_applies_same_tx_mint_self_delegation_vote_power -- --nocapture
- cargo test -p degov-datalens-indexer store::postgres::runner_store::token_store_tests -- --nocapture

## Replay note
After deploy, affected staging DAO token projections should be reset/replayed from the first divergent delegate block: bytom-dao 19624062, hai-dao 116092689, kton-dao 3463729, ring-dao 4779688, sudoswap-dao 16522733. anvil-dao also needs replay from 24849880 after Datalens cache repair cache-repair-a946e98def9344b8.