### PR TITLE
fix(indexer): store vote timestamps in milliseconds

### DIFF
--- a/apps/indexer/src/projection/vote.rs
+++ b/apps/indexer/src/projection/vote.rs
@@ -396,7 +396,8 @@ fn common(
         block_number: log.block_number.to_string(),
         block_timestamp: log
             .block_timestamp_ms
-            .map(|timestamp| (timestamp / 1_000).to_string()),
+            .map(normalize_timestamp_millis)
+            .map(|timestamp| timestamp.to_string()),
         transaction_hash: normalize_identifier(&log.transaction_hash),
     }
 }
@@ -711,6 +712,14 @@ fn normalize_identifier(value: &str) -> String {
     value.to_ascii_lowercase()
 }
 
+fn normalize_timestamp_millis(timestamp: u64) -> u64 {
+    if timestamp < 1_000_000_000_000 {
+        timestamp.saturating_mul(1_000)
+    } else {
+        timestamp
+    }
+}
+
 fn extend_map<T: Clone>(target: &mut BTreeMap<String, T>, rows: &[T], key: impl Fn(&T) -> String) {
     for row in rows {
         target.insert(key(row), row.clone());
@@ -782,4 +791,106 @@ fn compare_decimal_strings(left: &str, right: &str) -> Ordering {
     left.len()
         .cmp(&right.len())
         .then_with(|| left.as_str().cmp(right.as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_project_vote_events_normalizes_seconds_timestamp_to_millis() {
+        let context = test_context();
+        let batch = project_vote_events(
+            &context,
+            vec![VoteProjectionEvent {
+                log: test_log(Some(1_700_000_000)),
+                event: DecodedGovernorEvent::VoteCast(VoteCastEvent {
+                    voter: "0xVoter".to_owned(),
+                    proposal_id: "42".to_owned(),
+                    support: 1,
+                    weight: "100".to_owned(),
+                    reason: "for".to_owned(),
+                }),
+            }],
+        )
+        .expect("vote projection");
+
+        assert_eq!(
+            batch.vote_cast[0].block_timestamp.as_deref(),
+            Some("1700000000000")
+        );
+        assert_eq!(
+            batch.vote_cast_groups[0].block_timestamp.as_deref(),
+            Some("1700000000000")
+        );
+        assert_eq!(
+            batch.contributor_vote_signals[0]
+                .last_vote_timestamp
+                .as_deref(),
+            Some("1700000000000")
+        );
+    }
+
+    #[test]
+    fn test_project_vote_events_preserves_millis_timestamp() {
+        let context = test_context();
+        let batch = project_vote_events(
+            &context,
+            vec![VoteProjectionEvent {
+                log: test_log(Some(1_700_000_000_000)),
+                event: DecodedGovernorEvent::VoteCast(VoteCastEvent {
+                    voter: "0xVoter".to_owned(),
+                    proposal_id: "42".to_owned(),
+                    support: 1,
+                    weight: "100".to_owned(),
+                    reason: "for".to_owned(),
+                }),
+            }],
+        )
+        .expect("vote projection");
+
+        assert_eq!(
+            batch.vote_cast[0].block_timestamp.as_deref(),
+            Some("1700000000000")
+        );
+        assert_eq!(
+            batch.contributor_vote_signals[0]
+                .last_vote_timestamp
+                .as_deref(),
+            Some("1700000000000")
+        );
+    }
+
+    fn test_context() -> VoteProjectionContext {
+        VoteProjectionContext {
+            contract_set_id: "contract-set".to_owned(),
+            dao_code: "dao".to_owned(),
+            governor_address: "0xGovernor".to_owned(),
+            contracts: ChainContracts {
+                governor: "0xGovernor".to_owned(),
+                governor_token: "0xToken".to_owned(),
+                timelock: None,
+            },
+            read_plan_config: BatchReadPlanConfig::default().validated(),
+        }
+    }
+
+    fn test_log(block_timestamp_ms: Option<u64>) -> NormalizedEvmLog {
+        NormalizedEvmLog {
+            id: "evm:1135:10:0:1:0xvote".to_owned(),
+            chain_id: 1135,
+            block_number: 10,
+            block_hash: "0xblock".to_owned(),
+            block_timestamp_ms,
+            transaction_hash: "0xvote".to_owned(),
+            transaction_index: 1,
+            log_index: 0,
+            address: "0xGovernor".to_owned(),
+            topics: Vec::new(),
+            data: "0x".to_owned(),
+            removed: false,
+            raw_payload: json!({}),
+        }
+    }
 }

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -79,6 +79,7 @@ pub async fn apply_migrations(pool: &PgPool) -> Result<()> {
         drop_invalid_runtime_indexes_for_connection(&mut connection).await?;
         ensure_runtime_indexes(&mut connection).await?;
         repair_delegate_effective_counts_once(&mut connection).await?;
+        repair_vote_timestamps_millis_once(&mut connection).await?;
         drop_obsolete_runtime_indexes_for_connection(&mut connection).await?;
 
         Ok(())
@@ -456,12 +457,13 @@ async fn repair_invalid_runtime_indexes_for_connection(
     drop_invalid_runtime_indexes_for_connection(connection).await?;
     ensure_runtime_indexes(connection).await?;
     repair_delegate_effective_counts_once(connection).await?;
+    repair_vote_timestamps_millis_once(connection).await?;
     drop_obsolete_runtime_indexes_for_connection(connection).await?;
 
     Ok(())
 }
 
-async fn repair_delegate_effective_counts_once(connection: &mut PgConnection) -> Result<()> {
+async fn ensure_runtime_repair_marker_table(connection: &mut PgConnection) -> Result<()> {
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS degov_runtime_repair_marker (
             id TEXT PRIMARY KEY,
@@ -471,6 +473,12 @@ async fn repair_delegate_effective_counts_once(connection: &mut PgConnection) ->
     .execute(&mut *connection)
     .await
     .context("ensure DeGov runtime repair marker table")?;
+
+    Ok(())
+}
+
+async fn repair_delegate_effective_counts_once(connection: &mut PgConnection) -> Result<()> {
+    ensure_runtime_repair_marker_table(connection).await?;
 
     let already_applied = sqlx::query_scalar::<_, bool>(
         "SELECT EXISTS (
@@ -543,6 +551,86 @@ async fn repair_delegate_effective_counts_once(connection: &mut PgConnection) ->
     .execute(&mut *connection)
     .await
     .context("mark delegate effective count runtime repair complete")?;
+
+    Ok(())
+}
+
+async fn repair_vote_timestamps_millis_once(connection: &mut PgConnection) -> Result<()> {
+    ensure_runtime_repair_marker_table(connection).await?;
+
+    let already_applied = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM degov_runtime_repair_marker
+            WHERE id = 'vote_timestamps_millis_v1'
+         )",
+    )
+    .fetch_one(&mut *connection)
+    .await
+    .context("check vote timestamp millis runtime repair marker")?;
+
+    if already_applied {
+        return Ok(());
+    }
+
+    let row = sqlx::query_as::<_, (i64, i64, i64, i64)>(
+        "WITH updated_vote_cast AS (
+            UPDATE vote_cast
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_vote_cast_with_params AS (
+            UPDATE vote_cast_with_params
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_vote_cast_group AS (
+            UPDATE vote_cast_group
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_contributor AS (
+            UPDATE contributor
+            SET last_vote_timestamp = last_vote_timestamp * 1000
+            WHERE last_vote_timestamp IS NOT NULL
+              AND last_vote_timestamp < 1000000000000
+            RETURNING id
+         )
+         SELECT
+            (SELECT COUNT(*)::BIGINT FROM updated_vote_cast) AS vote_cast_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_vote_cast_with_params) AS vote_cast_with_params_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_vote_cast_group) AS vote_cast_group_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_contributor) AS contributor_updates",
+    )
+    .fetch_one(&mut *connection)
+    .await
+    .context("repair vote timestamps to milliseconds")?;
+
+    log::info!(
+        "DeGov vote timestamps repaired to milliseconds vote_cast_updates={} vote_cast_with_params_updates={} vote_cast_group_updates={} contributor_updates={}",
+        row.0,
+        row.1,
+        row.2,
+        row.3
+    );
+
+    sqlx::query(
+        "INSERT INTO degov_runtime_repair_marker (id, applied_at)
+         VALUES (
+            'vote_timestamps_millis_v1',
+            FLOOR(EXTRACT(EPOCH FROM now()) * 1000)::NUMERIC(78, 0)
+         )
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("mark vote timestamp millis runtime repair complete")?;
 
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -472,6 +472,8 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("degov_runtime_repair_marker"));
     assert!(runtime_migration.contains("delegate_effective_counts_v1"));
     assert!(runtime_migration.contains("repair_delegate_effective_counts_once"));
+    assert!(runtime_migration.contains("vote_timestamps_millis_v1"));
+    assert!(runtime_migration.contains("repair_vote_timestamps_millis_once"));
     assert!(runtime_migration.contains("onchain_refresh_data_metric_task"));
     assert!(runtime_migration.contains("onchain_refresh_task_pending_ready_claim_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_pending_scope_claim_idx"));

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -894,6 +894,32 @@ async fn test_postgres_data_metric_event_rows_are_idempotent_and_keep_global()
             .map_err(|error| format!("commit transaction failed: {error}"))?;
     }
 
+    let vote_row = sqlx::query(
+        "SELECT block_timestamp::TEXT AS block_timestamp
+         FROM vote_cast
+         WHERE id = '0000000003-vote'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(
+        vote_row.get::<String, _>("block_timestamp"),
+        "1700000003000"
+    );
+
+    let contributor = sqlx::query(
+        "SELECT last_vote_timestamp::TEXT AS last_vote_timestamp
+         FROM contributor
+         WHERE contract_set_id = $1
+           AND id = '0x4444444444444444444444444444444444444444'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(
+        contributor.get::<Option<String>, _>("last_vote_timestamp"),
+        Some("1700000003000".to_owned())
+    );
+
     let rows = sqlx::query(
         "SELECT id, proposals_count, votes_count, votes_without_params_count,
                 votes_weight_for_sum::TEXT AS votes_weight_for_sum,

--- a/apps/indexer/tests/vote_projection.rs
+++ b/apps/indexer/tests/vote_projection.rs
@@ -66,7 +66,7 @@ fn test_project_vote_events_preserves_vote_rows_groups_totals_and_signals() {
     assert_eq!(vote.weight, "100");
     assert_eq!(vote.reason, "looks good");
     assert_eq!(vote.block_number, "10");
-    assert_eq!(vote.block_timestamp.as_deref(), Some("1700000010"));
+    assert_eq!(vote.block_timestamp.as_deref(), Some("1700000010000"));
     assert_eq!(vote.transaction_hash, "0xtx10");
 
     let metric = &batch.data_metrics[0];


### PR DESCRIPTION
## Summary
- normalize vote projection timestamps to milliseconds
- keep millisecond timestamps unchanged while accepting second timestamps defensively
- add projection and Postgres regression coverage for vote_cast.block_timestamp and contributor.last_vote_timestamp

## Why
Lisk v5 data comparison showed vote_cast.block_timestamp and contributor.last_vote_timestamp were stored as seconds while proposal/token timestamps use milliseconds. This made v5 differ from the existing production index and can affect UI time rendering and sorting.

## Follow-up after deploy
Backfill existing v5 rows whose vote-related timestamp columns are still second-level values by multiplying by 1000.

## Tests
- cargo test -p degov-datalens-indexer --lib test_project_vote_events_ -- --nocapture
- cargo test -p degov-datalens-indexer --test vote_projection
- DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/postgres cargo test -p degov-datalens-indexer --test postgres_runtime_run
- cargo fmt --check
- git diff --check