### PR TITLE
fix(web): drop legacy d_user power column

### DIFF
--- a/apps/web/prisma/migrations/20260625054600_drop_d_user_power/migration.sql
+++ b/apps/web/prisma/migrations/20260625054600_drop_d_user_power/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "d_user" DROP COLUMN IF EXISTS "power";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -10,7 +10,6 @@ model d_user {
   id                 String    @id
   address            String
   dao_code           String? // todo: make this required and add unique constraint with address
-  power              String? // legacy cache only; governance power now comes from the indexer at read time
   name               String?
   email              String?
   twitter            String?

--- a/apps/web/scripts/profile-power-cutover.test.ts
+++ b/apps/web/scripts/profile-power-cutover.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -9,6 +9,21 @@ import {
 
 const getSource = (relativePath: string) =>
   readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+const getMigrationSources = () =>
+  readdirSync(new URL("../prisma/migrations", import.meta.url), {
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) =>
+      readFileSync(
+        new URL(
+          `../prisma/migrations/${entry.name}/migration.sql`,
+          import.meta.url
+        ),
+        "utf8"
+      )
+    );
 
 test("member ranking uses contributor power and ctime as the tie-breaker", () => {
   const rankedMembers = rankMembersByContributorPower(
@@ -117,11 +132,21 @@ test("profile overlays keep contributor power and default missing users to zero"
 });
 
 test("route sources no longer read or write d_user.power in scoped paths", () => {
+  const prismaSchema = getSource("../prisma/schema.prisma");
   const membersRoute = getSource("../src/app/api/degov/members/route.ts");
   const profilePullRoute = getSource("../src/app/api/profile/pull/route.ts");
   const profileRoute = getSource("../src/app/api/profile/[address]/route.ts");
   const loginRoute = getSource("../src/app/api/auth/login/route.ts");
   const syncRoute = getSource("../src/app/api/degov/sync/route.ts");
+  const migrations = getMigrationSources();
+
+  const dUserModel = prismaSchema.match(/model d_user \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.doesNotMatch(dUserModel, /\bpower\b/);
+  assert.ok(
+    migrations.some((migration) =>
+      /ALTER TABLE "d_user" DROP COLUMN(?: IF EXISTS)? "power"/.test(migration)
+    )
+  );
 
   assert.match(membersRoute, /inspectContributorsByAddress/);
   assert.doesNotMatch(membersRoute, /u\.power/);
@@ -136,6 +161,6 @@ test("route sources no longer read or write d_user.power in scoped paths", () =>
   assert.doesNotMatch(loginRoute, /"power"/);
   assert.doesNotMatch(loginRoute, /power:/);
 
-  assert.match(syncRoute, /sync\.user\.power/);
+  assert.doesNotMatch(syncRoute, /sync\.user\.power/);
   assert.doesNotMatch(syncRoute, /update d_user set power/i);
 });

--- a/apps/web/src/app/api/degov/sync/route.ts
+++ b/apps/web/src/app/api/degov/sync/route.ts
@@ -11,17 +11,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(Resp.err("invalid payloads"), { status: 400 });
     }
 
-    const invalidMethods = [];
-    for (const payload of payloads) {
-      switch (payload.method) {
-        case "sync.user.power": {
-          break;
-        }
-        default: {
-          invalidMethods.push(payload.method);
-        }
-      }
-    }
+    const invalidMethods = payloads.map((payload) => payload.method);
 
     return NextResponse.json(
       Resp.ok({


### PR DESCRIPTION
## Summary
- remove the legacy d_user.power field from the web Prisma schema
- add a Prisma migration to drop the old column
- make the deprecated sync endpoint report all submitted methods as invalid and extend the existing cutover regression test

## Validation
- node --test --experimental-strip-types apps/web/scripts/profile-power-cutover.test.ts
- pnpm --dir apps/web exec prisma validate
- pnpm --dir apps/web exec eslint scripts/profile-power-cutover.test.ts src/app/api/degov/sync/route.ts src/app/api/common/profile-power.ts

## Note
- pnpm --dir apps/web exec tsc --noEmit currently fails on an unrelated existing issue: scripts/demo-dao-config.test.ts(14,34): Type 'undefined' is not assignable to type 'string'.