### PR TITLE
fix(indexer): skip stale onchain refresh requeues

### DIFF
--- a/apps/indexer/src/store/postgres/onchain_refresh.rs
+++ b/apps/indexer/src/store/postgres/onchain_refresh.rs
@@ -652,7 +652,13 @@ fn onchain_refresh_task_upsert_sql() -> &'static str {
              THEN EXCLUDED.last_seen_transaction_hash
            ELSE NULL
          END,
-         updated_at = EXCLUDED.updated_at"
+         updated_at = EXCLUDED.updated_at
+     WHERE onchain_refresh_task.status <> 'completed'
+        OR EXCLUDED.reason = 'contributor-coverage'
+        OR EXCLUDED.last_seen_block_number > onchain_refresh_task.last_seen_block_number
+        OR EXCLUDED.last_seen_block_timestamp > onchain_refresh_task.last_seen_block_timestamp
+        OR (EXCLUDED.refresh_balance AND NOT onchain_refresh_task.refresh_balance)
+        OR (EXCLUDED.refresh_power AND NOT onchain_refresh_task.refresh_power)"
 }
 
 async fn upsert_deferred_onchain_refresh_candidate_chunk(

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -2442,6 +2442,51 @@ async fn test_onchain_refresh_worker_drains_deferred_tasks_to_claim_budget_in_sm
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_skips_stale_completed_deferred_task()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let task_id = "completed-task";
+    seed_task(
+        &database.pool,
+        task_id,
+        ACCOUNT_ONE,
+        "completed",
+        1,
+        false,
+        true,
+    )
+    .await?;
+    seed_deferred_task(&database.pool, "stale-deferred", ACCOUNT_ONE).await?;
+
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::new([]),
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.claimed, 0);
+    assert_eq!(report.completed, 0);
+    assert_eq!(report.failed, 0);
+    assert_task_status(&database.pool, task_id, "completed", 1).await?;
+    assert_table_count(&database.pool, "onchain_refresh_deferred_candidate", 0).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_repairs_missing_contributor_coverage()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;


### PR DESCRIPTION
## Summary
- avoid reopening completed onchain refresh tasks when a deferred candidate has no newer event data and no new refresh requirement
- keep contributor coverage repair able to requeue completed tasks when overlay coverage is missing
- add a regression test for stale completed deferred candidates

## Why
Staging showed completed onchain refresh rows could be materialized back into pending from deferred candidates, which makes status counts non-monotonic and can waste onchain RPC capacity.

## Tests
- cargo fmt --check
- DEGOV_INDEXER_TEST_DATABASE_URL='postgresql://postgres:postgres@localhost:55432/postgres' cargo test --locked -p degov-datalens-indexer --test onchain_refresh_worker -- --nocapture