### PR TITLE
perf(indexer): reuse broad datalens log selector

### DIFF
--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -185,35 +185,48 @@ fn query_plans(
     from_block: i32,
     to_block: i32,
 ) -> Vec<DaoLogQueryPlan> {
-    let mut sources = vec![
-        DaoLogAddressSource {
-            address: addresses.governor.clone(),
-            source: DaoLogSource::Governor,
-        },
-        DaoLogAddressSource {
-            address: addresses.governor_token.clone(),
-            source: DaoLogSource::GovernorToken,
-        },
-    ];
+    let mut governance_sources = vec![DaoLogAddressSource {
+        address: addresses.governor.clone(),
+        source: DaoLogSource::Governor,
+    }];
     if let Some(timelock) = &addresses.timelock {
-        sources.push(DaoLogAddressSource {
+        governance_sources.push(DaoLogAddressSource {
             address: timelock.clone(),
             source: DaoLogSource::Timelock,
         });
     }
 
-    vec![query_plan(config, sources, from_block, to_block)]
+    vec![
+        query_plan(
+            config,
+            governance_sources,
+            Vec::new(),
+            broad_governance_topic0_filters(),
+            from_block,
+            to_block,
+        ),
+        query_plan(
+            config,
+            vec![DaoLogAddressSource {
+                address: addresses.governor_token.clone(),
+                source: DaoLogSource::GovernorToken,
+            }],
+            vec![addresses.governor_token.clone()],
+            governor_token_topic0_filters(),
+            from_block,
+            to_block,
+        ),
+    ]
 }
 
 fn query_plan(
     config: &DatalensConfig,
     sources: Vec<DaoLogAddressSource>,
+    selector_addresses: Vec<String>,
+    topics: Vec<String>,
     from_block: i32,
     to_block: i32,
 ) -> DaoLogQueryPlan {
-    let addresses = source_addresses(&sources);
-    let topics = unified_topic0_filters();
-
     DaoLogQueryPlan {
         sources,
         from_block,
@@ -237,7 +250,7 @@ fn query_plan(
             selector: QuerySelectorInput {
                 kind: SelectorKindInput::EvmLogs,
                 evm_logs: Some(EvmLogsSelectorInput {
-                    addresses,
+                    addresses: selector_addresses,
                     topics: vec![topics],
                 }),
                 other: None,
@@ -255,29 +268,27 @@ fn query_plan(
     }
 }
 
-fn source_addresses(sources: &[DaoLogAddressSource]) -> Vec<String> {
-    let mut addresses = Vec::new();
-    for source in sources {
-        if !addresses.contains(&source.address) {
-            addresses.push(source.address.clone());
-        }
-    }
-    addresses
+fn broad_governance_topic0_filters() -> Vec<String> {
+    unique_topic0_filters(
+        GOVERNOR_TOPIC0_FILTERS
+            .iter()
+            .chain(TIMELOCK_TOPIC0_FILTERS),
+    )
 }
 
-fn unified_topic0_filters() -> Vec<String> {
-    let mut topics = Vec::new();
-    for topic in GOVERNOR_TOPIC0_FILTERS
-        .iter()
-        .chain(GOVERNOR_TOKEN_TOPIC0_FILTERS)
-        .chain(TIMELOCK_TOPIC0_FILTERS)
-    {
+fn governor_token_topic0_filters() -> Vec<String> {
+    unique_topic0_filters(GOVERNOR_TOKEN_TOPIC0_FILTERS.iter())
+}
+
+fn unique_topic0_filters<'a>(topics: impl Iterator<Item = &'a &'a str>) -> Vec<String> {
+    let mut values = Vec::new();
+    for topic in topics {
         let topic = (*topic).to_owned();
-        if !topics.contains(&topic) {
-            topics.push(topic);
+        if !values.contains(&topic) {
+            values.push(topic);
         }
     }
-    topics
+    values
 }
 
 const GOVERNOR_TOPIC0_FILTERS: &[&str] = &[

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -1371,10 +1371,15 @@ where
                     continue;
                 }
                 let Some(candidate_sources) = sources.get(&log.address) else {
-                    return Err(IndexerRunnerError::Normalize(format!(
-                        "Datalens log address {} was not part of the DAO log query plan",
+                    info!(
+                        "skipping Datalens EVM log outside DAO address set dao_code={} chain_id={} log_id={} block_number={} address={}",
+                        self.options.checkpoint_identity.dao_code,
+                        self.options.checkpoint_identity.chain_id,
+                        log.id,
+                        log.block_number,
                         log.address
-                    )));
+                    );
+                    continue;
                 };
                 let mut unsupported_event = None;
                 let mut decoded_event = None;

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -1632,9 +1632,9 @@ mod tests {
 
         assert_eq!(result, Some(1));
         assert_eq!(reader.latest_head_calls, 1);
-        assert_eq!(reader.ranges.len(), 1);
+        assert_eq!(reader.ranges.len(), 2);
         assert!(reader.ranges.iter().all(|range| *range == (21, 25)));
-        assert_eq!(reader.finalities.len(), 1);
+        assert_eq!(reader.finalities.len(), 2);
         assert!(
             reader
                 .finalities

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -15,7 +15,7 @@ fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelo
     let addresses = addresses();
     let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 1);
+    assert_eq!(plans.len(), 2);
     assert_query(
         &plans[0],
         &[
@@ -24,19 +24,49 @@ fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelo
                 source: DaoLogSource::Governor,
             },
             DaoLogAddressSource {
-                address: addresses.governor_token.clone(),
-                source: DaoLogSource::GovernorToken,
-            },
-            DaoLogAddressSource {
                 address: addresses.timelock.clone().expect("timelock"),
                 source: DaoLogSource::Timelock,
             },
         ],
-        &unified_topic0_values(),
+        &[],
+        &broad_governance_topic0_values(),
         100,
         199,
         "durable_only",
     );
+    assert_query(
+        &plans[1],
+        &[DaoLogAddressSource {
+            address: addresses.governor_token.clone(),
+            source: DaoLogSource::GovernorToken,
+        }],
+        std::slice::from_ref(&addresses.governor_token),
+        &governor_token_topic0_values(),
+        100,
+        199,
+        "durable_only",
+    );
+}
+
+#[test]
+fn test_plan_dao_log_queries_uses_broad_address_selector_for_reusable_datalens_cache() {
+    let config = config(1_000, DatalensFinality::DurableOnly);
+    let plans = plan_dao_log_queries(&config, &addresses(), 100, 199).expect("plans");
+
+    let evm_logs = plans[0].input.selector.evm_logs.as_ref().expect("evm logs");
+    assert!(evm_logs.addresses.is_empty());
+    assert_eq!(evm_logs.topics, vec![broad_governance_topic0_values()]);
+}
+
+#[test]
+fn test_plan_dao_log_queries_keeps_token_selector_address_scoped() {
+    let config = config(1_000, DatalensFinality::DurableOnly);
+    let addresses = addresses();
+    let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
+
+    let evm_logs = plans[1].input.selector.evm_logs.as_ref().expect("evm logs");
+    assert_eq!(evm_logs.addresses, vec![addresses.governor_token]);
+    assert_eq!(evm_logs.topics, vec![governor_token_topic0_values()]);
 }
 
 #[test]
@@ -47,19 +77,13 @@ fn test_plan_dao_log_queries_skips_timelock_when_not_configured() {
 
     let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 1);
+    assert_eq!(plans.len(), 2);
     assert_eq!(
         plans[0].sources,
-        vec![
-            DaoLogAddressSource {
-                address: addresses.governor,
-                source: DaoLogSource::Governor,
-            },
-            DaoLogAddressSource {
-                address: addresses.governor_token,
-                source: DaoLogSource::GovernorToken,
-            },
-        ]
+        vec![DaoLogAddressSource {
+            address: addresses.governor,
+            source: DaoLogSource::Governor,
+        },]
     );
     assert!(
         plans[0]
@@ -78,7 +102,7 @@ fn test_plan_dao_log_queries_chunks_ranges_by_config_limit() {
         .map(|plan| (plan.from_block, plan.to_block))
         .collect::<Vec<_>>();
 
-    let plans_per_chunk = 1;
+    let plans_per_chunk = 2;
 
     assert_eq!(ranges.len(), plans_per_chunk * 3);
     assert_eq!(
@@ -193,6 +217,7 @@ fn test_fetch_dao_log_pages_stops_without_later_pages_on_reader_error() {
 fn assert_query(
     plan: &DaoLogQueryPlan,
     sources: &[DaoLogAddressSource],
+    addresses: &[String],
     topic0_values: &[String],
     from_block: i32,
     to_block: i32,
@@ -211,13 +236,7 @@ fn assert_query(
     assert_eq!(plan.input.finality.as_deref(), Some(finality));
 
     let evm_logs = plan.input.selector.evm_logs.as_ref().expect("evm logs");
-    assert_eq!(
-        evm_logs.addresses,
-        sources
-            .iter()
-            .map(|source| source.address.clone())
-            .collect::<Vec<_>>()
-    );
+    assert_eq!(evm_logs.addresses, addresses);
     assert_eq!(
         evm_logs.topics,
         vec![
@@ -229,19 +248,23 @@ fn assert_query(
     );
 }
 
-fn unified_topic0_values() -> Vec<String> {
-    let mut topics = Vec::new();
-    for topic in GOVERNOR_TOPIC0_VALUES
-        .iter()
-        .chain(GOVERNOR_TOKEN_TOPIC0_VALUES)
-        .chain(TIMELOCK_TOPIC0_VALUES)
-    {
+fn broad_governance_topic0_values() -> Vec<String> {
+    unique_topic0_values(GOVERNOR_TOPIC0_VALUES.iter().chain(TIMELOCK_TOPIC0_VALUES))
+}
+
+fn governor_token_topic0_values() -> Vec<String> {
+    unique_topic0_values(GOVERNOR_TOKEN_TOPIC0_VALUES.iter())
+}
+
+fn unique_topic0_values<'a>(topics: impl Iterator<Item = &'a &'a str>) -> Vec<String> {
+    let mut values = Vec::new();
+    for topic in topics {
         let topic = (*topic).to_owned();
-        if !topics.contains(&topic) {
-            topics.push(topic);
+        if !values.contains(&topic) {
+            values.push(topic);
         }
     }
-    topics
+    values
 }
 
 fn config(block_range_limit: u32, finality: DatalensFinality) -> DatalensConfig {

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -32,15 +32,12 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
         outcome,
         DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.requests.len(), 1);
+    assert_eq!(ensurer.requests.len(), 2);
     let selector_addresses = &ensurer.requests[0].selector.addresses;
+    assert!(selector_addresses.is_empty());
     assert_eq!(
-        selector_addresses,
-        &vec![
-            "0x1111111111111111111111111111111111111111".to_owned(),
-            "0x2222222222222222222222222222222222222222".to_owned(),
-            "0x3333333333333333333333333333333333333333".to_owned(),
-        ]
+        ensurer.requests[1].selector.addresses,
+        vec![addresses().governor_token]
     );
     let topic_counts = ensurer
         .requests
@@ -50,7 +47,7 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
             request.selector.topics[0].len()
         })
         .collect::<Vec<_>>();
-    assert_eq!(topic_counts, vec![24]);
+    assert_eq!(topic_counts, vec![21, 3]);
     for request in &ensurer.requests {
         assert_eq!(request.chain.configured_name, "ethereum");
         assert_eq!(request.chain.network_id, Some(1));
@@ -80,11 +77,11 @@ fn test_ensure_datalens_warmup_task_reuses_existing_matching_task() {
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 1);
+    assert_eq!(ensurer.created_tasks.len(), 2);
 }
 
 #[test]
-fn test_ensure_datalens_warmup_task_submits_distinct_task_for_selector_mismatch() {
+fn test_ensure_datalens_warmup_task_reuses_broad_selector_for_dao_address_mismatch() {
     let config = config();
     let mut ensurer = MockWarmupEnsurer::default();
     let mut other_addresses = addresses();
@@ -96,7 +93,7 @@ fn test_ensure_datalens_warmup_task_submits_distinct_task_for_selector_mismatch(
 
     assert!(matches!(
         second,
-        DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
+        DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
     ));
     assert_eq!(ensurer.created_tasks.len(), 2);
 }

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -1087,10 +1087,38 @@ fn test_runner_decodes_distinct_log_addresses_with_matching_sources() {
 }
 
 #[test]
+fn test_runner_skips_logs_from_broad_datalens_selector_outside_dao_addresses() {
+    let attempts = Arc::new(Mutex::new(Vec::new()));
+    let mut runner = runner_with_decoder(
+        vec![vec![
+            row_at_address(1, 0, 1, FOREIGN),
+            row_at_address(1, 0, 0, GOVERNOR),
+        ]],
+        SourceMatchingDecoder::new(attempts.clone()),
+        options(),
+    );
+
+    runner.run_to_target(1).expect("runner succeeds");
+
+    let attempts = attempts.lock().expect("attempts");
+    assert_source_attempt_counts(&attempts, GOVERNOR_SELECTOR_COUNT, 0, 0);
+    assert_eq!(
+        runner.store().vote_repository().data_metric().votes_count,
+        1
+    );
+}
+
+#[test]
 fn test_runner_decodes_duplicate_address_token_log_with_token_source() {
     let attempts = Arc::new(Mutex::new(Vec::new()));
     let mut runner = runner_with_decoder(
-        vec![vec![row_at_address(1, 0, 1, GOVERNOR)]],
+        vec![vec![row_at_address_with_topic(
+            1,
+            0,
+            1,
+            GOVERNOR,
+            TOKEN_DELEGATE_CHANGED_TOPIC0,
+        )]],
         SourceMatchingDecoder::new(attempts.clone()),
         duplicate_address_options(),
     );
@@ -1098,12 +1126,7 @@ fn test_runner_decodes_duplicate_address_token_log_with_token_source() {
     runner.run_to_target(1).expect("runner succeeds");
 
     let attempts = attempts.lock().expect("attempts");
-    assert_source_attempt_counts(
-        &attempts,
-        GOVERNOR_SELECTOR_COUNT,
-        GOVERNOR_TOKEN_SELECTOR_COUNT,
-        0,
-    );
+    assert_source_attempt_counts(&attempts, 0, GOVERNOR_TOKEN_SELECTOR_COUNT, 0);
     assert_eq!(
         runner.store().token_repository().delegate_changed().len(),
         1
@@ -1125,7 +1148,7 @@ fn test_runner_keeps_duplicate_address_unsupported_topic_unsupported() {
     assert_source_attempt_counts(
         &attempts,
         GOVERNOR_SELECTOR_COUNT,
-        GOVERNOR_TOKEN_SELECTOR_COUNT,
+        0,
         TIMELOCK_SELECTOR_COUNT,
     );
     assert_eq!(
@@ -1200,6 +1223,13 @@ impl DatalensLogQueryReader for ScriptedDatalensReader {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+        let topic0_values = input
+            .selector
+            .evm_logs
+            .as_ref()
+            .and_then(|selector| selector.topics.first())
+            .cloned()
+            .unwrap_or_default();
         let rows = self
             .rows
             .iter()
@@ -1215,9 +1245,16 @@ impl DatalensLogQueryReader for ScriptedDatalensReader {
                     .and_then(Value::as_str)
                     .unwrap_or_default()
                     .to_ascii_lowercase();
+                let topic0 = row
+                    .pointer("/topics/0")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
 
                 (input.range.start..=input.range.end).contains(&block_number)
-                    && addresses.iter().any(|candidate| candidate == &address)
+                    && (addresses.is_empty()
+                        || addresses.iter().any(|candidate| candidate == &address))
+                    && (topic0_values.is_empty()
+                        || topic0_values.iter().any(|candidate| candidate == topic0))
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -1847,11 +1884,40 @@ fn row_at_address(
     log_index: u64,
     address: &str,
 ) -> Value {
-    row_with_removed(block_number, transaction_index, log_index, address, false)
+    let topic0 = if address.eq_ignore_ascii_case(TOKEN) {
+        TOKEN_DELEGATE_CHANGED_TOPIC0
+    } else {
+        GOVERNOR_VOTE_CAST_TOPIC0
+    };
+    row_at_address_with_topic(block_number, transaction_index, log_index, address, topic0)
+}
+
+fn row_at_address_with_topic(
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+    address: &str,
+    topic0: &str,
+) -> Value {
+    row_with_removed(
+        block_number,
+        transaction_index,
+        log_index,
+        address,
+        topic0,
+        false,
+    )
 }
 
 fn removed_row(block_number: u64, transaction_index: u64, log_index: u64) -> Value {
-    row_with_removed(block_number, transaction_index, log_index, GOVERNOR, true)
+    row_with_removed(
+        block_number,
+        transaction_index,
+        log_index,
+        GOVERNOR,
+        GOVERNOR_VOTE_CAST_TOPIC0,
+        true,
+    )
 }
 
 fn row_with_removed(
@@ -1859,6 +1925,7 @@ fn row_with_removed(
     transaction_index: u64,
     log_index: u64,
     address: &str,
+    topic0: &str,
     removed: bool,
 ) -> Value {
     json!({
@@ -1869,7 +1936,7 @@ fn row_with_removed(
         "transaction_index": transaction_index,
         "log_index": log_index,
         "address": address,
-        "topics": ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+        "topics": [topic0],
         "data": "0x",
         "removed": removed
     })
@@ -1877,7 +1944,12 @@ fn row_with_removed(
 
 const GOVERNOR: &str = "0x1111111111111111111111111111111111111111";
 const TOKEN: &str = "0x2222222222222222222222222222222222222222";
+const FOREIGN: &str = "0x9999999999999999999999999999999999999999";
+const GOVERNOR_VOTE_CAST_TOPIC0: &str =
+    "0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0";
+const TOKEN_DELEGATE_CHANGED_TOPIC0: &str =
+    "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f";
 const GOVERNOR_SELECTOR_COUNT: usize = 1;
 const GOVERNOR_TOKEN_SELECTOR_COUNT: usize = 1;
 const TIMELOCK_SELECTOR_COUNT: usize = 1;
-const DATALENS_QUERY_SELECTOR_COUNT: usize = 1;
+const DATALENS_QUERY_SELECTOR_COUNT: usize = 2;

--- a/apps/indexer/tests/native_runner_integration.rs
+++ b/apps/indexer/tests/native_runner_integration.rs
@@ -414,6 +414,13 @@ impl DatalensLogQueryReader for ScriptedReader {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+        let topic0_values = input
+            .selector
+            .evm_logs
+            .as_ref()
+            .and_then(|selector| selector.topics.first())
+            .cloned()
+            .unwrap_or_default();
         let rows = self
             .rows
             .iter()
@@ -429,9 +436,16 @@ impl DatalensLogQueryReader for ScriptedReader {
                     .and_then(Value::as_str)
                     .unwrap_or_default()
                     .to_ascii_lowercase();
+                let topic0 = row
+                    .pointer("/topics/0")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
 
                 (input.range.start..=input.range.end).contains(&block_number)
-                    && addresses.iter().any(|candidate| candidate == &address)
+                    && (addresses.is_empty()
+                        || addresses.iter().any(|candidate| candidate == &address))
+                    && (topic0_values.is_empty()
+                        || topic0_values.iter().any(|candidate| candidate == topic0))
             })
             .cloned()
             .collect::<Vec<_>>();

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -128,7 +128,7 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
     run_indexer_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 1);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 2);
     assert_table_count(&database.pool, "proposal_created", 1).await?;
     assert_table_count(&database.pool, "proposal", 1).await?;
     assert_table_count(&database.pool, "vote_cast", 1).await?;
@@ -366,7 +366,7 @@ async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
     run_indexer_all_contract_sets_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 0);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 2);
     assert_checkpoint_scope(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_scope(&database.pool, SECOND_CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_row_count(&database.pool, 2).await?;
@@ -3285,13 +3285,13 @@ fn handle_datalens_request(
         query_count.fetch_add(1, Ordering::Relaxed);
         let request_body = request.split("\r\n\r\n").nth(1).unwrap_or_default();
         let mut rows = Vec::new();
-        if request_body.contains(GOVERNOR) || request_body.contains(SECOND_GOVERNOR) {
+        if request_matches_addresses(&request_body, &[GOVERNOR, SECOND_GOVERNOR]) {
             rows.extend(matching_datalens_rows(request_body, governor_rows));
         }
-        if request_body.contains(TOKEN) || request_body.contains(SECOND_TOKEN) {
+        if request_matches_addresses(&request_body, &[TOKEN, SECOND_TOKEN]) {
             rows.extend(matching_datalens_rows(request_body, token_rows));
         }
-        if request_body.contains(TIMELOCK) || request_body.contains(SECOND_TIMELOCK) {
+        if request_matches_addresses(&request_body, &[TIMELOCK, SECOND_TIMELOCK]) {
             rows.extend(matching_datalens_rows(request_body, timelock_rows));
         }
 
@@ -3313,6 +3313,25 @@ fn handle_datalens_request(
     stream
         .write_all(response.as_bytes())
         .expect("write fake Datalens response");
+}
+
+fn request_matches_addresses(request_body: &str, addresses: &[&str]) -> bool {
+    request_uses_broad_address_selector(request_body)
+        || addresses
+            .iter()
+            .any(|address| request_body.contains(*address))
+}
+
+fn request_uses_broad_address_selector(request_body: &str) -> bool {
+    if request_body.contains(r#""addresses":[]"#) || request_body.contains(r#""addresses": []"#) {
+        return true;
+    }
+
+    serde_json::from_str::<Value>(request_body)
+        .ok()
+        .and_then(|body| body.pointer("/selector/evm_logs/addresses").cloned())
+        .and_then(|addresses| addresses.as_array().map(Vec::is_empty))
+        .unwrap_or(false)
 }
 
 fn matching_datalens_rows(request_body: &str, rows: &[Value]) -> Vec<Value> {
@@ -3370,7 +3389,7 @@ async fn assert_table_count(pool: &PgPool, table: &str, expected: i64) -> Result
         .await?
         .get(0);
 
-    assert_eq!(count, expected);
+    assert_eq!(count, expected, "unexpected row count for table {table}");
 
     Ok(())
 }

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -29,10 +29,15 @@ static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 #[test]
 fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
     let config = datalens_config();
-    let results = vec![Ok(DatalensProvisionalLogQueryResult {
-        rows: serde_json::json!([]),
-        segments: vec![cache_segment("provider", "latest", 100, 105)],
-    })];
+    let results = vec![
+        Ok(DatalensProvisionalLogQueryResult {
+            rows: serde_json::json!([]),
+            segments: vec![cache_segment("provider", "latest", 100, 105)],
+        }),
+        Ok(DatalensProvisionalLogQueryResult::rows_only(
+            serde_json::json!([]),
+        )),
+    ];
     let mut reader = MockProvisionalReader::new(results);
     let mut store = RecordingProvisionalStore::default();
     let mut worker = ProvisionalWorker::new(options(&config), &mut reader, &mut store);
@@ -40,7 +45,7 @@ fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
     let report = worker.run_once().expect("worker runs once");
 
     assert_eq!(report.segments_written, 1);
-    assert_eq!(reader.calls.len(), 1);
+    assert_eq!(reader.calls.len(), 2);
     assert!(
         reader
             .calls


### PR DESCRIPTION
## What changed
- Query Datalens EVM logs with a broad governance-topic selector instead of per-DAO address selectors.
- Filter returned logs back to the DAO source address set in the indexer runner.
- Update warmup/planner/runner tests so broad selectors are the reusable cache contract.

## Why
The staging indexer was repeatedly issuing address-constrained Datalens selectors per DAO. Those selectors produced different cache keys and kept hitting provider fill paths even when equivalent chain/range data had already been scanned. Using a stable broad selector lets Datalens reuse one cache/warmup path per chain/topic/range, while DeGov keeps DAO correctness by filtering locally before decoding.

## Validation
- `cargo test -p degov-datalens-indexer --test datalens_planner`
- `cargo test -p degov-datalens-indexer --test indexer_runner`
- `cargo test -p degov-datalens-indexer --test datalens_warmup`
- `cargo test -p degov-datalens-indexer --test native_runner_integration`
- `cargo test -p degov-datalens-indexer --test datalens_client`
- `cargo test -p degov-datalens-indexer --test datalens_warmup_effectiveness`
- `cargo fmt --check -p degov-datalens-indexer`
- `git diff --check`
