### PR TITLE
fix(indexer): retry onchain block-not-found reads

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -3029,13 +3029,16 @@ fn should_try_latest_block_fallback_after_error(message: &str) -> bool {
 
 fn should_try_direct_fallback_after_multicall_error(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
-    message.contains("out of gas") || message.contains("block not found")
+    message.contains("out of gas")
+        || message.contains("block not found")
+        || message.contains("header not found")
 }
 
 fn should_retry_multicall_direct_fallback_error(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
     message.contains("error sending request")
         || message.contains("block not found")
+        || message.contains("header not found")
         || message.contains("timed out")
         || message.contains("timeout")
         || message.contains("transport")
@@ -4975,6 +4978,14 @@ mod tests {
     #[test]
     fn test_onchain_refresh_retries_block_not_found_reads_immediately() {
         let error = "block not found: 25381885";
+
+        assert!(should_try_direct_fallback_after_multicall_error(error));
+        assert!(should_retry_multicall_direct_fallback_error(error));
+    }
+
+    #[test]
+    fn test_onchain_refresh_retries_header_not_found_reads_immediately() {
+        let error = "header not found";
 
         assert!(should_try_direct_fallback_after_multicall_error(error));
         assert!(should_retry_multicall_direct_fallback_error(error));

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -3028,12 +3028,14 @@ fn should_try_latest_block_fallback_after_error(message: &str) -> bool {
 }
 
 fn should_try_direct_fallback_after_multicall_error(message: &str) -> bool {
-    message.to_ascii_lowercase().contains("out of gas")
+    let message = message.to_ascii_lowercase();
+    message.contains("out of gas") || message.contains("block not found")
 }
 
 fn should_retry_multicall_direct_fallback_error(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
     message.contains("error sending request")
+        || message.contains("block not found")
         || message.contains("timed out")
         || message.contains("timeout")
         || message.contains("transport")
@@ -4968,6 +4970,14 @@ mod tests {
         assert!(is_retryable_onchain_refresh_task_error(error));
         assert_eq!(onchain_refresh_failure_status(error, 3, 3), "failed");
         assert_eq!(onchain_refresh_failure_attempts(error, 3, 3), 2);
+    }
+
+    #[test]
+    fn test_onchain_refresh_retries_block_not_found_reads_immediately() {
+        let error = "block not found: 25381885";
+
+        assert!(should_try_direct_fallback_after_multicall_error(error));
+        assert!(should_retry_multicall_direct_fallback_error(error));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat `block not found` and `header not found` multicall errors as eligible for direct fallback
- retry direct fallback reads when providers report transient block/header gaps near the head
- add regression tests for immediate block-not-found and header-not-found retry classification

## Context
Staging onchain refresh batches for ENS/Compound/Ark are seeing transient provider head gaps. `block not found` and `header not found` are already provider timing issues rather than permanent contract incompatibilities, but the read layer did not immediately fallback/retry all of them, so a single head race could mark many tasks failed and burn worker capacity.

## Verification
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer onchain_refresh_retries_header_not_found_reads_immediately --lib -- --nocapture`
- `cargo test -p degov-datalens-indexer onchain_refresh_retries_block_not_found_reads_immediately --lib -- --nocapture`
- `cargo test -p degov-datalens-indexer --lib onchain_refresh -- --nocapture`

Note: DB-backed tests requiring `DEGOV_INDEXER_TEST_DATABASE_URL` were not runnable in this local environment.
