### PR TITLE
perf(indexer): skip worker backlog count

### DIFF
--- a/apps/indexer/src/runtime/worker.rs
+++ b/apps/indexer/src/runtime/worker.rs
@@ -138,7 +138,7 @@ where
         OnchainRefreshWorkerBatchScope::Global => worker.run_once().await,
         OnchainRefreshWorkerBatchScope::Scoped(scope) => {
             worker
-                .run_once_with_batch_size_for_scope(batch_size, scope)
+                .run_once_with_batch_size_for_scope_without_backlog(batch_size, scope)
                 .await
         }
     }


### PR DESCRIPTION
## Summary
- skip the expensive ready backlog count in the scoped onchain-refresh-worker hot path
- keep the existing no-backlog path aligned with the indexer tick runner

## Why
The staging worker showed each Compound batch spending tens of seconds on the post-batch backlog count. That count is observational only and should not sit in the critical path for draining onchain refresh tasks.

## Tests
- cargo fmt --check
- cargo test --locked -p degov-datalens-indexer runtime::worker --lib