### PR TITLE
perf(indexer): debounce onchain data metric refresh

### DIFF
--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -805,18 +805,21 @@ where
     ) -> Result<usize, OnchainRefreshWorkerError> {
         let mut refreshed_total = 0usize;
         let mut attempted_ids = BTreeSet::<String>::new();
+        let ready_before = data_metric_refresh_ready_before(now_ms, self.config.debounce);
         for _ in 0..MAX_ONCHAIN_REFRESH_DATA_METRIC_REFRESH_ROWS {
             let mut transaction = self.pool.begin().await?;
             let skipped_ids = attempted_ids.iter().cloned().collect::<Vec<_>>();
             let row = sqlx::query(
                 "SELECT id, contract_set_id, chain_id, dao_code, governor_address, token_address
                  FROM onchain_refresh_data_metric_task
-                 WHERE NOT (id = ANY($1::TEXT[]))
+                 WHERE updated_at <= $2::NUMERIC(78, 0)
+                   AND NOT (id = ANY($1::TEXT[]))
                  ORDER BY updated_at ASC, id ASC
                  LIMIT 1
                  FOR UPDATE SKIP LOCKED",
             )
             .bind(&skipped_ids)
+            .bind(ready_before.to_string())
             .fetch_optional(&mut *transaction)
             .await?;
             let Some(row) = row else {
@@ -4122,6 +4125,10 @@ fn data_metric_refresh_task_id(scope: &DataMetricRefreshScope) -> String {
     )
 }
 
+fn data_metric_refresh_ready_before(now_ms: i64, debounce: Duration) -> i64 {
+    now_ms.saturating_sub(duration_millis_i64(debounce)).max(0)
+}
+
 async fn refresh_data_metric_scope(
     transaction: &mut Transaction<'_, Postgres>,
     scope: &DataMetricRefreshScope,
@@ -5019,6 +5026,18 @@ mod tests {
     fn test_worker_deferred_drain_target_tracks_claim_budget() {
         assert_eq!(worker_deferred_drain_target(100, 1_000), 1_000);
         assert_eq!(worker_deferred_drain_target(2_000, 1_000), 2_000);
+    }
+
+    #[test]
+    fn test_data_metric_refresh_ready_before_waits_for_quiet_period() {
+        assert_eq!(
+            data_metric_refresh_ready_before(10_000, Duration::from_secs(120)),
+            0
+        );
+        assert_eq!(
+            data_metric_refresh_ready_before(130_000, Duration::from_secs(120)),
+            10_000
+        );
     }
 
     #[test]

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -613,6 +613,41 @@ async fn test_onchain_refresh_worker_drains_data_metric_refresh_on_empty_work()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_waits_for_quiet_data_metric_refresh_task()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_data_metric(&database.pool, "7").await?;
+    seed_recent_data_metric_refresh_task(&database.pool).await?;
+
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::from_values(BTreeMap::new()),
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.claimed, 0);
+    assert_eq!(report.completed, 0);
+    assert_eq!(report.data_metric_refreshes, 0);
+    assert_table_count(&database.pool, "onchain_refresh_data_metric_task", 1).await?;
+    assert_data_metric_counts(&database.pool, "7", 1, 1, 1, 7).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_reconciles_current_delegate_relation_power_from_balance()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -1933,6 +1968,7 @@ async fn test_onchain_refresh_worker_updates_only_matching_contract_set_contribu
         ("31".to_owned(), Some("41".to_owned()))
     );
     assert_table_count(&database.pool, "onchain_refresh_data_metric_task", 1).await?;
+    age_data_metric_refresh_tasks(&database.pool).await?;
     let empty_report = worker.run_once().await?;
 
     assert_eq!(empty_report.claimed, 0);
@@ -3301,6 +3337,38 @@ async fn seed_data_metric_refresh_task(pool: &PgPool) -> Result<(), sqlx::Error>
     .bind(format!("demo-dao:46:demo-dao:{GOVERNOR}"))
     .bind(GOVERNOR)
     .bind(TOKEN)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn seed_recent_data_metric_refresh_task(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO onchain_refresh_data_metric_task (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            created_at, updated_at
+         )
+         VALUES (
+            $1, 'demo-dao', 46, 'demo-dao', $2, $3, 10000::NUMERIC(78, 0),
+            $4::NUMERIC(78, 0)
+         )",
+    )
+    .bind(format!("demo-dao:46:demo-dao:{GOVERNOR}"))
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .bind(unix_time_millis_for_test().to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn age_data_metric_refresh_tasks(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE onchain_refresh_data_metric_task
+         SET updated_at = 10000::NUMERIC(78, 0)",
+    )
     .execute(pool)
     .await?;
 


### PR DESCRIPTION
## Summary
- wait for the onchain refresh debounce quiet period before draining data metric refresh tasks
- avoids repeatedly running full-scope data_metric aggregates while a DAO is still receiving onchain refresh batches
- keeps the existing eventual full refresh behavior for correctness

## Evidence
- compound-dao data_metric aggregate currently scans ~583k contributor rows and took ~13s in EXPLAIN ANALYZE
- repeated refreshes can be triggered by empty worker scopes while the same scope is still being updated

## Verification
- cargo fmt --check
- cargo test -p degov-datalens-indexer test_data_metric_refresh_ready_before_waits_for_quiet_period --locked
- cargo test -p degov-datalens-indexer test_onchain_refresh_transport_error_does_not_exhaust --locked

Note: the new onchain_refresh_worker integration test requires DEGOV_INDEXER_TEST_DATABASE_URL and is expected to run in CI.