### PR TITLE
fix(indexer): retry transient onchain refresh errors

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -496,7 +496,7 @@ where
     }
 
     pub async fn run_once(&self) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(self.config.batch_size, None, false, true)
+        self.run_once_with_batch_size_and_scope(self.config.batch_size, None, false)
             .await
     }
 
@@ -504,7 +504,7 @@ where
         &self,
         batch_size: usize,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(batch_size, None, true, true)
+        self.run_once_with_batch_size_and_scope(batch_size, None, true)
             .await
     }
 
@@ -513,7 +513,7 @@ where
         batch_size: usize,
         scope: &OnchainRefreshTaskScope,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), true, true)
+        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), true)
             .await
     }
 
@@ -522,7 +522,7 @@ where
         batch_size: usize,
         scope: &OnchainRefreshTaskScope,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), false, false)
+        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), false)
             .await
     }
 
@@ -531,7 +531,6 @@ where
         batch_size: usize,
         scope: Option<&OnchainRefreshTaskScope>,
         include_backlog: bool,
-        repair_missing_coverage: bool,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
         let started_at = Instant::now();
         let now_ms = unix_time_millis();
@@ -539,6 +538,8 @@ where
         let deferred_drain_target =
             worker_deferred_drain_target(self.config.deferred_drain_batch_size, batch_size);
         self.restore_retryable_exhausted_tasks(now_ms).await?;
+        self.restore_retryable_stale_processing_tasks(now_ms)
+            .await?;
         self.archive_exhausted_tasks(now_ms).await?;
         let deferred_drain_count = self
             .drain_deferred_onchain_refresh_backlog(deferred_drain_target, scope)
@@ -562,7 +563,7 @@ where
             );
         }
         let mut tasks = self.claim_tasks(now_ms, batch_size, scope).await?;
-        if tasks.is_empty() && repair_missing_coverage {
+        if tasks.is_empty() {
             let coverage_repair_count = self
                 .repair_missing_contributor_coverage(deferred_drain_target, scope)
                 .await?;
@@ -1242,6 +1243,51 @@ where
              WHERE onchain_refresh_task.id = candidates.id",
             retryable_error_sql = ONCHAIN_REFRESH_RETRYABLE_ERROR_SQL,
         ))
+        .bind(MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS)
+        .bind(attempts)
+        .bind(next_run_at.to_string())
+        .bind(now_ms.to_string())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn restore_retryable_stale_processing_tasks(
+        &self,
+        now_ms: i64,
+    ) -> Result<(), OnchainRefreshWorkerError> {
+        let stale_before = now_ms.saturating_sub(duration_millis_i64(self.config.lock_ttl));
+        let attempts = retryable_onchain_refresh_attempts(self.config.max_attempts);
+        let next_run_at = now_ms.saturating_add(duration_millis_i64(
+            onchain_refresh_retry_backoff_delay(self.config.retry_delay, self.config.max_attempts),
+        ));
+        sqlx::query(&format!(
+            "WITH candidates AS (
+                SELECT id
+                FROM onchain_refresh_task
+                WHERE status = 'processing'
+                  AND attempts >= $1
+                  AND locked_at IS NOT NULL
+                  AND locked_at <= $2::NUMERIC(78, 0)
+                  AND ({retryable_error_sql})
+                LIMIT $3
+                FOR UPDATE SKIP LOCKED
+             )
+             UPDATE onchain_refresh_task
+             SET status = 'failed',
+                 attempts = $4,
+                 next_run_at = $5::NUMERIC(78, 0),
+                 locked_at = NULL,
+                 locked_by = NULL,
+                 processed_at = NULL,
+                 updated_at = $6::NUMERIC(78, 0)
+             FROM candidates
+             WHERE onchain_refresh_task.id = candidates.id",
+            retryable_error_sql = ONCHAIN_REFRESH_RETRYABLE_ERROR_SQL,
+        ))
+        .bind(self.config.max_attempts)
+        .bind(stale_before.to_string())
         .bind(MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS)
         .bind(attempts)
         .bind(next_run_at.to_string())

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -496,7 +496,7 @@ where
     }
 
     pub async fn run_once(&self) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(self.config.batch_size, None, false)
+        self.run_once_with_batch_size_and_scope(self.config.batch_size, None, false, true)
             .await
     }
 
@@ -504,7 +504,7 @@ where
         &self,
         batch_size: usize,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(batch_size, None, true)
+        self.run_once_with_batch_size_and_scope(batch_size, None, true, true)
             .await
     }
 
@@ -513,7 +513,7 @@ where
         batch_size: usize,
         scope: &OnchainRefreshTaskScope,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), true)
+        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), true, true)
             .await
     }
 
@@ -522,7 +522,7 @@ where
         batch_size: usize,
         scope: &OnchainRefreshTaskScope,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
-        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), false)
+        self.run_once_with_batch_size_and_scope(batch_size, Some(scope), false, false)
             .await
     }
 
@@ -531,6 +531,7 @@ where
         batch_size: usize,
         scope: Option<&OnchainRefreshTaskScope>,
         include_backlog: bool,
+        repair_missing_coverage: bool,
     ) -> Result<OnchainRefreshRunReport, OnchainRefreshWorkerError> {
         let started_at = Instant::now();
         let now_ms = unix_time_millis();
@@ -561,7 +562,7 @@ where
             );
         }
         let mut tasks = self.claim_tasks(now_ms, batch_size, scope).await?;
-        if tasks.is_empty() {
+        if tasks.is_empty() && repair_missing_coverage {
             let coverage_repair_count = self
                 .repair_missing_contributor_coverage(deferred_drain_target, scope)
                 .await?;

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -34,6 +34,22 @@ pub const MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE: usize = 1_000;
 const DEFAULT_ONCHAIN_REFRESH_MAX_ATTEMPTS: i32 = 3;
 const MAX_ONCHAIN_REFRESH_APPLY_ROWS: usize = MAX_ONCHAIN_REFRESH_APPLY_BATCH_SIZE;
 const MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS: i64 = 200;
+const ONCHAIN_REFRESH_RETRYABLE_ERROR_SQL: &str = "
+    COALESCE(error, '') ILIKE '%block not found%'
+    OR (
+      COALESCE(error, '') ILIKE '%historical state%'
+      AND COALESCE(error, '') ILIKE '%not available%'
+    )
+    OR COALESCE(error, '') ILIKE '%error sending request%'
+    OR COALESCE(error, '') ILIKE '%request timed out%'
+    OR COALESCE(error, '') ILIKE '%context canceled%'
+    OR COALESCE(error, '') ILIKE '%connection reset%'
+    OR COALESCE(error, '') ILIKE '%connection refused%'
+    OR COALESCE(error, '') ILIKE '%temporarily unavailable%'
+    OR COALESCE(error, '') ILIKE '%deadline has elapsed%'
+    OR COALESCE(error, '') ILIKE '%too many requests%'
+    OR COALESCE(error, '') ILIKE '%rate limit%'
+";
 const MAX_ONCHAIN_REFRESH_DATA_METRIC_REFRESH_ROWS: usize = 200;
 const ONCHAIN_REFRESH_APPLY_MAX_ATTEMPTS: usize = 3;
 const ONCHAIN_REFRESH_APPLY_RETRY_BASE_DELAY_MS: u64 = 50;
@@ -1204,18 +1220,12 @@ where
         let next_run_at = now_ms.saturating_add(duration_millis_i64(
             onchain_refresh_retry_backoff_delay(self.config.retry_delay, self.config.max_attempts),
         ));
-        sqlx::query(
+        sqlx::query(&format!(
             "WITH candidates AS (
                 SELECT id
                 FROM onchain_refresh_task
                 WHERE status = 'exhausted'
-                  AND (
-                    COALESCE(error, '') ILIKE '%block not found%'
-                    OR (
-                      COALESCE(error, '') ILIKE '%historical state%'
-                      AND COALESCE(error, '') ILIKE '%not available%'
-                    )
-                  )
+                  AND ({retryable_error_sql})
                 LIMIT $1
                 FOR UPDATE SKIP LOCKED
              )
@@ -1229,7 +1239,8 @@ where
                  updated_at = $4::NUMERIC(78, 0)
              FROM candidates
              WHERE onchain_refresh_task.id = candidates.id",
-        )
+            retryable_error_sql = ONCHAIN_REFRESH_RETRYABLE_ERROR_SQL,
+        ))
         .bind(MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS)
         .bind(attempts)
         .bind(next_run_at.to_string())
@@ -1242,19 +1253,13 @@ where
 
     async fn archive_exhausted_tasks(&self, now_ms: i64) -> Result<(), OnchainRefreshWorkerError> {
         let stale_before = now_ms.saturating_sub(duration_millis_i64(self.config.lock_ttl));
-        sqlx::query(
+        sqlx::query(&format!(
             "WITH candidates AS (
                 SELECT id
                 FROM onchain_refresh_task
                 WHERE status = 'failed'
                   AND attempts >= $1
-                  AND NOT (
-                    COALESCE(error, '') ILIKE '%block not found%'
-                    OR (
-                      COALESCE(error, '') ILIKE '%historical state%'
-                      AND COALESCE(error, '') ILIKE '%not available%'
-                    )
-                  )
+                  AND NOT ({retryable_error_sql})
                 LIMIT $2
                 FOR UPDATE SKIP LOCKED
              )
@@ -1266,14 +1271,15 @@ where
                  updated_at = $3::NUMERIC(78, 0)
              FROM candidates
              WHERE onchain_refresh_task.id = candidates.id",
-        )
+            retryable_error_sql = ONCHAIN_REFRESH_RETRYABLE_ERROR_SQL,
+        ))
         .bind(self.config.max_attempts)
         .bind(MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS)
         .bind(now_ms.to_string())
         .execute(&self.pool)
         .await?;
 
-        sqlx::query(
+        sqlx::query(&format!(
             "WITH candidates AS (
                 SELECT id
                 FROM onchain_refresh_task
@@ -1281,13 +1287,7 @@ where
                   AND attempts >= $1
                   AND locked_at IS NOT NULL
                   AND locked_at <= $2::NUMERIC(78, 0)
-                  AND NOT (
-                    COALESCE(error, '') ILIKE '%block not found%'
-                    OR (
-                      COALESCE(error, '') ILIKE '%historical state%'
-                      AND COALESCE(error, '') ILIKE '%not available%'
-                    )
-                  )
+                  AND NOT ({retryable_error_sql})
                 LIMIT $3
                 FOR UPDATE SKIP LOCKED
              )
@@ -1299,7 +1299,8 @@ where
                  updated_at = $4::NUMERIC(78, 0)
              FROM candidates
              WHERE onchain_refresh_task.id = candidates.id",
-        )
+            retryable_error_sql = ONCHAIN_REFRESH_RETRYABLE_ERROR_SQL,
+        ))
         .bind(self.config.max_attempts)
         .bind(stale_before.to_string())
         .bind(MAX_ONCHAIN_REFRESH_EXHAUSTED_ARCHIVE_ROWS)
@@ -1319,6 +1320,15 @@ fn is_retryable_onchain_refresh_task_error(error: &str) -> bool {
     let error = error.to_ascii_lowercase();
     error.contains("block not found")
         || (error.contains("historical state") && error.contains("not available"))
+        || error.contains("error sending request")
+        || error.contains("request timed out")
+        || error.contains("context canceled")
+        || error.contains("connection reset")
+        || error.contains("connection refused")
+        || error.contains("temporarily unavailable")
+        || error.contains("deadline has elapsed")
+        || error.contains("too many requests")
+        || error.contains("rate limit")
 }
 
 fn retryable_onchain_refresh_attempts(max_attempts: i32) -> i32 {
@@ -4983,6 +4993,24 @@ mod tests {
     #[test]
     fn test_onchain_refresh_historical_state_gap_does_not_exhaust() {
         let error = "multicall failed: historical state abc is not available";
+
+        assert!(is_retryable_onchain_refresh_task_error(error));
+        assert_eq!(onchain_refresh_failure_status(error, 3, 3), "failed");
+        assert_eq!(onchain_refresh_failure_attempts(error, 3, 3), 2);
+    }
+
+    #[test]
+    fn test_onchain_refresh_transport_error_does_not_exhaust() {
+        let error = "multicall failed: error sending request for url (<rpc-url>)";
+
+        assert!(is_retryable_onchain_refresh_task_error(error));
+        assert_eq!(onchain_refresh_failure_status(error, 3, 3), "failed");
+        assert_eq!(onchain_refresh_failure_attempts(error, 3, 3), 2);
+    }
+
+    #[test]
+    fn test_onchain_refresh_context_canceled_does_not_exhaust() {
+        let error = "alternate current power method eth_call failed: context canceled";
 
         assert!(is_retryable_onchain_refresh_task_error(error));
         assert_eq!(onchain_refresh_failure_status(error, 3, 3), "failed");

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -1234,6 +1234,64 @@ async fn test_onchain_refresh_worker_archives_stale_processing_task_at_max_attem
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_restores_retryable_stale_processing_task_at_max_attempts()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "processing",
+        3,
+        false,
+        true,
+    )
+    .await?;
+    sqlx::query(
+        "UPDATE onchain_refresh_task
+         SET locked_at = 0::NUMERIC(78, 0),
+             locked_by = 'stale-worker',
+             error = 'error sending request for url'
+         WHERE id = 'task-one'",
+    )
+    .execute(&database.pool)
+    .await?;
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::ZERO,
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::new([]),
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.claimed, 0);
+    assert_task_status(&database.pool, "task-one", "failed", 2).await?;
+    let row = sqlx::query(
+        "SELECT locked_at::TEXT AS locked_at, locked_by, next_run_at::TEXT AS next_run_at
+         FROM onchain_refresh_task
+         WHERE id = 'task-one'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(row.get::<Option<String>, _>("locked_at"), None);
+    assert_eq!(row.get::<Option<String>, _>("locked_by"), None);
+    assert!(row.get::<String, _>("next_run_at").parse::<i64>()? > 0);
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_prioritizes_stale_processing_before_pending_tasks()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -2543,6 +2601,76 @@ async fn test_onchain_refresh_worker_repairs_missing_contributor_coverage()
     assert_task_refresh_flags(&database.pool, &task_id, true, true).await?;
     assert_contributor_overlay(&database.pool, ACCOUNT_ONE, "11").await?;
     assert_contributor_overlay_balance(&database.pool, ACCOUNT_ONE, "17").await?;
+    assert_table_count(&database.pool, "onchain_refresh_deferred_candidate", 0).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_repairs_missing_contributor_coverage_without_backlog()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_contributor(&database.pool, ACCOUNT_ONE, "0", Some("0")).await?;
+
+    let task_id = format!("demo-dao:demo-dao:46:{GOVERNOR}:{TOKEN}:{ACCOUNT_ONE}");
+    seed_task(
+        &database.pool,
+        &task_id,
+        ACCOUNT_ONE,
+        "completed",
+        1,
+        true,
+        true,
+    )
+    .await?;
+    seed_contributor_overlay_with_balance(&database.pool, ACCOUNT_ONE, "9", None).await?;
+
+    let reader = MockOnchainRefreshReader::from_values(BTreeMap::from([(
+        task_id.clone(),
+        OnchainRefreshReadValue {
+            task_id: task_id.clone(),
+            balance: Some("17".to_owned()),
+            power: Some("11".to_owned()),
+            checkpoint_balance: Some("17".to_owned()),
+            checkpoint_power: Some("11".to_owned()),
+        },
+    )]));
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker
+        .run_once_with_batch_size_for_scope_without_backlog(
+            10,
+            &OnchainRefreshTaskScope {
+                chain_id: 46,
+                contract_set_id: "demo-dao".to_owned(),
+                dao_code: "demo-dao".to_owned(),
+            },
+        )
+        .await?;
+
+    assert_eq!(report.claimed, 1);
+    assert_eq!(report.completed, 1);
+    assert_eq!(report.failed, 0);
+    assert_eq!(
+        contributor_values(&database.pool, ACCOUNT_ONE).await?,
+        ("11".to_owned(), Some("17".to_owned()))
+    );
+    assert_completed_task(&database.pool, &task_id, 1).await?;
     assert_table_count(&database.pool, "onchain_refresh_deferred_candidate", 0).await?;
 
     database.cleanup().await?;


### PR DESCRIPTION
## Summary
- classify transient RPC/network onchain refresh failures as retryable
- restore exhausted transient tasks back into retry flow instead of leaving them permanently exhausted
- keep reverted/non-transient failures exhausted at the attempt limit

## Verification
- cargo fmt --check
- cargo test -p degov-datalens-indexer test_onchain_refresh_transport_error_does_not_exhaust --locked
- cargo test -p degov-datalens-indexer test_onchain_refresh_context_canceled_does_not_exhaust --locked
- cargo test -p degov-datalens-indexer test_onchain_refresh_non_retryable_error_exhausts_at_limit --locked

Note: broader cargo test -p degov-datalens-indexer onchain_refresh --locked compiled and all non-DB tests passed; DB-backed integration cases require DEGOV_INDEXER_TEST_DATABASE_URL in this environment.