### PR TITLE
fix(indexer): refresh proposal clock mode from reference

### DIFF
--- a/apps/indexer/src/runtime/proposal_reference_fields.rs
+++ b/apps/indexer/src/runtime/proposal_reference_fields.rs
@@ -26,6 +26,7 @@ pub struct ProposalReferenceFieldsReport {
 pub struct ReferenceProposalFields {
     pub proposal_id: String,
     pub title: String,
+    pub clock_mode: String,
     pub block_interval: Option<String>,
 }
 
@@ -87,8 +88,11 @@ pub fn plan_proposal_reference_field_updates(
         .filter_map(|candidate| {
             let key = normalize_proposal_id(&candidate.proposal_id)?;
             let reference = reference_by_proposal_id.get(&key)?;
-            let block_interval = reference_block_interval(candidate, reference);
-            if candidate.title == reference.title && candidate.block_interval == block_interval {
+            let block_interval = reference_block_interval(reference);
+            if candidate.title == reference.title
+                && candidate.clock_mode == reference.clock_mode
+                && candidate.block_interval == block_interval
+            {
                 return None;
             }
 
@@ -96,18 +100,17 @@ pub fn plan_proposal_reference_field_updates(
                 id: candidate.id.clone(),
                 previous_title: candidate.title.clone(),
                 previous_block_interval: candidate.block_interval.clone(),
+                previous_clock_mode: candidate.clock_mode.clone(),
                 title: reference.title.clone(),
+                clock_mode: reference.clock_mode.clone(),
                 block_interval,
             })
         })
         .collect()
 }
 
-fn reference_block_interval(
-    candidate: &ProposalReferenceFieldCandidate,
-    reference: &ReferenceProposalFields,
-) -> Option<String> {
-    (candidate.clock_mode == "blocknumber")
+fn reference_block_interval(reference: &ReferenceProposalFields) -> Option<String> {
+    (reference.clock_mode == "blocknumber")
         .then(|| reference.block_interval.clone())
         .flatten()
 }
@@ -230,6 +233,7 @@ async fn fetch_reference_proposal_fields(endpoint: &str) -> Result<Vec<Reference
         proposals.extend(rows.into_iter().map(|row| ReferenceProposalFields {
             proposal_id: row.proposal_id,
             title: row.title,
+            clock_mode: row.clock_mode,
             block_interval: row.block_interval,
         }));
         if row_count < LIMIT as usize {
@@ -244,6 +248,7 @@ query ProposalReferenceFields($limit: Int!, $offset: Int!) {
   proposals(orderBy: [id_ASC], limit: $limit, offset: $offset) {
     proposalId
     title
+    clockMode
     blockInterval
   }
 }
@@ -277,8 +282,14 @@ struct ReferenceProposalRow {
     #[serde(rename = "proposalId")]
     proposal_id: String,
     title: String,
+    #[serde(rename = "clockMode", default = "default_reference_clock_mode")]
+    clock_mode: String,
     #[serde(rename = "blockInterval")]
     block_interval: Option<String>,
+}
+
+fn default_reference_clock_mode() -> String {
+    "blocknumber".to_owned()
 }
 
 #[cfg(test)]
@@ -321,11 +332,13 @@ mod tests {
                 ReferenceProposalFields {
                     proposal_id: "0x2a".to_owned(),
                     title: "reference title".to_owned(),
+                    clock_mode: "blocknumber".to_owned(),
                     block_interval: Some("13.333333333333334".to_owned()),
                 },
                 ReferenceProposalFields {
                     proposal_id: "0x07".to_owned(),
                     title: "same title".to_owned(),
+                    clock_mode: "blocknumber".to_owned(),
                     block_interval: None,
                 },
             ],
@@ -337,7 +350,9 @@ mod tests {
                 id: "proposal:1".to_owned(),
                 previous_title: "local title".to_owned(),
                 previous_block_interval: Some("12".to_owned()),
+                previous_clock_mode: "blocknumber".to_owned(),
                 title: "reference title".to_owned(),
+                clock_mode: "blocknumber".to_owned(),
                 block_interval: Some("13.333333333333334".to_owned()),
             }]
         );
@@ -356,6 +371,7 @@ mod tests {
             &[ReferenceProposalFields {
                 proposal_id: "0x2a".to_owned(),
                 title: "reference title".to_owned(),
+                clock_mode: "timestamp".to_owned(),
                 block_interval: Some("13.333333333333334".to_owned()),
             }],
         );
@@ -366,7 +382,41 @@ mod tests {
                 id: "proposal:1".to_owned(),
                 previous_title: "local title".to_owned(),
                 previous_block_interval: Some("12".to_owned()),
+                previous_clock_mode: "timestamp".to_owned(),
                 title: "reference title".to_owned(),
+                clock_mode: "timestamp".to_owned(),
+                block_interval: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_plan_proposal_reference_field_updates_repairs_clock_mode_from_reference() {
+        let updates = plan_proposal_reference_field_updates(
+            &[ProposalReferenceFieldCandidate {
+                id: "proposal:1".to_owned(),
+                proposal_id: "42".to_owned(),
+                title: "same title".to_owned(),
+                block_interval: None,
+                clock_mode: "blocknumber".to_owned(),
+            }],
+            &[ReferenceProposalFields {
+                proposal_id: "0x2a".to_owned(),
+                title: "same title".to_owned(),
+                clock_mode: "timestamp".to_owned(),
+                block_interval: Some("13.333333333333334".to_owned()),
+            }],
+        );
+
+        assert_eq!(
+            updates,
+            vec![ProposalReferenceFieldUpdate {
+                id: "proposal:1".to_owned(),
+                previous_title: "same title".to_owned(),
+                previous_block_interval: None,
+                previous_clock_mode: "blocknumber".to_owned(),
+                title: "same title".to_owned(),
+                clock_mode: "timestamp".to_owned(),
                 block_interval: None,
             }]
         );

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -432,7 +432,9 @@ pub struct ProposalReferenceFieldUpdate {
     pub id: String,
     pub previous_title: String,
     pub previous_block_interval: Option<String>,
+    pub previous_clock_mode: String,
     pub title: String,
+    pub clock_mode: String,
     pub block_interval: Option<String>,
 }
 
@@ -535,7 +537,8 @@ pub async fn read_proposal_reference_field_candidates(
 
 const UPDATE_PROPOSAL_REFERENCE_FIELDS_SQL_PREFIX: &str =
     "UPDATE proposal SET title = proposal_reference_fields.title,
-         block_interval = proposal_reference_fields.block_interval
+         block_interval = proposal_reference_fields.block_interval,
+         clock_mode = proposal_reference_fields.clock_mode
      FROM (";
 const UPDATE_PROPOSAL_REFERENCE_FIELDS_CHUNK_SIZE: usize = 5_000;
 
@@ -567,22 +570,27 @@ async fn update_proposal_reference_field_chunk(
         row.push_bind(&update.id)
             .push_bind(&update.previous_title)
             .push_bind(&update.previous_block_interval)
+            .push_bind(&update.previous_clock_mode)
             .push_bind(&update.title)
+            .push_bind(&update.clock_mode)
             .push_bind(&update.block_interval);
     });
     builder.push(
         ") AS proposal_reference_fields(
-            id, previous_title, previous_block_interval, title, block_interval
+            id, previous_title, previous_block_interval, previous_clock_mode,
+            title, clock_mode, block_interval
          )
          WHERE proposal.id = proposal_reference_fields.id
            AND proposal.title = proposal_reference_fields.previous_title
            AND proposal.block_interval IS NOT DISTINCT FROM proposal_reference_fields.previous_block_interval
+           AND proposal.clock_mode = proposal_reference_fields.previous_clock_mode
            AND proposal.dao_code = ",
     );
     builder.push_bind(dao_code);
     builder.push(
         " AND (
             proposal.title IS DISTINCT FROM proposal_reference_fields.title
+            OR proposal.clock_mode IS DISTINCT FROM proposal_reference_fields.clock_mode
             OR proposal.block_interval IS DISTINCT FROM proposal_reference_fields.block_interval
          )",
     );


### PR DESCRIPTION
## Summary
- include `clockMode` when fetching reference proposal fields
- repair local proposal `clock_mode` together with title/blockInterval
- use the reference clock mode when deciding whether blockInterval should be retained

## Verification
- cargo fmt -p degov-datalens-indexer --check
- cargo test -p degov-datalens-indexer runtime::proposal_reference_fields
- cargo check -p degov-datalens-indexer
- git diff --check

## Context
Lisk v5 historical proposals already stored under the old logic kept `clockMode=blocknumber` even though the reference production indexer reports timestamp-clock proposals. This lets the reference refresh command repair existing rows without a full resync.
