### PR TITLE
perf(indexer): add scoped onchain refresh indexes

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -175,6 +175,17 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .context("ensure pending onchain refresh ready claim index")?;
 
     sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_pending_scope_claim_idx
+         ON onchain_refresh_task (
+            chain_id, contract_set_id, dao_code, next_run_at, updated_at, id
+         )
+         WHERE status = 'pending'",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure scoped pending onchain refresh claim index")?;
+
+    sqlx::query(
         "CREATE INDEX IF NOT EXISTS onchain_refresh_task_scope_claim_queue_idx
          ON onchain_refresh_task (
             chain_id, contract_set_id, dao_code, status, next_run_at, updated_at, id
@@ -221,6 +232,18 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .context("ensure failed onchain refresh ready status retry index")?;
 
     sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_failed_scope_retry_idx
+         ON onchain_refresh_task (
+            chain_id, contract_set_id, dao_code, next_run_at, updated_at, id
+         )
+         INCLUDE (attempts)
+         WHERE status = 'failed' AND attempts < 3",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure scoped failed onchain refresh retry index")?;
+
+    sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_processing_retry_idx
          ON onchain_refresh_task (next_run_at, updated_at, id)
          INCLUDE (locked_at, attempts)
@@ -238,6 +261,18 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .execute(&mut *connection)
     .await
     .context("ensure processing onchain refresh lock retry index")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_processing_scope_retry_idx
+         ON onchain_refresh_task (
+            chain_id, contract_set_id, dao_code, next_run_at, updated_at, id
+         )
+         INCLUDE (locked_at, attempts)
+         WHERE status = 'processing' AND locked_at IS NOT NULL",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure scoped processing onchain refresh retry index")?;
 
     sqlx::query(
         "CREATE INDEX IF NOT EXISTS onchain_refresh_deferred_candidate_scope_drain_idx
@@ -336,6 +371,16 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .execute(&mut *connection)
     .await
     .context("ensure contributor data metric scope index")?;
+
+    sqlx::query(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS contributor_onchain_refresh_coverage_scope_idx
+         ON contributor (chain_id, contract_set_id, dao_code, block_number, id)
+         INCLUDE (governor_address, token_address, block_timestamp, transaction_hash)
+         WHERE dao_code IS NOT NULL",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("ensure contributor onchain refresh coverage index")?;
 
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS onchain_refresh_data_metric_task (
@@ -529,6 +574,13 @@ async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnecti
     drop_invalid_runtime_index(connection, "onchain_refresh_task_processing_retry_idx").await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_processing_lock_retry_idx")
         .await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_pending_scope_claim_idx").await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_scope_retry_idx").await?;
+    drop_invalid_runtime_index(
+        connection,
+        "onchain_refresh_task_processing_scope_retry_idx",
+    )
+    .await?;
     drop_invalid_runtime_index(connection, "delegate_rolling_metadata_preload_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_current_from_scope_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_current_power_refresh_idx").await?;
@@ -536,6 +588,8 @@ async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnecti
     drop_invalid_runtime_index(connection, "delegate_mapping_effective_count_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_mapping_positive_count_idx").await?;
     drop_invalid_runtime_index(connection, "contributor_data_metric_scope_idx").await?;
+    drop_invalid_runtime_index(connection, "contributor_onchain_refresh_coverage_scope_idx")
+        .await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_data_metric_task_ready_idx").await?;
     drop_invalid_runtime_index(connection, "contributor_graphql_scope_power_idx").await?;
     drop_invalid_runtime_index(connection, "provisional_contributor_live_scope_power_idx").await?;

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -190,6 +190,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "contributor_onchain_refresh_coverage_scope_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "onchain_refresh_data_metric_task_ready_idx",
     )
     .await?;
@@ -221,6 +227,22 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
         &database.pool,
         &database.schema,
         "onchain_refresh_task_pending_ready_claim_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_pending_scope_claim_idx",
+    )
+    .await?;
+    assert_index_definition_contains(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_pending_scope_claim_idx",
+        &[
+            "USING btree (chain_id, contract_set_id, dao_code, next_run_at, updated_at, id)",
+            "WHERE (status = 'pending'::text)",
+        ],
     )
     .await?;
     assert_index_definition_contains(
@@ -255,6 +277,18 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
         &database.pool,
         &database.schema,
         "onchain_refresh_task_processing_lock_retry_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_failed_scope_retry_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_processing_scope_retry_idx",
     )
     .await?;
     assert_index_exists(
@@ -440,6 +474,10 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("repair_delegate_effective_counts_once"));
     assert!(runtime_migration.contains("onchain_refresh_data_metric_task"));
     assert!(runtime_migration.contains("onchain_refresh_task_pending_ready_claim_idx"));
+    assert!(runtime_migration.contains("onchain_refresh_task_pending_scope_claim_idx"));
+    assert!(runtime_migration.contains("onchain_refresh_task_failed_scope_retry_idx"));
+    assert!(runtime_migration.contains("onchain_refresh_task_processing_scope_retry_idx"));
+    assert!(runtime_migration.contains("contributor_onchain_refresh_coverage_scope_idx"));
     assert!(runtime_migration.contains("ON onchain_refresh_task (next_run_at, updated_at, id)"));
     assert!(runtime_migration.contains("WHERE status = 'pending'"));
     assert!(


### PR DESCRIPTION
## Summary
- add scoped partial indexes for pending/failed/processing onchain refresh claim and backlog paths
- add a contributor coverage scan index for scoped onchain refresh repair
- register the new runtime indexes in invalid-index repair and migration schema assertions

## Context
Staging onchain refresh logs show slow SQL around scoped task claim/backlog queries and contributor coverage repair. The slow paths filter by `chain_id`, `contract_set_id`, and `dao_code`, then order by `next_run_at`, `updated_at`, and `id`, but the existing hot indexes are mostly global or status-wide. These indexes keep the same runtime-index pattern used by the indexer and avoid changing worker behavior.

## Verification
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --test migration_schema -- --nocapture` *(static tests passed; DB-backed tests require `DEGOV_INDEXER_TEST_DATABASE_URL` and failed locally because it is not set)*
