### PR TITLE
fix(indexer): store token timestamps in milliseconds

### DIFF
--- a/apps/indexer/src/projection/token.rs
+++ b/apps/indexer/src/projection/token.rs
@@ -680,7 +680,7 @@ fn common(
         block_number: log.block_number.to_string(),
         block_timestamp: log
             .block_timestamp_ms
-            .map(|timestamp| (timestamp / 1_000).to_string()),
+            .map(|timestamp| timestamp.to_string()),
         transaction_hash: normalize_identifier(&log.transaction_hash),
     }
 }

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -80,6 +80,7 @@ pub async fn apply_migrations(pool: &PgPool) -> Result<()> {
         ensure_runtime_indexes(&mut connection).await?;
         repair_delegate_effective_counts_once(&mut connection).await?;
         repair_vote_timestamps_millis_once(&mut connection).await?;
+        repair_token_timestamps_millis_once(&mut connection).await?;
         drop_obsolete_runtime_indexes_for_connection(&mut connection).await?;
 
         Ok(())
@@ -458,6 +459,7 @@ async fn repair_invalid_runtime_indexes_for_connection(
     ensure_runtime_indexes(connection).await?;
     repair_delegate_effective_counts_once(connection).await?;
     repair_vote_timestamps_millis_once(connection).await?;
+    repair_token_timestamps_millis_once(connection).await?;
     drop_obsolete_runtime_indexes_for_connection(connection).await?;
 
     Ok(())
@@ -631,6 +633,159 @@ async fn repair_vote_timestamps_millis_once(connection: &mut PgConnection) -> Re
     .execute(&mut *connection)
     .await
     .context("mark vote timestamp millis runtime repair complete")?;
+
+    Ok(())
+}
+
+async fn repair_token_timestamps_millis_once(connection: &mut PgConnection) -> Result<()> {
+    ensure_runtime_repair_marker_table(connection).await?;
+
+    let already_applied = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM degov_runtime_repair_marker
+            WHERE id = 'token_timestamps_millis_v1'
+         )",
+    )
+    .fetch_one(&mut *connection)
+    .await
+    .context("check token timestamp millis runtime repair marker")?;
+
+    if already_applied {
+        return Ok(());
+    }
+
+    let row =
+        sqlx::query_as::<_, (i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64)>(
+        "WITH updated_delegate_changed AS (
+            UPDATE delegate_changed
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_delegate_votes_changed AS (
+            UPDATE delegate_votes_changed
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_token_transfer AS (
+            UPDATE token_transfer
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_delegate_rolling AS (
+            UPDATE delegate_rolling
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_delegate_mapping AS (
+            UPDATE delegate_mapping
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_delegate AS (
+            UPDATE delegate
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_contributor AS (
+            UPDATE contributor
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_token_balance_checkpoint AS (
+            UPDATE token_balance_checkpoint
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_vote_power_checkpoint AS (
+            UPDATE vote_power_checkpoint
+            SET block_timestamp = block_timestamp * 1000
+            WHERE block_timestamp IS NOT NULL
+              AND block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_onchain_refresh_task_last_seen AS (
+            UPDATE onchain_refresh_task
+            SET last_seen_block_timestamp = last_seen_block_timestamp * 1000
+            WHERE last_seen_block_timestamp IS NOT NULL
+              AND last_seen_block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_onchain_refresh_task_pending_after_lock AS (
+            UPDATE onchain_refresh_task
+            SET pending_after_lock_block_timestamp = pending_after_lock_block_timestamp * 1000
+            WHERE pending_after_lock_block_timestamp IS NOT NULL
+              AND pending_after_lock_block_timestamp < 1000000000000
+            RETURNING id
+         ),
+         updated_onchain_refresh_deferred_candidate AS (
+            UPDATE onchain_refresh_deferred_candidate
+            SET last_seen_block_timestamp = last_seen_block_timestamp * 1000
+            WHERE last_seen_block_timestamp IS NOT NULL
+              AND last_seen_block_timestamp < 1000000000000
+            RETURNING id
+         )
+         SELECT
+            (SELECT COUNT(*)::BIGINT FROM updated_delegate_changed) AS delegate_changed_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_delegate_votes_changed) AS delegate_votes_changed_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_token_transfer) AS token_transfer_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_delegate_rolling) AS delegate_rolling_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_delegate_mapping) AS delegate_mapping_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_delegate) AS delegate_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_contributor) AS contributor_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_token_balance_checkpoint) AS token_balance_checkpoint_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_vote_power_checkpoint) AS vote_power_checkpoint_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_onchain_refresh_task_last_seen) AS onchain_refresh_task_last_seen_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_onchain_refresh_task_pending_after_lock) AS onchain_refresh_task_pending_after_lock_updates,
+            (SELECT COUNT(*)::BIGINT FROM updated_onchain_refresh_deferred_candidate) AS onchain_refresh_deferred_candidate_updates",
+    )
+    .fetch_one(&mut *connection)
+    .await
+    .context("repair token timestamps to milliseconds")?;
+
+    log::info!(
+        "DeGov token timestamps repaired to milliseconds delegate_changed_updates={} delegate_votes_changed_updates={} token_transfer_updates={} delegate_rolling_updates={} delegate_mapping_updates={} delegate_updates={} contributor_updates={} token_balance_checkpoint_updates={} vote_power_checkpoint_updates={} onchain_refresh_task_last_seen_updates={} onchain_refresh_task_pending_after_lock_updates={} onchain_refresh_deferred_candidate_updates={}",
+        row.0,
+        row.1,
+        row.2,
+        row.3,
+        row.4,
+        row.5,
+        row.6,
+        row.7,
+        row.8,
+        row.9,
+        row.10,
+        row.11
+    );
+
+    sqlx::query(
+        "INSERT INTO degov_runtime_repair_marker (id, applied_at)
+         VALUES (
+            'token_timestamps_millis_v1',
+            FLOOR(EXTRACT(EPOCH FROM now()) * 1000)::NUMERIC(78, 0)
+         )
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .execute(&mut *connection)
+    .await
+    .context("mark token timestamp millis runtime repair complete")?;
 
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -371,6 +371,161 @@ async fn test_migration_can_run_twice_without_deleting_existing_rows() -> Result
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_migration_repairs_token_timestamps_to_millis() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    sqlx::query(
+        r#"
+        INSERT INTO delegate_changed (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            contract_address, log_index, transaction_index, delegator, from_delegate,
+            to_delegate, block_number, block_timestamp, transaction_hash
+        )
+        VALUES (
+            'delegate-change', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+            '0xtoken', 0, 0, '0xdelegator', '0xfrom',
+            '0xto', 10, 1700000010, '0xtx'
+        )
+        "#,
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO delegate_votes_changed (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            contract_address, log_index, transaction_index, delegate, previous_votes,
+            new_votes, block_number, block_timestamp, transaction_hash
+        )
+        VALUES (
+            'delegate-votes-change', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+            '0xtoken', 1, 0, '0xdelegate', 0,
+            10, 11, 1700000011, '0xtx'
+        )
+        "#,
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO token_transfer (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            contract_address, log_index, transaction_index, "from", "to",
+            value, standard, block_number, block_timestamp, transaction_hash
+        )
+        VALUES (
+            'token-transfer', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+            '0xtoken', 2, 0, '0xfrom', '0xto',
+            10, 'erc20', 12, 1700000012, '0xtx'
+        )
+        "#,
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO contributor (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            contract_address, log_index, transaction_index, block_number,
+            block_timestamp, transaction_hash, power, delegates_count_all,
+            delegates_count_effective
+        )
+        VALUES (
+            '0xcontributor', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+            '0xtoken', 3, 0, 13, 1700000013, '0xtx', 0, 0, 0
+        )
+        "#,
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO token_balance_checkpoint (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            contract_address, log_index, transaction_index, account, previous_balance,
+            new_balance, delta, source, cause, block_number, block_timestamp,
+            transaction_hash
+        )
+        VALUES (
+            'token-balance-checkpoint', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+            '0xtoken', 4, 0, '0xaccount', 0, 10, 10, 'event', 'transfer',
+            14, 1700000014, '0xtx'
+        )
+        "#,
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO vote_power_checkpoint (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            contract_address, log_index, transaction_index, account, clock_mode,
+            timepoint, previous_power, new_power, delta, source, cause, block_number,
+            block_timestamp, transaction_hash
+        )
+        VALUES (
+            'vote-power-checkpoint', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+            '0xtoken', 5, 0, '0xaccount', 'blocknumber', 15, 0, 10, 10,
+            'event', 'delegate-change', 15, 1700000015, '0xtx'
+        )
+        "#,
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "DELETE FROM degov_runtime_repair_marker
+         WHERE id = 'token_timestamps_millis_v1'",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    apply_migrations(&database.pool).await?;
+    apply_migrations(&database.pool).await?;
+
+    let row = sqlx::query(
+        "SELECT
+            (SELECT block_timestamp::TEXT FROM delegate_changed WHERE id = 'delegate-change') AS delegate_changed_timestamp,
+            (SELECT block_timestamp::TEXT FROM delegate_votes_changed WHERE id = 'delegate-votes-change') AS delegate_votes_changed_timestamp,
+            (SELECT block_timestamp::TEXT FROM token_transfer WHERE id = 'token-transfer') AS token_transfer_timestamp,
+            (SELECT block_timestamp::TEXT FROM contributor WHERE id = '0xcontributor') AS contributor_timestamp,
+            (SELECT block_timestamp::TEXT FROM token_balance_checkpoint WHERE id = 'token-balance-checkpoint') AS token_balance_checkpoint_timestamp,
+            (SELECT block_timestamp::TEXT FROM vote_power_checkpoint WHERE id = 'vote-power-checkpoint') AS vote_power_checkpoint_timestamp",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+
+    assert_eq!(
+        row.get::<String, _>("delegate_changed_timestamp"),
+        "1700000010000"
+    );
+    assert_eq!(
+        row.get::<String, _>("delegate_votes_changed_timestamp"),
+        "1700000011000"
+    );
+    assert_eq!(
+        row.get::<String, _>("token_transfer_timestamp"),
+        "1700000012000"
+    );
+    assert_eq!(
+        row.get::<String, _>("contributor_timestamp"),
+        "1700000013000"
+    );
+    assert_eq!(
+        row.get::<String, _>("token_balance_checkpoint_timestamp"),
+        "1700000014000"
+    );
+    assert_eq!(
+        row.get::<String, _>("vote_power_checkpoint_timestamp"),
+        "1700000015000"
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_migration_repairs_invalid_runtime_index() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
 
@@ -474,6 +629,8 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("repair_delegate_effective_counts_once"));
     assert!(runtime_migration.contains("vote_timestamps_millis_v1"));
     assert!(runtime_migration.contains("repair_vote_timestamps_millis_once"));
+    assert!(runtime_migration.contains("token_timestamps_millis_v1"));
+    assert!(runtime_migration.contains("repair_token_timestamps_millis_once"));
     assert!(runtime_migration.contains("onchain_refresh_data_metric_task"));
     assert!(runtime_migration.contains("onchain_refresh_task_pending_ready_claim_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_pending_scope_claim_idx"));

--- a/apps/indexer/tests/token_projection.rs
+++ b/apps/indexer/tests/token_projection.rs
@@ -56,9 +56,24 @@ fn test_project_token_events_preserves_history_mappings_relations_and_reconcile_
     assert_eq!(batch.token_transfers.len(), 2);
     assert_eq!(batch.delegate_rollings.len(), 1);
     assert_eq!(batch.delegate_changed[0].delegator, account("bbbb"));
+    assert_eq!(
+        batch.delegate_changed[0].common.block_timestamp.as_deref(),
+        Some("1700000010000")
+    );
     assert_eq!(batch.delegate_votes_changed[0].delegate, account("cccc"));
+    assert_eq!(
+        batch.delegate_votes_changed[0]
+            .common
+            .block_timestamp
+            .as_deref(),
+        Some("1700000011000")
+    );
     assert_eq!(batch.token_transfers[0].from, account("bbbb"));
     assert_eq!(batch.token_transfers[0].to, account("dddd"));
+    assert_eq!(
+        batch.token_transfers[0].common.block_timestamp.as_deref(),
+        Some("1700000012000")
+    );
 
     let mut repository = InMemoryTokenProjectionRepository::default();
     repository.apply(&batch).expect("write succeeds");


### PR DESCRIPTION
## Summary
- Preserve millisecond block timestamps when projecting token events.
- Add a one-time runtime repair for existing second-based token timestamps in token event and delegation tables.
- Add regression coverage for token projection timestamps and runtime repair markers.

## Verification
- cargo fmt --check
- cargo test --locked -p degov-datalens-indexer test_project_token_events_preserves_history_mappings_relations_and_reconcile_plan --test token_projection
- cargo test --locked -p degov-datalens-indexer test_indexer_keeps_init_migration_stable_and_appends_runtime_markers --test migration_schema

Note: test_migration_repairs_token_timestamps_to_millis requires DEGOV_INDEXER_TEST_DATABASE_URL, matching the existing migration integration tests.