### PR TITLE
fix(indexer): allow skipping token timestamp repair

### DIFF
--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -639,6 +639,7 @@ async fn repair_vote_timestamps_millis_once(connection: &mut PgConnection) -> Re
 
 async fn repair_token_timestamps_millis_once(connection: &mut PgConnection) -> Result<()> {
     const MARKER_ID: &str = "token_timestamps_millis_v1";
+    const ENABLED_ENV: &str = "DEGOV_INDEXER_TOKEN_TIMESTAMP_REPAIR_ENABLED";
     const MILLIS_THRESHOLD: i64 = 1_000_000_000_000;
     const TARGETS: &[(&str, &str)] = &[
         ("delegate_changed", "block_timestamp"),
@@ -659,6 +660,11 @@ async fn repair_token_timestamps_millis_once(connection: &mut PgConnection) -> R
     ];
 
     ensure_runtime_repair_marker_table(connection).await?;
+
+    if !optional_env_bool(ENABLED_ENV)?.unwrap_or(true) {
+        log::info!("DeGov token timestamp repair skipped because {ENABLED_ENV}=false");
+        return Ok(());
+    }
 
     let already_applied = sqlx::query_scalar::<_, bool>(
         "SELECT EXISTS (
@@ -730,6 +736,18 @@ async fn repair_timestamp_millis_column(
         .await?;
 
     Ok(result.rows_affected())
+}
+
+fn optional_env_bool(name: &str) -> Result<Option<bool>> {
+    match std::env::var(name) {
+        Ok(value) if value.eq_ignore_ascii_case("true") || value == "1" => Ok(Some(true)),
+        Ok(value) if value.eq_ignore_ascii_case("false") || value == "0" => Ok(Some(false)),
+        Ok(value) => Err(runtime_anyhow::Error::msg(format!(
+            "{name} must be true, false, 1, or 0: {value}"
+        ))),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read {name}")),
+    }
 }
 
 async fn drop_obsolete_runtime_indexes_for_connection(connection: &mut PgConnection) -> Result<()> {

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -698,6 +698,7 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("repair_vote_timestamps_millis_once"));
     assert!(runtime_migration.contains("token_timestamps_millis_v1"));
     assert!(runtime_migration.contains("repair_token_timestamps_millis_once"));
+    assert!(runtime_migration.contains("DEGOV_INDEXER_TOKEN_TIMESTAMP_REPAIR_ENABLED"));
     assert!(runtime_migration.contains("onchain_refresh_data_metric_task"));
     assert!(runtime_migration.contains("onchain_refresh_task_pending_ready_claim_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_pending_scope_claim_idx"));


### PR DESCRIPTION
## Summary
- add `DEGOV_INDEXER_TOKEN_TIMESTAMP_REPAIR_ENABLED=false` to skip the historical token timestamp repair at runtime startup
- keep the default enabled so explicit migration/repair behavior is unchanged
- add a migration source assertion for the safety switch

## Why
The staging DB has a large historical `token_transfer` repair that cannot safely run inside GraphQL/indexer/worker startup. This lets staging deploy the corrected projection code while historical repairs are performed explicitly per DAO/contract set.

## Tests
- `cargo fmt --check`
- `cargo test --locked -p degov-datalens-indexer --test token_projection`
- `cargo test --locked -p degov-datalens-indexer test_indexer_keeps_init_migration_stable_and_appends_runtime_markers --test migration_schema`