### PR TITLE
Fix indexer live overlay GraphQL indexes

### DIFF
--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -274,9 +274,9 @@ fn indexer_status_query<'a>() -> QueryBuilder<'a, Postgres> {
                 AND segment.chain_id IS NOT DISTINCT FROM degov_indexer_checkpoint.chain_id
                 AND segment.contract_set_id = degov_indexer_checkpoint.contract_set_id
                 AND segment.dataset_key = split_part(
-                  substring(degov_indexer_checkpoint.contract_set_id FROM '(^|[|])dataset=[^|]+'),
-                  'dataset=',
-                  2
+                  split_part(degov_indexer_checkpoint.contract_set_id, 'dataset=', 2),
+                  '|',
+                  1
                 )
               GROUP BY segment.source, segment.selector
             ) selector_coverage
@@ -1318,9 +1318,9 @@ mod tests {
         let query = indexer_status_query();
         let sql = query.sql();
 
+        assert!(sql.contains("segment.dataset_key = split_part"));
         assert!(
-            sql.contains("segment.dataset_key = split_part"),
-            "indexer status provisional height must scope segments by dataset key:\n{sql}"
+            sql.contains("split_part(degov_indexer_checkpoint.contract_set_id, 'dataset=', 2)")
         );
     }
 }

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -449,6 +449,34 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure live contributor overlay account lookup index")?;
 
+    execute_concurrent_runtime_index(
+        connection,
+        "provisional_delegate_live_graphql_scope_idx",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_live_graphql_scope_idx
+         ON degov_provisional_delegate_power_overlay (
+            contract_set_id, chain_id, dao_code, governor_address, delegator, delegate,
+            token_address
+         )
+         INCLUDE (power, is_current)
+         WHERE source = 'live-onchain' AND status = 'available'",
+    )
+    .await
+    .context("ensure live delegate overlay GraphQL scope index")?;
+
+    execute_concurrent_runtime_index(
+        connection,
+        "provisional_contributor_live_graphql_scope_idx",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_graphql_scope_idx
+         ON degov_provisional_contributor_power_overlay (
+            contract_set_id, chain_id, dao_code, governor_address, account,
+            token_address
+         )
+         INCLUDE (power, balance, delegates_count_all, last_vote_timestamp)
+         WHERE source = 'live-onchain' AND status = 'available'",
+    )
+    .await
+    .context("ensure live contributor overlay GraphQL scope index")?;
+
     Ok(())
 }
 
@@ -805,6 +833,9 @@ async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnecti
         "provisional_contributor_live_account_lookup_idx",
     )
     .await?;
+    drop_invalid_runtime_index(connection, "provisional_delegate_live_graphql_scope_idx").await?;
+    drop_invalid_runtime_index(connection, "provisional_contributor_live_graphql_scope_idx")
+        .await?;
 
     Ok(())
 }

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -455,9 +455,8 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_live_graphql_scope_idx
          ON degov_provisional_delegate_power_overlay (
             contract_set_id, chain_id, dao_code, governor_address, delegator, delegate,
-            token_address
          )
-         INCLUDE (power, is_current)
+         INCLUDE (token_address, power, is_current)
          WHERE source = 'live-onchain' AND status = 'available'",
     )
     .await
@@ -469,9 +468,8 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_graphql_scope_idx
          ON degov_provisional_contributor_power_overlay (
             contract_set_id, chain_id, dao_code, governor_address, account,
-            token_address
          )
-         INCLUDE (power, balance, delegates_count_all, last_vote_timestamp)
+         INCLUDE (token_address, power, balance, delegates_count_all, last_vote_timestamp)
          WHERE source = 'live-onchain' AND status = 'available'",
     )
     .await

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -454,7 +454,7 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
         "provisional_delegate_live_graphql_scope_idx",
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_live_graphql_scope_idx
          ON degov_provisional_delegate_power_overlay (
-            contract_set_id, chain_id, dao_code, governor_address, delegator, delegate,
+            contract_set_id, chain_id, dao_code, governor_address, delegator, delegate
          )
          INCLUDE (token_address, power, is_current)
          WHERE source = 'live-onchain' AND status = 'available'",
@@ -467,7 +467,7 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
         "provisional_contributor_live_graphql_scope_idx",
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_graphql_scope_idx
          ON degov_provisional_contributor_power_overlay (
-            contract_set_id, chain_id, dao_code, governor_address, account,
+            contract_set_id, chain_id, dao_code, governor_address, account
          )
          INCLUDE (token_address, power, balance, delegates_count_all, last_vote_timestamp)
          WHERE source = 'live-onchain' AND status = 'available'",

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -712,18 +712,16 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_live_graphql_scope_idx
          ON degov_provisional_delegate_power_overlay (
             contract_set_id, chain_id, dao_code, governor_address, delegator, delegate,
-            token_address
          )
-         INCLUDE (power, is_current)
+         INCLUDE (token_address, power, is_current)
          WHERE source = 'live-onchain' AND status = 'available'"
     ));
     assert!(runtime_migration.contains(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_graphql_scope_idx
          ON degov_provisional_contributor_power_overlay (
             contract_set_id, chain_id, dao_code, governor_address, account,
-            token_address
          )
-         INCLUDE (power, balance, delegates_count_all, last_vote_timestamp)
+         INCLUDE (token_address, power, balance, delegates_count_all, last_vote_timestamp)
          WHERE source = 'live-onchain' AND status = 'available'"
     ));
     assert!(runtime_migration.contains(

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -711,7 +711,7 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_live_graphql_scope_idx
          ON degov_provisional_delegate_power_overlay (
-            contract_set_id, chain_id, dao_code, governor_address, delegator, delegate,
+            contract_set_id, chain_id, dao_code, governor_address, delegator, delegate
          )
          INCLUDE (token_address, power, is_current)
          WHERE source = 'live-onchain' AND status = 'available'"
@@ -719,7 +719,7 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_graphql_scope_idx
          ON degov_provisional_contributor_power_overlay (
-            contract_set_id, chain_id, dao_code, governor_address, account,
+            contract_set_id, chain_id, dao_code, governor_address, account
          )
          INCLUDE (token_address, power, balance, delegates_count_all, last_vote_timestamp)
          WHERE source = 'live-onchain' AND status = 'available'"

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -708,6 +708,30 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("onchain_refresh_task_failed_scope_retry_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_processing_scope_retry_idx"));
     assert!(runtime_migration.contains("contributor_onchain_refresh_coverage_scope_idx"));
+    assert!(runtime_migration.contains(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_live_graphql_scope_idx
+         ON degov_provisional_delegate_power_overlay (
+            contract_set_id, chain_id, dao_code, governor_address, delegator, delegate,
+            token_address
+         )
+         INCLUDE (power, is_current)
+         WHERE source = 'live-onchain' AND status = 'available'"
+    ));
+    assert!(runtime_migration.contains(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_graphql_scope_idx
+         ON degov_provisional_contributor_power_overlay (
+            contract_set_id, chain_id, dao_code, governor_address, account,
+            token_address
+         )
+         INCLUDE (power, balance, delegates_count_all, last_vote_timestamp)
+         WHERE source = 'live-onchain' AND status = 'available'"
+    ));
+    assert!(runtime_migration.contains(
+        "drop_invalid_runtime_index(connection, \"provisional_delegate_live_graphql_scope_idx\")"
+    ));
+    assert!(runtime_migration.contains(
+        "drop_invalid_runtime_index(connection, \"provisional_contributor_live_graphql_scope_idx\")"
+    ));
     assert!(runtime_migration.contains("ON onchain_refresh_task (next_run_at, updated_at, id)"));
     assert!(runtime_migration.contains("WHERE status = 'pending'"));
     assert!(


### PR DESCRIPTION
## Summary
- add runtime-created concurrent partial indexes for live delegate and contributor overlay GraphQL joins
- include payload columns instead of making them btree keys to reduce index size and write/build cost
- register the new indexes with invalid runtime index cleanup and static migration assertions

## Why
Ring DAO GraphQL queries for delegates/contributors exhausted the DB pool after PostgreSQL planned expensive scans over live overlay tables. These indexes match the GraphQL live overlay join/filter shape and are created through the existing runtime index path.

Closes #1004

## Validation
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --locked test_indexer_keeps_init_migration_stable_and_appends_runtime_markers --test migration_schema`
- `cargo test -p degov-datalens-indexer --locked --test migration_schema` ran with 5 static tests passing and 5 DB-backed tests failing because `DEGOV_INDEXER_TEST_DATABASE_URL` is unset locally

## Follow-up
If production `EXPLAIN` still chooses sequential scans after these indexes are built and analyzed, follow up with GraphQL query rewrites and/or GraphQL connection `statement_timeout`.