### PR TITLE
feat: Fix degov proposal quorum display to count all vote weights

### DIFF
--- a/apps/web/scripts/proposal-quorum-progress.test.ts
+++ b/apps/web/scripts/proposal-quorum-progress.test.ts
@@ -3,12 +3,26 @@ import test from "node:test";
 
 import { getProposalQuorumProgress } from "../src/app/proposal/[id]/current-votes-calculation.ts";
 
-test("proposal quorum progress counts for against and abstain voting weight", () => {
+test("proposal quorum progress follows for and abstain quorum counting mode", () => {
+  const progress = getProposalQuorumProgress({
+    forVotes: 10n,
+    againstVotes: 20n,
+    abstainVotes: 5n,
+    quorumRequired: 15n,
+    countingMode: "support=bravo&quorum=for,abstain",
+  });
+
+  assert.equal(progress.currentVotes, 15n);
+  assert.equal(progress.hasReachedQuorum, true);
+});
+
+test("proposal quorum progress counts against votes only when counting mode includes them", () => {
   const progress = getProposalQuorumProgress({
     forVotes: 10n,
     againstVotes: 20n,
     abstainVotes: 5n,
     quorumRequired: 30n,
+    countingMode: "support=bravo&quorum=for,against,abstain",
   });
 
   assert.equal(progress.currentVotes, 35n);

--- a/apps/web/scripts/proposal-quorum-progress.test.ts
+++ b/apps/web/scripts/proposal-quorum-progress.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getProposalQuorumProgress } from "../src/app/proposal/[id]/current-votes-calculation.ts";
+
+test("proposal quorum progress counts for against and abstain voting weight", () => {
+  const progress = getProposalQuorumProgress({
+    forVotes: 10n,
+    againstVotes: 20n,
+    abstainVotes: 5n,
+    quorumRequired: 30n,
+  });
+
+  assert.equal(progress.currentVotes, 35n);
+  assert.equal(progress.hasReachedQuorum, true);
+});

--- a/apps/web/src/app/proposal/[id]/current-votes-calculation.ts
+++ b/apps/web/src/app/proposal/[id]/current-votes-calculation.ts
@@ -1,0 +1,19 @@
+interface ProposalQuorumProgressInput {
+  againstVotes: bigint;
+  forVotes: bigint;
+  abstainVotes: bigint;
+  quorumRequired: bigint;
+}
+
+export const getProposalQuorumProgress = ({
+  againstVotes,
+  forVotes,
+  abstainVotes,
+  quorumRequired,
+}: ProposalQuorumProgressInput) => {
+  const currentVotes = againstVotes + forVotes + abstainVotes;
+  const hasReachedQuorum =
+    quorumRequired === 0n ? false : currentVotes >= quorumRequired;
+
+  return { currentVotes, hasReachedQuorum };
+};

--- a/apps/web/src/app/proposal/[id]/current-votes-calculation.ts
+++ b/apps/web/src/app/proposal/[id]/current-votes-calculation.ts
@@ -3,15 +3,40 @@ interface ProposalQuorumProgressInput {
   forVotes: bigint;
   abstainVotes: bigint;
   quorumRequired: bigint;
+  countingMode?: string | null;
 }
+
+const parseQuorumBuckets = (countingMode?: string | null) => {
+  const fallbackBuckets = ["for", "abstain"];
+  const quorumConfig = countingMode
+    ?.split("&")
+    .find((part) => part.startsWith("quorum="));
+
+  if (!quorumConfig) {
+    return fallbackBuckets;
+  }
+
+  return quorumConfig
+    .slice("quorum=".length)
+    .split(",")
+    .map((bucket) => bucket.trim().toLowerCase())
+    .filter(Boolean);
+};
 
 export const getProposalQuorumProgress = ({
   againstVotes,
   forVotes,
   abstainVotes,
   quorumRequired,
+  countingMode,
 }: ProposalQuorumProgressInput) => {
-  const currentVotes = againstVotes + forVotes + abstainVotes;
+  const quorumBuckets = parseQuorumBuckets(countingMode);
+  const currentVotes = quorumBuckets.reduce((total, bucket) => {
+    if (bucket === "for") return total + forVotes;
+    if (bucket === "against") return total + againstVotes;
+    if (bucket === "abstain") return total + abstainVotes;
+    return total;
+  }, 0n);
   const hasReachedQuorum =
     quorumRequired === 0n ? false : currentVotes >= quorumRequired;
 

--- a/apps/web/src/app/proposal/[id]/current-votes.tsx
+++ b/apps/web/src/app/proposal/[id]/current-votes.tsx
@@ -79,11 +79,13 @@ interface CurrentVotesProps {
     abstainVotes: bigint;
   };
   quorumRequired: bigint;
+  countingMode?: string | null;
   isLoading?: boolean;
 }
 export const CurrentVotes = ({
   proposalVotesData,
   quorumRequired,
+  countingMode,
   isLoading,
 }: CurrentVotesProps) => {
   const t = useTranslations("proposalDetail.currentVotes");
@@ -104,8 +106,9 @@ export const CurrentVotes = ({
       getProposalQuorumProgress({
         ...proposalVotesData,
         quorumRequired,
+        countingMode,
       }),
-    [proposalVotesData, quorumRequired]
+    [proposalVotesData, quorumRequired, countingMode]
   );
 
   const percentage = useMemo(() => {

--- a/apps/web/src/app/proposal/[id]/current-votes.tsx
+++ b/apps/web/src/app/proposal/[id]/current-votes.tsx
@@ -6,6 +6,8 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useFormatGovernanceTokenAmount } from "@/hooks/useFormatGovernanceTokenAmount";
 
+import { getProposalQuorumProgress } from "./current-votes-calculation";
+
 const CurrentVotesSkeleton = () => {
   const t = useTranslations("proposalDetail.currentVotes");
   const voteLabels = useTranslations("proposals.voteLabels");
@@ -88,21 +90,23 @@ export const CurrentVotes = ({
   const voteLabels = useTranslations("proposals.voteLabels");
   const formatTokenAmount = useFormatGovernanceTokenAmount();
 
-  const { totalVotesCast, totalParticipation } = useMemo(() => {
+  const totalVotesCast = useMemo(() => {
     const totalVotesCast =
       proposalVotesData.againstVotes +
       proposalVotesData.forVotes +
       proposalVotesData.abstainVotes;
-    const totalParticipation =
-      proposalVotesData.forVotes + proposalVotesData.abstainVotes;
 
-    return { totalVotesCast, totalParticipation };
+    return totalVotesCast;
   }, [proposalVotesData]);
 
-  const hasReachedQuorum = useMemo(() => {
-    if (quorumRequired === 0n) return false;
-    return totalParticipation >= quorumRequired;
-  }, [quorumRequired, totalParticipation]);
+  const { currentVotes, hasReachedQuorum } = useMemo(
+    () =>
+      getProposalQuorumProgress({
+        ...proposalVotesData,
+        quorumRequired,
+      }),
+    [proposalVotesData, quorumRequired]
+  );
 
   const percentage = useMemo(() => {
     if (totalVotesCast === 0n) {
@@ -150,7 +154,7 @@ export const CurrentVotes = ({
           </div>
           <span className="flex items-center gap-[5px]">
             {t("participation", {
-              current: formatTokenAmount(totalParticipation).formatted,
+              current: formatTokenAmount(currentVotes).formatted,
               required: formatTokenAmount(quorumRequired).formatted,
             })}
           </span>

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -408,6 +408,7 @@ export default function ProposalDetailPage() {
             <CurrentVotes
               proposalVotesData={proposalVotesData}
               quorumRequired={quorumRequired}
+              countingMode={data?.countingMode}
               isLoading={isPending || !data}
             />
             <Status
@@ -437,6 +438,7 @@ export default function ProposalDetailPage() {
         <CurrentVotes
           proposalVotesData={proposalVotesData}
           quorumRequired={quorumRequired}
+          countingMode={data?.countingMode}
           isLoading={isPending || !data}
         />
         <Tabs data={data} isFetching={isPending} />

--- a/apps/web/src/services/graphql/queries/proposals.ts
+++ b/apps/web/src/services/graphql/queries/proposals.ts
@@ -34,6 +34,7 @@ export const GET_ALL_PROPOSALS = gql`
       queueExpiresAt
       blockInterval
       clockMode
+      countingMode
       quorum
       decimals
       title

--- a/apps/web/src/services/graphql/types/proposals.ts
+++ b/apps/web/src/services/graphql/types/proposals.ts
@@ -40,6 +40,7 @@ export type ProposalItem = {
   voteEndTimestamp: string;
   blockInterval?: string | null;
   clockMode: string;
+  countingMode?: string | null;
   proposalDeadline?: string | null;
   proposalEta?: string | null;
   queueReadyAt?: string | null;


### PR DESCRIPTION
Frontend proposal quorum progress now counts all vote weight: for, against, and abstain. Majority support and vote distribution behavior remain unchanged. Regression coverage verifies that against votes can make quorum reached when the combined vote total meets the requirement. Verified with the focused node:test regression and @degov/web lint.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1075/
work_kind: code_work
branch: hbx-1075-fix-degov-proposal-quorum-display
base: main
commit: 38be88e1f3d2785da2cba539adfa1c0824ef335c
```