### PR TITLE
chore(release): bump version to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "degov-datalens-indexer"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["apps/indexer"]
 resolver = "3"
+
+[workspace.package]
+version = "3.0.0"

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "degov-datalens-indexer"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 license = "MIT"
 publish = false

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@degov/web",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "postinstall": "prisma generate",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "degov",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "private": true,
   "packageManager": "pnpm@10.32.1",
   "scripts": {


### PR DESCRIPTION
## Summary\n- bump root package and web package versions to 3.0.0\n- define the Rust workspace package version as 3.0.0\n- inherit the indexer crate version from the workspace and refresh Cargo.lock\n\n## Validation\n- pnpm install --frozen-lockfile\n- cargo metadata --locked --format-version 1 --no-deps