### PR TITLE
fix(indexer): preserve data metric member count

### DIFF
--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -252,7 +252,7 @@ pub(super) async fn query_data_metrics(
           power_sum::text AS power_sum,
           COALESCE(contributor_count, member_count) AS contributor_count,
           COALESCE(holders_count, member_count) AS holders_count,
-          COALESCE(holders_count, member_count) AS member_count
+          COALESCE(member_count, holders_count, contributor_count) AS member_count
         FROM data_metric
         "#,
     );

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -3986,20 +3986,14 @@ async fn refresh_data_metric_scope(
                     ELSE count(*)
                 END
             )::INTEGER,
-            (
-                CASE
-                    WHEN count(balance) > 0 THEN count(*) FILTER (WHERE balance > 0)
-                    ELSE count(*)
-                END
-            )::INTEGER
+            count(*)::INTEGER
          FROM contributor
          WHERE contract_set_id = $2 AND chain_id = $3 AND governor_address = $5 AND dao_code IS NOT DISTINCT FROM $4
          ON CONFLICT ON CONSTRAINT data_metric_scope_unique DO UPDATE
          SET token_address = COALESCE(data_metric.token_address, EXCLUDED.token_address),
              power_sum = EXCLUDED.power_sum,
              contributor_count = EXCLUDED.contributor_count,
-             holders_count = EXCLUDED.holders_count,
-             member_count = EXCLUDED.member_count",
+             holders_count = EXCLUDED.holders_count",
     )
     .bind(metric_id)
     .bind(&scope.contract_set_id)

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -1604,12 +1604,14 @@ async fn increment_contributor_count_by(
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
     sqlx::query(
         "INSERT INTO data_metric (
-            id, contract_set_id, chain_id, dao_code, governor_address, token_address, contributor_count
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            contributor_count, member_count
          )
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
          ON CONFLICT ON CONSTRAINT data_metric_scope_unique DO UPDATE
          SET token_address = COALESCE(data_metric.token_address, EXCLUDED.token_address),
-             contributor_count = COALESCE(data_metric.contributor_count, 0) + EXCLUDED.contributor_count",
+             contributor_count = COALESCE(data_metric.contributor_count, 0) + EXCLUDED.contributor_count,
+             member_count = COALESCE(data_metric.member_count, 0) + EXCLUDED.member_count",
     )
     .bind(data_metric_id(
         common.chain_id,

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -262,7 +262,7 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
     assert_eq!(data["dataMetrics"][0]["powerSum"], "150");
     assert_eq!(data["dataMetrics"][0]["contributorCount"], 3);
     assert_eq!(data["dataMetrics"][0]["holdersCount"], 2);
-    assert_eq!(data["dataMetrics"][0]["memberCount"], 2);
+    assert_eq!(data["dataMetrics"][0]["memberCount"], 9);
     assert_eq!(data["dataMetricsPage"]["totalCount"], 1);
     assert_eq!(data["dataMetricsPage"]["offset"], 2);
     assert_eq!(data["dataMetricsPage"]["limit"], 0);
@@ -478,7 +478,7 @@ async fn test_graphql_data_metrics_parity_fields_filters_and_ordering() -> Resul
     assert_eq!(data["globalMetric"][0]["powerSum"], "150");
     assert_eq!(data["globalMetric"][0]["contributorCount"], 3);
     assert_eq!(data["globalMetric"][0]["holdersCount"], 2);
-    assert_eq!(data["globalMetric"][0]["memberCount"], 2);
+    assert_eq!(data["globalMetric"][0]["memberCount"], 9);
 
     database.cleanup().await?;
 
@@ -1530,9 +1530,9 @@ async fn seed_rows(pool: &PgPool) -> Result<(), sqlx::Error> {
           votes_without_params_count, votes_weight_for_sum, votes_weight_against_sum,
           votes_weight_abstain_sum, power_sum, contributor_count, holders_count, member_count, proposals_count
         ) VALUES
-          ('global', $1, 1135, 'lisk-dao', '0xgovernor', 2, 1, 1, 100, 25, 0, 150, 3, 2, 2, 2),
-          ('0000000800-proposal', $1, 1135, 'lisk-dao', '0xgovernor', 0, 0, 0, 0, 0, 0, 150, 3, 2, 2, 1),
-          ('0000000805-vote', $1, 1135, 'lisk-dao', '0xgovernor', 1, 0, 1, 100, 0, 0, 150, 3, 2, 2, 0)
+          ('global', $1, 1135, 'lisk-dao', '0xgovernor', 2, 1, 1, 100, 25, 0, 150, 3, 2, 9, 2),
+          ('0000000800-proposal', $1, 1135, 'lisk-dao', '0xgovernor', 0, 0, 0, 0, 0, 0, 150, 3, 2, 9, 1),
+          ('0000000805-vote', $1, 1135, 'lisk-dao', '0xgovernor', 1, 0, 1, 100, 0, 0, 150, 3, 2, 9, 0)
         "#,
     )
     .bind(CONTRACT_SET_ID)

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -472,7 +472,7 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
         Some("0"),
     )
     .await?;
-    seed_data_metric(&database.pool, "7").await?;
+    seed_data_metric_with_scope(&database.pool, "demo-dao", "7", 7, 7).await?;
     seed_final_delegate_with_scope(
         &database.pool,
         "demo-dao",
@@ -561,7 +561,7 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     );
     assert_completed_task(&database.pool, "task-one", 1).await?;
     assert_completed_task(&database.pool, "task-two", 2).await?;
-    assert_data_metric_counts(&database.pool, "16", 3, 1, 1, 7).await?;
+    assert_data_metric_counts(&database.pool, "16", 3, 1, 7, 7).await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_ONE, "3", "11", "8").await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_TWO, "0", "5", "5").await?;
     assert_balance_checkpoint(&database.pool, ACCOUNT_ONE, "4", "17", "13").await?;
@@ -1827,11 +1827,11 @@ async fn test_onchain_refresh_worker_updates_only_matching_contract_set_contribu
     );
     assert_eq!(
         data_metric_values_by_scope(&database.pool, SCOPE_ONE).await?,
-        ("11".to_owned(), 1)
+        ("11".to_owned(), Some(1))
     );
     assert_eq!(
         data_metric_values_by_scope(&database.pool, SCOPE_TWO).await?,
-        ("31".to_owned(), 1)
+        ("31".to_owned(), Some(1))
     );
     assert_table_count(&database.pool, "contributor", 2).await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_ONE, "3", "11", "8").await?;
@@ -3284,7 +3284,7 @@ async fn assert_contributor_delegate_counts(
 async fn data_metric_values_by_scope(
     pool: &PgPool,
     contract_set_id: &str,
-) -> Result<(String, i32), sqlx::Error> {
+) -> Result<(String, Option<i32>), sqlx::Error> {
     let row = sqlx::query(
         "SELECT power_sum::TEXT AS power_sum, member_count
          FROM data_metric
@@ -3296,7 +3296,7 @@ async fn data_metric_values_by_scope(
 
     Ok((
         row.get::<String, _>("power_sum"),
-        row.get::<i32, _>("member_count"),
+        row.get::<Option<i32>, _>("member_count"),
     ))
 }
 

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -997,7 +997,7 @@ async fn test_postgres_data_metric_event_snapshots_follow_mixed_batch_event_orde
     );
     assert_eq!(metric.get::<Option<i32>, _>("contributor_count"), Some(1));
     assert_eq!(metric.get::<Option<i32>, _>("holders_count"), Some(0));
-    assert_eq!(metric.get::<Option<i32>, _>("member_count"), Some(0));
+    assert_eq!(metric.get::<Option<i32>, _>("member_count"), Some(1));
 
     database.cleanup().await?;
 
@@ -1568,7 +1568,7 @@ async fn test_postgres_token_repeated_delegate_ensure_keeps_contributor_count_on
     .await?;
     assert_eq!(counts.get::<Option<i32>, _>("contributor_count"), Some(1));
     assert_eq!(counts.get::<Option<i32>, _>("holders_count"), None);
-    assert_eq!(counts.get::<Option<i32>, _>("member_count"), None);
+    assert_eq!(counts.get::<Option<i32>, _>("member_count"), Some(1));
 
     database.cleanup().await?;
 
@@ -1637,7 +1637,7 @@ async fn test_postgres_token_dense_delegate_count_deltas_are_batched() -> Result
     .await?;
     assert_eq!(counts.get::<Option<i32>, _>("contributor_count"), Some(1));
     assert_eq!(counts.get::<Option<i32>, _>("holders_count"), None);
-    assert_eq!(counts.get::<Option<i32>, _>("member_count"), None);
+    assert_eq!(counts.get::<Option<i32>, _>("member_count"), Some(1));
 
     database.cleanup().await?;
 
@@ -1845,7 +1845,7 @@ async fn test_postgres_token_preload_does_not_advance_contributor_count_before_t
         global_counts.get::<Option<i32>, _>("holders_count"),
         Some(2)
     );
-    assert_eq!(global_counts.get::<Option<i32>, _>("member_count"), Some(2));
+    assert_eq!(global_counts.get::<Option<i32>, _>("member_count"), Some(3));
 
     database.cleanup().await?;
 


### PR DESCRIPTION
## Summary
- Return GraphQL `dataMetrics.memberCount` from the stored legacy `member_count` value before falling back to split count columns
- Keep token projection writing legacy `member_count` when it writes the newer `contributor_count`, so resynced timelines preserve v4 semantics
- Stop onchain refresh from overwriting `data_metric.member_count` when refreshing `power_sum`, `contributor_count`, and `holders_count`
- Update regression coverage so split holder/contributor counts do not collapse the legacy member count

## Why
Lisk v5 data comparison showed `memberCount` had drifted from the existing production/v4 value. The split-count change moved token timeline increments to `contributor_count`, GraphQL mapped `memberCount` to holders, and onchain refresh rewrote global `member_count` with holder-count semantics. This patch preserves the old `member_count` contract while keeping the newer split fields.

Existing overwritten staging rows still need repair or resync after this lands. A resync is preferred for affected DAOs because non-global v5 `data_metric` ids differ from v4 ids, so copying by id is not a safe timeline repair.

## Verification
- `cargo fmt --manifest-path /code/helixbox/degov/Cargo.toml --check`
- `cargo test --manifest-path /code/helixbox/degov/Cargo.toml -p degov-datalens-indexer onchain_refresh --lib`
- `cargo test --manifest-path /code/helixbox/degov/Cargo.toml -p degov-datalens-indexer graphql --lib`
- `cargo test --manifest-path /code/helixbox/degov/Cargo.toml -p degov-datalens-indexer --test graphql_service --no-run`
- `cargo test --manifest-path /code/helixbox/degov/Cargo.toml -p degov-datalens-indexer --test onchain_refresh_worker --no-run`
- `cargo test --manifest-path /code/helixbox/degov/Cargo.toml -p degov-datalens-indexer --test postgres_runtime_run test_postgres_token_repeated_delegate_ensure_keeps_contributor_count_once --no-run`
- `git diff --check`

Note: DB-backed integration tests require `DEGOV_INDEXER_TEST_DATABASE_URL`, so I compiled them locally with `--no-run` and left execution to CI/test environments with a configured database.
