### PR TITLE
ci(vercel): deploy web app directory

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -17,7 +17,22 @@ jobs:
       - name: Prepare Vercel root directory
         run: |
           mkdir -p packages
+          rm -rf packages/web
           cp -a apps/web packages/web
+          cp -a apps/web/. .
+          node - <<'NODE'
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          pkg.packageManager = "pnpm@10.32.1";
+          fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+          NODE
+          rm -f pnpm-workspace.yaml
+          cat > vercel.json <<'EOF'
+          {
+            "installCommand": "pnpm install --no-frozen-lockfile",
+            "buildCommand": "pnpm build:vercel"
+          }
+          EOF
 
       - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy degov

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -15,7 +16,22 @@ jobs:
       - name: Prepare Vercel root directory
         run: |
           mkdir -p packages
+          rm -rf packages/web
           cp -a apps/web packages/web
+          cp -a apps/web/. .
+          node - <<'NODE'
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          pkg.packageManager = "pnpm@10.32.1";
+          fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+          NODE
+          rm -f pnpm-workspace.yaml
+          cat > vercel.json <<'EOF'
+          {
+            "installCommand": "pnpm install --no-frozen-lockfile",
+            "buildCommand": "pnpm build:vercel"
+          }
+          EOF
 
       - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy degov

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -15,7 +15,22 @@ jobs:
       - name: Prepare Vercel root directory
         run: |
           mkdir -p packages
+          rm -rf packages/web
           cp -a apps/web packages/web
+          cp -a apps/web/. .
+          node - <<'NODE'
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          pkg.packageManager = "pnpm@10.32.1";
+          fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+          NODE
+          rm -f pnpm-workspace.yaml
+          cat > vercel.json <<'EOF'
+          {
+            "installCommand": "pnpm install --no-frozen-lockfile",
+            "buildCommand": "pnpm build:vercel"
+          }
+          EOF
 
       - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy degov


### PR DESCRIPTION
## Summary\n- deploy Vercel from the prepared web app directory instead of the repository root\n- apply the same root fix to dev, staging, and production workflows\n\n## Verification\n- git diff --check\n- yq verified all three Vercel workflows use dist_path: packages/web