### PR TITLE
Fix indexer runtime migration DDL ownership

### DIFF
--- a/apps/indexer/src/runtime/graphql.rs
+++ b/apps/indexer/src/runtime/graphql.rs
@@ -4,7 +4,7 @@ use sqlx::postgres::PgPoolOptions;
 
 use crate::{GraphqlRuntimeConfig, MetricsRuntimeConfig, graphql, required_env};
 
-use super::migrate::apply_migrations;
+use super::migrate::apply_schema_migrations;
 
 pub async fn run_graphql() -> Result<()> {
     let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
@@ -14,7 +14,7 @@ pub async fn run_graphql() -> Result<()> {
         .connect(&database_url)
         .await
         .context("connect to DeGov indexer Postgres")?;
-    apply_migrations(&pool).await?;
+    apply_schema_migrations(&pool).await?;
     let _metrics_server = crate::metrics::spawn_metrics_server(
         pool.clone(),
         MetricsRuntimeConfig::from_env().context("load metrics runtime configuration")?,

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -39,21 +39,7 @@ pub async fn repair_invalid_runtime_indexes() -> Result<()> {
 
     let result = repair_invalid_runtime_indexes_for_connection(&mut connection).await;
 
-    let unlock_result = sqlx::query_scalar::<_, bool>(
-        "SELECT pg_advisory_unlock(hashtext('degov_indexer_runtime_migration'))",
-    )
-    .fetch_one(&mut *connection)
-    .await
-    .context("release DeGov indexer runtime migration lock")
-    .and_then(|unlocked| {
-        if unlocked {
-            Ok(())
-        } else {
-            Err(runtime_anyhow::Error::msg(
-                "DeGov indexer runtime migration lock was not held",
-            ))
-        }
-    });
+    let unlock_result = release_runtime_migration_lock(&mut connection).await;
 
     result?;
     unlock_result?;
@@ -87,26 +73,56 @@ pub async fn apply_migrations(pool: &PgPool) -> Result<()> {
     }
     .await;
 
-    let unlock_result = sqlx::query_scalar::<_, bool>(
-        "SELECT pg_advisory_unlock(hashtext('degov_indexer_runtime_migration'))",
-    )
-    .fetch_one(&mut *connection)
-    .await
-    .context("release DeGov indexer runtime migration lock")
-    .and_then(|unlocked| {
-        if unlocked {
-            Ok(())
-        } else {
-            Err(runtime_anyhow::Error::msg(
-                "DeGov indexer runtime migration lock was not held",
-            ))
-        }
-    });
+    let unlock_result = release_runtime_migration_lock(&mut connection).await;
 
     result?;
     unlock_result?;
 
     Ok(())
+}
+
+pub async fn apply_schema_migrations(pool: &PgPool) -> Result<()> {
+    let mut connection = pool
+        .acquire()
+        .await
+        .context("acquire DeGov indexer schema migration connection")?;
+
+    acquire_runtime_migration_lock(&mut connection).await?;
+
+    let result: Result<()> = async {
+        MIGRATOR
+            .run(&mut *connection)
+            .await
+            .context("apply Datalens-native DeGov indexer schema migration")?;
+        ensure_onchain_refresh_data_metric_task_table(&mut connection).await?;
+
+        Ok(())
+    }
+    .await;
+
+    let unlock_result = release_runtime_migration_lock(&mut connection).await;
+
+    result?;
+    unlock_result?;
+
+    Ok(())
+}
+
+async fn release_runtime_migration_lock(connection: &mut PgConnection) -> Result<()> {
+    let unlocked = sqlx::query_scalar::<_, bool>(
+        "SELECT pg_advisory_unlock(hashtext('degov_indexer_runtime_migration'))",
+    )
+    .fetch_one(connection)
+    .await
+    .context("release DeGov indexer runtime migration lock")?;
+
+    if unlocked {
+        Ok(())
+    } else {
+        Err(runtime_anyhow::Error::msg(
+            "DeGov indexer runtime migration lock was not held",
+        ))
+    }
 }
 
 async fn acquire_runtime_migration_lock(connection: &mut PgConnection) -> Result<()> {
@@ -388,23 +404,7 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure contributor onchain refresh coverage index")?;
 
-    sqlx::query(
-        "CREATE TABLE IF NOT EXISTS onchain_refresh_data_metric_task (
-            id TEXT PRIMARY KEY,
-            contract_set_id TEXT NOT NULL,
-            chain_id INTEGER NOT NULL,
-            dao_code TEXT,
-            governor_address TEXT NOT NULL,
-            token_address TEXT NOT NULL,
-            attempts INTEGER NOT NULL DEFAULT 0,
-            last_error TEXT,
-            created_at NUMERIC(78, 0) NOT NULL,
-            updated_at NUMERIC(78, 0) NOT NULL
-         )",
-    )
-    .execute(&mut *connection)
-    .await
-    .context("ensure onchain refresh data metric task table")?;
+    ensure_onchain_refresh_data_metric_task_table(connection).await?;
 
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_data_metric_task_ready_idx
@@ -474,6 +474,30 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     )
     .await
     .context("ensure live contributor overlay GraphQL scope index")?;
+
+    Ok(())
+}
+
+async fn ensure_onchain_refresh_data_metric_task_table(
+    connection: &mut PgConnection,
+) -> Result<()> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS onchain_refresh_data_metric_task (
+            id TEXT PRIMARY KEY,
+            contract_set_id TEXT NOT NULL,
+            chain_id INTEGER NOT NULL,
+            dao_code TEXT,
+            governor_address TEXT NOT NULL,
+            token_address TEXT NOT NULL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            created_at NUMERIC(78, 0) NOT NULL,
+            updated_at NUMERIC(78, 0) NOT NULL
+         )",
+    )
+    .execute(connection)
+    .await
+    .context("ensure onchain refresh data metric task table")?;
 
     Ok(())
 }

--- a/apps/indexer/src/runtime/mod.rs
+++ b/apps/indexer/src/runtime/mod.rs
@@ -10,7 +10,9 @@ pub mod worker;
 pub use datalens::smoke_datalens;
 pub use graphql::run_graphql;
 pub use indexer::run_indexer;
-pub use migrate::{apply_migrations, migrate, repair_invalid_runtime_indexes};
+pub use migrate::{
+    apply_migrations, apply_schema_migrations, migrate, repair_invalid_runtime_indexes,
+};
 pub use proposal_reference_fields::refresh_proposal_reference_fields;
 pub use proposal_title_refresh::refresh_proposal_titles;
 pub use timelock_proposal_link_backfill::{

--- a/apps/indexer/src/runtime/worker.rs
+++ b/apps/indexer/src/runtime/worker.rs
@@ -11,7 +11,7 @@ use crate::{
     OnchainRefreshScopeMode, OnchainRefreshTaskScope, OnchainRefreshWorker, required_env,
 };
 
-use super::migrate::apply_migrations;
+use super::migrate::apply_schema_migrations;
 
 pub async fn run_worker() -> Result<()> {
     let database_url = required_env("DEGOV_INDEXER_DATABASE_URL")?;
@@ -39,7 +39,7 @@ pub async fn run_worker() -> Result<()> {
         .connect(&database_url)
         .await
         .context("connect to DeGov indexer Postgres")?;
-    apply_migrations(&pool).await?;
+    apply_schema_migrations(&pool).await?;
     let _metrics_server = crate::metrics::spawn_metrics_server(
         pool.clone(),
         MetricsRuntimeConfig::from_env().context("load metrics runtime configuration")?,

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -7,7 +7,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use degov_datalens_indexer::runtime::{apply_migrations, repair_invalid_runtime_indexes};
+use degov_datalens_indexer::runtime::{
+    apply_migrations, apply_schema_migrations, repair_invalid_runtime_indexes,
+};
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
 
@@ -648,6 +650,25 @@ async fn test_migration_repairs_invalid_runtime_index() -> Result<(), Box<dyn Er
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_schema_only_migration_creates_worker_owned_task_table() -> Result<(), Box<dyn Error>>
+{
+    let database = TestDatabase::connect().await?;
+
+    apply_schema_migrations(&database.pool).await?;
+
+    assert_table_exists(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_data_metric_task",
+    )
+    .await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
 #[test]
 fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
 -> Result<(), Box<dyn Error>> {
@@ -708,6 +729,7 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("onchain_refresh_task_failed_scope_retry_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_processing_scope_retry_idx"));
     assert!(runtime_migration.contains("contributor_onchain_refresh_coverage_scope_idx"));
+    assert!(runtime_migration.contains("release_runtime_migration_lock"));
     assert!(runtime_migration.contains(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_live_graphql_scope_idx
          ON degov_provisional_delegate_power_overlay (
@@ -742,6 +764,23 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     );
 
     Ok(())
+}
+
+#[test]
+fn test_graphql_and_worker_use_schema_only_migrations() {
+    let graphql_runtime = include_str!("../src/runtime/graphql.rs");
+    let worker_runtime = include_str!("../src/runtime/worker.rs");
+    let runtime_module = include_str!("../src/runtime/mod.rs");
+
+    assert!(runtime_module.contains("apply_schema_migrations"));
+    assert!(graphql_runtime.contains("use super::migrate::apply_schema_migrations"));
+    assert!(worker_runtime.contains("use super::migrate::apply_schema_migrations"));
+    assert!(graphql_runtime.contains("apply_schema_migrations(&pool).await?"));
+    assert!(worker_runtime.contains("apply_schema_migrations(&pool).await?"));
+    assert!(!graphql_runtime.contains("use super::migrate::apply_migrations"));
+    assert!(!worker_runtime.contains("use super::migrate::apply_migrations"));
+    assert!(!graphql_runtime.contains("apply_migrations(&pool).await?"));
+    assert!(!worker_runtime.contains("apply_migrations(&pool).await?"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a schema-only migration path for GraphQL and onchain refresh worker startup
- keep full runtime index/data repair DDL owned by the indexer/migrate path
- add a regression test so GraphQL and worker do not call the runtime index migration path

## Context
Follow-up to #1005. I checked the PR review threads: the four Copilot conversations were resolved/outdated and the merged code already moved token_address into INCLUDE for the overlay GraphQL indexes. During rollout of sha-a8f2ea8, however, the run/graphql/worker containers all entered the runtime migration path; CREATE INDEX CONCURRENTLY deadlocked and left an invalid contributor index. This PR prevents the sidecar services from executing that runtime DDL path.

## Tests
- cargo fmt --check
- cargo test -p degov-datalens-indexer --test migration_schema test_graphql_and_worker_use_schema_only_migrations
- cargo test -p degov-datalens-indexer --test migration_schema test_indexer_keeps_init_migration_stable_and_appends_runtime_markers
- cargo test -p degov-datalens-indexer --lib