### PR TITLE
fix(web): show indexing state for pending proposals

### DIFF
--- a/apps/web/messages/en/proposal-detail.json
+++ b/apps/web/messages/en/proposal-detail.json
@@ -7,7 +7,13 @@
     "on": "on",
     "discussion": "Discussion",
     "loadingTitle": "Proposal Loading",
-    "loadingDescription": "Loading proposal data, please wait..."
+    "loadingDescription": "Loading proposal data, please wait...",
+    "checkingProposalTitle": "Checking Proposal",
+    "checkingProposalDescription": "Checking whether this proposal is available.",
+    "indexingTitle": "Proposal Indexing",
+    "indexingDescription": "This proposal is on chain and will appear here shortly.",
+    "indexingProblemTitle": "Proposal Indexing Delayed",
+    "indexingProblemDescription": "This proposal is on chain, but the page data is still unavailable. Please try again later."
   },
   "tabs": {
     "content": "Content",

--- a/apps/web/scripts/proposal-indexing-state.test.ts
+++ b/apps/web/scripts/proposal-indexing-state.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getProposalMissingState,
+  PROPOSAL_INDEXING_PROBLEM_MS,
+} from "../src/app/proposal/[id]/proposal-indexing-state.ts";
+
+test("missing proposal waits while the chain existence check is pending", () => {
+  assert.equal(
+    getProposalMissingState({
+      chainExists: false,
+      chainCheckPending: true,
+      chainCheckError: null,
+      missingObservedAt: 1000,
+      now: 2000,
+    }),
+    "checking"
+  );
+});
+
+test("missing proposal shows indexing while the chain has it and the threshold has not elapsed", () => {
+  assert.equal(
+    getProposalMissingState({
+      chainExists: true,
+      chainCheckPending: false,
+      chainCheckError: null,
+      missingObservedAt: 1000,
+      now: 1000 + PROPOSAL_INDEXING_PROBLEM_MS - 1,
+    }),
+    "indexing"
+  );
+});
+
+test("missing proposal shows a problem when the chain has it past the threshold", () => {
+  assert.equal(
+    getProposalMissingState({
+      chainExists: true,
+      chainCheckPending: false,
+      chainCheckError: null,
+      missingObservedAt: 1000,
+      now: 1000 + PROPOSAL_INDEXING_PROBLEM_MS,
+    }),
+    "problem"
+  );
+});
+
+test("missing proposal shows not found after the chain check rejects it", () => {
+  assert.equal(
+    getProposalMissingState({
+      chainExists: false,
+      chainCheckPending: false,
+      chainCheckError: new Error("GovernorNonexistentProposal"),
+      missingObservedAt: 1000,
+      now: 2000,
+    }),
+    "not-found"
+  );
+});
+
+test("missing proposal keeps checking when the chain check fails for another reason", () => {
+  assert.equal(
+    getProposalMissingState({
+      chainExists: false,
+      chainCheckPending: false,
+      chainCheckError: new Error("HTTP request failed"),
+      missingObservedAt: 1000,
+      now: 2000,
+    }),
+    "checking"
+  );
+});

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -4,12 +4,12 @@ import { isNil } from "lodash-es";
 import dynamic from "next/dynamic";
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useReadContract } from "wagmi";
 
 import NotFound from "@/components/not-found";
 import { ProposalNotification } from "@/components/proposal-notification";
-import { LoadingState } from "@/components/ui/loading-spinner";
+import { ErrorState, LoadingState } from "@/components/ui/loading-spinner";
 import { abi as GovernorAbi } from "@/config/abi/governor";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useNotificationVisibility } from "@/hooks/useNotificationVisibility";
@@ -20,6 +20,7 @@ import { parseDescription } from "@/utils";
 import { CACHE_TIMES } from "@/utils/query-config";
 
 import { CurrentVotes } from "./current-votes";
+import { getProposalMissingState } from "./proposal-indexing-state";
 import Status from "./status";
 import { Summary } from "./summary";
 import { Tabs } from "./tabs";
@@ -91,6 +92,10 @@ export default function ProposalDetailPage() {
     () => buildGovernanceScope(daoConfig),
     [daoConfig]
   );
+  const [missingObservedAt, setMissingObservedAt] = useState<number | null>(
+    null
+  );
+  const [now, setNow] = useState(() => Date.now());
 
   const {
     data: allData,
@@ -114,6 +119,10 @@ export default function ProposalDetailPage() {
     enabled: !!validId && !!daoConfig?.indexer.endpoint,
     refetchInterval: isActive ? CACHE_TIMES.TEN_SECONDS : false,
   });
+  const chainExists = !isNil(proposalStatus?.data);
+  const isProposalMissingFromIndexer =
+    !isPending && (!allData || allData.length === 0);
+  const shouldPollMissingProposal = isProposalMissingFromIndexer && chainExists;
 
   const data = useMemo(() => {
     if (allData?.[0]) {
@@ -217,6 +226,30 @@ export default function ProposalDetailPage() {
 
   const wasActiveRef = useRef(false);
   useEffect(() => {
+    if (isProposalMissingFromIndexer) {
+      setMissingObservedAt((observedAt) => observedAt ?? Date.now());
+      return;
+    }
+
+    setMissingObservedAt(null);
+  }, [isProposalMissingFromIndexer]);
+
+  useEffect(() => {
+    if (!shouldPollMissingProposal) {
+      return;
+    }
+
+    setNow(Date.now());
+    void refetchProposal();
+    const interval = window.setInterval(() => {
+      setNow(Date.now());
+      void refetchProposal();
+    }, CACHE_TIMES.TEN_SECONDS);
+
+    return () => window.clearInterval(interval);
+  }, [refetchProposal, shouldPollMissingProposal]);
+
+  useEffect(() => {
     if (wasActiveRef.current && !isActive) {
       void refetchProposal();
       void refetchProposalCanceledById();
@@ -301,8 +334,48 @@ export default function ProposalDetailPage() {
     );
   }
 
-  if (!allData || allData.length === 0) {
-    return <NotFound />;
+  if (isProposalMissingFromIndexer) {
+    const missingState = getProposalMissingState({
+      chainExists,
+      chainCheckPending:
+        proposalStatus?.isPending || proposalStatus?.isLoading || false,
+      chainCheckError: proposalStatus?.error,
+      missingObservedAt,
+      now,
+    });
+
+    if (missingState === "not-found") {
+      return <NotFound />;
+    }
+
+    if (missingState === "problem") {
+      return (
+        <div className="w-full h-full flex items-center justify-center">
+          <ErrorState
+            title={t("indexingProblemTitle")}
+            description={t("indexingProblemDescription")}
+            onRetry={refetchProposal}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <LoadingState
+          title={
+            missingState === "checking"
+              ? t("checkingProposalTitle")
+              : t("indexingTitle")
+          }
+          description={
+            missingState === "checking"
+              ? t("checkingProposalDescription")
+              : t("indexingDescription")
+          }
+        />
+      </div>
+    );
   }
   return (
     <div className="flex w-full flex-col gap-[20px] h-full min-h-0">

--- a/apps/web/src/app/proposal/[id]/proposal-indexing-state.ts
+++ b/apps/web/src/app/proposal/[id]/proposal-indexing-state.ts
@@ -1,0 +1,52 @@
+export const PROPOSAL_INDEXING_PROBLEM_MS = 30 * 60 * 1000;
+
+export type ProposalMissingState =
+  | "checking"
+  | "indexing"
+  | "problem"
+  | "not-found";
+
+function isGovernorNonexistentProposalError(error: unknown) {
+  if (!error) {
+    return false;
+  }
+
+  const message =
+    error instanceof Error ? error.message : JSON.stringify(error);
+
+  return /GovernorNonexistentProposal|nonexistent proposal/i.test(message);
+}
+
+export function getProposalMissingState({
+  chainExists,
+  chainCheckPending,
+  chainCheckError,
+  missingObservedAt,
+  now,
+}: {
+  chainExists: boolean;
+  chainCheckPending: boolean;
+  chainCheckError: unknown;
+  missingObservedAt: number | null;
+  now: number;
+}): ProposalMissingState {
+  if (chainExists) {
+    const elapsed = missingObservedAt ? now - missingObservedAt : 0;
+
+    if (elapsed >= PROPOSAL_INDEXING_PROBLEM_MS) {
+      return "problem";
+    }
+
+    return "indexing";
+  }
+
+  if (chainCheckPending) {
+    return "checking";
+  }
+
+  if (isGovernorNonexistentProposalError(chainCheckError)) {
+    return "not-found";
+  }
+
+  return "checking";
+}


### PR DESCRIPTION
## Summary\n- Avoid showing a generic 404 while a chain-confirmed proposal is waiting for indexer data.\n- Use the Governor state read as the chain existence check when GraphQL has no proposal.\n- Show checking/indexing/delayed states, and keep true nonexistent proposals on 404.\n\n## Verification\n- node apps/web/scripts/proposal-indexing-state.test.ts\n- just web lint\n\n## Notes\n- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "tsc" not found is still blocked by the existing unrelated demo DAO config test typing issue reported previously.