### PR TITLE
fix(indexer): set block intervals for configured chains

### DIFF
--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -1793,7 +1793,7 @@ fn block_interval(chain_id: i32, clock_mode: &str) -> Option<String> {
         1 => Some("12".to_owned()),
         10 => Some("2".to_owned()),
         46 => Some("6".to_owned()),
-        56 => Some("3".to_owned()),
+        56 => Some("0.45".to_owned()),
         1135 => Some("2".to_owned()),
         8453 => Some("2".to_owned()),
         42161 => Some("0.25".to_owned()),
@@ -1903,7 +1903,7 @@ mod tests {
         assert_eq!(block_interval(1, "blocknumber").as_deref(), Some("12"));
         assert_eq!(block_interval(10, "blocknumber").as_deref(), Some("2"));
         assert_eq!(block_interval(46, "blocknumber").as_deref(), Some("6"));
-        assert_eq!(block_interval(56, "blocknumber").as_deref(), Some("3"));
+        assert_eq!(block_interval(56, "blocknumber").as_deref(), Some("0.45"));
         assert_eq!(block_interval(1135, "blocknumber").as_deref(), Some("2"));
         assert_eq!(block_interval(8453, "blocknumber").as_deref(), Some("2"));
         assert_eq!(

--- a/apps/indexer/src/projection/proposal.rs
+++ b/apps/indexer/src/projection/proposal.rs
@@ -1785,9 +1785,20 @@ fn estimate_blocknumber_timestamp(
 }
 
 fn block_interval(chain_id: i32, clock_mode: &str) -> Option<String> {
-    const ETHEREUM_MAINNET_CHAIN_ID: i32 = 1;
+    if clock_mode != "blocknumber" {
+        return None;
+    }
 
-    (chain_id == ETHEREUM_MAINNET_CHAIN_ID && clock_mode == "blocknumber").then(|| "12".to_owned())
+    match chain_id {
+        1 => Some("12".to_owned()),
+        10 => Some("2".to_owned()),
+        46 => Some("6".to_owned()),
+        56 => Some("3".to_owned()),
+        1135 => Some("2".to_owned()),
+        8453 => Some("2".to_owned()),
+        42161 => Some("0.25".to_owned()),
+        _ => None,
+    }
 }
 
 fn merge_block_interval(
@@ -1880,5 +1891,30 @@ fn chain_read_state(value: &ChainReadValue) -> Option<String> {
 fn extend_map<T: Clone>(map: &mut BTreeMap<String, T>, rows: &[T], key: impl Fn(&T) -> String) {
     for row in rows {
         map.insert(key(row), row.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::block_interval;
+
+    #[test]
+    fn test_block_interval_supports_configured_chains() {
+        assert_eq!(block_interval(1, "blocknumber").as_deref(), Some("12"));
+        assert_eq!(block_interval(10, "blocknumber").as_deref(), Some("2"));
+        assert_eq!(block_interval(46, "blocknumber").as_deref(), Some("6"));
+        assert_eq!(block_interval(56, "blocknumber").as_deref(), Some("3"));
+        assert_eq!(block_interval(1135, "blocknumber").as_deref(), Some("2"));
+        assert_eq!(block_interval(8453, "blocknumber").as_deref(), Some("2"));
+        assert_eq!(
+            block_interval(42161, "blocknumber").as_deref(),
+            Some("0.25")
+        );
+    }
+
+    #[test]
+    fn test_block_interval_skips_timestamp_clock_mode() {
+        assert_eq!(block_interval(1, "timestamp"), None);
+        assert_eq!(block_interval(8453, "timestamp"), None);
     }
 }

--- a/apps/indexer/tests/proposal_projection.rs
+++ b/apps/indexer/tests/proposal_projection.rs
@@ -455,7 +455,7 @@ fn test_project_proposal_created_preserves_fallback_when_block_timestamp_read_fa
 }
 
 #[test]
-fn test_project_proposal_created_omits_block_interval_for_non_ethereum_blocknumber() {
+fn test_project_proposal_created_sets_configured_block_interval_for_base_blocknumber() {
     let mut event_log = production_log(
         "0022339715-afd3c-000054",
         22_339_715,
@@ -486,9 +486,9 @@ fn test_project_proposal_created_omits_block_interval_for_non_ethereum_blocknumb
     let proposal = &batch.proposals[0];
     assert_eq!(proposal.chain_id, 8453);
     assert_eq!(proposal.clock_mode, "blocknumber");
-    assert_eq!(proposal.block_interval, None);
-    assert_eq!(proposal.vote_start_timestamp, "22339716");
-    assert_eq!(proposal.vote_end_timestamp, "22385534");
+    assert_eq!(proposal.block_interval, Some("2".to_owned()));
+    assert_eq!(proposal.vote_start_timestamp, "1745507989000");
+    assert_eq!(proposal.vote_end_timestamp, "1745599625000");
 }
 
 #[test]
@@ -567,7 +567,7 @@ fn test_project_proposal_lifecycle_events_builds_metadata_and_state_epochs() {
 }
 
 #[test]
-fn test_project_proposal_lifecycle_stub_omits_block_interval_for_non_ethereum_chain() {
+fn test_project_proposal_lifecycle_stub_sets_configured_block_interval_for_base_chain() {
     let mut event_log = log(13, 0, 1);
     event_log.chain_id = 8453;
     let batch = project_proposal_events(
@@ -585,7 +585,7 @@ fn test_project_proposal_lifecycle_stub_omits_block_interval_for_non_ethereum_ch
     let proposal = &batch.proposals[0];
     assert_eq!(proposal.chain_id, 8453);
     assert_eq!(proposal.clock_mode, "blocknumber");
-    assert_eq!(proposal.block_interval, None);
+    assert_eq!(proposal.block_interval, Some("2".to_owned()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Return default block intervals for configured non-mainnet chains when proposal clock mode is blocknumber.
- Keep timestamp clock mode returning no block interval.
- Add unit coverage for Ethereum, Optimism, Darwinia, BSC, Lisk, Base, and Arbitrum.

## Context
Staging v5 proposal metadata still had missing blockInterval for blocknumber proposals on BSC/Base/Arbitrum/Optimism because the helper only handled Ethereum mainnet.

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p degov-datalens-indexer projection::proposal::tests::test_block_interval -- --nocapture