### PR TITLE
perf(indexer): use unified Datalens log selector

### DIFF
--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -185,58 +185,37 @@ fn query_plans(
     from_block: i32,
     to_block: i32,
 ) -> Vec<DaoLogQueryPlan> {
-    let mut plans = vec![query_plan(
-        config,
+    let mut sources = vec![
         DaoLogAddressSource {
             address: addresses.governor.clone(),
             source: DaoLogSource::Governor,
         },
-        GOVERNOR_TOPIC0_FILTERS,
-        from_block,
-        to_block,
-    )];
-    plans.push(query_plan(
-        config,
         DaoLogAddressSource {
             address: addresses.governor_token.clone(),
             source: DaoLogSource::GovernorToken,
         },
-        GOVERNOR_TOKEN_TOPIC0_FILTERS,
-        from_block,
-        to_block,
-    ));
-
+    ];
     if let Some(timelock) = &addresses.timelock {
-        plans.push(query_plan(
-            config,
-            DaoLogAddressSource {
-                address: timelock.clone(),
-                source: DaoLogSource::Timelock,
-            },
-            TIMELOCK_TOPIC0_FILTERS,
-            from_block,
-            to_block,
-        ));
+        sources.push(DaoLogAddressSource {
+            address: timelock.clone(),
+            source: DaoLogSource::Timelock,
+        });
     }
 
-    plans
+    vec![query_plan(config, sources, from_block, to_block)]
 }
 
 fn query_plan(
     config: &DatalensConfig,
-    source: DaoLogAddressSource,
-    topic0_filters: &[&str],
+    sources: Vec<DaoLogAddressSource>,
     from_block: i32,
     to_block: i32,
 ) -> DaoLogQueryPlan {
-    let topics = topic0_filters
-        .iter()
-        .map(|topic| topic.to_string())
-        .collect();
-    let address = source.address.clone();
+    let addresses = source_addresses(&sources);
+    let topics = unified_topic0_filters();
 
     DaoLogQueryPlan {
-        sources: vec![source],
+        sources,
         from_block,
         to_block,
         input: QueryInput {
@@ -258,7 +237,7 @@ fn query_plan(
             selector: QuerySelectorInput {
                 kind: SelectorKindInput::EvmLogs,
                 evm_logs: Some(EvmLogsSelectorInput {
-                    addresses: vec![address],
+                    addresses,
                     topics: vec![topics],
                 }),
                 other: None,
@@ -274,6 +253,31 @@ fn query_plan(
             fields: None,
         },
     }
+}
+
+fn source_addresses(sources: &[DaoLogAddressSource]) -> Vec<String> {
+    let mut addresses = Vec::new();
+    for source in sources {
+        if !addresses.contains(&source.address) {
+            addresses.push(source.address.clone());
+        }
+    }
+    addresses
+}
+
+fn unified_topic0_filters() -> Vec<String> {
+    let mut topics = Vec::new();
+    for topic in GOVERNOR_TOPIC0_FILTERS
+        .iter()
+        .chain(GOVERNOR_TOKEN_TOPIC0_FILTERS)
+        .chain(TIMELOCK_TOPIC0_FILTERS)
+    {
+        let topic = (*topic).to_owned();
+        if !topics.contains(&topic) {
+            topics.push(topic);
+        }
+    }
+    topics
 }
 
 const GOVERNOR_TOPIC0_FILTERS: &[&str] = &[

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -1632,9 +1632,9 @@ mod tests {
 
         assert_eq!(result, Some(1));
         assert_eq!(reader.latest_head_calls, 1);
-        assert_eq!(reader.ranges.len(), 2);
+        assert_eq!(reader.ranges.len(), 1);
         assert!(reader.ranges.iter().all(|range| *range == (21, 25)));
-        assert_eq!(reader.finalities.len(), 2);
+        assert_eq!(reader.finalities.len(), 1);
         assert!(
             reader
                 .finalities

--- a/apps/indexer/tests/datalens_client.rs
+++ b/apps/indexer/tests/datalens_client.rs
@@ -239,7 +239,7 @@ fn test_datalens_warmup_ensurer_uses_ensure_endpoint() {
             "created": false
         }),
     );
-    let server = FakeQueryServer::start(vec![response.clone(), response.clone(), response]);
+    let server = FakeQueryServer::start(vec![response]);
     let mut config = datalens_config(&server.endpoint, DatalensFinality::DurableOnly);
     config.warmup.enabled = true;
     let mut client = DatalensNativeClient::from_config(&config).expect("client");
@@ -247,7 +247,7 @@ fn test_datalens_warmup_ensurer_uses_ensure_endpoint() {
     ensure_datalens_warmup_task(&mut client, &config, &addresses(), 100).expect("warmup ensured");
 
     let requests = server.join();
-    assert_eq!(requests.len(), 3);
+    assert_eq!(requests.len(), 1);
     for request in requests {
         assert!(
             request.starts_with("POST /v1/warmup/tasks/ensure "),

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -15,30 +15,24 @@ fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelo
     let addresses = addresses();
     let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 3);
-    assert_source_queries(
-        &plans,
-        DaoLogSource::Governor,
-        &addresses.governor,
-        GOVERNOR_TOPIC0_VALUES,
-        100,
-        199,
-        "durable_only",
-    );
-    assert_source_queries(
-        &plans,
-        DaoLogSource::GovernorToken,
-        &addresses.governor_token,
-        GOVERNOR_TOKEN_TOPIC0_VALUES,
-        100,
-        199,
-        "durable_only",
-    );
-    assert_source_queries(
-        &plans,
-        DaoLogSource::Timelock,
-        addresses.timelock.as_ref().expect("timelock"),
-        TIMELOCK_TOPIC0_VALUES,
+    assert_eq!(plans.len(), 1);
+    assert_query(
+        &plans[0],
+        &[
+            DaoLogAddressSource {
+                address: addresses.governor.clone(),
+                source: DaoLogSource::Governor,
+            },
+            DaoLogAddressSource {
+                address: addresses.governor_token.clone(),
+                source: DaoLogSource::GovernorToken,
+            },
+            DaoLogAddressSource {
+                address: addresses.timelock.clone().expect("timelock"),
+                source: DaoLogSource::Timelock,
+            },
+        ],
+        &unified_topic0_values(),
         100,
         199,
         "durable_only",
@@ -53,25 +47,25 @@ fn test_plan_dao_log_queries_skips_timelock_when_not_configured() {
 
     let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 2);
+    assert_eq!(plans.len(), 1);
     assert_eq!(
-        plans
-            .iter()
-            .filter(|plan| plan.sources[0].source == DaoLogSource::Governor)
-            .count(),
-        1
-    );
-    assert_eq!(
-        plans
-            .iter()
-            .filter(|plan| plan.sources[0].source == DaoLogSource::GovernorToken)
-            .count(),
-        1
+        plans[0].sources,
+        vec![
+            DaoLogAddressSource {
+                address: addresses.governor,
+                source: DaoLogSource::Governor,
+            },
+            DaoLogAddressSource {
+                address: addresses.governor_token,
+                source: DaoLogSource::GovernorToken,
+            },
+        ]
     );
     assert!(
-        plans
+        plans[0]
+            .sources
             .iter()
-            .all(|plan| plan.sources[0].source != DaoLogSource::Timelock)
+            .all(|source| source.source != DaoLogSource::Timelock)
     );
 }
 
@@ -84,7 +78,7 @@ fn test_plan_dao_log_queries_chunks_ranges_by_config_limit() {
         .map(|plan| (plan.from_block, plan.to_block))
         .collect::<Vec<_>>();
 
-    let plans_per_chunk = 3;
+    let plans_per_chunk = 1;
 
     assert_eq!(ranges.len(), plans_per_chunk * 3);
     assert_eq!(
@@ -196,38 +190,10 @@ fn test_fetch_dao_log_pages_stops_without_later_pages_on_reader_error() {
     assert_eq!(reader.calls.len(), 1);
 }
 
-fn assert_source_queries(
-    plans: &[DaoLogQueryPlan],
-    source: DaoLogSource,
-    address: &str,
-    topic0_values: &[&str],
-    from_block: i32,
-    to_block: i32,
-    finality: &str,
-) {
-    let source_plans = plans
-        .iter()
-        .filter(|plan| plan.sources[0].source == source)
-        .collect::<Vec<_>>();
-
-    assert_eq!(source_plans.len(), 1);
-    assert_query(
-        source_plans[0],
-        &[DaoLogAddressSource {
-            address: address.to_owned(),
-            source,
-        }],
-        topic0_values,
-        from_block,
-        to_block,
-        finality,
-    );
-}
-
 fn assert_query(
     plan: &DaoLogQueryPlan,
     sources: &[DaoLogAddressSource],
-    topic0_values: &[&str],
+    topic0_values: &[String],
     from_block: i32,
     to_block: i32,
     finality: &str,
@@ -261,6 +227,21 @@ fn assert_query(
                 .collect::<Vec<_>>()
         ]
     );
+}
+
+fn unified_topic0_values() -> Vec<String> {
+    let mut topics = Vec::new();
+    for topic in GOVERNOR_TOPIC0_VALUES
+        .iter()
+        .chain(GOVERNOR_TOKEN_TOPIC0_VALUES)
+        .chain(TIMELOCK_TOPIC0_VALUES)
+    {
+        let topic = (*topic).to_owned();
+        if !topics.contains(&topic) {
+            topics.push(topic);
+        }
+    }
+    topics
 }
 
 fn config(block_range_limit: u32, finality: DatalensFinality) -> DatalensConfig {

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -32,32 +32,15 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
         outcome,
         DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.requests.len(), 3);
-    let selector_addresses = ensurer
-        .requests
-        .iter()
-        .map(|request| request.selector.addresses.clone())
-        .collect::<Vec<_>>();
+    assert_eq!(ensurer.requests.len(), 1);
+    let selector_addresses = &ensurer.requests[0].selector.addresses;
     assert_eq!(
-        selector_addresses
-            .iter()
-            .filter(|addresses| addresses[0] == "0x1111111111111111111111111111111111111111")
-            .count(),
-        1
-    );
-    assert_eq!(
-        selector_addresses
-            .iter()
-            .filter(|addresses| addresses[0] == "0x2222222222222222222222222222222222222222")
-            .count(),
-        1
-    );
-    assert_eq!(
-        selector_addresses
-            .iter()
-            .filter(|addresses| addresses[0] == "0x3333333333333333333333333333333333333333")
-            .count(),
-        1
+        selector_addresses,
+        &vec![
+            "0x1111111111111111111111111111111111111111".to_owned(),
+            "0x2222222222222222222222222222222222222222".to_owned(),
+            "0x3333333333333333333333333333333333333333".to_owned(),
+        ]
     );
     let topic_counts = ensurer
         .requests
@@ -67,7 +50,7 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
             request.selector.topics[0].len()
         })
         .collect::<Vec<_>>();
-    assert_eq!(topic_counts, vec![13, 3, 8]);
+    assert_eq!(topic_counts, vec![24]);
     for request in &ensurer.requests {
         assert_eq!(request.chain.configured_name, "ethereum");
         assert_eq!(request.chain.network_id, Some(1));
@@ -97,7 +80,7 @@ fn test_ensure_datalens_warmup_task_reuses_existing_matching_task() {
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 3);
+    assert_eq!(ensurer.created_tasks.len(), 1);
 }
 
 #[test]
@@ -115,7 +98,7 @@ fn test_ensure_datalens_warmup_task_submits_distinct_task_for_selector_mismatch(
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 4);
+    assert_eq!(ensurer.created_tasks.len(), 2);
 }
 
 #[test]

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -377,9 +377,9 @@ fn test_runner_splits_provider_limit_range_and_advances_checkpoint_after_subrang
     assert_eq!(runner.store().commit_count(), 2);
     let observed = observed_ranges.lock().expect("observed ranges");
     assert_range_count(&observed, (1, 1_000), 1);
-    assert_range_count(&observed, (1, 500), ALL_SELECTOR_COUNT);
-    assert_range_count(&observed, (501, 1_000), ALL_SELECTOR_COUNT);
-    assert_eq!(observed.len(), 1 + ALL_SELECTOR_COUNT * 2);
+    assert_range_count(&observed, (1, 500), DATALENS_QUERY_SELECTOR_COUNT);
+    assert_range_count(&observed, (501, 1_000), DATALENS_QUERY_SELECTOR_COUNT);
+    assert_eq!(observed.len(), 1 + DATALENS_QUERY_SELECTOR_COUNT * 2);
 }
 
 #[test]
@@ -410,8 +410,8 @@ fn test_runner_splits_transient_range_and_retries_without_pass_error() {
     assert_eq!(runner.store().commit_count(), 1);
     let observed = observed_ranges.lock().expect("observed ranges");
     assert_range_count(&observed, (1, 5_000), 1);
-    assert_range_count(&observed, (1, 2_500), ALL_SELECTOR_COUNT);
-    assert_eq!(observed.len(), 1 + ALL_SELECTOR_COUNT);
+    assert_range_count(&observed, (1, 2_500), DATALENS_QUERY_SELECTOR_COUNT);
+    assert_eq!(observed.len(), 1 + DATALENS_QUERY_SELECTOR_COUNT);
 }
 
 #[test]
@@ -445,8 +445,8 @@ fn test_runner_splits_transient_failure_below_normal_min_and_advances_checkpoint
         &observed[..6],
         &[(1, 101), (1, 50), (1, 25), (1, 12), (1, 6), (1, 3)]
     );
-    assert_range_count(&observed, (1, 1), ALL_SELECTOR_COUNT);
-    assert_eq!(observed.len(), 6 + ALL_SELECTOR_COUNT);
+    assert_range_count(&observed, (1, 1), DATALENS_QUERY_SELECTOR_COUNT);
+    assert_eq!(observed.len(), 6 + DATALENS_QUERY_SELECTOR_COUNT);
 }
 
 #[test]
@@ -477,8 +477,8 @@ fn test_runner_splits_two_block_transient_failure_to_single_block() {
     assert_eq!(runner.store().commit_count(), 1);
     let observed = observed_ranges.lock().expect("observed ranges");
     assert_range_count(&observed, (1, 2), 1);
-    assert_range_count(&observed, (1, 1), ALL_SELECTOR_COUNT);
-    assert_eq!(observed.len(), 1 + ALL_SELECTOR_COUNT);
+    assert_range_count(&observed, (1, 1), DATALENS_QUERY_SELECTOR_COUNT);
+    assert_eq!(observed.len(), 1 + DATALENS_QUERY_SELECTOR_COUNT);
 }
 
 #[test]
@@ -1102,7 +1102,7 @@ fn test_runner_decodes_duplicate_address_token_log_with_token_source() {
         &attempts,
         GOVERNOR_SELECTOR_COUNT,
         GOVERNOR_TOKEN_SELECTOR_COUNT,
-        TIMELOCK_SELECTOR_COUNT,
+        0,
     );
     assert_eq!(
         runner.store().token_repository().delegate_changed().len(),
@@ -1880,5 +1880,4 @@ const TOKEN: &str = "0x2222222222222222222222222222222222222222";
 const GOVERNOR_SELECTOR_COUNT: usize = 1;
 const GOVERNOR_TOKEN_SELECTOR_COUNT: usize = 1;
 const TIMELOCK_SELECTOR_COUNT: usize = 1;
-const ALL_SELECTOR_COUNT: usize =
-    GOVERNOR_SELECTOR_COUNT + GOVERNOR_TOKEN_SELECTOR_COUNT + TIMELOCK_SELECTOR_COUNT;
+const DATALENS_QUERY_SELECTOR_COUNT: usize = 1;

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -128,7 +128,7 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
     run_indexer_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 1);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
     assert_table_count(&database.pool, "proposal_created", 1).await?;
     assert_table_count(&database.pool, "proposal", 1).await?;
     assert_table_count(&database.pool, "vote_cast", 1).await?;
@@ -366,7 +366,7 @@ async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
     run_indexer_all_contract_sets_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 0);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 3);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
     assert_checkpoint_scope(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_scope(&database.pool, SECOND_CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_row_count(&database.pool, 2).await?;
@@ -3284,15 +3284,16 @@ fn handle_datalens_request(
     } else {
         query_count.fetch_add(1, Ordering::Relaxed);
         let request_body = request.split("\r\n\r\n").nth(1).unwrap_or_default();
-        let rows = if request_body.contains(GOVERNOR) || request_body.contains(SECOND_GOVERNOR) {
-            matching_datalens_rows(request_body, governor_rows)
-        } else if request_body.contains(TOKEN) || request_body.contains(SECOND_TOKEN) {
-            matching_datalens_rows(request_body, token_rows)
-        } else if request_body.contains(TIMELOCK) || request_body.contains(SECOND_TIMELOCK) {
-            matching_datalens_rows(request_body, timelock_rows)
-        } else {
-            Vec::new()
-        };
+        let mut rows = Vec::new();
+        if request_body.contains(GOVERNOR) || request_body.contains(SECOND_GOVERNOR) {
+            rows.extend(matching_datalens_rows(request_body, governor_rows));
+        }
+        if request_body.contains(TOKEN) || request_body.contains(SECOND_TOKEN) {
+            rows.extend(matching_datalens_rows(request_body, token_rows));
+        }
+        if request_body.contains(TIMELOCK) || request_body.contains(SECOND_TIMELOCK) {
+            rows.extend(matching_datalens_rows(request_body, timelock_rows));
+        }
 
         json!({
             "chain": {},

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -29,16 +29,10 @@ static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 #[test]
 fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
     let config = datalens_config();
-    let mut results = vec![Ok(DatalensProvisionalLogQueryResult {
+    let results = vec![Ok(DatalensProvisionalLogQueryResult {
         rows: serde_json::json!([]),
         segments: vec![cache_segment("provider", "latest", 100, 105)],
     })];
-    results.extend((1..3).map(|_| {
-        Ok(DatalensProvisionalLogQueryResult {
-            rows: serde_json::json!([]),
-            segments: Vec::new(),
-        })
-    }));
     let mut reader = MockProvisionalReader::new(results);
     let mut store = RecordingProvisionalStore::default();
     let mut worker = ProvisionalWorker::new(options(&config), &mut reader, &mut store);
@@ -46,7 +40,7 @@ fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
     let report = worker.run_once().expect("worker runs once");
 
     assert_eq!(report.segments_written, 1);
-    assert_eq!(reader.calls.len(), 3);
+    assert_eq!(reader.calls.len(), 1);
     assert!(
         reader
             .calls


### PR DESCRIPTION
## Summary
- query governor, token, and timelock logs through one Datalens EVM logs selector per chunk
- keep the existing API shape while reducing per-chunk Datalens requests from 2-3 to 1
- update provisional worker and planner tests for the unified selector behavior

## Why
The staging indexer was still issuing separate Datalens selectors per DAO contract address, which created separate cache fingerprints and caused repeated provider fills even after Datalens broad selector/cache fixes were deployed. A unified selector lets Datalens reuse coverage at the DAO contract-set level and reduces query fanout.

## Tests
- cargo test -p degov-datalens-indexer --lib --locked
- cargo test -p degov-datalens-indexer --test datalens_planner --locked

## Notes
- Full `cargo test -p degov-datalens-indexer --locked` reaches Postgres integration tests and requires `DEGOV_INDEXER_TEST_DATABASE_URL`; local run stopped there after the non-DB tests passed.
