### PR TITLE
fix(indexer): refresh data metric member count

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -4084,7 +4084,8 @@ async fn refresh_data_metric_scope(
          SET token_address = COALESCE(data_metric.token_address, EXCLUDED.token_address),
              power_sum = EXCLUDED.power_sum,
              contributor_count = EXCLUDED.contributor_count,
-             holders_count = EXCLUDED.holders_count",
+             holders_count = EXCLUDED.holders_count,
+             member_count = EXCLUDED.member_count",
     )
     .bind(metric_id)
     .bind(&scope.contract_set_id)

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -561,7 +561,7 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     );
     assert_completed_task(&database.pool, "task-one", 1).await?;
     assert_completed_task(&database.pool, "task-two", 2).await?;
-    assert_data_metric_counts(&database.pool, "16", 3, 1, 7, 7).await?;
+    assert_data_metric_counts(&database.pool, "16", 3, 1, 3, 7).await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_ONE, "3", "11", "8").await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_TWO, "0", "5", "5").await?;
     assert_balance_checkpoint(&database.pool, ACCOUNT_ONE, "4", "17", "13").await?;


### PR DESCRIPTION
## Summary
- update data metric refresh conflict writes to replace stale member_count
- adjust onchain refresh regression coverage so recomputed member_count is asserted

## Why
The onchain refresh recompute path calculated member_count but did not write it on an existing global data_metric row. This left member_count behind after balance/power refreshes, while contributor_count and holders_count were already refreshed.

## Tests
- cargo fmt --check
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/postgres cargo test -p degov-datalens-indexer --test onchain_refresh_worker test_onchain_refresh_worker_updates_contributors_tasks_and_metrics -- --exact
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/postgres cargo test -p degov-datalens-indexer --test onchain_refresh_worker