### PR TITLE
fix(indexer): repair proposal counting mode from reference

### DIFF
--- a/apps/indexer/src/runtime/proposal_reference_fields.rs
+++ b/apps/indexer/src/runtime/proposal_reference_fields.rs
@@ -28,6 +28,7 @@ pub struct ReferenceProposalFields {
     pub title: String,
     pub clock_mode: String,
     pub block_interval: Option<String>,
+    pub counting_mode: Option<String>,
 }
 
 pub async fn refresh_proposal_reference_fields(
@@ -92,6 +93,7 @@ pub fn plan_proposal_reference_field_updates(
             if candidate.title == reference.title
                 && candidate.clock_mode == reference.clock_mode
                 && candidate.block_interval == block_interval
+                && candidate.counting_mode == reference.counting_mode
             {
                 return None;
             }
@@ -101,9 +103,11 @@ pub fn plan_proposal_reference_field_updates(
                 previous_title: candidate.title.clone(),
                 previous_block_interval: candidate.block_interval.clone(),
                 previous_clock_mode: candidate.clock_mode.clone(),
+                previous_counting_mode: candidate.counting_mode.clone(),
                 title: reference.title.clone(),
                 clock_mode: reference.clock_mode.clone(),
                 block_interval,
+                counting_mode: reference.counting_mode.clone(),
             })
         })
         .collect()
@@ -235,6 +239,7 @@ async fn fetch_reference_proposal_fields(endpoint: &str) -> Result<Vec<Reference
             title: row.title,
             clock_mode: row.clock_mode,
             block_interval: row.block_interval,
+            counting_mode: row.counting_mode,
         }));
         if row_count < LIMIT as usize {
             return Ok(proposals);
@@ -250,6 +255,7 @@ query ProposalReferenceFields($limit: Int!, $offset: Int!) {
     title
     clockMode
     blockInterval
+    countingMode
   }
 }
 "#;
@@ -286,6 +292,8 @@ struct ReferenceProposalRow {
     clock_mode: String,
     #[serde(rename = "blockInterval")]
     block_interval: Option<String>,
+    #[serde(rename = "countingMode")]
+    counting_mode: Option<String>,
 }
 
 fn default_reference_clock_mode() -> String {
@@ -319,6 +327,7 @@ mod tests {
                     title: "local title".to_owned(),
                     block_interval: Some("12".to_owned()),
                     clock_mode: "blocknumber".to_owned(),
+                    counting_mode: None,
                 },
                 ProposalReferenceFieldCandidate {
                     id: "proposal:2".to_owned(),
@@ -326,6 +335,7 @@ mod tests {
                     title: "same title".to_owned(),
                     block_interval: None,
                     clock_mode: "blocknumber".to_owned(),
+                    counting_mode: Some("support=bravo&quorum=for,abstain".to_owned()),
                 },
             ],
             &[
@@ -334,12 +344,14 @@ mod tests {
                     title: "reference title".to_owned(),
                     clock_mode: "blocknumber".to_owned(),
                     block_interval: Some("13.333333333333334".to_owned()),
+                    counting_mode: Some("support=bravo&quorum=for,abstain".to_owned()),
                 },
                 ReferenceProposalFields {
                     proposal_id: "0x07".to_owned(),
                     title: "same title".to_owned(),
                     clock_mode: "blocknumber".to_owned(),
                     block_interval: None,
+                    counting_mode: Some("support=bravo&quorum=for,abstain".to_owned()),
                 },
             ],
         );
@@ -351,9 +363,11 @@ mod tests {
                 previous_title: "local title".to_owned(),
                 previous_block_interval: Some("12".to_owned()),
                 previous_clock_mode: "blocknumber".to_owned(),
+                previous_counting_mode: None,
                 title: "reference title".to_owned(),
                 clock_mode: "blocknumber".to_owned(),
                 block_interval: Some("13.333333333333334".to_owned()),
+                counting_mode: Some("support=bravo&quorum=for,abstain".to_owned()),
             }]
         );
     }
@@ -367,12 +381,14 @@ mod tests {
                 title: "local title".to_owned(),
                 block_interval: Some("12".to_owned()),
                 clock_mode: "timestamp".to_owned(),
+                counting_mode: None,
             }],
             &[ReferenceProposalFields {
                 proposal_id: "0x2a".to_owned(),
                 title: "reference title".to_owned(),
                 clock_mode: "timestamp".to_owned(),
                 block_interval: Some("13.333333333333334".to_owned()),
+                counting_mode: None,
             }],
         );
 
@@ -383,9 +399,11 @@ mod tests {
                 previous_title: "local title".to_owned(),
                 previous_block_interval: Some("12".to_owned()),
                 previous_clock_mode: "timestamp".to_owned(),
+                previous_counting_mode: None,
                 title: "reference title".to_owned(),
                 clock_mode: "timestamp".to_owned(),
                 block_interval: None,
+                counting_mode: None,
             }]
         );
     }
@@ -399,12 +417,14 @@ mod tests {
                 title: "same title".to_owned(),
                 block_interval: None,
                 clock_mode: "blocknumber".to_owned(),
+                counting_mode: None,
             }],
             &[ReferenceProposalFields {
                 proposal_id: "0x2a".to_owned(),
                 title: "same title".to_owned(),
                 clock_mode: "timestamp".to_owned(),
                 block_interval: Some("13.333333333333334".to_owned()),
+                counting_mode: None,
             }],
         );
 
@@ -415,9 +435,11 @@ mod tests {
                 previous_title: "same title".to_owned(),
                 previous_block_interval: None,
                 previous_clock_mode: "blocknumber".to_owned(),
+                previous_counting_mode: None,
                 title: "same title".to_owned(),
                 clock_mode: "timestamp".to_owned(),
                 block_interval: None,
+                counting_mode: None,
             }]
         );
     }

--- a/apps/indexer/src/store/postgres/proposal.rs
+++ b/apps/indexer/src/store/postgres/proposal.rs
@@ -434,6 +434,7 @@ pub struct ProposalReferenceFieldCandidate {
     pub title: String,
     pub block_interval: Option<String>,
     pub clock_mode: String,
+    pub counting_mode: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -442,9 +443,11 @@ pub struct ProposalReferenceFieldUpdate {
     pub previous_title: String,
     pub previous_block_interval: Option<String>,
     pub previous_clock_mode: String,
+    pub previous_counting_mode: Option<String>,
     pub title: String,
     pub clock_mode: String,
     pub block_interval: Option<String>,
+    pub counting_mode: Option<String>,
 }
 
 pub async fn read_proposal_title_refresh_candidates(
@@ -523,7 +526,7 @@ pub async fn read_proposal_reference_field_candidates(
     dao_code: &str,
 ) -> Result<Vec<ProposalReferenceFieldCandidate>, PostgresIndexerRunnerStoreError> {
     let rows = sqlx::query(
-        "SELECT id, proposal_id, title, block_interval, clock_mode
+        "SELECT id, proposal_id, title, block_interval, clock_mode, counting_mode
          FROM proposal
          WHERE dao_code = $1
          ORDER BY block_number, transaction_index, log_index, id",
@@ -540,6 +543,7 @@ pub async fn read_proposal_reference_field_candidates(
             title: row.get("title"),
             block_interval: row.get("block_interval"),
             clock_mode: row.get("clock_mode"),
+            counting_mode: row.get("counting_mode"),
         })
         .collect())
 }
@@ -547,7 +551,8 @@ pub async fn read_proposal_reference_field_candidates(
 const UPDATE_PROPOSAL_REFERENCE_FIELDS_SQL_PREFIX: &str =
     "UPDATE proposal SET title = proposal_reference_fields.title,
          block_interval = proposal_reference_fields.block_interval,
-         clock_mode = proposal_reference_fields.clock_mode
+         clock_mode = proposal_reference_fields.clock_mode,
+         counting_mode = proposal_reference_fields.counting_mode
      FROM (";
 const UPDATE_PROPOSAL_REFERENCE_FIELDS_CHUNK_SIZE: usize = 5_000;
 
@@ -580,19 +585,22 @@ async fn update_proposal_reference_field_chunk(
             .push_bind(&update.previous_title)
             .push_bind(&update.previous_block_interval)
             .push_bind(&update.previous_clock_mode)
+            .push_bind(&update.previous_counting_mode)
             .push_bind(&update.title)
             .push_bind(&update.clock_mode)
-            .push_bind(&update.block_interval);
+            .push_bind(&update.block_interval)
+            .push_bind(&update.counting_mode);
     });
     builder.push(
         ") AS proposal_reference_fields(
-            id, previous_title, previous_block_interval, previous_clock_mode,
-            title, clock_mode, block_interval
+            id, previous_title, previous_block_interval, previous_clock_mode, previous_counting_mode,
+            title, clock_mode, block_interval, counting_mode
          )
          WHERE proposal.id = proposal_reference_fields.id
            AND proposal.title = proposal_reference_fields.previous_title
            AND proposal.block_interval IS NOT DISTINCT FROM proposal_reference_fields.previous_block_interval
            AND proposal.clock_mode = proposal_reference_fields.previous_clock_mode
+           AND proposal.counting_mode IS NOT DISTINCT FROM proposal_reference_fields.previous_counting_mode
            AND proposal.dao_code = ",
     );
     builder.push_bind(dao_code);
@@ -601,6 +609,7 @@ async fn update_proposal_reference_field_chunk(
             proposal.title IS DISTINCT FROM proposal_reference_fields.title
             OR proposal.clock_mode IS DISTINCT FROM proposal_reference_fields.clock_mode
             OR proposal.block_interval IS DISTINCT FROM proposal_reference_fields.block_interval
+            OR proposal.counting_mode IS DISTINCT FROM proposal_reference_fields.counting_mode
          )",
     );
 

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -313,7 +313,8 @@ async fn test_refresh_proposal_reference_fields_command_updates_only_scoped_dao(
     let reference = FakeReferenceGraphqlServer::start(vec![json!({
         "proposalId": "0x2a",
         "title": "Reference demo title",
-        "blockInterval": "13.333333333333334"
+        "blockInterval": "13.333333333333334",
+        "countingMode": "support=bravo&quorum=for,abstain"
     })]);
 
     run_refresh_proposal_reference_fields_command(
@@ -323,25 +324,32 @@ async fn test_refresh_proposal_reference_fields_command_updates_only_scoped_dao(
     )
     .await?;
 
-    let demo_row =
-        sqlx::query("SELECT title, block_interval FROM proposal WHERE dao_code = 'demo-dao'")
-            .fetch_one(&database.pool)
-            .await?;
-    let other_row =
-        sqlx::query("SELECT title, block_interval FROM proposal WHERE dao_code = 'other-dao'")
-            .fetch_one(&database.pool)
-            .await?;
+    let demo_row = sqlx::query(
+        "SELECT title, block_interval, counting_mode FROM proposal WHERE dao_code = 'demo-dao'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    let other_row = sqlx::query(
+        "SELECT title, block_interval, counting_mode FROM proposal WHERE dao_code = 'other-dao'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
 
     assert_eq!(demo_row.get::<String, _>("title"), "Reference demo title");
     assert_eq!(
         demo_row.get::<Option<String>, _>("block_interval"),
         Some("13.333333333333334".to_owned())
     );
+    assert_eq!(
+        demo_row.get::<Option<String>, _>("counting_mode"),
+        Some("support=bravo&quorum=for,abstain".to_owned())
+    );
     assert_eq!(other_row.get::<String, _>("title"), "stale title");
     assert_eq!(
         other_row.get::<Option<String>, _>("block_interval"),
         Some("12".to_owned())
     );
+    assert_eq!(other_row.get::<Option<String>, _>("counting_mode"), None);
 
     database.cleanup().await?;
 


### PR DESCRIPTION
## Summary
- Include countingMode in the proposal reference-field refresh query.
- Write repaired counting_mode alongside title, clock_mode, and block_interval.
- Extend command and planning tests to cover counting_mode repair.

## Context
Lisk v5 proposal core counts match v4, but proposal metadata still had empty counting_mode after the existing reference repair because the repair query did not fetch or update countingMode.

## Validation
- cargo fmt --check
- git diff --check
- DEGOV_INDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres cargo test -p degov-datalens-indexer --test postgres_runtime_run test_refresh_proposal_reference_fields_command_updates_only_scoped_dao -- --nocapture
- cargo test -p degov-datalens-indexer runtime::proposal_reference_fields::tests::test_plan_proposal_reference_field_updates -- --nocapture