### PR TITLE
fix(indexer): repair v5 data alignment gaps

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -140,7 +140,7 @@ pub use runner::{
 pub use runtime_config::{
     ContractSetConcurrencyLimit, GraphqlRuntimeConfig, IndexerContractSetMode,
     IndexerContractSetRuntimeConfig, IndexerRuntimeConfig, IndexerTargetHeight,
-    OnchainRefreshRuntimeConfig, ProvisionalRuntimeConfig, datalens_retry_config,
-    onchain_refresh_debounce_from_env, onchain_refresh_worker_enabled, parse_bool_env_value,
-    parse_i64_env_value, required_env,
+    OnchainRefreshRuntimeConfig, OnchainRefreshScopeMode, ProvisionalRuntimeConfig,
+    datalens_retry_config, onchain_refresh_debounce_from_env, onchain_refresh_worker_enabled,
+    parse_bool_env_value, parse_i64_env_value, required_env,
 };

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -24,6 +24,8 @@ use crate::{
     ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ReadRequirement,
     store::postgres::{
         drain_deferred_onchain_refresh_tasks, drain_deferred_onchain_refresh_tasks_for_scope,
+        repair_missing_onchain_refresh_contributor_coverage,
+        repair_missing_onchain_refresh_contributor_coverage_for_scope,
     },
 };
 
@@ -540,7 +542,48 @@ where
                 deferred_drain_started_at.elapsed().as_millis()
             );
         }
-        let tasks = self.claim_tasks(now_ms, batch_size, scope).await?;
+        let mut tasks = self.claim_tasks(now_ms, batch_size, scope).await?;
+        if tasks.is_empty() {
+            let coverage_repair_count = self
+                .repair_missing_contributor_coverage(deferred_drain_target, scope)
+                .await?;
+            if coverage_repair_count > 0 {
+                log::info!(
+                    "onchain refresh worker repaired contributor coverage dao_code={} chain_id={} contract_set_id={} repaired_count={} repair_batch_size={}",
+                    scope
+                        .map(|scope| scope.dao_code.as_str())
+                        .unwrap_or("global"),
+                    scope
+                        .map(|scope| scope.chain_id.to_string())
+                        .unwrap_or_else(|| "global".to_owned()),
+                    scope
+                        .map(|scope| scope.contract_set_id.as_str())
+                        .unwrap_or("global"),
+                    coverage_repair_count,
+                    deferred_drain_target
+                );
+                let repaired_deferred_drain_count = self
+                    .drain_deferred_onchain_refresh_backlog(deferred_drain_target, scope)
+                    .await?;
+                if repaired_deferred_drain_count > 0 {
+                    log::info!(
+                        "onchain refresh worker materialized repaired contributor coverage dao_code={} chain_id={} contract_set_id={} deferred_drain_count={} deferred_drain_target={}",
+                        scope
+                            .map(|scope| scope.dao_code.as_str())
+                            .unwrap_or("global"),
+                        scope
+                            .map(|scope| scope.chain_id.to_string())
+                            .unwrap_or_else(|| "global".to_owned()),
+                        scope
+                            .map(|scope| scope.contract_set_id.as_str())
+                            .unwrap_or("global"),
+                        repaired_deferred_drain_count,
+                        deferred_drain_target
+                    );
+                }
+                tasks = self.claim_tasks(now_ms, batch_size, scope).await?;
+            }
+        }
         if tasks.is_empty() {
             let data_metric_refreshes = self.drain_data_metric_refresh_tasks(now_ms).await?;
             return Ok(OnchainRefreshRunReport {
@@ -718,6 +761,23 @@ where
         }
 
         Ok(drained_total)
+    }
+
+    async fn repair_missing_contributor_coverage(
+        &self,
+        max_rows: usize,
+        scope: Option<&OnchainRefreshTaskScope>,
+    ) -> Result<usize, OnchainRefreshWorkerError> {
+        match scope {
+            Some(scope) => {
+                repair_missing_onchain_refresh_contributor_coverage_for_scope(
+                    &self.pool, max_rows, scope,
+                )
+                .await
+            }
+            None => repair_missing_onchain_refresh_contributor_coverage(&self.pool, max_rows).await,
+        }
+        .map_err(|error| OnchainRefreshWorkerError::DeferredDrain(error.to_string()))
     }
 
     async fn drain_data_metric_refresh_tasks(

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -1443,10 +1443,15 @@ impl ProposalWrite {
             merged.proposal_eta = self.proposal_eta.clone().or(merged.proposal_eta);
             merged.queue_ready_at = self.queue_ready_at.clone().or(merged.queue_ready_at);
             merged.queue_expires_at = self.queue_expires_at.clone().or(merged.queue_expires_at);
-            merged.block_interval = self.block_interval.clone().or(merged.block_interval);
             if merged.clock_mode == "blocknumber" && self.clock_mode != "blocknumber" {
                 merged.clock_mode = self.clock_mode.clone();
             }
+            merged.block_interval = merge_block_interval(
+                merged.chain_id,
+                &merged.clock_mode,
+                self.block_interval.clone(),
+                next.block_interval.clone(),
+            );
             if merged.quorum == "0" {
                 merged.quorum = self.quorum.clone();
             }
@@ -1507,10 +1512,15 @@ impl ProposalWrite {
                 .queue_expires_at
                 .clone()
                 .or(self.queue_expires_at.clone());
-            self.block_interval = next.block_interval.clone().or(self.block_interval.clone());
             if self.clock_mode == "blocknumber" && next.clock_mode != "blocknumber" {
                 self.clock_mode = next.clock_mode.clone();
             }
+            self.block_interval = merge_block_interval(
+                self.chain_id,
+                &self.clock_mode,
+                next.block_interval.clone(),
+                self.block_interval.clone(),
+            );
             if self.quorum == "0" {
                 self.quorum = next.quorum.clone();
             }
@@ -1759,6 +1769,21 @@ fn block_interval(chain_id: i32, clock_mode: &str) -> Option<String> {
     const ETHEREUM_MAINNET_CHAIN_ID: i32 = 1;
 
     (chain_id == ETHEREUM_MAINNET_CHAIN_ID && clock_mode == "blocknumber").then(|| "12".to_owned())
+}
+
+fn merge_block_interval(
+    chain_id: i32,
+    clock_mode: &str,
+    preferred: Option<String>,
+    fallback: Option<String>,
+) -> Option<String> {
+    (clock_mode == "blocknumber")
+        .then(|| {
+            preferred
+                .or(fallback)
+                .or_else(|| block_interval(chain_id, clock_mode))
+        })
+        .flatten()
 }
 
 fn timepoint_timestamp_for_proposal(proposal: &ProposalWrite, timepoint: &str) -> String {

--- a/apps/indexer/src/runtime/proposal_reference_fields.rs
+++ b/apps/indexer/src/runtime/proposal_reference_fields.rs
@@ -87,9 +87,8 @@ pub fn plan_proposal_reference_field_updates(
         .filter_map(|candidate| {
             let key = normalize_proposal_id(&candidate.proposal_id)?;
             let reference = reference_by_proposal_id.get(&key)?;
-            if candidate.title == reference.title
-                && candidate.block_interval == reference.block_interval
-            {
+            let block_interval = reference_block_interval(candidate, reference);
+            if candidate.title == reference.title && candidate.block_interval == block_interval {
                 return None;
             }
 
@@ -98,10 +97,19 @@ pub fn plan_proposal_reference_field_updates(
                 previous_title: candidate.title.clone(),
                 previous_block_interval: candidate.block_interval.clone(),
                 title: reference.title.clone(),
-                block_interval: reference.block_interval.clone(),
+                block_interval,
             })
         })
         .collect()
+}
+
+fn reference_block_interval(
+    candidate: &ProposalReferenceFieldCandidate,
+    reference: &ReferenceProposalFields,
+) -> Option<String> {
+    (candidate.clock_mode == "blocknumber")
+        .then(|| reference.block_interval.clone())
+        .flatten()
 }
 
 pub fn normalize_proposal_id(value: &str) -> Option<String> {
@@ -299,12 +307,14 @@ mod tests {
                     proposal_id: "42".to_owned(),
                     title: "local title".to_owned(),
                     block_interval: Some("12".to_owned()),
+                    clock_mode: "blocknumber".to_owned(),
                 },
                 ProposalReferenceFieldCandidate {
                     id: "proposal:2".to_owned(),
                     proposal_id: "7".to_owned(),
                     title: "same title".to_owned(),
                     block_interval: None,
+                    clock_mode: "blocknumber".to_owned(),
                 },
             ],
             &[
@@ -329,6 +339,35 @@ mod tests {
                 previous_block_interval: Some("12".to_owned()),
                 title: "reference title".to_owned(),
                 block_interval: Some("13.333333333333334".to_owned()),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_plan_proposal_reference_field_updates_clears_timestamp_block_interval() {
+        let updates = plan_proposal_reference_field_updates(
+            &[ProposalReferenceFieldCandidate {
+                id: "proposal:1".to_owned(),
+                proposal_id: "42".to_owned(),
+                title: "local title".to_owned(),
+                block_interval: Some("12".to_owned()),
+                clock_mode: "timestamp".to_owned(),
+            }],
+            &[ReferenceProposalFields {
+                proposal_id: "0x2a".to_owned(),
+                title: "reference title".to_owned(),
+                block_interval: Some("13.333333333333334".to_owned()),
+            }],
+        );
+
+        assert_eq!(
+            updates,
+            vec![ProposalReferenceFieldUpdate {
+                id: "proposal:1".to_owned(),
+                previous_title: "local title".to_owned(),
+                previous_block_interval: Some("12".to_owned()),
+                title: "reference title".to_owned(),
+                block_interval: None,
             }]
         );
     }

--- a/apps/indexer/src/runtime/worker.rs
+++ b/apps/indexer/src/runtime/worker.rs
@@ -6,8 +6,9 @@ use sqlx::postgres::PgPoolOptions;
 use tokio::time::sleep;
 
 use crate::{
-    EvmRpcChainTool, MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig,
-    OnchainRefreshWorker, required_env,
+    DatalensConfig, EvmRpcChainTool, IndexerRuntimeConfig, MultiChainToolOnchainRefreshReader,
+    OnchainRefreshRunReport, OnchainRefreshRuntimeConfig, OnchainRefreshScopeMode,
+    OnchainRefreshTaskScope, OnchainRefreshWorker, required_env,
 };
 
 use super::migrate::apply_migrations;
@@ -60,6 +61,8 @@ pub async fn run_worker() -> Result<()> {
     );
     let worker = OnchainRefreshWorker::new(pool, runtime.worker_config(), reader)
         .with_current_power_method(runtime.current_power_method);
+    let scopes = load_onchain_refresh_worker_scopes(&runtime)?;
+    let mut scope_schedule = OnchainRefreshWorkerScopeSchedule::new(scopes);
 
     loop {
         let mut poll_claimed = 0;
@@ -73,10 +76,11 @@ pub async fn run_worker() -> Result<()> {
         let mut poll_debounced_tasks = 0;
 
         for _ in 0..runtime.max_batches_per_poll {
-            let report = worker
-                .run_once()
-                .await
-                .context("run onchain refresh batch")?;
+            let batch_scope = scope_schedule.next_batch_scope();
+            let report =
+                run_onchain_refresh_worker_batch(&worker, &batch_scope, runtime.batch_size)
+                    .await
+                    .context("run onchain refresh batch")?;
             poll_claimed += report.claimed;
             poll_completed += report.completed;
             poll_failed += report.failed;
@@ -87,7 +91,7 @@ pub async fn run_worker() -> Result<()> {
             poll_cache_hits += report.cache_hits;
             poll_debounced_tasks += report.debounced_tasks;
 
-            if report.claimed == 0 {
+            if !scope_schedule.observe_batch_report(&report) {
                 break;
             }
         }
@@ -110,6 +114,142 @@ pub async fn run_worker() -> Result<()> {
         }
 
         sleep(runtime.poll_interval).await;
+    }
+}
+
+async fn run_onchain_refresh_worker_batch<R>(
+    worker: &OnchainRefreshWorker<R>,
+    batch_scope: &OnchainRefreshWorkerBatchScope,
+    batch_size: usize,
+) -> Result<OnchainRefreshRunReport, crate::OnchainRefreshWorkerError>
+where
+    R: crate::OnchainRefreshReader,
+{
+    match batch_scope {
+        OnchainRefreshWorkerBatchScope::Global => worker.run_once().await,
+        OnchainRefreshWorkerBatchScope::Scoped(scope) => {
+            worker
+                .run_once_with_batch_size_for_scope(batch_size, scope)
+                .await
+        }
+    }
+}
+
+fn load_onchain_refresh_worker_scopes(
+    runtime: &OnchainRefreshRuntimeConfig,
+) -> Result<Vec<OnchainRefreshTaskScope>> {
+    match runtime.scope_mode {
+        OnchainRefreshScopeMode::Global => Ok(Vec::new()),
+        OnchainRefreshScopeMode::ConfiguredContractSets => {
+            let indexer_runtime =
+                IndexerRuntimeConfig::from_env().context("load DeGov indexer runtime config")?;
+            let datalens_config = DatalensConfig::from_env().context("load Datalens config")?;
+            let scopes = runtime
+                .configured_task_scopes(&indexer_runtime, &datalens_config)
+                .context("select onchain refresh worker configured contract set scopes")?;
+            log_onchain_refresh_worker_scopes(&scopes);
+            Ok(scopes)
+        }
+        OnchainRefreshScopeMode::AllModeConfiguredContractSets => {
+            let scopes = load_all_mode_onchain_refresh_worker_scopes(runtime)?;
+            log_onchain_refresh_worker_scopes(&scopes);
+            Ok(scopes)
+        }
+    }
+}
+
+fn load_all_mode_onchain_refresh_worker_scopes(
+    runtime: &OnchainRefreshRuntimeConfig,
+) -> Result<Vec<OnchainRefreshTaskScope>> {
+    let indexer_runtime = match IndexerRuntimeConfig::from_env() {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            log::warn!(
+                "onchain refresh worker could not load all-mode indexer runtime config for scoped scheduling; using global scheduling error={error}"
+            );
+            return Ok(Vec::new());
+        }
+    };
+    let datalens_config = match DatalensConfig::from_env() {
+        Ok(config) => config,
+        Err(error) => {
+            log::warn!(
+                "onchain refresh worker could not load Datalens config for scoped scheduling; using global scheduling error={error}"
+            );
+            return Ok(Vec::new());
+        }
+    };
+
+    runtime
+        .configured_task_scopes(&indexer_runtime, &datalens_config)
+        .context("select all-mode onchain refresh worker configured contract set scopes")
+}
+
+fn log_onchain_refresh_worker_scopes(scopes: &[OnchainRefreshTaskScope]) {
+    if scopes.is_empty() {
+        log::info!("onchain refresh worker is using global task scheduling");
+        return;
+    }
+
+    log::info!(
+        "onchain refresh worker is using scoped task scheduling scope_count={}",
+        scopes.len()
+    );
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OnchainRefreshWorkerBatchScope {
+    Global,
+    Scoped(OnchainRefreshTaskScope),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OnchainRefreshWorkerScopeSchedule {
+    scopes: Vec<OnchainRefreshTaskScope>,
+    next_scope_index: usize,
+    consecutive_empty_scoped_batches: usize,
+}
+
+impl OnchainRefreshWorkerScopeSchedule {
+    pub fn new(scopes: Vec<OnchainRefreshTaskScope>) -> Self {
+        Self {
+            scopes,
+            next_scope_index: 0,
+            consecutive_empty_scoped_batches: 0,
+        }
+    }
+
+    pub fn next_batch_scope(&mut self) -> OnchainRefreshWorkerBatchScope {
+        if self.scopes.is_empty() {
+            return OnchainRefreshWorkerBatchScope::Global;
+        }
+
+        let scope = self.scopes[self.next_scope_index].clone();
+        self.next_scope_index = (self.next_scope_index + 1) % self.scopes.len();
+        OnchainRefreshWorkerBatchScope::Scoped(scope)
+    }
+
+    pub fn observe_batch_report(&mut self, report: &OnchainRefreshRunReport) -> bool {
+        self.observe_batch_claimed(report.claimed)
+    }
+
+    pub fn observe_batch_claimed(&mut self, claimed: usize) -> bool {
+        if self.scopes.is_empty() {
+            return claimed > 0;
+        }
+
+        if claimed > 0 {
+            self.consecutive_empty_scoped_batches = 0;
+            return true;
+        }
+
+        self.consecutive_empty_scoped_batches += 1;
+        if self.consecutive_empty_scoped_batches >= self.scopes.len() {
+            self.consecutive_empty_scoped_batches = 0;
+            return false;
+        }
+
+        true
     }
 }
 

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -10,9 +10,9 @@ use crate::{
     DEFAULT_ONCHAIN_REFRESH_APPLY_BATCH_SIZE, DatalensConfig, DatalensProvisionalFinality,
     DatalensQueryConcurrencyConfig, DatalensRuntimeContractSet, IndexerCheckpointIdentity,
     IndexerRunnerContexts, IndexerRunnerOptions, MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE,
-    OnchainRefreshTickConfig, OnchainRefreshWorkerConfig, ProposalProjectionContext,
-    ProposalTimestampBackfillConfig, SecretString, TimelockProjectionContext,
-    TokenProjectionContext, VoteProjectionContext,
+    OnchainRefreshTaskScope, OnchainRefreshTickConfig, OnchainRefreshWorkerConfig,
+    ProposalProjectionContext, ProposalTimestampBackfillConfig, SecretString,
+    TimelockProjectionContext, TokenProjectionContext, VoteProjectionContext,
     store::postgres::DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS,
 };
 
@@ -591,6 +591,7 @@ impl IndexerContractSetRuntimeConfig {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OnchainRefreshRuntimeConfig {
     pub enabled: bool,
+    pub scope_mode: OnchainRefreshScopeMode,
     pub rpc_chains: BTreeMap<i32, OnchainRefreshRpcChainConfig>,
     pub batch_size: usize,
     pub apply_batch_size: usize,
@@ -607,6 +608,13 @@ pub struct OnchainRefreshRuntimeConfig {
     pub max_concurrency: usize,
     pub multicall_batch_size: usize,
     pub current_power_method: ChainReadMethod,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OnchainRefreshScopeMode {
+    Global,
+    ConfiguredContractSets,
+    AllModeConfiguredContractSets,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -643,6 +651,7 @@ impl OnchainRefreshRuntimeConfig {
     }
 
     fn from_env_with_enabled(enabled: bool) -> Result<Self> {
+        let scope_mode = load_onchain_refresh_scope_mode()?;
         let rpc_chains = load_onchain_refresh_rpc_chains(enabled)?;
         let batch_size = onchain_refresh_batch_size_from_env()?;
         let apply_batch_size = onchain_refresh_apply_batch_size_from_env()?;
@@ -697,6 +706,7 @@ impl OnchainRefreshRuntimeConfig {
 
         Ok(Self {
             enabled,
+            scope_mode,
             rpc_chains,
             batch_size,
             apply_batch_size,
@@ -735,6 +745,55 @@ impl OnchainRefreshRuntimeConfig {
             retry_delay: self.retry_delay,
             lock_owner: format!("degov-onchain-refresh-worker:{}", std::process::id()),
         }
+    }
+
+    pub fn configured_task_scopes(
+        &self,
+        indexer_runtime: &IndexerRuntimeConfig,
+        config: &DatalensConfig,
+    ) -> Result<Vec<OnchainRefreshTaskScope>> {
+        if matches!(self.scope_mode, OnchainRefreshScopeMode::Global) {
+            return Ok(Vec::new());
+        }
+
+        indexer_runtime
+            .configured_contract_sets(config)?
+            .into_iter()
+            .map(|contract_set| {
+                Ok(OnchainRefreshTaskScope {
+                    chain_id: contract_set.contract.chain_id,
+                    contract_set_id: contract_set.contract_set_id,
+                    dao_code: contract_set.dao_code,
+                })
+            })
+            .collect()
+    }
+}
+
+fn load_onchain_refresh_scope_mode() -> Result<OnchainRefreshScopeMode> {
+    if let Some(value) = optional_env("DEGOV_ONCHAIN_REFRESH_SCOPE_MODE")? {
+        return parse_onchain_refresh_scope_mode(&value);
+    }
+
+    if optional_env("DEGOV_INDEXER_CONTRACT_SET_MODE")?
+        .as_deref()
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("all"))
+    {
+        return Ok(OnchainRefreshScopeMode::AllModeConfiguredContractSets);
+    }
+
+    Ok(OnchainRefreshScopeMode::Global)
+}
+
+fn parse_onchain_refresh_scope_mode(value: &str) -> Result<OnchainRefreshScopeMode> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "global" => Ok(OnchainRefreshScopeMode::Global),
+        "configured-contract-sets" | "configured_contract_sets" => {
+            Ok(OnchainRefreshScopeMode::ConfiguredContractSets)
+        }
+        _ => bail!(
+            "DEGOV_ONCHAIN_REFRESH_SCOPE_MODE must be one of global or configured-contract-sets"
+        ),
     }
 }
 

--- a/apps/indexer/src/store/postgres/mod.rs
+++ b/apps/indexer/src/store/postgres/mod.rs
@@ -9,5 +9,7 @@ pub use runner_store::{
     ProposalTitleRefreshUpdate, drain_deferred_onchain_refresh_tasks,
     drain_deferred_onchain_refresh_tasks_for_scope, read_proposal_reference_field_candidates,
     read_proposal_timestamp_backfill_candidates, read_proposal_title_refresh_candidates,
+    repair_missing_onchain_refresh_contributor_coverage,
+    repair_missing_onchain_refresh_contributor_coverage_for_scope,
     update_proposal_reference_fields, update_proposal_timestamp_backfill, update_proposal_titles,
 };

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -131,6 +131,138 @@ pub async fn drain_deferred_onchain_refresh_tasks_for_scope(
     drain_deferred_onchain_refresh_tasks_with_scope(pool, max_rows, Some(scope)).await
 }
 
+pub async fn repair_missing_onchain_refresh_contributor_coverage(
+    pool: &PgPool,
+    max_rows: usize,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    repair_missing_onchain_refresh_contributor_coverage_with_scope(pool, max_rows, None).await
+}
+
+pub async fn repair_missing_onchain_refresh_contributor_coverage_for_scope(
+    pool: &PgPool,
+    max_rows: usize,
+    scope: &crate::OnchainRefreshTaskScope,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    repair_missing_onchain_refresh_contributor_coverage_with_scope(pool, max_rows, Some(scope))
+        .await
+}
+
+async fn repair_missing_onchain_refresh_contributor_coverage_with_scope(
+    pool: &PgPool,
+    max_rows: usize,
+    scope: Option<&crate::OnchainRefreshTaskScope>,
+) -> Result<usize, PostgresIndexerRunnerStoreError> {
+    if max_rows == 0 {
+        return Ok(0);
+    }
+
+    let max_rows = i64::try_from(max_rows).map_err(|_| {
+        PostgresIndexerRunnerStoreError::new("contributor coverage repair batch size exceeds i64")
+    })?;
+    let now_ms = unix_time_millis();
+    let mut query = QueryBuilder::<Postgres>::new(
+        "WITH candidates AS (
+            SELECT contributor.contract_set_id,
+                   contributor.chain_id,
+                   COALESCE(contributor.dao_code, '') AS dao_code,
+                   contributor.governor_address,
+                   contributor.token_address,
+                   contributor.id AS account,
+                   contributor.block_number,
+                   contributor.block_timestamp,
+                   contributor.transaction_hash
+            FROM contributor
+            WHERE contributor.dao_code IS NOT NULL
+            AND NOT EXISTS (
+                SELECT 1
+                FROM degov_provisional_contributor_power_overlay overlay
+                WHERE overlay.contract_set_id = contributor.contract_set_id
+                  AND overlay.chain_id IS NOT DISTINCT FROM contributor.chain_id
+                  AND overlay.dao_code IS NOT DISTINCT FROM contributor.dao_code
+                  AND overlay.governor_address IS NOT DISTINCT FROM contributor.governor_address
+                  AND overlay.token_address IS NOT DISTINCT FROM contributor.token_address
+                  AND overlay.account = contributor.id
+                  AND overlay.source = 'live-onchain'
+                  AND overlay.status = 'available'
+                  AND overlay.power IS NOT NULL
+                  AND overlay.balance IS NOT NULL
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                FROM onchain_refresh_task task
+                WHERE task.contract_set_id = contributor.contract_set_id
+                  AND task.chain_id = contributor.chain_id
+                  AND task.dao_code IS NOT DISTINCT FROM contributor.dao_code
+                  AND task.governor_address = contributor.governor_address
+                  AND task.token_address = contributor.token_address
+                  AND task.account = contributor.id
+                  AND task.status IN ('pending', 'processing', 'failed')
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                FROM onchain_refresh_deferred_candidate deferred
+                WHERE deferred.contract_set_id = contributor.contract_set_id
+                  AND deferred.chain_id = contributor.chain_id
+                  AND deferred.dao_code IS NOT DISTINCT FROM contributor.dao_code
+                  AND deferred.governor_address = contributor.governor_address
+                  AND deferred.token_address = contributor.token_address
+                  AND deferred.account = contributor.id
+            )",
+    );
+    push_contributor_coverage_repair_scope_filter(&mut query, scope);
+    query
+        .push(
+            "
+            ORDER BY contributor.block_number ASC, contributor.id ASC
+            LIMIT ",
+        )
+        .push_bind(max_rows)
+        .push(
+            "
+        )
+        INSERT INTO onchain_refresh_deferred_candidate (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address, account,
+            refresh_balance, refresh_power, reason, first_seen_block_number,
+            last_seen_block_number, last_seen_block_timestamp, last_seen_transaction_hash,
+            next_run_at, created_at, updated_at
+        )
+        SELECT
+            candidates.contract_set_id || ':' || candidates.dao_code || ':' ||
+                candidates.chain_id::TEXT || ':' || candidates.governor_address || ':' ||
+                candidates.token_address || ':' || candidates.account,
+            candidates.contract_set_id,
+            candidates.chain_id,
+            candidates.dao_code,
+            candidates.governor_address,
+            candidates.token_address,
+            candidates.account,
+            TRUE,
+            TRUE,
+            'contributor-coverage',
+            candidates.block_number,
+            candidates.block_number,
+            candidates.block_timestamp,
+            candidates.transaction_hash,
+            0::NUMERIC(78, 0),
+            ",
+        )
+        .push_bind(now_ms.to_string())
+        .push(
+            "::NUMERIC(78, 0),
+            ",
+        )
+        .push_bind(now_ms.to_string())
+        .push(
+            "::NUMERIC(78, 0)
+        FROM candidates
+        ON CONFLICT ON CONSTRAINT onchain_refresh_deferred_candidate_account_unique DO NOTHING",
+        );
+
+    let result = query.build().execute(pool).await?;
+
+    Ok(result.rows_affected().try_into().unwrap_or_default())
+}
+
 async fn drain_deferred_onchain_refresh_tasks_with_scope(
     pool: &PgPool,
     max_rows: usize,
@@ -714,6 +846,21 @@ fn push_deferred_onchain_refresh_scope_filter<'args>(
             .push(" AND contract_set_id = ")
             .push_bind(&scope.contract_set_id)
             .push(" AND dao_code IS NOT DISTINCT FROM ")
+            .push_bind(&scope.dao_code);
+    }
+}
+
+fn push_contributor_coverage_repair_scope_filter<'args>(
+    query: &mut QueryBuilder<'args, Postgres>,
+    scope: Option<&'args crate::OnchainRefreshTaskScope>,
+) {
+    if let Some(scope) = scope {
+        query
+            .push(" AND contributor.chain_id = ")
+            .push_bind(scope.chain_id)
+            .push(" AND contributor.contract_set_id = ")
+            .push_bind(&scope.contract_set_id)
+            .push(" AND contributor.dao_code IS NOT DISTINCT FROM ")
             .push_bind(&scope.dao_code);
     }
 }

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -300,7 +300,10 @@ const UPSERT_PROPOSAL_SQL: &str = "INSERT INTO proposal (
              proposal_eta = COALESCE(EXCLUDED.proposal_eta, proposal.proposal_eta),
              queue_ready_at = COALESCE(EXCLUDED.queue_ready_at, proposal.queue_ready_at),
              queue_expires_at = COALESCE(EXCLUDED.queue_expires_at, proposal.queue_expires_at),
-             block_interval = COALESCE(EXCLUDED.block_interval, proposal.block_interval),
+             block_interval = CASE
+                 WHEN EXCLUDED.clock_mode <> 'blocknumber' THEN EXCLUDED.block_interval
+                 ELSE COALESCE(EXCLUDED.block_interval, proposal.block_interval)
+             END,
              clock_mode = EXCLUDED.clock_mode,
              quorum = CASE WHEN EXCLUDED.quorum = 0::NUMERIC(78, 0) THEN proposal.quorum ELSE EXCLUDED.quorum END,
              decimals = CASE WHEN EXCLUDED.decimals = 0::NUMERIC(78, 0) THEN proposal.decimals ELSE EXCLUDED.decimals END,
@@ -421,6 +424,7 @@ pub struct ProposalReferenceFieldCandidate {
     pub proposal_id: String,
     pub title: String,
     pub block_interval: Option<String>,
+    pub clock_mode: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -508,7 +512,7 @@ pub async fn read_proposal_reference_field_candidates(
     dao_code: &str,
 ) -> Result<Vec<ProposalReferenceFieldCandidate>, PostgresIndexerRunnerStoreError> {
     let rows = sqlx::query(
-        "SELECT id, proposal_id, title, block_interval
+        "SELECT id, proposal_id, title, block_interval, clock_mode
          FROM proposal
          WHERE dao_code = $1
          ORDER BY block_number, transaction_index, log_index, id",
@@ -524,6 +528,7 @@ pub async fn read_proposal_reference_field_candidates(
             proposal_id: row.get("proposal_id"),
             title: row.get("title"),
             block_interval: row.get("block_interval"),
+            clock_mode: row.get("clock_mode"),
         })
         .collect())
 }

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -4,9 +4,10 @@ use degov_datalens_indexer::{
     ContractSetConcurrencyLimit, DEFAULT_ONCHAIN_REFRESH_APPLY_BATCH_SIZE, DatalensConfig,
     DatalensProvisionalFinality, DatalensQueryConcurrencyConfig, GraphqlRuntimeConfig,
     IndexerContractSetMode, IndexerRuntimeConfig, IndexerTargetHeight,
-    MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE, OnchainRefreshRuntimeConfig, OnchainRefreshTickConfig,
-    ProposalTimestampBackfillConfig, ProvisionalRuntimeConfig, datalens_retry_config,
-    onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value,
+    MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE, OnchainRefreshRuntimeConfig, OnchainRefreshScopeMode,
+    OnchainRefreshTickConfig, ProposalTimestampBackfillConfig, ProvisionalRuntimeConfig,
+    datalens_retry_config, onchain_refresh_worker_enabled, parse_bool_env_value,
+    parse_i64_env_value,
 };
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -50,6 +51,63 @@ fn test_onchain_refresh_runtime_config_defaults_debounce() {
             assert_eq!(
                 config.worker_config().debounce,
                 Duration::from_millis(120_000)
+            );
+        },
+    );
+}
+
+#[test]
+fn test_onchain_refresh_runtime_config_defaults_global_scope() {
+    with_env_vars!(
+        [
+            ("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED", Some("false")),
+            ("DEGOV_ONCHAIN_REFRESH_SCOPE_MODE", None::<&str>),
+            ("DEGOV_INDEXER_CONTRACT_SET_MODE", None::<&str>),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(config.scope_mode, OnchainRefreshScopeMode::Global);
+        },
+    );
+}
+
+#[test]
+fn test_onchain_refresh_runtime_config_uses_all_mode_contract_set_scopes() {
+    with_env_vars!(
+        [
+            ("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED", Some("false")),
+            ("DEGOV_ONCHAIN_REFRESH_SCOPE_MODE", None::<&str>),
+            ("DEGOV_INDEXER_CONTRACT_SET_MODE", Some("all")),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(
+                config.scope_mode,
+                OnchainRefreshScopeMode::AllModeConfiguredContractSets
+            );
+        },
+    );
+}
+
+#[test]
+fn test_onchain_refresh_runtime_config_accepts_explicit_contract_set_scope_mode() {
+    with_env_vars!(
+        [
+            ("DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED", Some("false")),
+            (
+                "DEGOV_ONCHAIN_REFRESH_SCOPE_MODE",
+                Some("configured-contract-sets"),
+            ),
+            ("DEGOV_INDEXER_CONTRACT_SET_MODE", None::<&str>),
+        ],
+        || {
+            let config = OnchainRefreshRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(
+                config.scope_mode,
+                OnchainRefreshScopeMode::ConfiguredContractSets
             );
         },
     );

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -21,7 +21,10 @@ use degov_datalens_indexer::{
     PostgresProvisionalPowerOverlayStore, ProvisionalContributorPowerOverlayWrite,
     ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
     ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, refresh_live_power_overlays,
-    runtime::apply_migrations,
+    runtime::{
+        apply_migrations,
+        worker::{OnchainRefreshWorkerBatchScope, OnchainRefreshWorkerScopeSchedule},
+    },
 };
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
@@ -318,6 +321,67 @@ fn test_onchain_refresh_tick_failure_does_not_advance_schedule() {
         Some(OnchainRefreshTickSkipReason::EmptyQueue)
     );
     assert_eq!(retry_runner.calls, vec![10]);
+}
+
+#[test]
+fn test_onchain_refresh_worker_scope_schedule_uses_global_default_empty_stop() {
+    let mut schedule = OnchainRefreshWorkerScopeSchedule::new(Vec::new());
+
+    assert_eq!(
+        schedule.next_batch_scope(),
+        OnchainRefreshWorkerBatchScope::Global
+    );
+    assert!(!schedule.observe_batch_claimed(0));
+}
+
+#[test]
+fn test_onchain_refresh_worker_scope_schedule_round_robins_scopes_until_empty_cycle() {
+    let scopes = vec![
+        OnchainRefreshTaskScope {
+            chain_id: 1,
+            contract_set_id: "contract-set-a".to_owned(),
+            dao_code: "dao-a".to_owned(),
+        },
+        OnchainRefreshTaskScope {
+            chain_id: 1135,
+            contract_set_id: "contract-set-b".to_owned(),
+            dao_code: "dao-b".to_owned(),
+        },
+    ];
+    let mut schedule = OnchainRefreshWorkerScopeSchedule::new(scopes.clone());
+
+    assert_eq!(
+        schedule.next_batch_scope(),
+        OnchainRefreshWorkerBatchScope::Scoped(scopes[0].clone())
+    );
+    assert!(schedule.observe_batch_claimed(0));
+    assert_eq!(
+        schedule.next_batch_scope(),
+        OnchainRefreshWorkerBatchScope::Scoped(scopes[1].clone())
+    );
+    assert!(!schedule.observe_batch_claimed(0));
+
+    assert_eq!(
+        schedule.next_batch_scope(),
+        OnchainRefreshWorkerBatchScope::Scoped(scopes[0].clone())
+    );
+    assert!(schedule.observe_batch_claimed(0));
+    assert_eq!(
+        schedule.next_batch_scope(),
+        OnchainRefreshWorkerBatchScope::Scoped(scopes[1].clone())
+    );
+    assert!(!schedule.observe_batch_claimed(0));
+
+    assert_eq!(
+        schedule.next_batch_scope(),
+        OnchainRefreshWorkerBatchScope::Scoped(scopes[0].clone())
+    );
+    assert!(schedule.observe_batch_claimed(1));
+    assert_eq!(
+        schedule.next_batch_scope(),
+        OnchainRefreshWorkerBatchScope::Scoped(scopes[1].clone())
+    );
+    assert!(schedule.observe_batch_claimed(0));
 }
 
 #[tokio::test]
@@ -2324,6 +2388,70 @@ async fn test_onchain_refresh_worker_drains_deferred_tasks_to_claim_budget_in_sm
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_repairs_missing_contributor_coverage()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_contributor(&database.pool, ACCOUNT_ONE, "0", Some("0")).await?;
+
+    let task_id = format!("demo-dao:demo-dao:46:{GOVERNOR}:{TOKEN}:{ACCOUNT_ONE}");
+    seed_task(
+        &database.pool,
+        &task_id,
+        ACCOUNT_ONE,
+        "completed",
+        1,
+        true,
+        true,
+    )
+    .await?;
+    seed_contributor_overlay_with_balance(&database.pool, ACCOUNT_ONE, "9", None).await?;
+
+    let reader = MockOnchainRefreshReader::from_values(BTreeMap::from([(
+        task_id.clone(),
+        OnchainRefreshReadValue {
+            task_id: task_id.clone(),
+            balance: Some("17".to_owned()),
+            power: Some("11".to_owned()),
+            checkpoint_balance: Some("17".to_owned()),
+            checkpoint_power: Some("11".to_owned()),
+        },
+    )]));
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.claimed, 1);
+    assert_eq!(report.completed, 1);
+    assert_eq!(report.failed, 0);
+    assert_eq!(
+        contributor_values(&database.pool, ACCOUNT_ONE).await?,
+        ("11".to_owned(), Some("17".to_owned()))
+    );
+    assert_completed_task(&database.pool, &task_id, 1).await?;
+    assert_task_refresh_flags(&database.pool, &task_id, true, true).await?;
+    assert_contributor_overlay(&database.pool, ACCOUNT_ONE, "11").await?;
+    assert_contributor_overlay_balance(&database.pool, ACCOUNT_ONE, "17").await?;
+    assert_table_count(&database.pool, "onchain_refresh_deferred_candidate", 0).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_fails_only_missing_rpc_chain_group()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -2404,6 +2532,10 @@ impl MockOnchainRefreshReader {
                 .map(|(task_id, value)| (task_id.to_owned(), value))
                 .collect(),
         }
+    }
+
+    fn from_values(values: BTreeMap<String, OnchainRefreshReadValue>) -> Self {
+        Self { values }
     }
 }
 
@@ -3252,6 +3384,30 @@ async fn assert_task_status(
     Ok(())
 }
 
+async fn assert_task_refresh_flags(
+    pool: &PgPool,
+    task_id: &str,
+    expected_refresh_balance: bool,
+    expected_refresh_power: bool,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT refresh_balance, refresh_power
+         FROM onchain_refresh_task
+         WHERE id = $1",
+    )
+    .bind(task_id)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(
+        row.get::<bool, _>("refresh_balance"),
+        expected_refresh_balance
+    );
+    assert_eq!(row.get::<bool, _>("refresh_power"), expected_refresh_power);
+
+    Ok(())
+}
+
 async fn idle_transaction_count(_pool: &PgPool) -> Result<i64, sqlx::Error> {
     let database_url = env::var("DEGOV_INDEXER_TEST_DATABASE_URL").map_err(|error| {
         sqlx::Error::Configuration(
@@ -3536,6 +3692,58 @@ async fn assert_contributor_overlay_with_scope(
     assert_eq!(row.get::<String, _>("source"), "live-onchain");
     assert_eq!(row.get::<String, _>("status"), "available");
     assert_eq!(row.get::<String, _>("anchor_block_number"), "12");
+
+    Ok(())
+}
+
+async fn assert_contributor_overlay_balance(
+    pool: &PgPool,
+    account: &str,
+    balance: &str,
+) -> Result<(), sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT account, balance::TEXT AS balance
+         FROM degov_provisional_contributor_power_overlay
+         WHERE contract_set_id = 'demo-dao' AND account = $1",
+    )
+    .bind(account)
+    .fetch_one(pool)
+    .await?;
+
+    assert_eq!(row.get::<String, _>("account"), account);
+    assert_eq!(row.get::<String, _>("balance"), balance);
+
+    Ok(())
+}
+
+async fn seed_contributor_overlay_with_balance(
+    pool: &PgPool,
+    account: &str,
+    power: &str,
+    balance: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO degov_provisional_contributor_power_overlay (
+             id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+             account, power, balance, delegates_count_all, delegates_count_effective, source,
+             status, anchor_block_number, anchor_block_timestamp
+         )
+         VALUES (
+             $1, 'demo-dao', 46, 'demo-dao', $2, $3, $4, $5::NUMERIC(78, 0),
+             $6::NUMERIC(78, 0), 0, 0, 'live-onchain', 'available',
+             12::NUMERIC(78, 0), 12000::NUMERIC(78, 0)
+         )",
+    )
+    .bind(format!(
+        "live-onchain:demo-dao:46:{GOVERNOR}:{TOKEN}:{account}"
+    ))
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .bind(account)
+    .bind(power)
+    .bind(balance)
+    .execute(pool)
+    .await?;
 
     Ok(())
 }

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -1,10 +1,11 @@
 use degov_datalens_indexer::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadExecutionReport, ChainReadKey,
     ChainReadMethod, ChainReadResult, ChainReadValue, DecodedGovernorEvent,
-    GovernanceTokenStandard, NormalizedEvmLog, ProposalCreatedEvent, ProposalExtendedEvent,
-    ProposalIdEvent, ProposalProjectionContext, ProposalProjectionError, ProposalProjectionEvent,
-    ProposalProjectionRepository, ProposalQueuedEvent, ProposalStateWriteKind, ReadRequirement,
-    TimelockChangeEvent, project_proposal_events,
+    GovernanceTokenStandard, InMemoryProposalProjectionRepository, NormalizedEvmLog,
+    ProposalCreatedEvent, ProposalExtendedEvent, ProposalIdEvent, ProposalProjectionContext,
+    ProposalProjectionError, ProposalProjectionEvent, ProposalProjectionRepository,
+    ProposalQueuedEvent, ProposalStateWriteKind, ReadRequirement, TimelockChangeEvent,
+    project_proposal_events,
 };
 use serde_json::json;
 
@@ -273,6 +274,67 @@ fn test_project_proposal_created_uses_raw_log_id_and_timestamp_clock_enrichment(
         Some("1722633201000")
     );
     assert_eq!(active.end_block_timestamp.as_deref(), Some("1723238001000"));
+}
+
+#[test]
+fn test_project_proposal_created_clears_stub_block_interval_for_timestamp_clock() {
+    let mut repository = InMemoryProposalProjectionRepository::default();
+    let queued_batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: production_log(
+                "0003952206-5710e-000001",
+                3_952_206,
+                0,
+                1,
+                1_722_633_202_000,
+            ),
+            event: DecodedGovernorEvent::ProposalQueued(ProposalQueuedEvent {
+                proposal_id: "0xa26d54b01695a650afc589fdce860697298a329911503f71d6cb187cb297ffeb"
+                    .to_owned(),
+                eta_seconds: "1723239001".to_owned(),
+            }),
+        }],
+    )
+    .expect("projection succeeds");
+    repository.apply(&queued_batch).expect("apply queued batch");
+
+    let created_batch = project_proposal_events(
+        &context(),
+        vec![ProposalProjectionEvent {
+            log: production_log(
+                "0003952205-5710e-000000",
+                3_952_205,
+                0,
+                0,
+                1_722_633_201_000,
+            ),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "0xa26d54b01695a650afc589fdce860697298a329911503f71d6cb187cb297ffeb"
+                    .to_owned(),
+                proposer: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+                targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "1722633201".to_owned(),
+                vote_end: "1723238001".to_owned(),
+                description: "Production shaped proposal".to_owned(),
+            }),
+        }],
+    )
+    .expect("projection succeeds");
+    repository
+        .apply(&created_batch)
+        .expect("apply created batch");
+
+    let proposal = repository
+        .proposals()
+        .values()
+        .next()
+        .expect("stored proposal");
+    assert_eq!(proposal.clock_mode, "timestamp");
+    assert_eq!(proposal.block_interval, None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- clear stale block intervals for timestamp-clock proposals and keep reference-field refresh from restoring them
- repair missing or incomplete contributor live-onchain coverage, including old completed tasks with null balance overlays
- add scoped onchain refresh worker scheduling for all-mode runs so large DAO queues do not starve smaller scopes

## Validation
- cargo fmt -p degov-datalens-indexer
- cargo check -p degov-datalens-indexer
- cargo test -p degov-datalens-indexer --test cli_runtime_config
- cargo test -p degov-datalens-indexer --test proposal_projection
- cargo test -p degov-datalens-indexer runtime::proposal_reference_fields
- cargo test -p degov-datalens-indexer --test onchain_refresh_worker test_onchain_refresh_worker_scope_schedule -- --nocapture
- git diff --check

## Notes
- The DB-backed regression test test_onchain_refresh_worker_repairs_missing_contributor_coverage requires DEGOV_INDEXER_TEST_DATABASE_URL; this local environment does not have that test database configured.
- Current staging Lisk comparison before this deployment shows delegates aligned, proposal differences concentrated in clockMode/blockInterval, and 15 contributor rows with null balance overlays that this repair path should requeue and refill.