### PR TITLE
fix(indexer): project governor timelock rows from queued proposals

### DIFF
--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -83,6 +83,7 @@ pub use crate::projection::timelock::{
     TimelockProjectionContext, TimelockProjectionError, TimelockProjectionEvent,
     TimelockProjectionRepository, TimelockProposalActionLink, TimelockProposalLinkContext,
     TimelockRoleEventWrite, project_timelock_events, project_timelock_events_with_proposal_links,
+    project_timelock_proposal_links,
 };
 pub use crate::projection::token::{
     DelegateChangedWrite, DelegateRollingWrite, DelegateVotesChangedWrite,

--- a/apps/indexer/src/projection/timelock.rs
+++ b/apps/indexer/src/projection/timelock.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use ethabi::ethereum_types::U256;
+
 use crate::{
     BatchReadPlanConfig, CallExecutedEvent, CallScheduledEvent, ChainContracts,
     ChainReadExecutionReport, ChainReadMethod, ChainReadPlan, ChainReadPlanBuilder,
@@ -39,7 +41,13 @@ pub struct TimelockProposalActionLink {
     pub proposal_ref: String,
     pub raw_proposal_id: String,
     pub queue_transaction_hash: String,
+    pub queue_block_number: Option<String>,
+    pub queue_block_timestamp: Option<String>,
+    pub queue_log_index: u64,
+    pub queue_transaction_index: u64,
     pub execution_transaction_hash: Option<String>,
+    pub execution_block_number: Option<String>,
+    pub execution_block_timestamp: Option<String>,
     pub queue_eta: Option<String>,
     pub proposal_action_id: String,
     pub proposal_action_index: usize,
@@ -61,7 +69,14 @@ struct TimelockProposalActionKey {
 
 impl TimelockProposalLinkContext {
     pub fn from_proposal_batch(batch: &ProposalProjectionBatch) -> Self {
-        Self::from_proposal_rows(batch.proposals.iter(), batch.proposal_actions.iter())
+        let mut links =
+            Self::from_proposal_rows(batch.proposals.iter(), batch.proposal_actions.iter());
+        links.extend(Self::from_queued_proposal_rows(
+            batch.proposal_queued.iter(),
+            batch.proposals.iter(),
+            batch.proposal_actions.iter(),
+        ));
+        links
     }
 
     pub fn from_proposal_rows<'a>(
@@ -87,10 +102,16 @@ impl TimelockProposalLinkContext {
                 proposal_ref: action.proposal_ref.clone(),
                 raw_proposal_id: proposal.proposal_id.clone(),
                 queue_transaction_hash: normalize_identifier(queue_transaction_hash),
+                queue_block_number: proposal.queued_block_number.clone(),
+                queue_block_timestamp: proposal.queued_block_timestamp.clone(),
+                queue_log_index: proposal.log_index,
+                queue_transaction_index: proposal.transaction_index,
                 execution_transaction_hash: proposal
                     .executed_transaction_hash
                     .as_deref()
                     .map(normalize_identifier),
+                execution_block_number: proposal.executed_block_number.clone(),
+                execution_block_timestamp: proposal.executed_block_timestamp.clone(),
                 queue_eta: proposal.proposal_eta.clone(),
                 proposal_action_id: action.id.clone(),
                 proposal_action_index: action.action_index,
@@ -151,10 +172,16 @@ impl TimelockProposalLinkContext {
                     proposal_ref: action.proposal_ref.clone(),
                     raw_proposal_id: proposal.proposal_id.clone(),
                     queue_transaction_hash: normalize_identifier(&queued.common.transaction_hash),
+                    queue_block_number: Some(queued.common.block_number.clone()),
+                    queue_block_timestamp: queued.common.block_timestamp.clone(),
+                    queue_log_index: queued.common.log_index,
+                    queue_transaction_index: queued.common.transaction_index,
                     execution_transaction_hash: proposal
                         .executed_transaction_hash
                         .as_deref()
                         .map(normalize_identifier),
+                    execution_block_number: proposal.executed_block_number.clone(),
+                    execution_block_timestamp: proposal.executed_block_timestamp.clone(),
                     queue_eta: Some(queued.eta_seconds.clone()),
                     proposal_action_id: action.id.clone(),
                     proposal_action_index: action.action_index,
@@ -168,9 +195,17 @@ impl TimelockProposalLinkContext {
         context
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.proposal_actions.is_empty()
+    }
+
     pub fn insert_action_link(&mut self, link: TimelockProposalActionLink) {
-        self.action_lookup
-            .insert(link.key(), self.proposal_actions.len());
+        let key = link.key();
+        if let Some(index) = self.action_lookup.get(&key).copied() {
+            self.proposal_actions[index] = link;
+            return;
+        }
+        self.action_lookup.insert(key, self.proposal_actions.len());
         self.proposal_actions.push(link);
     }
 
@@ -517,6 +552,55 @@ pub fn project_timelock_events(
     )
 }
 
+pub fn project_timelock_proposal_links(
+    context: &TimelockProjectionContext,
+    proposal_links: &TimelockProposalLinkContext,
+) -> Result<TimelockProjectionBatch, TimelockProjectionError> {
+    let governor_address = normalize_identifier(&context.governor_address);
+    let timelock_address = normalize_identifier(&context.timelock_address);
+    let chain_id = proposal_links
+        .proposal_actions
+        .first()
+        .map(|link| link.chain_id)
+        .unwrap_or_default();
+    let builder = ChainReadPlanBuilder::new(
+        chain_id,
+        context.contracts.clone(),
+        context.read_plan_config,
+    );
+    let mut operations = BTreeMap::new();
+    let mut calls = BTreeMap::new();
+
+    for proposal_link in &proposal_links.proposal_actions {
+        let common =
+            proposal_link_common(context, &governor_address, &timelock_address, proposal_link);
+        let operation_id = proposal_link_operation_id(proposal_link);
+        let operation =
+            governor_timelock_control_operation_write(&common, &operation_id, proposal_link);
+        operations
+            .entry(operation.id.clone())
+            .and_modify(|stored: &mut TimelockOperationWrite| stored.merge(&operation))
+            .or_insert(operation);
+
+        let operation_ref = operation_ref(&common, &operation_id);
+        let call = governor_timelock_control_call_write(&common, &operation_ref, proposal_link);
+        calls
+            .entry(call.id.clone())
+            .and_modify(|stored: &mut TimelockCallWrite| stored.merge(&call))
+            .or_insert(call);
+    }
+
+    Ok(TimelockProjectionBatch {
+        event_order: Vec::new(),
+        timelock_operations: operations.into_values().collect(),
+        timelock_calls: calls.into_values().collect(),
+        timelock_role_events: Vec::new(),
+        timelock_min_delay_changes: Vec::new(),
+        timelock_operation_hints: Vec::new(),
+        chain_read_plan: builder.build(),
+    })
+}
+
 pub fn project_timelock_events_with_proposal_links(
     context: &TimelockProjectionContext,
     proposal_links: &TimelockProposalLinkContext,
@@ -673,6 +757,110 @@ fn common(
             .map(|timestamp| (timestamp / 1_000).to_string()),
         transaction_hash: normalize_identifier(&log.transaction_hash),
     }
+}
+
+fn proposal_link_common(
+    context: &TimelockProjectionContext,
+    governor_address: &str,
+    timelock_address: &str,
+    proposal_link: &TimelockProposalActionLink,
+) -> TimelockEventCommon {
+    TimelockEventCommon {
+        contract_set_id: context.contract_set_id.clone(),
+        chain_id: proposal_link.chain_id,
+        dao_code: context.dao_code.clone(),
+        governor_address: governor_address.to_owned(),
+        timelock_address: timelock_address.to_owned(),
+        contract_address: proposal_link.governor_address.clone(),
+        log_index: proposal_link.queue_log_index,
+        transaction_index: proposal_link.queue_transaction_index,
+        block_number: proposal_link
+            .queue_block_number
+            .clone()
+            .unwrap_or_else(|| "0".to_owned()),
+        block_timestamp: proposal_link.queue_block_timestamp.clone(),
+        transaction_hash: proposal_link.queue_transaction_hash.clone(),
+    }
+}
+
+fn governor_timelock_control_operation_write(
+    common: &TimelockEventCommon,
+    operation_id: &str,
+    proposal_link: &TimelockProposalActionLink,
+) -> TimelockOperationWrite {
+    let mut operation = operation_stub(common, operation_id, "Queued");
+    operation.timelock_type = "GovernorTimelockControl".to_owned();
+    operation.call_count = Some(1);
+    operation.delay_seconds = proposal_link
+        .queue_eta
+        .as_deref()
+        .zip(common.block_timestamp.as_deref())
+        .and_then(|(eta, timestamp)| subtract_decimal_strings(eta, timestamp));
+    operation.ready_at = proposal_link.queue_eta.clone();
+    operation.queued_block_number = proposal_link.queue_block_number.clone();
+    operation.queued_block_timestamp = proposal_link.queue_block_timestamp.clone();
+    operation.queued_transaction_hash = Some(proposal_link.queue_transaction_hash.clone());
+    if let Some(execution_transaction_hash) = &proposal_link.execution_transaction_hash {
+        operation.state = "Done".to_owned();
+        operation.executed_call_count = Some(1);
+        operation.executed_block_number = proposal_link.execution_block_number.clone();
+        operation.executed_block_timestamp = proposal_link.execution_block_timestamp.clone();
+        operation.executed_transaction_hash = Some(execution_transaction_hash.clone());
+    }
+    bind_operation_to_proposal(&mut operation, Some(proposal_link));
+    operation
+}
+
+fn governor_timelock_control_call_write(
+    common: &TimelockEventCommon,
+    operation_ref: &str,
+    proposal_link: &TimelockProposalActionLink,
+) -> TimelockCallWrite {
+    let mut call = TimelockCallWrite {
+        id: call_ref(
+            operation_ref,
+            &proposal_link.proposal_action_index.to_string(),
+        ),
+        contract_set_id: common.contract_set_id.clone(),
+        chain_id: common.chain_id,
+        dao_code: common.dao_code.clone(),
+        governor_address: common.governor_address.clone(),
+        timelock_address: common.timelock_address.clone(),
+        contract_address: common.contract_address.clone(),
+        log_index: common.log_index,
+        transaction_index: common.transaction_index,
+        operation_id: proposal_link_operation_id(proposal_link),
+        operation_ref: operation_ref.to_owned(),
+        proposal_ref: None,
+        proposal_id: None,
+        proposal_action_id: None,
+        proposal_action_index: None,
+        action_index: proposal_link.proposal_action_index,
+        target: proposal_link.target.clone(),
+        value: proposal_link.value.clone(),
+        data: proposal_link.calldata.clone(),
+        predecessor: None,
+        delay_seconds: proposal_link
+            .queue_eta
+            .as_deref()
+            .zip(common.block_timestamp.as_deref())
+            .and_then(|(eta, timestamp)| subtract_decimal_strings(eta, timestamp)),
+        state: "Scheduled".to_owned(),
+        scheduled_block_number: proposal_link.queue_block_number.clone(),
+        scheduled_block_timestamp: proposal_link.queue_block_timestamp.clone(),
+        scheduled_transaction_hash: Some(proposal_link.queue_transaction_hash.clone()),
+        executed_block_number: None,
+        executed_block_timestamp: None,
+        executed_transaction_hash: None,
+    };
+    if let Some(execution_transaction_hash) = &proposal_link.execution_transaction_hash {
+        call.state = "Done".to_owned();
+        call.executed_block_number = proposal_link.execution_block_number.clone();
+        call.executed_block_timestamp = proposal_link.execution_block_timestamp.clone();
+        call.executed_transaction_hash = Some(execution_transaction_hash.clone());
+    }
+    bind_call_to_proposal(&mut call, Some(proposal_link));
+    call
 }
 
 fn scheduled_operation_write(
@@ -1120,6 +1308,16 @@ fn operation_id(event: &DecodedTimelockEvent) -> Option<&str> {
     }
 }
 
+fn proposal_link_operation_id(proposal_link: &TimelockProposalActionLink) -> String {
+    let raw_proposal_id = proposal_link.raw_proposal_id.trim();
+    if raw_proposal_id.starts_with("0x") {
+        return normalize_identifier(raw_proposal_id);
+    }
+    U256::from_dec_str(raw_proposal_id)
+        .map(|value| format!("0x{value:064x}"))
+        .unwrap_or_else(|_| normalize_identifier(raw_proposal_id))
+}
+
 fn operation_ref(common: &TimelockEventCommon, operation_id: &str) -> String {
     format!(
         "timelock-operation:{}:{}:{}:{}:{}",
@@ -1176,6 +1374,20 @@ fn add_decimal_strings(left: &str, right: &str) -> Option<String> {
     } else {
         value.to_owned()
     })
+}
+
+fn subtract_decimal_strings(left: &str, right: &str) -> Option<String> {
+    if left.is_empty()
+        || right.is_empty()
+        || !left.bytes().all(|byte| byte.is_ascii_digit())
+        || !right.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let left = U256::from_dec_str(left).ok()?;
+    let right = U256::from_dec_str(right).ok()?;
+    (left >= right).then(|| (left - right).to_string())
 }
 
 fn merge_sum(left: Option<usize>, right: Option<usize>) -> Option<usize> {

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -22,7 +22,8 @@ use crate::{
     classify_datalens_query_error, datalens_selector_fingerprint, decode_dao_log,
     fetch_dao_log_pages, normalize_evm_log_rows, plan_dao_log_queries, plan_next_checkpoint_range,
     plan_proposal_timestamp_backfill_updates, project_proposal_events,
-    project_timelock_events_with_proposal_links, project_token_events, project_vote_events,
+    project_timelock_events_with_proposal_links, project_timelock_proposal_links,
+    project_token_events, project_vote_events,
 };
 
 use crate::OnchainRefreshTickReport;
@@ -1486,8 +1487,8 @@ where
             .contexts
             .timelock
             .as_ref()
-            .filter(|_| !timelock_events.is_empty())
             .cloned()
+            .filter(|_| !timelock_events.is_empty() || proposal.is_some())
         {
             let mut proposal_links = self
                 .store
@@ -1496,14 +1497,21 @@ where
             if let Some(proposal) = &proposal {
                 proposal_links.extend(TimelockProposalLinkContext::from_proposal_batch(proposal));
             }
-            Some(
-                project_timelock_events_with_proposal_links(
-                    &context,
-                    &proposal_links,
-                    timelock_events,
+            if timelock_events.is_empty() {
+                (!proposal_links.is_empty())
+                    .then(|| project_timelock_proposal_links(&context, &proposal_links))
+                    .transpose()
+                    .map_err(|error| IndexerRunnerError::Projection(format!("{error:?}")))?
+            } else {
+                Some(
+                    project_timelock_events_with_proposal_links(
+                        &context,
+                        &proposal_links,
+                        timelock_events,
+                    )
+                    .map_err(|error| IndexerRunnerError::Projection(format!("{error:?}")))?,
                 )
-                .map_err(|error| IndexerRunnerError::Projection(format!("{error:?}")))?,
-            )
+            }
         } else {
             None
         };

--- a/apps/indexer/src/store/postgres/timelock.rs
+++ b/apps/indexer/src/store/postgres/timelock.rs
@@ -42,7 +42,13 @@ async fn read_timelock_proposal_link_context(
             "SELECT p.chain_id, p.governor_address, p.id AS proposal_ref,
                     p.proposal_id AS raw_proposal_id,
                     pq.transaction_hash AS queue_transaction_hash,
+                    pq.block_number::TEXT AS queue_block_number,
+                    pq.block_timestamp::TEXT AS queue_block_timestamp,
+                    pq.log_index AS queue_log_index,
+                    pq.transaction_index AS queue_transaction_index,
                     pe.transaction_hash AS execution_transaction_hash,
+                    pe.block_number::TEXT AS execution_block_number,
+                    pe.block_timestamp::TEXT AS execution_block_timestamp,
                     pq.eta_seconds::TEXT AS queue_eta,
                     pa.id AS proposal_action_id,
                     pa.action_index AS proposal_action_index,
@@ -102,7 +108,13 @@ async fn read_timelock_proposal_link_context(
                     "SELECT p.chain_id, p.governor_address, p.id AS proposal_ref,
                             p.proposal_id AS raw_proposal_id,
                             $3::TEXT AS queue_transaction_hash,
+                            $11::TEXT AS queue_block_number,
+                            $12::TEXT AS queue_block_timestamp,
+                            $13::INT AS queue_log_index,
+                            $14::INT AS queue_transaction_index,
                             pe.transaction_hash AS execution_transaction_hash,
+                            pe.block_number::TEXT AS execution_block_number,
+                            pe.block_timestamp::TEXT AS execution_block_timestamp,
                             $4::TEXT AS queue_eta,
                             pa.id AS proposal_action_id,
                             pa.action_index AS proposal_action_index,
@@ -134,10 +146,66 @@ async fn read_timelock_proposal_link_context(
                 .bind(&event.value)
                 .bind(normalize_identifier(&event.data))
                 .bind(&context.contract_set_id)
+                .bind(&queued.common.block_number)
+                .bind(queued.common.block_timestamp.as_deref())
+                .bind(u64_to_i32(queued.common.log_index, "proposal_queued.log_index")?)
+                .bind(u64_to_i32(
+                    queued.common.transaction_index,
+                    "proposal_queued.transaction_index",
+                )?)
                 .fetch_optional(pool)
                 .await?;
 
                 let Some(row) = row else { continue };
+                insert_link_from_row(&mut links, row)?;
+            }
+        }
+
+        for queued in &proposal.proposal_queued {
+            let rows = sqlx::query(
+                "SELECT p.chain_id, p.governor_address, p.id AS proposal_ref,
+                        p.proposal_id AS raw_proposal_id,
+                        $3::TEXT AS queue_transaction_hash,
+                        $4::TEXT AS queue_block_number,
+                        $5::TEXT AS queue_block_timestamp,
+                        $6::INT AS queue_log_index,
+                        $7::INT AS queue_transaction_index,
+                        pe.transaction_hash AS execution_transaction_hash,
+                        pe.block_number::TEXT AS execution_block_number,
+                        pe.block_timestamp::TEXT AS execution_block_timestamp,
+                        $8::TEXT AS queue_eta,
+                        pa.id AS proposal_action_id,
+                        pa.action_index AS proposal_action_index,
+                        pa.target, pa.value, pa.calldata
+                 FROM proposal p
+                 JOIN proposal_action pa ON pa.proposal_ref = p.id
+                 LEFT JOIN proposal_executed pe
+                   ON pe.chain_id IS NOT DISTINCT FROM p.chain_id
+                  AND pe.governor_address IS NOT DISTINCT FROM p.governor_address
+                  AND pe.proposal_id = p.proposal_id
+                 WHERE p.chain_id IS NOT DISTINCT FROM $1
+                   AND p.governor_address IS NOT DISTINCT FROM $2
+                   AND p.contract_set_id = $9
+                   AND p.proposal_id = $10
+                 ORDER BY p.id, pa.action_index, pa.id",
+            )
+            .bind(queued.common.chain_id)
+            .bind(&governor_address)
+            .bind(normalize_identifier(&queued.common.transaction_hash))
+            .bind(&queued.common.block_number)
+            .bind(queued.common.block_timestamp.as_deref())
+            .bind(u64_to_i32(queued.common.log_index, "proposal_queued.log_index")?)
+            .bind(u64_to_i32(
+                queued.common.transaction_index,
+                "proposal_queued.transaction_index",
+            )?)
+            .bind(&queued.eta_seconds)
+            .bind(&context.contract_set_id)
+            .bind(&queued.proposal_id)
+            .fetch_all(pool)
+            .await?;
+
+            for row in rows {
                 insert_link_from_row(&mut links, row)?;
             }
         }
@@ -160,7 +228,17 @@ fn insert_link_from_row(
         proposal_ref: row.get("proposal_ref"),
         raw_proposal_id: row.get("raw_proposal_id"),
         queue_transaction_hash: row.get("queue_transaction_hash"),
+        queue_block_number: row.get("queue_block_number"),
+        queue_block_timestamp: row.get("queue_block_timestamp"),
+        queue_log_index: u64::try_from(row.get::<i32, _>("queue_log_index"))
+            .map_err(|_| PostgresIndexerRunnerStoreError::new("queue_log_index cannot be negative"))?,
+        queue_transaction_index: u64::try_from(row.get::<i32, _>("queue_transaction_index"))
+            .map_err(|_| {
+                PostgresIndexerRunnerStoreError::new("queue_transaction_index cannot be negative")
+            })?,
         execution_transaction_hash: row.get("execution_transaction_hash"),
+        execution_block_number: row.get("execution_block_number"),
+        execution_block_timestamp: row.get("execution_block_timestamp"),
         queue_eta: row.get("queue_eta"),
         proposal_action_id: row.get("proposal_action_id"),
         proposal_action_index,

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -150,6 +150,61 @@ fn test_native_runner_links_timelock_to_proposal_actions_from_previous_range() {
     assert_eq!(runner.store().commit_count, 2);
 }
 
+#[test]
+fn test_native_runner_projects_governor_timelock_control_rows_without_timelock_logs() {
+    let mut runner = native_runner(
+        vec![vec![
+            proposal_created_row(),
+            proposal_queued_row(),
+            proposal_executed_row(),
+        ]],
+        CapturingStore::new(identity(), 1),
+    );
+
+    runner.run_to_target(5).expect("runner succeeds");
+
+    let proposal = runner
+        .store()
+        .proposal_repository
+        .proposals()
+        .values()
+        .next()
+        .expect("proposal");
+    let operation = runner
+        .store()
+        .timelock_repository
+        .timelock_operations()
+        .values()
+        .next()
+        .expect("timelock operation");
+    assert_eq!(operation.operation_id, bytes32_uint(42));
+    assert_eq!(operation.timelock_type, "GovernorTimelockControl");
+    assert_eq!(operation.state, "Done");
+    assert_eq!(
+        operation.proposal_ref.as_deref(),
+        Some(proposal.id.as_str())
+    );
+    assert_eq!(operation.call_count, Some(1));
+    assert_eq!(operation.executed_call_count, Some(1));
+
+    let call = runner
+        .store()
+        .timelock_repository
+        .timelock_calls()
+        .values()
+        .next()
+        .expect("timelock call");
+    assert_eq!(call.operation_ref, operation.id);
+    assert_eq!(call.state, "Done");
+    assert_eq!(call.proposal_ref.as_deref(), Some(proposal.id.as_str()));
+    assert_eq!(
+        call.proposal_action_id.as_deref(),
+        Some(format!("{}:action:0", proposal.id).as_str())
+    );
+    assert_eq!(call.scheduled_transaction_hash.as_deref(), Some("0xtx40"));
+    assert_eq!(call.executed_transaction_hash.as_deref(), Some("0xtx50"));
+}
+
 fn assert_projected_domains(store: &CapturingStore) {
     let proposal = store
         .proposal_repository
@@ -744,6 +799,17 @@ fn proposal_queued_row() -> Value {
     )
 }
 
+fn proposal_executed_row() -> Value {
+    raw_log(
+        5,
+        0,
+        0,
+        GOVERNOR,
+        vec![PROPOSAL_EXECUTED],
+        encode(&[uint(42)]),
+    )
+}
+
 fn vote_cast_row() -> Value {
     raw_log(
         3,
@@ -872,6 +938,10 @@ fn topic_uint(value: u64) -> String {
     format!("0x{value:064x}")
 }
 
+fn bytes32_uint(value: u64) -> String {
+    format!("0x{value:064x}")
+}
+
 const GOVERNOR: &str = "0x1111111111111111111111111111111111111111";
 const TOKEN: &str = "0x2222222222222222222222222222222222222222";
 const TIMELOCK: &str = "0x3333333333333333333333333333333333333333";
@@ -886,6 +956,8 @@ const OPERATION_ID: &str = "0x01010101010101010101010101010101010101010101010101
 
 const PROPOSAL_CREATED: &str = "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0";
 const PROPOSAL_QUEUED: &str = "0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892";
+const PROPOSAL_EXECUTED: &str =
+    "0x712ae1383f79ac853f8d882153778e0260ef8f03b504e2866e0593e04d2b291f";
 const VOTE_CAST: &str = "0xb8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4";
 const TRANSFER: &str = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 const DELEGATE_CHANGED: &str = "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f";

--- a/apps/indexer/tests/timelock_projection.rs
+++ b/apps/indexer/tests/timelock_projection.rs
@@ -2,11 +2,12 @@ use degov_datalens_indexer::{
     BatchReadPlanConfig, CallExecutedEvent, CallSaltEvent, CallScheduledEvent, ChainContracts,
     ChainReadExecutionReport, ChainReadKey, ChainReadMethod, ChainReadResult, ChainReadValue,
     DecodedGovernorEvent, DecodedTimelockEvent, GovernanceTokenStandard, NormalizedEvmLog,
-    ParameterChangeEvent, ProposalCreatedEvent, ProposalProjectionContext, ProposalProjectionEvent,
-    ProposalQueuedEvent, ReadRequirement, RoleAccountEvent, RoleAdminChangedEvent,
-    TimelockOperationIdEvent, TimelockProjectionContext, TimelockProjectionError,
-    TimelockProjectionEvent, TimelockProjectionRepository, TimelockProposalLinkContext,
-    project_proposal_events, project_timelock_events, project_timelock_events_with_proposal_links,
+    ParameterChangeEvent, ProposalCreatedEvent, ProposalIdEvent, ProposalProjectionContext,
+    ProposalProjectionEvent, ProposalQueuedEvent, ReadRequirement, RoleAccountEvent,
+    RoleAdminChangedEvent, TimelockOperationIdEvent, TimelockProjectionContext,
+    TimelockProjectionError, TimelockProjectionEvent, TimelockProjectionRepository,
+    TimelockProposalLinkContext, project_proposal_events, project_timelock_events,
+    project_timelock_events_with_proposal_links, project_timelock_proposal_links,
 };
 use serde_json::json;
 use sha3::{Digest, Keccak256};
@@ -390,6 +391,93 @@ fn test_project_timelock_links_scheduled_calls_to_known_proposal_actions() {
 }
 
 #[test]
+fn test_project_timelock_proposal_links_materializes_governor_timelock_control_rows() {
+    let proposal_batch = project_proposal_events(
+        &proposal_context(),
+        vec![
+            ProposalProjectionEvent {
+                log: proposal_log(8, 0, 0),
+                event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                    proposal_id: "42".to_owned(),
+                    proposer: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+                    targets: vec!["0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC".to_owned()],
+                    values: vec!["100".to_owned()],
+                    signatures: vec!["".to_owned()],
+                    calldatas: vec!["0x1234".to_owned()],
+                    vote_start: "20".to_owned(),
+                    vote_end: "40".to_owned(),
+                    description: "Proposal title".to_owned(),
+                }),
+            },
+            ProposalProjectionEvent {
+                log: proposal_log(10, 0, 0),
+                event: DecodedGovernorEvent::ProposalQueued(ProposalQueuedEvent {
+                    proposal_id: "42".to_owned(),
+                    eta_seconds: "1700003600".to_owned(),
+                }),
+            },
+            ProposalProjectionEvent {
+                log: proposal_log(11, 0, 0),
+                event: DecodedGovernorEvent::ProposalExecuted(ProposalIdEvent {
+                    proposal_id: "42".to_owned(),
+                }),
+            },
+        ],
+    )
+    .expect("proposal projection succeeds");
+    let links = TimelockProposalLinkContext::from_proposal_batch(&proposal_batch);
+
+    let batch = project_timelock_proposal_links(&context(), &links)
+        .expect("timelock proposal link projection succeeds");
+
+    assert_eq!(batch.event_order, Vec::<String>::new());
+    assert_eq!(batch.timelock_operations.len(), 1);
+    assert_eq!(batch.timelock_calls.len(), 1);
+    assert_eq!(batch.timelock_operation_hints.len(), 0);
+    assert_eq!(batch.chain_read_plan.reads.len(), 0);
+
+    let operation = &batch.timelock_operations[0];
+    let expected_proposal_ref = proposal_ref("42");
+    assert_eq!(operation.operation_id, bytes32_uint(42));
+    assert_eq!(operation.timelock_type, "GovernorTimelockControl");
+    assert_eq!(operation.state, "Done");
+    assert_eq!(
+        operation.proposal_ref.as_deref(),
+        Some(expected_proposal_ref)
+    );
+    assert_eq!(
+        operation.proposal_id.as_deref(),
+        Some(expected_proposal_ref)
+    );
+    assert_eq!(operation.call_count, Some(1));
+    assert_eq!(operation.executed_call_count, Some(1));
+    assert_eq!(operation.delay_seconds, None);
+    assert_eq!(operation.ready_at.as_deref(), Some("1700003600"));
+    assert_eq!(operation.queued_block_number.as_deref(), Some("10"));
+    assert_eq!(
+        operation.executed_transaction_hash.as_deref(),
+        Some("0xtx11")
+    );
+
+    let call = &batch.timelock_calls[0];
+    assert_eq!(call.operation_ref, operation.id);
+    assert_eq!(call.operation_id, operation.operation_id);
+    assert_eq!(call.action_index, 0);
+    assert_eq!(call.target, "0xcccccccccccccccccccccccccccccccccccccccc");
+    assert_eq!(call.value, "100");
+    assert_eq!(call.data, "0x1234");
+    assert_eq!(call.state, "Done");
+    assert_eq!(call.proposal_ref.as_deref(), Some(expected_proposal_ref));
+    assert_eq!(
+        call.proposal_action_id.as_deref(),
+        Some(format!("{expected_proposal_ref}:action:0").as_str())
+    );
+    assert_eq!(call.scheduled_block_number.as_deref(), Some("10"));
+    assert_eq!(call.scheduled_transaction_hash.as_deref(), Some("0xtx10"));
+    assert_eq!(call.executed_transaction_hash.as_deref(), Some("0xtx11"));
+}
+
+#[test]
 fn test_project_timelock_repository_merges_incremental_operation_and_call_state() {
     let mut repository = degov_datalens_indexer::InMemoryTimelockProjectionRepository::default();
     let scheduled_batch = project_timelock_events(
@@ -699,6 +787,10 @@ fn predecessor_id() -> String {
 
 fn salt_id() -> String {
     "0x1111111111111111111111111111111111111111111111111111111111111111".to_owned()
+}
+
+fn bytes32_uint(value: u64) -> String {
+    format!("0x{value:064x}")
 }
 
 fn proposer_role() -> String {


### PR DESCRIPTION
## Summary
- project GovernorTimelockControl timelock operation/call rows from Governor ProposalQueued/ProposalExecuted proposal links when TimelockController lifecycle logs are absent
- hydrate queued/executed metadata in timelock proposal link contexts, including Postgres queued-only lookup
- add projection and native runner regressions for queued-only timelock rows

## Verification
- cargo test -p degov-datalens-indexer --test timelock_projection
- cargo test -p degov-datalens-indexer --test native_runner_integration
- cargo test -p degov-datalens-indexer --no-run