### PR TITLE
perf(indexer): use indexable onchain refresh scope filters

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -1330,7 +1330,7 @@ fn push_onchain_refresh_scope_filter<'args>(
             .push_bind(scope.chain_id)
             .push(" AND contract_set_id = ")
             .push_bind(&scope.contract_set_id)
-            .push(" AND dao_code IS NOT DISTINCT FROM ")
+            .push(" AND dao_code = ")
             .push_bind(&scope.dao_code);
     }
 }
@@ -4564,6 +4564,24 @@ mod tests {
         assert!(sql.contains("OFFSET 0"));
         assert!(!sql.contains("from_delegate = ANY"));
         assert!(!sql.contains("IS NOT DISTINCT FROM"));
+    }
+
+    #[test]
+    fn test_onchain_refresh_scope_filter_uses_indexable_dao_code_equality() {
+        let scope = OnchainRefreshTaskScope {
+            chain_id: 1,
+            contract_set_id: "contract-set".to_owned(),
+            dao_code: "dao".to_owned(),
+        };
+        let mut query = QueryBuilder::<Postgres>::new("SELECT 1 WHERE true");
+
+        push_onchain_refresh_scope_filter(&mut query, Some(&scope));
+        let sql = query.sql();
+
+        assert!(sql.contains("chain_id = "));
+        assert!(sql.contains("contract_set_id = "));
+        assert!(sql.contains("dao_code = "));
+        assert!(!sql.contains("dao_code IS NOT DISTINCT FROM"));
     }
 
     #[test]

--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -845,7 +845,7 @@ fn push_deferred_onchain_refresh_scope_filter<'args>(
             .push_bind(scope.chain_id)
             .push(" AND contract_set_id = ")
             .push_bind(&scope.contract_set_id)
-            .push(" AND dao_code IS NOT DISTINCT FROM ")
+            .push(" AND dao_code = ")
             .push_bind(&scope.dao_code);
     }
 }
@@ -860,7 +860,7 @@ fn push_contributor_coverage_repair_scope_filter<'args>(
             .push_bind(scope.chain_id)
             .push(" AND contributor.contract_set_id = ")
             .push_bind(&scope.contract_set_id)
-            .push(" AND contributor.dao_code IS NOT DISTINCT FROM ")
+            .push(" AND contributor.dao_code = ")
             .push_bind(&scope.dao_code);
     }
 }
@@ -923,6 +923,27 @@ mod tests {
         let deduped = dedupe_onchain_refresh_tasks(&rows);
 
         assert_eq!(deduped.len(), rows.len());
+    }
+
+    #[test]
+    fn test_deferred_scope_filters_use_indexable_dao_code_equality() {
+        let scope = crate::OnchainRefreshTaskScope {
+            chain_id: 1,
+            contract_set_id: "contract-set".to_owned(),
+            dao_code: "demo-dao".to_owned(),
+        };
+        let mut deferred_query = QueryBuilder::<Postgres>::new("SELECT 1 WHERE true");
+        let mut repair_query = QueryBuilder::<Postgres>::new("SELECT 1 WHERE true");
+
+        push_deferred_onchain_refresh_scope_filter(&mut deferred_query, Some(&scope));
+        push_contributor_coverage_repair_scope_filter(&mut repair_query, Some(&scope));
+
+        let deferred_sql = deferred_query.sql();
+        let repair_sql = repair_query.sql();
+        assert!(deferred_sql.contains("dao_code = "));
+        assert!(!deferred_sql.contains("dao_code IS NOT DISTINCT FROM"));
+        assert!(repair_sql.contains("contributor.dao_code = "));
+        assert!(!repair_sql.contains("contributor.dao_code IS NOT DISTINCT FROM"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Use regular equality for scoped onchain refresh DAO filters so Postgres can use the existing scope queue indexes.
- Apply the same scoped equality to deferred candidate drain and contributor coverage repair queries.
- Add SQL-shape regression tests to keep these filters indexable.

## Why
Staging showed scoped deferred drains using null-safe DAO comparisons, which made Postgres choose the account uniqueness index and then sort/filter many rows. For one active scope this was around 10s per 100-row drain. With regular DAO equality, Postgres uses the existing scope drain index; the same sampled query dropped to about 1.3s, and task claim was about 0.2s.

## Tests
- cargo fmt --manifest-path /code/helixbox/degov/Cargo.toml
- cargo test --manifest-path /code/helixbox/degov/Cargo.toml -p degov-datalens-indexer onchain_refresh_scope_filter -- --nocapture
- cargo test --manifest-path /code/helixbox/degov/Cargo.toml -p degov-datalens-indexer deferred_scope_filters -- --nocapture
- cargo test --manifest-path /code/helixbox/degov/Cargo.toml -p degov-datalens-indexer onchain_refresh --lib
