### PR TITLE
fix(indexer): use per-table timestamp repair

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -1,7 +1,7 @@
 use anyhow as runtime_anyhow;
 use runtime_anyhow::{Context, Result};
 use sqlx::{PgConnection, PgPool, migrate::Migrator, postgres::PgPoolOptions};
-use std::{env, time::Duration};
+use std::time::Duration;
 
 use crate::required_env;
 
@@ -640,7 +640,6 @@ async fn repair_vote_timestamps_millis_once(connection: &mut PgConnection) -> Re
 async fn repair_token_timestamps_millis_once(connection: &mut PgConnection) -> Result<()> {
     const MARKER_ID: &str = "token_timestamps_millis_v1";
     const MILLIS_THRESHOLD: i64 = 1_000_000_000_000;
-    const DEFAULT_BATCH_SIZE: i64 = 50_000;
     const TARGETS: &[(&str, &str)] = &[
         ("delegate_changed", "block_timestamp"),
         ("delegate_votes_changed", "block_timestamp"),
@@ -677,56 +676,21 @@ async fn repair_token_timestamps_millis_once(connection: &mut PgConnection) -> R
         return Ok(());
     }
 
-    let batch_size = positive_env_i64(
-        "DEGOV_INDEXER_TOKEN_TIMESTAMP_REPAIR_BATCH_SIZE",
-        DEFAULT_BATCH_SIZE,
-    );
-
     for (table_name, column_name) in TARGETS {
-        let mut target_updates = 0u64;
-
-        loop {
-            let updated = repair_timestamp_millis_batch(
-                connection,
-                table_name,
-                column_name,
-                batch_size,
-                MILLIS_THRESHOLD,
-            )
-            .await
-            .with_context(|| {
-                format!("repair {table_name}.{column_name} timestamps to milliseconds")
-            })?;
-
-            if updated == 0 {
-                break;
-            }
-
-            target_updates += updated;
-        }
-
-        let target_complete = !timestamp_millis_repair_has_remaining(
-            connection,
-            table_name,
-            column_name,
-            MILLIS_THRESHOLD,
-        )
-        .await
-        .with_context(|| format!("check remaining {table_name}.{column_name} second timestamps"))?;
+        let target_updates =
+            repair_timestamp_millis_column(connection, table_name, column_name, MILLIS_THRESHOLD)
+                .await
+                .with_context(|| {
+                    format!("repair {table_name}.{column_name} timestamps to milliseconds")
+                })?;
 
         log::info!(
-            "DeGov token timestamp repair batch table={} column={} updates={} complete={}",
+            "DeGov token timestamp repair table={} column={} updates={} complete={}",
             table_name,
             column_name,
             target_updates,
-            target_complete
+            true
         );
-
-        if !target_complete {
-            return Err(runtime_anyhow::Error::msg(format!(
-                "DeGov token timestamp repair did not complete for {table_name}.{column_name}"
-            )));
-        }
     }
 
     sqlx::query(
@@ -747,63 +711,25 @@ async fn repair_token_timestamps_millis_once(connection: &mut PgConnection) -> R
     Ok(())
 }
 
-fn positive_env_i64(name: &str, default_value: i64) -> i64 {
-    env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<i64>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default_value)
-}
-
-async fn repair_timestamp_millis_batch(
+async fn repair_timestamp_millis_column(
     connection: &mut PgConnection,
     table_name: &str,
     column_name: &str,
-    batch_size: i64,
     millis_threshold: i64,
 ) -> Result<u64, sqlx::Error> {
     let sql = format!(
-        "WITH candidate AS (
-            SELECT ctid
-            FROM {table_name}
-            WHERE {column_name} IS NOT NULL
-              AND {column_name} < $2
-            LIMIT $1
-         )
-         UPDATE {table_name}
+        "UPDATE {table_name}
          SET {column_name} = {column_name} * 1000
-         FROM candidate
-         WHERE {table_name}.ctid = candidate.ctid"
+         WHERE {column_name} IS NOT NULL
+           AND {column_name} < $1"
     );
 
     let result = sqlx::query(&sql)
-        .bind(batch_size)
         .bind(millis_threshold)
         .execute(&mut *connection)
         .await?;
 
     Ok(result.rows_affected())
-}
-
-async fn timestamp_millis_repair_has_remaining(
-    connection: &mut PgConnection,
-    table_name: &str,
-    column_name: &str,
-    millis_threshold: i64,
-) -> Result<bool, sqlx::Error> {
-    let sql = format!(
-        "SELECT EXISTS (
-            SELECT 1
-            FROM {table_name}
-            WHERE {column_name} IS NOT NULL
-              AND {column_name} < $1
-         )"
-    );
-
-    sqlx::query_scalar::<_, bool>(&sql)
-        .bind(millis_threshold)
-        .fetch_one(&mut *connection)
-        .await
 }
 
 async fn drop_obsolete_runtime_indexes_for_connection(connection: &mut PgConnection) -> Result<()> {

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -526,8 +526,8 @@ async fn test_migration_repairs_token_timestamps_to_millis() -> Result<(), Box<d
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_migration_repairs_token_timestamps_across_multiple_batches()
--> Result<(), Box<dyn Error>> {
+async fn test_migration_repairs_token_timestamps_and_marks_completion() -> Result<(), Box<dyn Error>>
+{
     let database = TestDatabase::connect().await?;
 
     apply_migrations(&database.pool).await?;
@@ -540,17 +540,17 @@ async fn test_migration_repairs_token_timestamps_across_multiple_batches()
         )
         VALUES
             (
-                'token-transfer-batch-1', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+                'token-transfer-repair-1', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
                 '0xtoken', 1, 0, '0xfrom', '0xto',
                 10, 'erc20', 12, 1700000012, '0xtx1'
             ),
             (
-                'token-transfer-batch-2', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+                'token-transfer-repair-2', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
                 '0xtoken', 2, 0, '0xfrom', '0xto',
                 10, 'erc20', 13, 1700000013, '0xtx2'
             ),
             (
-                'token-transfer-batch-3', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
+                'token-transfer-repair-3', 'scope', 1, 'dao', '0xgovernor', '0xtoken',
                 '0xtoken', 3, 0, '0xfrom', '0xto',
                 10, 'erc20', 14, 1700000014, '0xtx3'
             )
@@ -565,19 +565,7 @@ async fn test_migration_repairs_token_timestamps_across_multiple_batches()
     .execute(&database.pool)
     .await?;
 
-    let previous_batch_size = env::var("DEGOV_INDEXER_TOKEN_TIMESTAMP_REPAIR_BATCH_SIZE").ok();
-    unsafe {
-        env::set_var("DEGOV_INDEXER_TOKEN_TIMESTAMP_REPAIR_BATCH_SIZE", "2");
-    }
-
     apply_migrations(&database.pool).await?;
-
-    unsafe {
-        match previous_batch_size {
-            Some(value) => env::set_var("DEGOV_INDEXER_TOKEN_TIMESTAMP_REPAIR_BATCH_SIZE", value),
-            None => env::remove_var("DEGOV_INDEXER_TOKEN_TIMESTAMP_REPAIR_BATCH_SIZE"),
-        }
-    }
 
     let remaining_after_repair: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)


### PR DESCRIPTION
## Summary
- replace the token timestamp repair ctid batch loop with one direct UPDATE per target table/column
- keep the all-or-nothing marker semantics from #977
- update the migration regression test to verify completion marker behavior without batch env overrides

## Why
The #977 staging deploy showed that `ctid LIMIT` batches repeatedly scan large timestamp tables and are slower than intended. The safer shape is still to avoid one giant multi-table CTE, but use direct per-table updates so each table is scanned once.

## Tests
- `cargo fmt --check`
- `cargo test --locked -p degov-datalens-indexer --test token_projection`
- `cargo test --locked -p degov-datalens-indexer test_indexer_keeps_init_migration_stable_and_appends_runtime_markers --test migration_schema`