### PR TITLE
feat: Add lightweight degov web health probe for GitHub #727

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Check build
         run: |
           pnpm install --filter @degov/web... --frozen-lockfile
+          pnpm run test:web-scripts
           pnpm --filter @degov/web build
 
   check-indexer:

--- a/apps/web/scripts/web-health-probe.test.mjs
+++ b/apps/web/scripts/web-health-probe.test.mjs
@@ -10,6 +10,7 @@ test("web health route stays dependency-light", () => {
 
   const routeSource = readFileSync(routePath, "utf8");
 
+  assert.match(routeSource, /dynamic\s*=\s*"force-dynamic"/);
   assert.match(routeSource, /export async function GET\(/);
   assert.match(routeSource, /status:\s*"ok"/);
   assert.doesNotMatch(routeSource, /loadConfig|getConfig|DEGOV_CONFIG|remote|graphql|prisma|database/i);

--- a/apps/web/scripts/web-health-probe.test.mjs
+++ b/apps/web/scripts/web-health-probe.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import test from "node:test";
+
+const routePath = new URL("../src/app/api/health/route.ts", import.meta.url);
+const dockerfilePath = new URL("../../../docker/web.Dockerfile", import.meta.url);
+
+test("web health route stays dependency-light", () => {
+  assert.equal(existsSync(routePath), true);
+
+  const routeSource = readFileSync(routePath, "utf8");
+
+  assert.match(routeSource, /export async function GET\(/);
+  assert.match(routeSource, /status:\s*"ok"/);
+  assert.doesNotMatch(routeSource, /loadConfig|getConfig|DEGOV_CONFIG|remote|graphql|prisma|database/i);
+});
+
+test("web container healthcheck uses the lightweight health route", () => {
+  const dockerfileSource = readFileSync(dockerfilePath, "utf8");
+
+  assert.match(dockerfileSource, /HEALTHCHECK/);
+  assert.match(dockerfileSource, /\/api\/health/);
+  assert.doesNotMatch(dockerfileSource, /HEALTHCHECK[\s\S]*http:\/\/127\.0\.0\.1:3000\/\s/m);
+});

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ status: "ok" });
+}

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   return Response.json({ status: "ok" });
 }

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -63,4 +63,6 @@ ENV HOSTNAME="0.0.0.0"
 
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 CMD node -e "const http = require('http'); const req = http.get({ host: '127.0.0.1', port: process.env.PORT || 3000, path: '/api/health', timeout: 2000 }, (res) => process.exit(res.statusCode === 200 ? 0 : 1)); req.on('error', () => process.exit(1)); req.on('timeout', () => { req.destroy(); process.exit(1); });"
+
 ENTRYPOINT [ "/app/apps/web/scripts/entrypoint.sh" ]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "indexer:smoke-datalens": "cargo run -p degov-datalens-indexer --locked -- smoke-datalens",
     "indexer:worker": "cargo run -p degov-datalens-indexer --locked -- worker",
     "test:indexer": "cargo test -p degov-datalens-indexer --locked",
-    "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/runtime-packaging.test.mjs && node apps/indexer/scripts/staging-deployment-contract.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs && node apps/indexer/scripts/v4-parity-audit.test.mjs && node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs"
+    "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/runtime-packaging.test.mjs && node apps/indexer/scripts/staging-deployment-contract.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs && node apps/indexer/scripts/v4-parity-audit.test.mjs && node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs",
+    "test:web-scripts": "node --test apps/web/scripts/*.test.ts apps/web/scripts/*.test.mjs"
   },
   "pnpm": {
     "packageExtensions": {


### PR DESCRIPTION
Adds a dependency-light `GET /api/health` web endpoint and updates the in-repository web container healthcheck default to use it instead of exercising the full `/` page path. This reduces probe-triggered restart risk under config/cache pressure because the health check only proves the web process can serve HTTP. Related to ringecosystem/degov#727. If production probes are owned by external GitOps values, mirror the probe path there as follow-up.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1080/
work_kind: code_work
branch: hbx-1080-add-lightweight-degov-web-health
base: main
commit: e5ddde0a5c2523a8f656af620aec8166a1db67fd
```