### PR TITLE
fix(web): avoid demo config fallback for remote dao

### DIFF
--- a/apps/web/scripts/demo-dao-config.test.ts
+++ b/apps/web/scripts/demo-dao-config.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { isDemoDaoConfig } from "../src/utils/is-demo-dao.ts";
+
+const readSource = (relativePath: string) =>
+  readFileSync(path.join(import.meta.dirname, "..", relativePath), "utf8");
+
+test("demo DAO detection uses the stable DAO code", () => {
+  assert.equal(isDemoDaoConfig({ code: "degov-demo-dao" }), true);
+  assert.equal(isDemoDaoConfig({ code: "kton-dao" }), false);
+  assert.equal(isDemoDaoConfig({ code: undefined }), false);
+});
+
+test("layout and hooks do not detect demo DAO by display name", () => {
+  assert.doesNotMatch(readSource("src/app/layout.tsx"), /name\s*===\s*["']DeGov Demo DAO["']/);
+  assert.doesNotMatch(readSource("src/hooks/useIsDemoDao.ts"), /name\s*===\s*["']DeGov Demo DAO["']/);
+});
+
+test("remote config does not fallback to bundled demo config when API mode fails", () => {
+  const source = readSource("src/app/_server/config-remote.ts");
+
+  assert.match(source, /const requiresOrigin = !process\.env\.NEXT_PUBLIC_DEGOV_DAO/);
+  assert.match(source, /Unable to resolve request origin for remote config/);
+  assert.doesNotMatch(source, /fallback to local/);
+});

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -1,8 +1,8 @@
 import { unstable_cache } from "next/cache";
 import { headers } from "next/headers";
 
-import { loadConfigYaml } from "@/lib/config-yaml";
 import { getDaoConfigServer } from "@/lib/config";
+import { loadConfigYaml } from "@/lib/config-yaml";
 import type { Config } from "@/types/config";
 import { degovApiDaoConfigServer } from "@/utils/remote-api";
 
@@ -38,12 +38,17 @@ export async function getConfigCachedByHost(): Promise<Config> {
 
   const get = unstable_cache(
     async () => {
-      try {
-        const apiUrl = degovApiDaoConfigServer();
-        if (!apiUrl) {
-          return getDaoConfigServer();
-        }
+      const apiUrl = degovApiDaoConfigServer();
+      if (!apiUrl) {
+        return getDaoConfigServer();
+      }
 
+      const requiresOrigin = !process.env.NEXT_PUBLIC_DEGOV_DAO;
+      if (requiresOrigin && !resolvedOrigin) {
+        throw new Error("Unable to resolve request origin for remote config.");
+      }
+
+      try {
         console.log(`[Cache] MISS: Fetching remote config for origin: ${resolvedOrigin}`);
         const res = await fetch(apiUrl, {
           headers: resolvedOrigin ? { Origin: resolvedOrigin } : undefined,
@@ -56,8 +61,8 @@ export async function getConfigCachedByHost(): Promise<Config> {
 
         return result;
       } catch (err) {
-        console.error("[Cache] Remote config failed, fallback to local:", err);
-        return getDaoConfigServer();
+        console.error("[Cache] Remote config failed:", err);
+        throw err;
       }
     },
     ["metadata-config", hostKey],

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { buildSiteMetadata } from "@/lib/metadata";
 import { ConfigProvider } from "@/providers/config.provider";
 import { NextThemeProvider } from "@/providers/theme.provider";
 import type { Config } from "@/types/config";
+import { isDemoDaoConfig } from "@/utils/is-demo-dao";
 import { isDegovApiConfiguredServer } from "@/utils/remote-api";
 import { parseOrigin } from "@/utils/url";
 
@@ -97,7 +98,7 @@ export default async function RootLayout({
   const indexerOrigin = parseOrigin(initialConfig?.indexer?.endpoint);
   const rpcOrigin = parseOrigin(initialConfig?.chain?.rpcs?.[0]);
   const siteOrigin = parseOrigin(initialConfig?.siteUrl);
-  const isDemoDao = initialConfig?.name === "DeGov Demo DAO";
+  const isDemoDao = isDemoDaoConfig(initialConfig);
 
   return (
     <html lang={locale} suppressHydrationWarning>

--- a/apps/web/src/hooks/useIsDemoDao.ts
+++ b/apps/web/src/hooks/useIsDemoDao.ts
@@ -1,6 +1,8 @@
+import { isDemoDaoConfig } from "@/utils/is-demo-dao";
+
 import { useDaoConfig } from "./useDaoConfig";
 
 export const useIsDemoDao = () => {
   const daoConfig = useDaoConfig();
-  return daoConfig?.name === "DeGov Demo DAO";
+  return isDemoDaoConfig(daoConfig);
 };

--- a/apps/web/src/utils/is-demo-dao.ts
+++ b/apps/web/src/utils/is-demo-dao.ts
@@ -1,0 +1,7 @@
+import type { Config } from "@/types/config";
+
+const DEMO_DAO_CODE = "degov-demo-dao";
+
+export function isDemoDaoConfig(config?: Pick<Config, "code"> | null) {
+  return config?.code === DEMO_DAO_CODE;
+}


### PR DESCRIPTION
## Summary

- Detect the demo DAO by the stable DAO code instead of the display name.
- Stop falling back to the bundled local demo config when remote config mode cannot resolve or fetch the DAO config.
- Add a regression test covering demo detection and remote-config fail-closed behavior.

## Root Cause

`gov.ktondao.xyz` was served with the bundled demo config when the remote config lookup failed or could not resolve a public origin. The fallback result could be cached for the host, which made a real DAO render the DeGov demo banner and demo metadata.

## Validation

- `node --test apps/web/scripts/demo-dao-config.test.ts`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
