### PR TITLE
feat(indexer): expose Prometheus metrics

### DIFF
--- a/apps/indexer/migrations/0008_indexer_latest_head.sql
+++ b/apps/indexer/migrations/0008_indexer_latest_head.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS degov_indexer_latest_head (
+  dao_code TEXT NOT NULL,
+  chain_id INTEGER NOT NULL,
+  contract_set_id TEXT NOT NULL,
+  stream_id TEXT NOT NULL,
+  data_source_version TEXT NOT NULL,
+  latest_height NUMERIC(78, 0) NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (dao_code, chain_id, contract_set_id, stream_id, data_source_version)
+);

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -5,6 +5,7 @@ pub mod datalens;
 pub mod decode;
 pub mod error;
 pub mod graphql;
+pub mod metrics;
 pub mod onchain;
 pub mod projection;
 pub mod provisional;
@@ -142,7 +143,7 @@ pub use runner::{
 pub use runtime_config::{
     ContractSetConcurrencyLimit, GraphqlRuntimeConfig, IndexerContractSetMode,
     IndexerContractSetRuntimeConfig, IndexerRuntimeConfig, IndexerTargetHeight,
-    OnchainRefreshRuntimeConfig, OnchainRefreshScopeMode, ProvisionalRuntimeConfig,
-    datalens_retry_config, onchain_refresh_debounce_from_env, onchain_refresh_worker_enabled,
-    parse_bool_env_value, parse_i64_env_value, required_env,
+    MetricsRuntimeConfig, OnchainRefreshRuntimeConfig, OnchainRefreshScopeMode,
+    ProvisionalRuntimeConfig, datalens_retry_config, onchain_refresh_debounce_from_env,
+    onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value, required_env,
 };

--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -1,0 +1,1029 @@
+use std::{
+    collections::BTreeMap,
+    sync::{Mutex, OnceLock},
+};
+
+use axum::{
+    Router,
+    extract::State,
+    http::{HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use sqlx::{PgPool, Row};
+use thiserror::Error;
+use tokio::task::JoinHandle;
+
+use crate::{IndexerCheckpointIdentity, MetricsRuntimeConfig, runner::IndexerRunnerProgress};
+use crate::{OnchainRefreshRunReport, OnchainRefreshTaskScope};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct IndexerMetricsSnapshot {
+    pub sync_rows: Vec<IndexerSyncMetricsRow>,
+    pub onchain_backlog_rows: Vec<OnchainRefreshBacklogMetricsRow>,
+    pub deferred_onchain_backlog_rows: Vec<OnchainRefreshBacklogMetricsRow>,
+    pub chunk_runtime_rows: Vec<IndexerChunkRuntimeMetricsRow>,
+    pub onchain_worker_rows: Vec<OnchainRefreshWorkerMetricsRow>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IndexerSyncMetricsRow {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub contract_set_id: String,
+    pub processed_height: Option<i64>,
+    pub target_height: Option<i64>,
+    pub provisional_height: Option<i64>,
+    pub latest_height: Option<i64>,
+    pub synced_percentage: Option<f64>,
+    pub updated_timestamp_seconds: Option<f64>,
+    pub last_error_present: bool,
+    pub current_rate_blocks_per_second: Option<f64>,
+    pub eta_seconds: Option<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct OnchainRefreshBacklogMetricsRow {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub contract_set_id: String,
+    pub status: String,
+    pub tasks: i64,
+    pub ready_tasks: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct IndexerChunkRuntimeMetricsRow {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub contract_set_id: String,
+    pub chunks_total: u64,
+    pub datalens_requests_total: u64,
+    pub cache_full_hit_total: u64,
+    pub cache_partial_hit_total: u64,
+    pub cache_miss_total: u64,
+    pub cache_provider_fill_total: u64,
+    pub chunk_duration_seconds_sum: f64,
+    pub chunk_duration_seconds_count: u64,
+    pub last_chunk_size: Option<u32>,
+    pub current_chunk_size: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IndexerChunkMetricsObservation {
+    pub datalens_request_count: usize,
+    pub cache_full_hit_count: usize,
+    pub cache_partial_hit_count: usize,
+    pub cache_miss_count: usize,
+    pub cache_provider_fill_count: usize,
+    pub chunk_duration_seconds: f64,
+    pub last_chunk_size: u32,
+    pub current_chunk_size: u32,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct OnchainRefreshWorkerMetricsRow {
+    pub scope: String,
+    pub dao_code: String,
+    pub chain_id: String,
+    pub contract_set_id: String,
+    pub claimed_total: u64,
+    pub completed_total: u64,
+    pub failed_total: u64,
+    pub skipped_total: u64,
+    pub cache_hits_total: u64,
+    pub data_metric_refreshes_total: u64,
+    pub duration_seconds_sum: f64,
+    pub duration_seconds_count: u64,
+    pub last_backlog: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexerLatestHeadRecord {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub contract_set_id: String,
+    pub stream_id: String,
+    pub data_source_version: String,
+    pub latest_height: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct MetricsScopeKey {
+    dao_code: String,
+    chain_id: i32,
+    contract_set_id: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RuntimeMetricsState {
+    sync_rows: BTreeMap<MetricsScopeKey, RuntimeSyncMetricsRow>,
+    chunk_rows: BTreeMap<MetricsScopeKey, IndexerChunkRuntimeMetricsRow>,
+    onchain_worker_rows: BTreeMap<OnchainWorkerMetricsScopeKey, OnchainRefreshWorkerMetricsRow>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RuntimeSyncMetricsRow {
+    current_rate_blocks_per_second: Option<f64>,
+    eta_seconds: Option<f64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct OnchainWorkerMetricsScopeKey {
+    scope: String,
+    dao_code: String,
+    chain_id: String,
+    contract_set_id: String,
+}
+
+static RUNTIME_METRICS: OnceLock<Mutex<RuntimeMetricsState>> = OnceLock::new();
+
+#[derive(Debug, Error)]
+pub enum MetricsError {
+    #[error("query indexer metrics")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("bind DeGov indexer metrics endpoint")]
+    Bind(#[source] std::io::Error),
+}
+
+pub async fn collect_prometheus_metrics(pool: &PgPool) -> Result<String, MetricsError> {
+    let snapshot = collect_indexer_metrics_snapshot(pool).await?;
+    Ok(render_prometheus_metrics(&snapshot))
+}
+
+pub async fn record_indexer_latest_head(
+    pool: &PgPool,
+    record: &IndexerLatestHeadRecord,
+) -> Result<(), MetricsError> {
+    sqlx::query(
+        r#"
+        INSERT INTO degov_indexer_latest_head (
+          dao_code,
+          chain_id,
+          contract_set_id,
+          stream_id,
+          data_source_version,
+          latest_height,
+          updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6::NUMERIC(78, 0), now())
+        ON CONFLICT (dao_code, chain_id, contract_set_id, stream_id, data_source_version)
+        DO UPDATE SET
+          latest_height = GREATEST(
+            degov_indexer_latest_head.latest_height,
+            EXCLUDED.latest_height
+          ),
+          updated_at = now()
+        "#,
+    )
+    .bind(&record.dao_code)
+    .bind(record.chain_id)
+    .bind(&record.contract_set_id)
+    .bind(&record.stream_id)
+    .bind(&record.data_source_version)
+    .bind(record.latest_height)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn spawn_metrics_server(
+    pool: PgPool,
+    config: MetricsRuntimeConfig,
+) -> Result<Option<JoinHandle<()>>, MetricsError> {
+    if !config.enabled {
+        return Ok(None);
+    }
+
+    let app = build_metrics_router(pool);
+    let listener = tokio::net::TcpListener::bind(config.bind_address)
+        .await
+        .map_err(MetricsError::Bind)?;
+    let bind_address = config.bind_address;
+    log::info!("DeGov indexer metrics service listening bind_address={bind_address}");
+
+    let handle = tokio::spawn(async move {
+        if let Err(error) = axum::serve(listener, app).await {
+            log::error!("DeGov indexer metrics service stopped with error: {error}");
+        }
+    });
+
+    Ok(Some(handle))
+}
+
+pub fn build_metrics_router(pool: PgPool) -> Router {
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .with_state(pool)
+}
+
+pub async fn collect_indexer_metrics_snapshot(
+    pool: &PgPool,
+) -> Result<IndexerMetricsSnapshot, MetricsError> {
+    let mut sync_rows = collect_sync_metrics(pool).await?;
+    let onchain_backlog_rows = collect_onchain_refresh_backlog_metrics(pool).await?;
+    let deferred_onchain_backlog_rows =
+        collect_deferred_onchain_refresh_backlog_metrics(pool).await?;
+    let chunk_runtime_rows = collect_runtime_metrics(&mut sync_rows);
+    let onchain_worker_rows = collect_onchain_worker_runtime_metrics();
+
+    Ok(IndexerMetricsSnapshot {
+        sync_rows,
+        onchain_backlog_rows,
+        deferred_onchain_backlog_rows,
+        chunk_runtime_rows,
+        onchain_worker_rows,
+    })
+}
+
+pub fn record_indexer_chunk_metrics(
+    identity: &IndexerCheckpointIdentity,
+    progress: &IndexerRunnerProgress,
+    observation: IndexerChunkMetricsObservation,
+) {
+    let key = MetricsScopeKey {
+        dao_code: identity.dao_code.clone(),
+        chain_id: identity.chain_id,
+        contract_set_id: identity.contract_set_id.clone(),
+    };
+    let mut state = runtime_metrics_state()
+        .lock()
+        .expect("runtime metrics mutex is not poisoned");
+    state.sync_rows.insert(
+        key.clone(),
+        RuntimeSyncMetricsRow {
+            current_rate_blocks_per_second: progress.current_rate_blocks_per_second,
+            eta_seconds: progress.eta_seconds,
+        },
+    );
+    let row =
+        state
+            .chunk_rows
+            .entry(key.clone())
+            .or_insert_with(|| IndexerChunkRuntimeMetricsRow {
+                dao_code: key.dao_code.clone(),
+                chain_id: key.chain_id,
+                contract_set_id: key.contract_set_id.clone(),
+                ..Default::default()
+            });
+    row.chunks_total = row.chunks_total.saturating_add(1);
+    row.datalens_requests_total = row
+        .datalens_requests_total
+        .saturating_add(observation.datalens_request_count as u64);
+    row.cache_full_hit_total = row
+        .cache_full_hit_total
+        .saturating_add(observation.cache_full_hit_count as u64);
+    row.cache_partial_hit_total = row
+        .cache_partial_hit_total
+        .saturating_add(observation.cache_partial_hit_count as u64);
+    row.cache_miss_total = row
+        .cache_miss_total
+        .saturating_add(observation.cache_miss_count as u64);
+    row.cache_provider_fill_total = row
+        .cache_provider_fill_total
+        .saturating_add(observation.cache_provider_fill_count as u64);
+    row.chunk_duration_seconds_sum += observation.chunk_duration_seconds;
+    row.chunk_duration_seconds_count = row.chunk_duration_seconds_count.saturating_add(1);
+    row.last_chunk_size = Some(observation.last_chunk_size);
+    row.current_chunk_size = Some(observation.current_chunk_size);
+}
+
+pub fn record_onchain_refresh_worker_report(
+    scope: Option<&OnchainRefreshTaskScope>,
+    report: &OnchainRefreshRunReport,
+) {
+    let key = match scope {
+        Some(scope) => OnchainWorkerMetricsScopeKey {
+            scope: "contract_set".to_owned(),
+            dao_code: scope.dao_code.clone(),
+            chain_id: scope.chain_id.to_string(),
+            contract_set_id: scope.contract_set_id.clone(),
+        },
+        None => OnchainWorkerMetricsScopeKey {
+            scope: "global".to_owned(),
+            dao_code: "global".to_owned(),
+            chain_id: "global".to_owned(),
+            contract_set_id: "global".to_owned(),
+        },
+    };
+
+    let mut state = runtime_metrics_state()
+        .lock()
+        .expect("runtime metrics mutex is not poisoned");
+    let row = state
+        .onchain_worker_rows
+        .entry(key.clone())
+        .or_insert_with(|| OnchainRefreshWorkerMetricsRow {
+            scope: key.scope.clone(),
+            dao_code: key.dao_code.clone(),
+            chain_id: key.chain_id.clone(),
+            contract_set_id: key.contract_set_id.clone(),
+            ..Default::default()
+        });
+    row.claimed_total = row.claimed_total.saturating_add(report.claimed as u64);
+    row.completed_total = row.completed_total.saturating_add(report.completed as u64);
+    row.failed_total = row.failed_total.saturating_add(report.failed as u64);
+    row.skipped_total = row
+        .skipped_total
+        .saturating_add(report.skipped_tasks as u64);
+    row.cache_hits_total = row
+        .cache_hits_total
+        .saturating_add(report.cache_hits as u64);
+    row.data_metric_refreshes_total = row
+        .data_metric_refreshes_total
+        .saturating_add(report.data_metric_refreshes as u64);
+    row.duration_seconds_sum += report.duration_ms as f64 / 1000.0;
+    row.duration_seconds_count = row.duration_seconds_count.saturating_add(1);
+    row.last_backlog = report.backlog;
+}
+
+async fn metrics_handler(State(pool): State<PgPool>) -> Response {
+    match collect_prometheus_metrics(&pool).await {
+        Ok(body) => (
+            [(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
+            )],
+            body,
+        )
+            .into_response(),
+        Err(error) => {
+            log::warn!("collect DeGov indexer metrics failed: {error}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("collect DeGov indexer metrics failed: {error}"),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub fn render_prometheus_metrics(snapshot: &IndexerMetricsSnapshot) -> String {
+    let mut output = String::new();
+
+    metric_header(
+        &mut output,
+        "degov_indexer_processed_height",
+        "Durable processed block height for a DeGov indexer contract set.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_target_height",
+        "Durable target block height for a DeGov indexer contract set.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_provisional_height",
+        "Highest fully covered provisional block height for a DeGov indexer contract set.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_latest_height",
+        "Latest observed Datalens head block height for a DeGov indexer contract set.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_remaining_blocks",
+        "Durable target blocks remaining for a DeGov indexer contract set.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_latest_lag_blocks",
+        "Blocks between the latest observed head and durable processed height.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_synced_percent",
+        "Durable sync percentage for a DeGov indexer contract set.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_checkpoint_updated_timestamp_seconds",
+        "Unix timestamp of the last durable checkpoint update.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_last_error_present",
+        "Whether the durable checkpoint has a last_error value.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_current_rate_blocks_per_second",
+        "Current durable sync speed in blocks per second.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_eta_seconds",
+        "Estimated seconds until durable target height is reached.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_tasks",
+        "Onchain refresh task count by status.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_ready_tasks",
+        "Onchain refresh task count ready to be claimed by status.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_deferred_candidates",
+        "Deferred onchain refresh candidate count.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_ready_deferred_candidates",
+        "Deferred onchain refresh candidate count ready to drain.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_chunks_total",
+        "Completed Datalens indexer chunks.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_datalens_requests_total",
+        "Datalens requests issued while processing completed chunks.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_datalens_cache_ranges_total",
+        "Datalens cache range outcomes observed while processing chunks.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_chunk_duration_seconds",
+        "Completed Datalens indexer chunk duration summary.",
+        "summary",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_last_chunk_size",
+        "Last requested durable chunk size.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_current_chunk_size",
+        "Current adaptive durable chunk size after the last completed chunk.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_worker_tasks_total",
+        "Onchain refresh worker task outcomes.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_worker_cache_hits_total",
+        "Onchain refresh worker chain read cache hits.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_worker_data_metric_refreshes_total",
+        "Onchain refresh worker data metric refreshes.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_worker_batch_duration_seconds",
+        "Onchain refresh worker batch duration summary.",
+        "summary",
+    );
+    metric_header(
+        &mut output,
+        "degov_onchain_refresh_worker_last_backlog",
+        "Last observed onchain refresh worker backlog.",
+        "gauge",
+    );
+
+    for row in &snapshot.sync_rows {
+        let labels = sync_labels(row);
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_processed_height",
+            &labels,
+            row.processed_height,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_target_height",
+            &labels,
+            row.target_height,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_provisional_height",
+            &labels,
+            row.provisional_height,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_latest_height",
+            &labels,
+            row.latest_height,
+        );
+        if let (Some(target_height), Some(processed_height)) =
+            (row.target_height, row.processed_height)
+        {
+            append_metric(
+                &mut output,
+                "degov_indexer_remaining_blocks",
+                &labels,
+                target_height.saturating_sub(processed_height),
+            );
+        }
+        if let (Some(latest_height), Some(processed_height)) =
+            (row.latest_height, row.processed_height)
+        {
+            append_metric(
+                &mut output,
+                "degov_indexer_latest_lag_blocks",
+                &labels,
+                latest_height.saturating_sub(processed_height),
+            );
+        }
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_synced_percent",
+            &labels,
+            row.synced_percentage,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_checkpoint_updated_timestamp_seconds",
+            &labels,
+            row.updated_timestamp_seconds,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_last_error_present",
+            &labels,
+            i64::from(row.last_error_present),
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_current_rate_blocks_per_second",
+            &labels,
+            row.current_rate_blocks_per_second,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_eta_seconds",
+            &labels,
+            row.eta_seconds,
+        );
+    }
+
+    for row in &snapshot.onchain_backlog_rows {
+        let labels = onchain_labels(row);
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_tasks",
+            &labels,
+            row.tasks,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_ready_tasks",
+            &labels,
+            row.ready_tasks,
+        );
+    }
+
+    for row in &snapshot.deferred_onchain_backlog_rows {
+        let labels = onchain_labels(row);
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_deferred_candidates",
+            &labels,
+            row.tasks,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_ready_deferred_candidates",
+            &labels,
+            row.ready_tasks,
+        );
+    }
+
+    for row in &snapshot.chunk_runtime_rows {
+        let labels = chunk_labels(row);
+        append_metric(
+            &mut output,
+            "degov_indexer_chunks_total",
+            &labels,
+            row.chunks_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_datalens_requests_total",
+            &labels,
+            row.datalens_requests_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_datalens_cache_ranges_total",
+            &cache_labels(row, "full_hit"),
+            row.cache_full_hit_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_datalens_cache_ranges_total",
+            &cache_labels(row, "partial_hit"),
+            row.cache_partial_hit_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_datalens_cache_ranges_total",
+            &cache_labels(row, "miss"),
+            row.cache_miss_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_datalens_cache_ranges_total",
+            &cache_labels(row, "provider_fill"),
+            row.cache_provider_fill_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_chunk_duration_seconds_sum",
+            &labels,
+            row.chunk_duration_seconds_sum,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_chunk_duration_seconds_count",
+            &labels,
+            row.chunk_duration_seconds_count,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_last_chunk_size",
+            &labels,
+            row.last_chunk_size,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_current_chunk_size",
+            &labels,
+            row.current_chunk_size,
+        );
+    }
+
+    for row in &snapshot.onchain_worker_rows {
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_tasks_total",
+            &worker_result_labels(row, "claimed"),
+            row.claimed_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_tasks_total",
+            &worker_result_labels(row, "completed"),
+            row.completed_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_tasks_total",
+            &worker_result_labels(row, "failed"),
+            row.failed_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_tasks_total",
+            &worker_result_labels(row, "skipped"),
+            row.skipped_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_cache_hits_total",
+            &worker_labels(row),
+            row.cache_hits_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_data_metric_refreshes_total",
+            &worker_labels(row),
+            row.data_metric_refreshes_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_batch_duration_seconds_sum",
+            &worker_labels(row),
+            row.duration_seconds_sum,
+        );
+        append_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_batch_duration_seconds_count",
+            &worker_labels(row),
+            row.duration_seconds_count,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_onchain_refresh_worker_last_backlog",
+            &worker_labels(row),
+            row.last_backlog,
+        );
+    }
+
+    output
+}
+
+fn collect_runtime_metrics(
+    sync_rows: &mut [IndexerSyncMetricsRow],
+) -> Vec<IndexerChunkRuntimeMetricsRow> {
+    let state = runtime_metrics_state()
+        .lock()
+        .expect("runtime metrics mutex is not poisoned");
+    for row in sync_rows {
+        let key = MetricsScopeKey {
+            dao_code: row.dao_code.clone(),
+            chain_id: row.chain_id,
+            contract_set_id: row.contract_set_id.clone(),
+        };
+        if let Some(runtime_row) = state.sync_rows.get(&key) {
+            row.current_rate_blocks_per_second = runtime_row.current_rate_blocks_per_second;
+            row.eta_seconds = runtime_row.eta_seconds;
+        }
+    }
+
+    state.chunk_rows.values().cloned().collect()
+}
+
+fn runtime_metrics_state() -> &'static Mutex<RuntimeMetricsState> {
+    RUNTIME_METRICS.get_or_init(|| Mutex::new(RuntimeMetricsState::default()))
+}
+
+fn collect_onchain_worker_runtime_metrics() -> Vec<OnchainRefreshWorkerMetricsRow> {
+    runtime_metrics_state()
+        .lock()
+        .expect("runtime metrics mutex is not poisoned")
+        .onchain_worker_rows
+        .values()
+        .cloned()
+        .collect()
+}
+
+async fn collect_sync_metrics(pool: &PgPool) -> Result<Vec<IndexerSyncMetricsRow>, MetricsError> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+          checkpoint.dao_code,
+          checkpoint.chain_id,
+          checkpoint.contract_set_id,
+          checkpoint.processed_height::BIGINT AS processed_height,
+          checkpoint.target_height::BIGINT AS target_height,
+          (
+            SELECT MIN(selector_coverage.range_end_block)::BIGINT
+            FROM (
+              SELECT MAX(segment.range_end_block) AS range_end_block
+              FROM degov_provisional_segment segment
+              WHERE segment.status = 'available'
+                AND segment.dao_code = checkpoint.dao_code
+                AND segment.chain_id IS NOT DISTINCT FROM checkpoint.chain_id
+                AND segment.contract_set_id = checkpoint.contract_set_id
+              GROUP BY segment.source, segment.selector
+            ) selector_coverage
+          ) AS provisional_height,
+          latest.latest_height::BIGINT AS latest_height,
+          CASE
+            WHEN checkpoint.target_height IS NULL THEN NULL
+            WHEN checkpoint.target_height <= 0 THEN 100.0::DOUBLE PRECISION
+            WHEN checkpoint.processed_height IS NULL THEN 0.0::DOUBLE PRECISION
+            ELSE LEAST(
+              (checkpoint.processed_height::DOUBLE PRECISION / checkpoint.target_height::DOUBLE PRECISION) * 100.0,
+              100.0
+            )
+          END AS synced_percentage,
+          EXTRACT(EPOCH FROM checkpoint.updated_at)::DOUBLE PRECISION AS updated_timestamp_seconds,
+          checkpoint.last_error IS NOT NULL AS last_error_present
+        FROM degov_indexer_checkpoint checkpoint
+        LEFT JOIN degov_indexer_latest_head latest
+          ON latest.dao_code = checkpoint.dao_code
+         AND latest.chain_id = checkpoint.chain_id
+         AND latest.contract_set_id = checkpoint.contract_set_id
+         AND latest.stream_id = checkpoint.stream_id
+         AND latest.data_source_version = checkpoint.data_source_version
+        ORDER BY checkpoint.dao_code, checkpoint.chain_id, checkpoint.contract_set_id
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| IndexerSyncMetricsRow {
+            dao_code: row.get("dao_code"),
+            chain_id: row.get("chain_id"),
+            contract_set_id: row.get("contract_set_id"),
+            processed_height: row.get("processed_height"),
+            target_height: row.get("target_height"),
+            provisional_height: row.get("provisional_height"),
+            latest_height: row.get("latest_height"),
+            synced_percentage: row.get("synced_percentage"),
+            updated_timestamp_seconds: row.get("updated_timestamp_seconds"),
+            last_error_present: row.get("last_error_present"),
+            current_rate_blocks_per_second: None,
+            eta_seconds: None,
+        })
+        .collect())
+}
+
+async fn collect_onchain_refresh_backlog_metrics(
+    pool: &PgPool,
+) -> Result<Vec<OnchainRefreshBacklogMetricsRow>, MetricsError> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+          COALESCE(dao_code, '') AS dao_code,
+          chain_id,
+          contract_set_id,
+          status,
+          COUNT(*)::BIGINT AS tasks,
+          COUNT(*) FILTER (
+            WHERE next_run_at <= FLOOR(EXTRACT(EPOCH FROM now()) * 1000)::NUMERIC
+          )::BIGINT AS ready_tasks
+        FROM onchain_refresh_task
+        GROUP BY dao_code, chain_id, contract_set_id, status
+        ORDER BY dao_code, chain_id, contract_set_id, status
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| OnchainRefreshBacklogMetricsRow {
+            dao_code: row.get("dao_code"),
+            chain_id: row.get("chain_id"),
+            contract_set_id: row.get("contract_set_id"),
+            status: row.get("status"),
+            tasks: row.get("tasks"),
+            ready_tasks: row.get("ready_tasks"),
+        })
+        .collect())
+}
+
+async fn collect_deferred_onchain_refresh_backlog_metrics(
+    pool: &PgPool,
+) -> Result<Vec<OnchainRefreshBacklogMetricsRow>, MetricsError> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+          COALESCE(dao_code, '') AS dao_code,
+          chain_id,
+          contract_set_id,
+          'deferred' AS status,
+          COUNT(*)::BIGINT AS tasks,
+          COUNT(*) FILTER (
+            WHERE next_run_at <= FLOOR(EXTRACT(EPOCH FROM now()) * 1000)::NUMERIC
+          )::BIGINT AS ready_tasks
+        FROM onchain_refresh_deferred_candidate
+        GROUP BY dao_code, chain_id, contract_set_id
+        ORDER BY dao_code, chain_id, contract_set_id
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| OnchainRefreshBacklogMetricsRow {
+            dao_code: row.get("dao_code"),
+            chain_id: row.get("chain_id"),
+            contract_set_id: row.get("contract_set_id"),
+            status: row.get("status"),
+            tasks: row.get("tasks"),
+            ready_tasks: row.get("ready_tasks"),
+        })
+        .collect())
+}
+
+fn metric_header(output: &mut String, name: &str, help: &str, type_: &str) {
+    output.push_str("# HELP ");
+    output.push_str(name);
+    output.push(' ');
+    output.push_str(help);
+    output.push('\n');
+    output.push_str("# TYPE ");
+    output.push_str(name);
+    output.push(' ');
+    output.push_str(type_);
+    output.push('\n');
+}
+
+fn sync_labels(row: &IndexerSyncMetricsRow) -> Vec<(&'static str, String)> {
+    vec![
+        ("dao_code", row.dao_code.clone()),
+        ("chain_id", row.chain_id.to_string()),
+        ("contract_set_id", row.contract_set_id.clone()),
+    ]
+}
+
+fn onchain_labels(row: &OnchainRefreshBacklogMetricsRow) -> Vec<(&'static str, String)> {
+    vec![
+        ("dao_code", row.dao_code.clone()),
+        ("chain_id", row.chain_id.to_string()),
+        ("contract_set_id", row.contract_set_id.clone()),
+        ("status", row.status.clone()),
+    ]
+}
+
+fn chunk_labels(row: &IndexerChunkRuntimeMetricsRow) -> Vec<(&'static str, String)> {
+    vec![
+        ("dao_code", row.dao_code.clone()),
+        ("chain_id", row.chain_id.to_string()),
+        ("contract_set_id", row.contract_set_id.clone()),
+    ]
+}
+
+fn cache_labels(
+    row: &IndexerChunkRuntimeMetricsRow,
+    outcome: &'static str,
+) -> Vec<(&'static str, String)> {
+    let mut labels = chunk_labels(row);
+    labels.push(("outcome", outcome.to_owned()));
+    labels
+}
+
+fn worker_labels(row: &OnchainRefreshWorkerMetricsRow) -> Vec<(&'static str, String)> {
+    vec![
+        ("scope", row.scope.clone()),
+        ("dao_code", row.dao_code.clone()),
+        ("chain_id", row.chain_id.clone()),
+        ("contract_set_id", row.contract_set_id.clone()),
+    ]
+}
+
+fn worker_result_labels(
+    row: &OnchainRefreshWorkerMetricsRow,
+    result: &'static str,
+) -> Vec<(&'static str, String)> {
+    let mut labels = worker_labels(row);
+    labels.push(("result", result.to_owned()));
+    labels
+}
+
+fn append_optional_metric<T>(
+    output: &mut String,
+    name: &str,
+    labels: &[(&str, String)],
+    value: Option<T>,
+) where
+    T: std::fmt::Display,
+{
+    if let Some(value) = value {
+        append_metric(output, name, labels, value);
+    }
+}
+
+fn append_metric<T>(output: &mut String, name: &str, labels: &[(&str, String)], value: T)
+where
+    T: std::fmt::Display,
+{
+    output.push_str(name);
+    output.push('{');
+    for (index, (label, value)) in labels.iter().enumerate() {
+        if index > 0 {
+            output.push(',');
+        }
+        output.push_str(label);
+        output.push_str("=\"");
+        output.push_str(&escape_label_value(value));
+        output.push('"');
+    }
+    output.push_str("} ");
+    output.push_str(&value.to_string());
+    output.push('\n');
+}
+
+fn escape_label_value(value: &str) -> String {
+    value
+        .replace('\\', r"\\")
+        .replace('\n', r"\n")
+        .replace('"', r#"\""#)
+}

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -977,6 +977,27 @@ where
                 progress_rate.blocks_per_second(),
                 self.options.progress_refresh_lag_blocks,
             );
+            let total_duration = chunk_started_at.elapsed();
+            crate::metrics::record_indexer_chunk_metrics(
+                &self.options.checkpoint_identity,
+                &chunk_progress,
+                crate::metrics::IndexerChunkMetricsObservation {
+                    datalens_request_count: processing.metrics.datalens_request_count,
+                    cache_full_hit_count: processing.metrics.warmup_effectiveness.full_hit_count,
+                    cache_partial_hit_count: processing
+                        .metrics
+                        .warmup_effectiveness
+                        .partial_hit_count,
+                    cache_miss_count: processing.metrics.warmup_effectiveness.miss_count,
+                    cache_provider_fill_count: processing
+                        .metrics
+                        .warmup_effectiveness
+                        .provider_fill_range_count,
+                    chunk_duration_seconds: total_duration.as_secs_f64(),
+                    last_chunk_size: sizing_decision.previous_chunk_size,
+                    current_chunk_size: sizing_decision.current_chunk_size,
+                },
+            );
             info!(
                 "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={} adaptive_cache_full_hit_count={} adaptive_cache_partial_hit_count={} adaptive_cache_miss_count={} adaptive_cache_provider_fill_range_count={} adaptive_query_duration_max_ms={} onchain_refresh_deferred_drain_enabled={} onchain_refresh_deferred_drain_batch_size={} onchain_refresh_deferred_drain_count={} onchain_refresh_deferred_drain_duration_ms={}",
                 self.options.checkpoint_identity.dao_code,
@@ -1001,7 +1022,7 @@ where
                 processing.metrics.project_duration.as_millis(),
                 write_duration.as_millis(),
                 local_processing_write_duration.as_millis(),
-                chunk_started_at.elapsed().as_millis(),
+                total_duration.as_millis(),
                 checkpoint_next_block_before,
                 range.to_block,
                 range.to_block + 1,

--- a/apps/indexer/src/runtime/graphql.rs
+++ b/apps/indexer/src/runtime/graphql.rs
@@ -2,7 +2,7 @@ use anyhow as runtime_anyhow;
 use runtime_anyhow::{Context, Result};
 use sqlx::postgres::PgPoolOptions;
 
-use crate::{GraphqlRuntimeConfig, graphql, required_env};
+use crate::{GraphqlRuntimeConfig, MetricsRuntimeConfig, graphql, required_env};
 
 use super::migrate::apply_migrations;
 
@@ -15,6 +15,12 @@ pub async fn run_graphql() -> Result<()> {
         .await
         .context("connect to DeGov indexer Postgres")?;
     apply_migrations(&pool).await?;
+    let _metrics_server = crate::metrics::spawn_metrics_server(
+        pool.clone(),
+        MetricsRuntimeConfig::from_env().context("load metrics runtime configuration")?,
+    )
+    .await
+    .context("start DeGov indexer metrics service")?;
 
     let app = graphql::build_router_with_paths(graphql::build_schema(pool), config.paths.clone());
     let listener = tokio::net::TcpListener::bind(config.bind_address)

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -13,7 +13,7 @@ use crate::{
     DatalensQueryConcurrencyGate, DatalensQueryErrorClass, DatalensRuntimeContractSet,
     DatalensWarmupEnsureOutcome, EvmRpcChainTool, IndexerContractSetMode,
     IndexerContractSetRuntimeConfig, IndexerOnchainRefreshTick, IndexerRunner, IndexerRunnerReport,
-    IndexerRunnerStore, IndexerRuntimeConfig, IndexerTargetHeight,
+    IndexerRunnerStore, IndexerRuntimeConfig, IndexerTargetHeight, MetricsRuntimeConfig,
     MultiChainToolOnchainRefreshReader, OnchainRefreshRuntimeConfig, OnchainRefreshTaskScope,
     OnchainRefreshTickReport, OnchainRefreshTickRunner, OnchainRefreshTickScheduler,
     OnchainRefreshWorker, OnchainRefreshWorkerError, PostgresIndexerRunnerStore,
@@ -21,7 +21,9 @@ use crate::{
     ProvisionalWorkerOptions,
     checkpoint::configured_range_progress,
     classify_datalens_query_error, datalens_query_error_is_current_head_race,
-    datalens_retry_config, ensure_datalens_warmup_task, onchain_refresh_debounce_from_env,
+    datalens_retry_config, ensure_datalens_warmup_task,
+    metrics::IndexerLatestHeadRecord,
+    onchain_refresh_debounce_from_env,
     provisional::{DatalensProvisionalSegmentStore, ProvisionalWorkerError},
     required_env,
 };
@@ -53,6 +55,12 @@ pub async fn run_indexer() -> Result<()> {
         .await
         .context("connect to DeGov indexer Postgres")?;
     apply_migrations(&pool).await?;
+    let _metrics_server = crate::metrics::spawn_metrics_server(
+        pool.clone(),
+        MetricsRuntimeConfig::from_env().context("load metrics runtime configuration")?,
+    )
+    .await
+    .context("start DeGov indexer metrics service")?;
     ensure_warmup_on_startup(&runtime, &config).await?;
     let datalens_query_gate = if runtime.datalens_query_concurrency.is_limited() {
         Some(
@@ -1064,8 +1072,9 @@ async fn run_contract_set_pass(
             if let Some(gate) = datalens_query_gate {
                 provisional_client = provisional_client.with_query_concurrency_gate(gate);
             }
+            let metrics_pool = pool.clone();
             let mut provisional_store = PostgresProvisionalSegmentStore::new(pool);
-            if let Err(error) = run_provisional_worker_once(
+            match run_provisional_worker_once(
                 &runtime,
                 &config,
                 &contracts,
@@ -1073,15 +1082,42 @@ async fn run_contract_set_pass(
                 &mut provisional_client,
                 &mut provisional_store,
             )
-            .context("run Datalens provisional worker")
             {
-                log::warn!(
-                    "Datalens provisional worker failed after durable pass dao_code={} chain_id={:?} contract_set_id={} error={:#}",
-                    runtime.dao_code,
-                    config.chain.network_id,
-                    runtime.checkpoint_contract_set_id,
-                    error
-                );
+                Ok(provisional_report) => {
+                    if let (Some(chain_id), Some(latest_height)) =
+                        (config.chain.network_id, provisional_report.latest_height)
+                    {
+                        let record = IndexerLatestHeadRecord {
+                            dao_code: runtime.dao_code.clone(),
+                            chain_id,
+                            contract_set_id: runtime.checkpoint_contract_set_id.clone(),
+                            stream_id: runtime.checkpoint_stream_id.clone(),
+                            data_source_version: runtime.data_source_version.clone(),
+                            latest_height,
+                        };
+                        if let Err(error) = Handle::current().block_on(
+                            crate::metrics::record_indexer_latest_head(&metrics_pool, &record),
+                        ) {
+                            log::warn!(
+                                "record Datalens latest head failed dao_code={} chain_id={} contract_set_id={} latest_height={} error={:#}",
+                                runtime.dao_code,
+                                chain_id,
+                                runtime.checkpoint_contract_set_id,
+                                latest_height,
+                                error
+                            );
+                        }
+                    }
+                }
+                Err(error) => {
+                    log::warn!(
+                        "Datalens provisional worker failed after durable pass dao_code={} chain_id={:?} contract_set_id={} error={:#}",
+                        runtime.dao_code,
+                        config.chain.network_id,
+                        runtime.checkpoint_contract_set_id,
+                        error.context("run Datalens provisional worker")
+                    );
+                }
             }
         } else {
             log::debug!(
@@ -1109,7 +1145,7 @@ fn run_provisional_worker_once<R, S>(
     report: &IndexerRunnerReport,
     reader: &mut R,
     store: &mut S,
-) -> Result<Option<usize>>
+) -> Result<ProvisionalWorkerRunReport>
 where
     R: DatalensDurableHeadReader + DatalensProvisionalLogQueryReader,
     S: DatalensProvisionalSegmentStore,
@@ -1121,7 +1157,7 @@ where
             config.chain.network_id,
             runtime.checkpoint_contract_set_id
         );
-        return Ok(None);
+        return Ok(ProvisionalWorkerRunReport::default());
     }
 
     let Some(chain_id) = config.chain.network_id else {
@@ -1144,7 +1180,10 @@ where
             runtime.target_height,
             latest_height
         );
-        return Ok(None);
+        return Ok(ProvisionalWorkerRunReport {
+            latest_height: Some(latest_height),
+            segments_written: None,
+        });
     };
     let options = ProvisionalWorkerOptions {
         datalens_config: config.clone(),
@@ -1172,7 +1211,10 @@ where
                     latest_height,
                     reason
                 );
-                return Ok(None);
+                return Ok(ProvisionalWorkerRunReport {
+                    latest_height: Some(latest_height),
+                    segments_written: None,
+                });
             }
 
             return Err(provisional_worker_error_to_anyhow(error));
@@ -1190,7 +1232,16 @@ where
         report.segments_written
     );
 
-    Ok(Some(report.segments_written))
+    Ok(ProvisionalWorkerRunReport {
+        latest_height: Some(latest_height),
+        segments_written: Some(report.segments_written),
+    })
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct ProvisionalWorkerRunReport {
+    latest_height: Option<i64>,
+    segments_written: Option<usize>,
 }
 
 fn provisional_tail_range(
@@ -1593,7 +1644,8 @@ mod tests {
         )
         .expect("disabled provisional worker skips cleanly");
 
-        assert_eq!(result, None);
+        assert_eq!(result.segments_written, None);
+        assert_eq!(result.latest_height, None);
         assert_eq!(reader.latest_head_calls, 0);
         assert!(reader.finalities.is_empty());
         assert!(store.writes.is_empty());
@@ -1630,7 +1682,8 @@ mod tests {
         )
         .expect("enabled provisional worker runs");
 
-        assert_eq!(result, Some(1));
+        assert_eq!(result.segments_written, Some(1));
+        assert_eq!(result.latest_height, Some(25));
         assert_eq!(reader.latest_head_calls, 1);
         assert_eq!(reader.ranges.len(), 2);
         assert!(reader.ranges.iter().all(|range| *range == (21, 25)));
@@ -1668,7 +1721,8 @@ mod tests {
         )
         .expect("provisional worker skips while durable pass is behind");
 
-        assert_eq!(result, None);
+        assert_eq!(result.segments_written, None);
+        assert_eq!(result.latest_height, Some(25));
         assert_eq!(reader.latest_head_calls, 1);
         assert!(reader.finalities.is_empty());
         assert!(reader.ranges.is_empty());
@@ -1699,7 +1753,8 @@ mod tests {
         )
         .expect("current head race skips provisional worker run");
 
-        assert_eq!(result, None);
+        assert_eq!(result.segments_written, None);
+        assert_eq!(result.latest_height, Some(25));
         assert_eq!(reader.latest_head_calls, 1);
         assert_eq!(reader.ranges, vec![(21, 25)]);
         assert_eq!(reader.finalities, vec![Some("safe_to_latest".to_owned())]);

--- a/apps/indexer/src/runtime/worker.rs
+++ b/apps/indexer/src/runtime/worker.rs
@@ -6,9 +6,9 @@ use sqlx::postgres::PgPoolOptions;
 use tokio::time::sleep;
 
 use crate::{
-    DatalensConfig, EvmRpcChainTool, IndexerRuntimeConfig, MultiChainToolOnchainRefreshReader,
-    OnchainRefreshRunReport, OnchainRefreshRuntimeConfig, OnchainRefreshScopeMode,
-    OnchainRefreshTaskScope, OnchainRefreshWorker, required_env,
+    DatalensConfig, EvmRpcChainTool, IndexerRuntimeConfig, MetricsRuntimeConfig,
+    MultiChainToolOnchainRefreshReader, OnchainRefreshRunReport, OnchainRefreshRuntimeConfig,
+    OnchainRefreshScopeMode, OnchainRefreshTaskScope, OnchainRefreshWorker, required_env,
 };
 
 use super::migrate::apply_migrations;
@@ -40,6 +40,12 @@ pub async fn run_worker() -> Result<()> {
         .await
         .context("connect to DeGov indexer Postgres")?;
     apply_migrations(&pool).await?;
+    let _metrics_server = crate::metrics::spawn_metrics_server(
+        pool.clone(),
+        MetricsRuntimeConfig::from_env().context("load metrics runtime configuration")?,
+    )
+    .await
+    .context("start DeGov indexer metrics service")?;
 
     let chain_tools = runtime
         .rpc_chains
@@ -82,6 +88,11 @@ pub async fn run_worker() -> Result<()> {
                 run_onchain_refresh_worker_batch(&worker, &batch_scope, runtime.batch_size)
                     .await
                     .context("run onchain refresh batch")?;
+            let metrics_scope = match &batch_scope {
+                OnchainRefreshWorkerBatchScope::Global => None,
+                OnchainRefreshWorkerBatchScope::Scoped(scope) => Some(scope),
+            };
+            crate::metrics::record_onchain_refresh_worker_report(metrics_scope, &report);
             poll_claimed += report.claimed;
             poll_completed += report.completed;
             poll_failed += report.failed;

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -24,6 +24,12 @@ pub struct GraphqlRuntimeConfig {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MetricsRuntimeConfig {
+    pub enabled: bool,
+    pub bind_address: SocketAddr,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProvisionalRuntimeConfig {
     pub enabled: bool,
     pub finality: DatalensProvisionalFinality,
@@ -63,6 +69,23 @@ impl GraphqlRuntimeConfig {
             bind_address,
             public_endpoint,
             paths,
+        })
+    }
+}
+
+impl MetricsRuntimeConfig {
+    pub fn from_env() -> Result<Self> {
+        let enabled = optional_env_bool("DEGOV_INDEXER_METRICS_ENABLED")?.unwrap_or(false);
+        let bind_address = match optional_env("DEGOV_INDEXER_METRICS_BIND_ADDRESS")? {
+            Some(address) => parse_bind_address("DEGOV_INDEXER_METRICS_BIND_ADDRESS", &address)?,
+            None => "0.0.0.0:9464"
+                .parse()
+                .expect("default metrics bind address parses"),
+        };
+
+        Ok(Self {
+            enabled,
+            bind_address,
         })
     }
 }

--- a/apps/indexer/tests/metrics_service.rs
+++ b/apps/indexer/tests/metrics_service.rs
@@ -1,0 +1,152 @@
+use degov_datalens_indexer::MetricsRuntimeConfig;
+use degov_datalens_indexer::metrics::{
+    IndexerChunkRuntimeMetricsRow, IndexerMetricsSnapshot, IndexerSyncMetricsRow,
+    OnchainRefreshBacklogMetricsRow, OnchainRefreshWorkerMetricsRow, render_prometheus_metrics,
+};
+
+#[test]
+fn test_prometheus_renderer_emits_indexer_sync_and_onchain_backlog_gauges() {
+    let snapshot = IndexerMetricsSnapshot {
+        sync_rows: vec![IndexerSyncMetricsRow {
+            dao_code: "ring-dao".to_owned(),
+            chain_id: 46,
+            contract_set_id: "dao=ring-dao|chain=46|governor=0xgovernor".to_owned(),
+            processed_height: Some(12_209_673),
+            target_height: Some(12_209_908),
+            provisional_height: Some(12_209_931),
+            latest_height: Some(12_209_940),
+            synced_percentage: Some(99.998),
+            updated_timestamp_seconds: Some(1_782_437_000.0),
+            last_error_present: false,
+            current_rate_blocks_per_second: Some(4.5),
+            eta_seconds: Some(52.2),
+        }],
+        onchain_backlog_rows: vec![OnchainRefreshBacklogMetricsRow {
+            dao_code: "ring-dao".to_owned(),
+            chain_id: 46,
+            contract_set_id: "dao=ring-dao|chain=46|governor=0xgovernor".to_owned(),
+            status: "pending".to_owned(),
+            tasks: 15,
+            ready_tasks: 9,
+        }],
+        deferred_onchain_backlog_rows: vec![OnchainRefreshBacklogMetricsRow {
+            dao_code: "ring-dao".to_owned(),
+            chain_id: 46,
+            contract_set_id: "dao=ring-dao|chain=46|governor=0xgovernor".to_owned(),
+            status: "deferred".to_owned(),
+            tasks: 7,
+            ready_tasks: 3,
+        }],
+        chunk_runtime_rows: vec![IndexerChunkRuntimeMetricsRow {
+            dao_code: "ring-dao".to_owned(),
+            chain_id: 46,
+            contract_set_id: "dao=ring-dao|chain=46|governor=0xgovernor".to_owned(),
+            chunks_total: 2,
+            datalens_requests_total: 4,
+            cache_full_hit_total: 3,
+            cache_partial_hit_total: 1,
+            cache_miss_total: 0,
+            cache_provider_fill_total: 0,
+            chunk_duration_seconds_sum: 3.5,
+            chunk_duration_seconds_count: 2,
+            last_chunk_size: Some(5000),
+            current_chunk_size: Some(10000),
+        }],
+        onchain_worker_rows: vec![OnchainRefreshWorkerMetricsRow {
+            scope: "contract_set".to_owned(),
+            dao_code: "ring-dao".to_owned(),
+            chain_id: "46".to_owned(),
+            contract_set_id: "dao=ring-dao|chain=46|governor=0xgovernor".to_owned(),
+            claimed_total: 12,
+            completed_total: 10,
+            failed_total: 2,
+            skipped_total: 1,
+            cache_hits_total: 8,
+            data_metric_refreshes_total: 3,
+            duration_seconds_sum: 6.0,
+            duration_seconds_count: 2,
+            last_backlog: Some(5),
+        }],
+    };
+
+    let output = render_prometheus_metrics(&snapshot);
+
+    assert!(output.contains(
+        "degov_indexer_processed_height{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 12209673"
+    ));
+    assert!(output.contains(
+        "degov_indexer_target_height{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 12209908"
+    ));
+    assert!(output.contains(
+        "degov_indexer_provisional_height{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 12209931"
+    ));
+    assert!(output.contains(
+        "degov_indexer_latest_height{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 12209940"
+    ));
+    assert!(output.contains(
+        "degov_indexer_remaining_blocks{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 235"
+    ));
+    assert!(output.contains(
+        "degov_indexer_latest_lag_blocks{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 267"
+    ));
+    assert!(output.contains(
+        "degov_indexer_current_rate_blocks_per_second{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 4.5"
+    ));
+    assert!(output.contains(
+        "degov_indexer_eta_seconds{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 52.2"
+    ));
+    assert!(output.contains(
+        "degov_onchain_refresh_tasks{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",status=\"pending\"} 15"
+    ));
+    assert!(output.contains(
+        "degov_onchain_refresh_ready_tasks{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",status=\"pending\"} 9"
+    ));
+    assert!(output.contains(
+        "degov_onchain_refresh_deferred_candidates{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",status=\"deferred\"} 7"
+    ));
+    assert!(output.contains(
+        "degov_indexer_chunks_total{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 2"
+    ));
+    assert!(output.contains(
+        "degov_indexer_datalens_cache_ranges_total{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",outcome=\"full_hit\"} 3"
+    ));
+    assert!(output.contains(
+        "degov_indexer_chunk_duration_seconds_sum{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 3.5"
+    ));
+    assert!(output.contains(
+        "degov_onchain_refresh_worker_tasks_total{scope=\"contract_set\",dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",result=\"completed\"} 10"
+    ));
+    assert!(output.contains(
+        "degov_onchain_refresh_worker_last_backlog{scope=\"contract_set\",dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 5"
+    ));
+}
+
+#[test]
+fn test_metrics_runtime_config_is_disabled_by_default_and_parses_bind_address() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_METRICS_ENABLED", None::<&str>),
+            ("DEGOV_INDEXER_METRICS_BIND_ADDRESS", None::<&str>),
+        ],
+        || {
+            let config = MetricsRuntimeConfig::from_env().expect("default metrics config");
+            assert!(!config.enabled);
+            assert_eq!(config.bind_address.to_string(), "0.0.0.0:9464");
+        },
+    );
+
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_METRICS_ENABLED", Some("true")),
+            (
+                "DEGOV_INDEXER_METRICS_BIND_ADDRESS",
+                Some("127.0.0.1:19464"),
+            ),
+        ],
+        || {
+            let config = MetricsRuntimeConfig::from_env().expect("enabled metrics config");
+            assert!(config.enabled);
+            assert_eq!(config.bind_address.to_string(), "127.0.0.1:19464");
+        },
+    );
+}

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -668,7 +668,8 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
             "0004_onchain_refresh_claim_retry_indexes.sql",
             "0005_onchain_refresh_failed_ready_retry_index.sql",
             "0006_onchain_refresh_pending_ready_claim_index.sql",
-            "0007_checkpoint_adaptive_chunk_state.sql"
+            "0007_checkpoint_adaptive_chunk_state.sql",
+            "0008_indexer_latest_head.sql"
         ]
     );
 


### PR DESCRIPTION
## Summary
- add an internal Prometheus metrics server controlled by DEGOV_INDEXER_METRICS_ENABLED and DEGOV_INDEXER_METRICS_BIND_ADDRESS
- expose DB-derived indexer sync gauges for processed/target/provisional/latest heights, lag, stale-checkpoint inputs, and onchain refresh backlog
- persist latest observed Datalens head height from the provisional worker
- record runtime chunk throughput/cache/duration metrics and onchain refresh worker throughput metrics

## Metrics highlights
- degov_indexer_processed_height / target_height / provisional_height / latest_height
- degov_indexer_remaining_blocks / latest_lag_blocks / current_rate_blocks_per_second / eta_seconds
- degov_indexer_checkpoint_updated_timestamp_seconds / last_error_present
- degov_indexer_chunks_total / datalens_requests_total / datalens_cache_ranges_total / chunk_duration_seconds
- degov_onchain_refresh_tasks / ready_tasks / deferred_candidates
- degov_onchain_refresh_worker_tasks_total / cache_hits_total / batch_duration_seconds / last_backlog

## Verification
- cargo fmt --check
- cargo check -p degov-datalens-indexer
- cargo test -p degov-datalens-indexer --test metrics_service
- cargo test -p degov-datalens-indexer runtime::indexer::tests::test_provisional_worker_runtime
- cargo test -p degov-datalens-indexer runtime::worker::tests::test_onchain_refresh_report_consumes_poll_batch_for_claimed_tasks