### PR TITLE
perf(indexer): cache prometheus db metrics

### DIFF
--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -1,18 +1,21 @@
 use std::{
     collections::BTreeMap,
-    sync::{Mutex, OnceLock},
+    fmt::Display,
+    future::Future,
+    sync::{Arc, Mutex, OnceLock},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use axum::{
     Router,
     extract::State,
-    http::{HeaderValue, StatusCode, header},
+    http::{HeaderValue, header},
     response::{IntoResponse, Response},
     routing::get,
 };
 use sqlx::{PgPool, Row};
 use thiserror::Error;
-use tokio::task::JoinHandle;
+use tokio::{sync::RwLock, task::JoinHandle, time};
 
 use crate::{IndexerCheckpointIdentity, MetricsRuntimeConfig, runner::IndexerRunnerProgress};
 use crate::{OnchainRefreshRunReport, OnchainRefreshTaskScope};
@@ -24,6 +27,17 @@ pub struct IndexerMetricsSnapshot {
     pub deferred_onchain_backlog_rows: Vec<OnchainRefreshBacklogMetricsRow>,
     pub chunk_runtime_rows: Vec<IndexerChunkRuntimeMetricsRow>,
     pub onchain_worker_rows: Vec<OnchainRefreshWorkerMetricsRow>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MetricsCacheStatus {
+    pub db_collection_enabled: bool,
+    pub last_success_timestamp_seconds: Option<f64>,
+    pub snapshot_age_seconds: Option<f64>,
+    pub last_refresh_duration_seconds: Option<f64>,
+    pub last_refresh_success: bool,
+    pub refresh_errors_total: u64,
+    pub stale: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -138,6 +152,32 @@ struct OnchainWorkerMetricsScopeKey {
 
 static RUNTIME_METRICS: OnceLock<Mutex<RuntimeMetricsState>> = OnceLock::new();
 
+#[derive(Clone, Debug)]
+pub struct MetricsSnapshotCache {
+    state: Arc<RwLock<MetricsSnapshotCacheState>>,
+    db_collection_enabled: bool,
+    stale_after: Duration,
+}
+
+#[derive(Clone, Debug, Default)]
+struct MetricsSnapshotCacheState {
+    db_snapshot: IndexerMetricsSnapshot,
+    last_success_at: Option<Instant>,
+    last_success_timestamp_seconds: Option<f64>,
+    last_refresh_duration_seconds: Option<f64>,
+    last_refresh_success: bool,
+    refresh_errors_total: u64,
+    last_error: Option<String>,
+}
+
+#[derive(Clone)]
+struct MetricsServerState {
+    pool: PgPool,
+    cache: MetricsSnapshotCache,
+    refresh_interval: Duration,
+    refresh_timeout: Duration,
+}
+
 #[derive(Debug, Error)]
 pub enum MetricsError {
     #[error("query indexer metrics")]
@@ -149,6 +189,75 @@ pub enum MetricsError {
 pub async fn collect_prometheus_metrics(pool: &PgPool) -> Result<String, MetricsError> {
     let snapshot = collect_indexer_metrics_snapshot(pool).await?;
     Ok(render_prometheus_metrics(&snapshot))
+}
+
+impl MetricsSnapshotCache {
+    pub fn new(db_collection_enabled: bool, stale_after: Duration) -> Self {
+        Self {
+            state: Arc::new(RwLock::new(MetricsSnapshotCacheState::default())),
+            db_collection_enabled,
+            stale_after,
+        }
+    }
+
+    pub async fn refresh_with<F, Fut, E>(&self, collect: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<IndexerMetricsSnapshot, E>>,
+        E: Display,
+    {
+        if !self.db_collection_enabled {
+            return;
+        }
+
+        let started_at = Instant::now();
+        match collect().await {
+            Ok(mut snapshot) => {
+                snapshot.chunk_runtime_rows.clear();
+                snapshot.onchain_worker_rows.clear();
+                let mut state = self.state.write().await;
+                state.db_snapshot = snapshot;
+                state.last_success_at = Some(Instant::now());
+                state.last_success_timestamp_seconds = Some(unix_timestamp_seconds());
+                state.last_refresh_duration_seconds = Some(started_at.elapsed().as_secs_f64());
+                state.last_refresh_success = true;
+                state.last_error = None;
+            }
+            Err(error) => {
+                let mut state = self.state.write().await;
+                state.last_refresh_duration_seconds = Some(started_at.elapsed().as_secs_f64());
+                state.last_refresh_success = false;
+                state.refresh_errors_total = state.refresh_errors_total.saturating_add(1);
+                state.last_error = Some(error.to_string());
+            }
+        }
+    }
+
+    pub async fn snapshot(&self) -> (IndexerMetricsSnapshot, MetricsCacheStatus) {
+        let state = self.state.read().await;
+        let mut snapshot = state.db_snapshot.clone();
+        let snapshot_age_seconds = state
+            .last_success_at
+            .map(|last_success_at| last_success_at.elapsed().as_secs_f64());
+        let stale = self.db_collection_enabled
+            && snapshot_age_seconds
+                .map(|age| age > self.stale_after.as_secs_f64())
+                .unwrap_or(true);
+        let status = MetricsCacheStatus {
+            db_collection_enabled: self.db_collection_enabled,
+            last_success_timestamp_seconds: state.last_success_timestamp_seconds,
+            snapshot_age_seconds,
+            last_refresh_duration_seconds: state.last_refresh_duration_seconds,
+            last_refresh_success: state.last_refresh_success,
+            refresh_errors_total: state.refresh_errors_total,
+            stale,
+        };
+        drop(state);
+
+        snapshot.chunk_runtime_rows = collect_runtime_metrics(&mut snapshot.sync_rows);
+        snapshot.onchain_worker_rows = collect_onchain_worker_runtime_metrics();
+        (snapshot, status)
+    }
 }
 
 pub async fn record_indexer_latest_head(
@@ -196,10 +305,21 @@ pub async fn spawn_metrics_server(
         return Ok(None);
     }
 
-    let app = build_metrics_router(pool);
     let listener = tokio::net::TcpListener::bind(config.bind_address)
         .await
         .map_err(MetricsError::Bind)?;
+
+    let state = MetricsServerState {
+        pool,
+        cache: MetricsSnapshotCache::new(config.db_collection_enabled, config.refresh_interval * 3),
+        refresh_interval: config.refresh_interval,
+        refresh_timeout: config.refresh_timeout,
+    };
+    if state.cache.db_collection_enabled {
+        spawn_metrics_refresh_loop(state.clone());
+    }
+
+    let app = build_metrics_router(state);
     let bind_address = config.bind_address;
     log::info!("DeGov indexer metrics service listening bind_address={bind_address}");
 
@@ -212,28 +332,62 @@ pub async fn spawn_metrics_server(
     Ok(Some(handle))
 }
 
-pub fn build_metrics_router(pool: PgPool) -> Router {
+fn build_metrics_router(state: MetricsServerState) -> Router {
     Router::new()
         .route("/metrics", get(metrics_handler))
-        .with_state(pool)
+        .with_state(state)
+}
+
+fn spawn_metrics_refresh_loop(state: MetricsServerState) {
+    tokio::spawn(async move {
+        refresh_metrics_cache(&state).await;
+        loop {
+            time::sleep(state.refresh_interval).await;
+            refresh_metrics_cache(&state).await;
+        }
+    });
+}
+
+async fn refresh_metrics_cache(state: &MetricsServerState) {
+    let pool = state.pool.clone();
+    let timeout = state.refresh_timeout;
+    state
+        .cache
+        .refresh_with(|| async move {
+            match time::timeout(timeout, collect_db_metrics_snapshot(&pool)).await {
+                Ok(result) => result.map_err(|error| error.to_string()),
+                Err(_) => Err(format!(
+                    "collect DeGov indexer metrics exceeded {}s timeout",
+                    timeout.as_secs_f64()
+                )),
+            }
+        })
+        .await;
 }
 
 pub async fn collect_indexer_metrics_snapshot(
     pool: &PgPool,
 ) -> Result<IndexerMetricsSnapshot, MetricsError> {
-    let mut sync_rows = collect_sync_metrics(pool).await?;
+    let mut snapshot = collect_db_metrics_snapshot(pool).await?;
+    snapshot.chunk_runtime_rows = collect_runtime_metrics(&mut snapshot.sync_rows);
+    snapshot.onchain_worker_rows = collect_onchain_worker_runtime_metrics();
+
+    Ok(snapshot)
+}
+
+async fn collect_db_metrics_snapshot(
+    pool: &PgPool,
+) -> Result<IndexerMetricsSnapshot, MetricsError> {
+    let sync_rows = collect_sync_metrics(pool).await?;
     let onchain_backlog_rows = collect_onchain_refresh_backlog_metrics(pool).await?;
     let deferred_onchain_backlog_rows =
         collect_deferred_onchain_refresh_backlog_metrics(pool).await?;
-    let chunk_runtime_rows = collect_runtime_metrics(&mut sync_rows);
-    let onchain_worker_rows = collect_onchain_worker_runtime_metrics();
 
     Ok(IndexerMetricsSnapshot {
         sync_rows,
         onchain_backlog_rows,
         deferred_onchain_backlog_rows,
-        chunk_runtime_rows,
-        onchain_worker_rows,
+        ..Default::default()
     })
 }
 
@@ -338,30 +492,71 @@ pub fn record_onchain_refresh_worker_report(
     row.last_backlog = report.backlog;
 }
 
-async fn metrics_handler(State(pool): State<PgPool>) -> Response {
-    match collect_prometheus_metrics(&pool).await {
-        Ok(body) => (
-            [(
-                header::CONTENT_TYPE,
-                HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
-            )],
-            body,
-        )
-            .into_response(),
-        Err(error) => {
-            log::warn!("collect DeGov indexer metrics failed: {error}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("collect DeGov indexer metrics failed: {error}"),
-            )
-                .into_response()
-        }
-    }
+async fn metrics_handler(State(state): State<MetricsServerState>) -> Response {
+    let (snapshot, status) = state.cache.snapshot().await;
+    let body = render_prometheus_metrics_with_status(&snapshot, &status);
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
+        )],
+        body,
+    )
+        .into_response()
 }
 
 pub fn render_prometheus_metrics(snapshot: &IndexerMetricsSnapshot) -> String {
+    render_prometheus_metrics_with_status(snapshot, &MetricsCacheStatus::default_for_legacy())
+}
+
+pub fn render_prometheus_metrics_with_status(
+    snapshot: &IndexerMetricsSnapshot,
+    status: &MetricsCacheStatus,
+) -> String {
     let mut output = String::new();
 
+    metric_header(
+        &mut output,
+        "degov_metrics_db_collection_enabled",
+        "Whether this metrics endpoint collects DB-backed DeGov indexer metrics.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_metrics_snapshot_last_success_timestamp_seconds",
+        "Unix timestamp of the last successful DB-backed metrics snapshot refresh.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_metrics_snapshot_age_seconds",
+        "Seconds since the last successful DB-backed metrics snapshot refresh.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_metrics_refresh_duration_seconds",
+        "Duration of the most recent DB-backed metrics snapshot refresh.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_metrics_refresh_success",
+        "Whether the most recent DB-backed metrics snapshot refresh succeeded.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_metrics_refresh_errors_total",
+        "Failed DB-backed metrics snapshot refresh attempts.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_metrics_snapshot_stale",
+        "Whether the DB-backed metrics snapshot is older than the configured freshness threshold.",
+        "gauge",
+    );
     metric_header(
         &mut output,
         "degov_indexer_processed_height",
@@ -517,6 +712,49 @@ pub fn render_prometheus_metrics(snapshot: &IndexerMetricsSnapshot) -> String {
         "degov_onchain_refresh_worker_last_backlog",
         "Last observed onchain refresh worker backlog.",
         "gauge",
+    );
+
+    append_metric(
+        &mut output,
+        "degov_metrics_db_collection_enabled",
+        &[],
+        i64::from(status.db_collection_enabled),
+    );
+    append_optional_metric(
+        &mut output,
+        "degov_metrics_snapshot_last_success_timestamp_seconds",
+        &[],
+        status.last_success_timestamp_seconds,
+    );
+    append_optional_metric(
+        &mut output,
+        "degov_metrics_snapshot_age_seconds",
+        &[],
+        status.snapshot_age_seconds,
+    );
+    append_optional_metric(
+        &mut output,
+        "degov_metrics_refresh_duration_seconds",
+        &[],
+        status.last_refresh_duration_seconds,
+    );
+    append_metric(
+        &mut output,
+        "degov_metrics_refresh_success",
+        &[],
+        i64::from(status.last_refresh_success),
+    );
+    append_metric(
+        &mut output,
+        "degov_metrics_refresh_errors_total",
+        &[],
+        status.refresh_errors_total,
+    );
+    append_metric(
+        &mut output,
+        "degov_metrics_snapshot_stale",
+        &[],
+        i64::from(status.stale),
     );
 
     for row in &snapshot.sync_rows {
@@ -751,6 +989,27 @@ pub fn render_prometheus_metrics(snapshot: &IndexerMetricsSnapshot) -> String {
     }
 
     output
+}
+
+impl MetricsCacheStatus {
+    fn default_for_legacy() -> Self {
+        Self {
+            db_collection_enabled: true,
+            last_success_timestamp_seconds: None,
+            snapshot_age_seconds: None,
+            last_refresh_duration_seconds: None,
+            last_refresh_success: true,
+            refresh_errors_total: 0,
+            stale: false,
+        }
+    }
+}
+
+fn unix_timestamp_seconds() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
 }
 
 fn collect_runtime_metrics(

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -27,6 +27,9 @@ pub struct GraphqlRuntimeConfig {
 pub struct MetricsRuntimeConfig {
     pub enabled: bool,
     pub bind_address: SocketAddr,
+    pub db_collection_enabled: bool,
+    pub refresh_interval: Duration,
+    pub refresh_timeout: Duration,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -76,6 +79,20 @@ impl GraphqlRuntimeConfig {
 impl MetricsRuntimeConfig {
     pub fn from_env() -> Result<Self> {
         let enabled = optional_env_bool("DEGOV_INDEXER_METRICS_ENABLED")?.unwrap_or(false);
+        let db_collection_enabled =
+            optional_env_bool("DEGOV_INDEXER_METRICS_DB_COLLECTION_ENABLED")?.unwrap_or(true);
+        let refresh_interval_ms =
+            optional_env_u64("DEGOV_INDEXER_METRICS_REFRESH_INTERVAL_MS")?.unwrap_or(15_000);
+        if refresh_interval_ms == 0 {
+            bail!("DEGOV_INDEXER_METRICS_REFRESH_INTERVAL_MS must be greater than zero");
+        }
+        let refresh_timeout_ms =
+            optional_env_u64("DEGOV_INDEXER_METRICS_REFRESH_TIMEOUT_MS")?.unwrap_or(25_000);
+        if refresh_timeout_ms == 0 {
+            bail!("DEGOV_INDEXER_METRICS_REFRESH_TIMEOUT_MS must be greater than zero");
+        }
+        let refresh_interval = Duration::from_millis(refresh_interval_ms);
+        let refresh_timeout = Duration::from_millis(refresh_timeout_ms);
         let bind_address = match optional_env("DEGOV_INDEXER_METRICS_BIND_ADDRESS")? {
             Some(address) => parse_bind_address("DEGOV_INDEXER_METRICS_BIND_ADDRESS", &address)?,
             None => "0.0.0.0:9464"
@@ -86,6 +103,9 @@ impl MetricsRuntimeConfig {
         Ok(Self {
             enabled,
             bind_address,
+            db_collection_enabled,
+            refresh_interval,
+            refresh_timeout,
         })
     }
 }

--- a/apps/indexer/tests/metrics_service.rs
+++ b/apps/indexer/tests/metrics_service.rs
@@ -1,7 +1,13 @@
 use degov_datalens_indexer::MetricsRuntimeConfig;
 use degov_datalens_indexer::metrics::{
     IndexerChunkRuntimeMetricsRow, IndexerMetricsSnapshot, IndexerSyncMetricsRow,
-    OnchainRefreshBacklogMetricsRow, OnchainRefreshWorkerMetricsRow, render_prometheus_metrics,
+    MetricsCacheStatus, MetricsSnapshotCache, OnchainRefreshBacklogMetricsRow,
+    OnchainRefreshWorkerMetricsRow, render_prometheus_metrics,
+    render_prometheus_metrics_with_status,
+};
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
 };
 
 #[test]
@@ -127,11 +133,17 @@ fn test_metrics_runtime_config_is_disabled_by_default_and_parses_bind_address() 
         [
             ("DEGOV_INDEXER_METRICS_ENABLED", None::<&str>),
             ("DEGOV_INDEXER_METRICS_BIND_ADDRESS", None::<&str>),
+            ("DEGOV_INDEXER_METRICS_DB_COLLECTION_ENABLED", None::<&str>),
+            ("DEGOV_INDEXER_METRICS_REFRESH_INTERVAL_MS", None::<&str>),
+            ("DEGOV_INDEXER_METRICS_REFRESH_TIMEOUT_MS", None::<&str>),
         ],
         || {
             let config = MetricsRuntimeConfig::from_env().expect("default metrics config");
             assert!(!config.enabled);
             assert_eq!(config.bind_address.to_string(), "0.0.0.0:9464");
+            assert!(config.db_collection_enabled);
+            assert_eq!(config.refresh_interval, Duration::from_secs(15));
+            assert_eq!(config.refresh_timeout, Duration::from_secs(25));
         },
     );
 
@@ -142,11 +154,141 @@ fn test_metrics_runtime_config_is_disabled_by_default_and_parses_bind_address() 
                 "DEGOV_INDEXER_METRICS_BIND_ADDRESS",
                 Some("127.0.0.1:19464"),
             ),
+            ("DEGOV_INDEXER_METRICS_DB_COLLECTION_ENABLED", Some("false")),
+            ("DEGOV_INDEXER_METRICS_REFRESH_INTERVAL_MS", Some("30000")),
+            ("DEGOV_INDEXER_METRICS_REFRESH_TIMEOUT_MS", Some("5000")),
         ],
         || {
             let config = MetricsRuntimeConfig::from_env().expect("enabled metrics config");
             assert!(config.enabled);
             assert_eq!(config.bind_address.to_string(), "127.0.0.1:19464");
+            assert!(!config.db_collection_enabled);
+            assert_eq!(config.refresh_interval, Duration::from_secs(30));
+            assert_eq!(config.refresh_timeout, Duration::from_secs(5));
         },
     );
+}
+
+#[test]
+fn test_metrics_runtime_config_rejects_zero_refresh_durations() {
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_METRICS_REFRESH_INTERVAL_MS", Some("0")),
+            ("DEGOV_INDEXER_METRICS_REFRESH_TIMEOUT_MS", None::<&str>),
+        ],
+        || {
+            let error = MetricsRuntimeConfig::from_env()
+                .expect_err("zero metrics refresh interval should fail");
+            assert!(
+                error
+                    .to_string()
+                    .contains("DEGOV_INDEXER_METRICS_REFRESH_INTERVAL_MS")
+            );
+        },
+    );
+
+    temp_env::with_vars(
+        [
+            ("DEGOV_INDEXER_METRICS_REFRESH_INTERVAL_MS", None::<&str>),
+            ("DEGOV_INDEXER_METRICS_REFRESH_TIMEOUT_MS", Some("0")),
+        ],
+        || {
+            let error = MetricsRuntimeConfig::from_env()
+                .expect_err("zero metrics refresh timeout should fail");
+            assert!(
+                error
+                    .to_string()
+                    .contains("DEGOV_INDEXER_METRICS_REFRESH_TIMEOUT_MS")
+            );
+        },
+    );
+}
+
+#[test]
+fn test_prometheus_renderer_emits_metrics_cache_status() {
+    let status = MetricsCacheStatus {
+        db_collection_enabled: true,
+        last_success_timestamp_seconds: Some(1_782_437_001.0),
+        snapshot_age_seconds: Some(3.5),
+        last_refresh_duration_seconds: Some(0.25),
+        last_refresh_success: true,
+        refresh_errors_total: 2,
+        stale: false,
+    };
+
+    let output = render_prometheus_metrics_with_status(&IndexerMetricsSnapshot::default(), &status);
+
+    assert!(output.contains("degov_metrics_db_collection_enabled{} 1"));
+    assert!(output.contains("degov_metrics_refresh_success{} 1"));
+    assert!(output.contains("degov_metrics_refresh_errors_total{} 2"));
+    assert!(output.contains("degov_metrics_snapshot_age_seconds{} 3.5"));
+    assert!(output.contains("degov_metrics_refresh_duration_seconds{} 0.25"));
+    assert!(output.contains("degov_metrics_snapshot_stale{} 0"));
+}
+
+#[tokio::test]
+async fn test_metrics_snapshot_cache_keeps_last_success_after_refresh_failure() {
+    let cache = MetricsSnapshotCache::new(true, Duration::from_secs(60));
+    let calls = AtomicUsize::new(0);
+
+    cache
+        .refresh_with(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok::<IndexerMetricsSnapshot, String>(sample_snapshot(100))
+        })
+        .await;
+
+    cache
+        .refresh_with(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err("database timeout".to_owned())
+        })
+        .await;
+
+    let (snapshot, status) = cache.snapshot().await;
+
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(snapshot.sync_rows[0].processed_height, Some(100));
+    assert_eq!(status.refresh_errors_total, 1);
+    assert!(!status.last_refresh_success);
+    assert!(status.snapshot_age_seconds.is_some());
+}
+
+#[tokio::test]
+async fn test_metrics_snapshot_cache_disabled_skips_db_refresh() {
+    let cache = MetricsSnapshotCache::new(false, Duration::from_secs(60));
+    let calls = AtomicUsize::new(0);
+
+    cache
+        .refresh_with(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok::<IndexerMetricsSnapshot, String>(sample_snapshot(100))
+        })
+        .await;
+
+    let (snapshot, status) = cache.snapshot().await;
+
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert!(snapshot.sync_rows.is_empty());
+    assert!(!status.db_collection_enabled);
+}
+
+fn sample_snapshot(processed_height: i64) -> IndexerMetricsSnapshot {
+    IndexerMetricsSnapshot {
+        sync_rows: vec![IndexerSyncMetricsRow {
+            dao_code: "ring-dao".to_owned(),
+            chain_id: 46,
+            contract_set_id: "dao=ring-dao|chain=46|governor=0xgovernor".to_owned(),
+            processed_height: Some(processed_height),
+            target_height: Some(200),
+            provisional_height: Some(150),
+            latest_height: Some(210),
+            synced_percentage: Some(50.0),
+            updated_timestamp_seconds: Some(1_782_437_000.0),
+            last_error_present: false,
+            current_rate_blocks_per_second: None,
+            eta_seconds: None,
+        }],
+        ..Default::default()
+    }
 }


### PR DESCRIPTION
## Summary
- move DB-backed Prometheus metrics collection out of the `/metrics` scrape path into a background cached snapshot
- keep serving the last successful DB metrics snapshot when refreshes fail or time out
- add metrics self-observability for DB collection enablement, snapshot age, refresh duration, refresh success, refresh errors, and stale status
- add config for DB collection enablement plus refresh interval/timeout

## Why
Production Prometheus targets were timing out because each scrape synchronously ran checkpoint/backlog SQL, including large `onchain_refresh_task` aggregations. Scrapes should be constant-time and should not directly contend with indexer DB work.

## Validation
- `cargo test -p degov-datalens-indexer --locked --test metrics_service`
- `cargo check -p degov-datalens-indexer --locked`
- `cargo test -p degov-datalens-indexer --locked --lib`
- `git diff --check`
