### PR TITLE
fix(indexer): report disabled metrics collection healthy

### DIFF
--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -248,7 +248,7 @@ impl MetricsSnapshotCache {
             last_success_timestamp_seconds: state.last_success_timestamp_seconds,
             snapshot_age_seconds,
             last_refresh_duration_seconds: state.last_refresh_duration_seconds,
-            last_refresh_success: state.last_refresh_success,
+            last_refresh_success: !self.db_collection_enabled || state.last_refresh_success,
             refresh_errors_total: state.refresh_errors_total,
             stale,
         };

--- a/apps/indexer/tests/metrics_service.rs
+++ b/apps/indexer/tests/metrics_service.rs
@@ -271,6 +271,7 @@ async fn test_metrics_snapshot_cache_disabled_skips_db_refresh() {
     assert_eq!(calls.load(Ordering::SeqCst), 0);
     assert!(snapshot.sync_rows.is_empty());
     assert!(!status.db_collection_enabled);
+    assert!(status.last_refresh_success);
 }
 
 fn sample_snapshot(processed_height: i64) -> IndexerMetricsSnapshot {


### PR DESCRIPTION
## Summary
- report `degov_metrics_refresh_success` as healthy when DB-backed metrics collection is intentionally disabled
- cover disabled metrics collection status with a regression test

## Why
GraphQL and onchain-refresh-worker metrics endpoints intentionally skip DB-backed collection after #994. They should not expose a refresh failure signal that can be mistaken for an unhealthy metrics pipeline.

## Validation
- `cargo test -p degov-datalens-indexer --locked --test metrics_service`
- `cargo check -p degov-datalens-indexer --locked`
- `git diff --check`
