### PR TITLE
fix(indexer): combine DeGov Datalens log selectors

### DIFF
--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -185,38 +185,36 @@ fn query_plans(
     from_block: i32,
     to_block: i32,
 ) -> Vec<DaoLogQueryPlan> {
-    let mut governance_sources = vec![DaoLogAddressSource {
-        address: addresses.governor.clone(),
-        source: DaoLogSource::Governor,
-    }];
+    let mut sources = vec![
+        DaoLogAddressSource {
+            address: addresses.governor.clone(),
+            source: DaoLogSource::Governor,
+        },
+        DaoLogAddressSource {
+            address: addresses.governor_token.clone(),
+            source: DaoLogSource::GovernorToken,
+        },
+    ];
     if let Some(timelock) = &addresses.timelock {
-        governance_sources.push(DaoLogAddressSource {
+        sources.push(DaoLogAddressSource {
             address: timelock.clone(),
             source: DaoLogSource::Timelock,
         });
     }
+    let topics = if addresses.timelock.is_some() {
+        broad_dao_topic0_filters()
+    } else {
+        dao_topic0_filters_without_timelock()
+    };
 
-    vec![
-        query_plan(
-            config,
-            governance_sources,
-            Vec::new(),
-            broad_governance_topic0_filters(),
-            from_block,
-            to_block,
-        ),
-        query_plan(
-            config,
-            vec![DaoLogAddressSource {
-                address: addresses.governor_token.clone(),
-                source: DaoLogSource::GovernorToken,
-            }],
-            vec![addresses.governor_token.clone()],
-            governor_token_topic0_filters(),
-            from_block,
-            to_block,
-        ),
-    ]
+    vec![query_plan(
+        config,
+        sources,
+        Vec::new(),
+        topics,
+        from_block,
+        to_block,
+    )]
 }
 
 fn query_plan(
@@ -268,16 +266,21 @@ fn query_plan(
     }
 }
 
-fn broad_governance_topic0_filters() -> Vec<String> {
+fn broad_dao_topic0_filters() -> Vec<String> {
     unique_topic0_filters(
         GOVERNOR_TOPIC0_FILTERS
             .iter()
-            .chain(TIMELOCK_TOPIC0_FILTERS),
+            .chain(TIMELOCK_TOPIC0_FILTERS)
+            .chain(GOVERNOR_TOKEN_TOPIC0_FILTERS),
     )
 }
 
-fn governor_token_topic0_filters() -> Vec<String> {
-    unique_topic0_filters(GOVERNOR_TOKEN_TOPIC0_FILTERS.iter())
+fn dao_topic0_filters_without_timelock() -> Vec<String> {
+    unique_topic0_filters(
+        GOVERNOR_TOPIC0_FILTERS
+            .iter()
+            .chain(GOVERNOR_TOKEN_TOPIC0_FILTERS),
+    )
 }
 
 fn unique_topic0_filters<'a>(topics: impl Iterator<Item = &'a &'a str>) -> Vec<String> {

--- a/apps/indexer/src/decode/dao_event.rs
+++ b/apps/indexer/src/decode/dao_event.rs
@@ -322,6 +322,51 @@ pub fn decode_dao_log(
     }
 }
 
+pub fn dao_log_source_supports_topic0(source: DaoLogSource, topic0: &str) -> bool {
+    match source {
+        DaoLogSource::Governor => governor_topic0_supported(topic0),
+        DaoLogSource::GovernorToken => token_topic0_supported(topic0),
+        DaoLogSource::Timelock => timelock_topic0_supported(topic0),
+    }
+}
+
+fn governor_topic0_supported(topic0: &str) -> bool {
+    matches!(
+        topic0,
+        PROPOSAL_CREATED
+            | PROPOSAL_QUEUED
+            | PROPOSAL_EXTENDED
+            | PROPOSAL_EXECUTED
+            | PROPOSAL_CANCELED
+            | VOTING_DELAY_SET
+            | VOTING_PERIOD_SET
+            | PROPOSAL_THRESHOLD_SET
+            | QUORUM_NUMERATOR_UPDATED
+            | LATE_QUORUM_VOTE_EXTENSION_SET
+            | TIMELOCK_CHANGE
+            | VOTE_CAST
+            | VOTE_CAST_WITH_PARAMS
+    )
+}
+
+fn token_topic0_supported(topic0: &str) -> bool {
+    matches!(topic0, DELEGATE_CHANGED | DELEGATE_VOTES_CHANGED | TRANSFER)
+}
+
+fn timelock_topic0_supported(topic0: &str) -> bool {
+    matches!(
+        topic0,
+        CALL_SCHEDULED
+            | CALL_EXECUTED
+            | CALL_SALT
+            | CANCELLED
+            | MIN_DELAY_CHANGE
+            | ROLE_GRANTED
+            | ROLE_REVOKED
+            | ROLE_ADMIN_CHANGED
+    )
+}
+
 fn decode_governor_event(
     context: &DecodeContext<'_>,
     topic0: &str,

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -43,7 +43,8 @@ pub use crate::decode::dao_event::{
     DelegateVotesChangedEvent, GovernanceTokenStandard, ParameterChangeEvent, ProposalCreatedEvent,
     ProposalExtendedEvent, ProposalIdEvent, ProposalQueuedEvent, RoleAccountEvent,
     RoleAdminChangedEvent, TimelockChangeEvent, TimelockOperationIdEvent, TokenTransferEvent,
-    UnsupportedTopicEvent, VoteCastEvent, VoteCastWithParamsEvent, decode_dao_log,
+    UnsupportedTopicEvent, VoteCastEvent, VoteCastWithParamsEvent, dao_log_source_supports_topic0,
+    decode_dao_log,
 };
 pub use crate::decode::evm_log::{
     EvmLogNormalizationError, NormalizedEvmLog, normalize_evm_log_rows,

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -19,9 +19,9 @@ use crate::{
     TimelockProjectionEvent, TimelockProjectionRepository, TimelockProposalLinkContext,
     TokenProjectionBatch, TokenProjectionContext, TokenProjectionEvent, TokenProjectionRepository,
     VoteProjectionBatch, VoteProjectionContext, VoteProjectionEvent, VoteProjectionRepository,
-    classify_datalens_query_error, datalens_selector_fingerprint, decode_dao_log,
-    fetch_dao_log_pages, normalize_evm_log_rows, plan_dao_log_queries, plan_next_checkpoint_range,
-    plan_proposal_timestamp_backfill_updates, project_proposal_events,
+    classify_datalens_query_error, dao_log_source_supports_topic0, datalens_selector_fingerprint,
+    decode_dao_log, fetch_dao_log_pages, normalize_evm_log_rows, plan_dao_log_queries,
+    plan_next_checkpoint_range, plan_proposal_timestamp_backfill_updates, project_proposal_events,
     project_timelock_events_with_proposal_links, project_timelock_proposal_links,
     project_token_events, project_vote_events,
 };
@@ -1402,9 +1402,20 @@ where
                     );
                     continue;
                 };
+                let Some(topic0) = log.topics.first() else {
+                    continue;
+                };
+                let candidate_sources = candidate_sources
+                    .iter()
+                    .copied()
+                    .filter(|source| dao_log_source_supports_topic0(*source, topic0))
+                    .collect::<Vec<_>>();
+                if candidate_sources.is_empty() {
+                    continue;
+                }
                 let mut unsupported_event = None;
                 let mut decoded_event = None;
-                for source in candidate_sources {
+                for source in &candidate_sources {
                     let token_standard = (*source == DaoLogSource::GovernorToken)
                         .then_some(self.options.addresses.governor_token_standard);
                     let event = self.decoder.decode(

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -1705,9 +1705,9 @@ mod tests {
         assert_eq!(result.segments_written, Some(1));
         assert_eq!(result.latest_height, Some(25));
         assert_eq!(reader.latest_head_calls, 1);
-        assert_eq!(reader.ranges.len(), 2);
+        assert_eq!(reader.ranges.len(), 1);
         assert!(reader.ranges.iter().all(|range| *range == (21, 25)));
-        assert_eq!(reader.finalities.len(), 2);
+        assert_eq!(reader.finalities.len(), 1);
         assert!(
             reader
                 .finalities

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -10,12 +10,12 @@ use degov_datalens_indexer::{
 };
 
 #[test]
-fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelock() {
+fn test_plan_dao_log_queries_combines_sources_into_single_evm_log_selector() {
     let config = config(1_000, DatalensFinality::DurableOnly);
     let addresses = addresses();
     let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 2);
+    assert_eq!(plans.len(), 1);
     assert_query(
         &plans[0],
         &[
@@ -24,24 +24,20 @@ fn test_plan_dao_log_queries_builds_evm_log_inputs_for_governor_token_and_timelo
                 source: DaoLogSource::Governor,
             },
             DaoLogAddressSource {
+                address: addresses.governor_token.clone(),
+                source: DaoLogSource::GovernorToken,
+            },
+            DaoLogAddressSource {
                 address: addresses.timelock.clone().expect("timelock"),
                 source: DaoLogSource::Timelock,
             },
         ],
         &[],
-        &broad_governance_topic0_values(),
-        100,
-        199,
-        "durable_only",
-    );
-    assert_query(
-        &plans[1],
-        &[DaoLogAddressSource {
-            address: addresses.governor_token.clone(),
-            source: DaoLogSource::GovernorToken,
-        }],
-        std::slice::from_ref(&addresses.governor_token),
-        &governor_token_topic0_values(),
+        &topic0_union(&[
+            GOVERNOR_TOPIC0_VALUES,
+            TIMELOCK_TOPIC0_VALUES,
+            GOVERNOR_TOKEN_TOPIC0_VALUES,
+        ]),
         100,
         199,
         "durable_only",
@@ -55,18 +51,14 @@ fn test_plan_dao_log_queries_uses_broad_address_selector_for_reusable_datalens_c
 
     let evm_logs = plans[0].input.selector.evm_logs.as_ref().expect("evm logs");
     assert!(evm_logs.addresses.is_empty());
-    assert_eq!(evm_logs.topics, vec![broad_governance_topic0_values()]);
-}
-
-#[test]
-fn test_plan_dao_log_queries_keeps_token_selector_address_scoped() {
-    let config = config(1_000, DatalensFinality::DurableOnly);
-    let addresses = addresses();
-    let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
-
-    let evm_logs = plans[1].input.selector.evm_logs.as_ref().expect("evm logs");
-    assert_eq!(evm_logs.addresses, vec![addresses.governor_token]);
-    assert_eq!(evm_logs.topics, vec![governor_token_topic0_values()]);
+    assert_eq!(
+        evm_logs.topics,
+        vec![topic0_union(&[
+            GOVERNOR_TOPIC0_VALUES,
+            TIMELOCK_TOPIC0_VALUES,
+            GOVERNOR_TOKEN_TOPIC0_VALUES,
+        ])]
+    );
 }
 
 #[test]
@@ -77,19 +69,24 @@ fn test_plan_dao_log_queries_skips_timelock_when_not_configured() {
 
     let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
-    assert_eq!(plans.len(), 2);
-    assert_eq!(
-        plans[0].sources,
-        vec![DaoLogAddressSource {
-            address: addresses.governor,
-            source: DaoLogSource::Governor,
-        },]
-    );
-    assert!(
-        plans[0]
-            .sources
-            .iter()
-            .all(|source| source.source != DaoLogSource::Timelock)
+    assert_eq!(plans.len(), 1);
+    assert_query(
+        &plans[0],
+        &[
+            DaoLogAddressSource {
+                address: addresses.governor.clone(),
+                source: DaoLogSource::Governor,
+            },
+            DaoLogAddressSource {
+                address: addresses.governor_token.clone(),
+                source: DaoLogSource::GovernorToken,
+            },
+        ],
+        &[],
+        &topic0_union(&[GOVERNOR_TOPIC0_VALUES, GOVERNOR_TOKEN_TOPIC0_VALUES]),
+        100,
+        199,
+        "durable_only",
     );
 }
 
@@ -102,21 +99,17 @@ fn test_plan_dao_log_queries_chunks_ranges_by_config_limit() {
         .map(|plan| (plan.from_block, plan.to_block))
         .collect::<Vec<_>>();
 
-    let plans_per_chunk = 2;
-
-    assert_eq!(ranges.len(), plans_per_chunk * 3);
-    assert_eq!(
-        ranges.iter().filter(|range| **range == (100, 149)).count(),
-        plans_per_chunk
-    );
-    assert_eq!(
-        ranges.iter().filter(|range| **range == (150, 199)).count(),
-        plans_per_chunk
-    );
-    assert_eq!(
-        ranges.iter().filter(|range| **range == (200, 220)).count(),
-        plans_per_chunk
-    );
+    assert_eq!(ranges, vec![(100, 149), (150, 199), (200, 220)]);
+    assert!(plans.iter().all(|plan| plan.sources.len() == 3));
+    assert!(plans.iter().all(|plan| {
+        plan.input
+            .selector
+            .evm_logs
+            .as_ref()
+            .expect("evm logs")
+            .addresses
+            .is_empty()
+    }));
 }
 
 #[test]
@@ -237,34 +230,18 @@ fn assert_query(
 
     let evm_logs = plan.input.selector.evm_logs.as_ref().expect("evm logs");
     assert_eq!(evm_logs.addresses, addresses);
-    assert_eq!(
-        evm_logs.topics,
-        vec![
-            topic0_values
-                .iter()
-                .map(|topic| topic.to_string())
-                .collect::<Vec<_>>()
-        ]
-    );
+    assert_eq!(evm_logs.topics, vec![topic0_values.to_vec()]);
 }
 
-fn broad_governance_topic0_values() -> Vec<String> {
-    unique_topic0_values(GOVERNOR_TOPIC0_VALUES.iter().chain(TIMELOCK_TOPIC0_VALUES))
-}
-
-fn governor_token_topic0_values() -> Vec<String> {
-    unique_topic0_values(GOVERNOR_TOKEN_TOPIC0_VALUES.iter())
-}
-
-fn unique_topic0_values<'a>(topics: impl Iterator<Item = &'a &'a str>) -> Vec<String> {
-    let mut values = Vec::new();
-    for topic in topics {
-        let topic = (*topic).to_owned();
-        if !values.contains(&topic) {
-            values.push(topic);
+fn topic0_union(topic_groups: &[&[&str]]) -> Vec<String> {
+    topic_groups.iter().fold(Vec::new(), |mut union, topics| {
+        for topic in *topics {
+            if !union.iter().any(|existing| existing == topic) {
+                union.push((*topic).to_owned());
+            }
         }
-    }
-    values
+        union
+    })
 }
 
 fn config(block_range_limit: u32, finality: DatalensFinality) -> DatalensConfig {

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -32,22 +32,11 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
         outcome,
         DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.requests.len(), 2);
-    let selector_addresses = &ensurer.requests[0].selector.addresses;
-    assert!(selector_addresses.is_empty());
-    assert_eq!(
-        ensurer.requests[1].selector.addresses,
-        vec![addresses().governor_token]
-    );
-    let topic_counts = ensurer
-        .requests
-        .iter()
-        .map(|request| {
-            assert_eq!(request.selector.topics.len(), 1);
-            request.selector.topics[0].len()
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(topic_counts, vec![21, 3]);
+    assert_eq!(ensurer.requests.len(), 1);
+    let request = &ensurer.requests[0];
+    assert!(request.selector.addresses.is_empty());
+    assert_eq!(request.selector.topics.len(), 1);
+    assert_eq!(request.selector.topics[0].len(), 24);
     for request in &ensurer.requests {
         assert_eq!(request.chain.configured_name, "ethereum");
         assert_eq!(request.chain.network_id, Some(1));
@@ -77,7 +66,7 @@ fn test_ensure_datalens_warmup_task_reuses_existing_matching_task() {
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 2);
+    assert_eq!(ensurer.created_tasks.len(), 1);
 }
 
 #[test]
@@ -95,7 +84,7 @@ fn test_ensure_datalens_warmup_task_reuses_broad_selector_for_dao_address_mismat
         second,
         DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 2);
+    assert_eq!(ensurer.created_tasks.len(), 1);
 }
 
 #[test]

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -377,9 +377,9 @@ fn test_runner_splits_provider_limit_range_and_advances_checkpoint_after_subrang
     assert_eq!(runner.store().commit_count(), 2);
     let observed = observed_ranges.lock().expect("observed ranges");
     assert_range_count(&observed, (1, 1_000), 1);
-    assert_range_count(&observed, (1, 500), DATALENS_QUERY_SELECTOR_COUNT);
-    assert_range_count(&observed, (501, 1_000), DATALENS_QUERY_SELECTOR_COUNT);
-    assert_eq!(observed.len(), 1 + DATALENS_QUERY_SELECTOR_COUNT * 2);
+    assert_range_count(&observed, (1, 500), 1);
+    assert_range_count(&observed, (501, 1_000), 1);
+    assert_eq!(observed.len(), 3);
 }
 
 #[test]
@@ -410,8 +410,8 @@ fn test_runner_splits_transient_range_and_retries_without_pass_error() {
     assert_eq!(runner.store().commit_count(), 1);
     let observed = observed_ranges.lock().expect("observed ranges");
     assert_range_count(&observed, (1, 5_000), 1);
-    assert_range_count(&observed, (1, 2_500), DATALENS_QUERY_SELECTOR_COUNT);
-    assert_eq!(observed.len(), 1 + DATALENS_QUERY_SELECTOR_COUNT);
+    assert_range_count(&observed, (1, 2_500), 1);
+    assert_eq!(observed.len(), 2);
 }
 
 #[test]
@@ -445,8 +445,8 @@ fn test_runner_splits_transient_failure_below_normal_min_and_advances_checkpoint
         &observed[..6],
         &[(1, 101), (1, 50), (1, 25), (1, 12), (1, 6), (1, 3)]
     );
-    assert_range_count(&observed, (1, 1), DATALENS_QUERY_SELECTOR_COUNT);
-    assert_eq!(observed.len(), 6 + DATALENS_QUERY_SELECTOR_COUNT);
+    assert_range_count(&observed, (1, 1), 1);
+    assert_eq!(observed.len(), 7);
 }
 
 #[test]
@@ -477,8 +477,8 @@ fn test_runner_splits_two_block_transient_failure_to_single_block() {
     assert_eq!(runner.store().commit_count(), 1);
     let observed = observed_ranges.lock().expect("observed ranges");
     assert_range_count(&observed, (1, 2), 1);
-    assert_range_count(&observed, (1, 1), DATALENS_QUERY_SELECTOR_COUNT);
-    assert_eq!(observed.len(), 1 + DATALENS_QUERY_SELECTOR_COUNT);
+    assert_range_count(&observed, (1, 1), 1);
+    assert_eq!(observed.len(), 2);
 }
 
 #[test]
@@ -1145,12 +1145,7 @@ fn test_runner_keeps_duplicate_address_unsupported_topic_unsupported() {
     runner.run_to_target(1).expect("runner succeeds");
 
     let attempts = attempts.lock().expect("attempts");
-    assert_source_attempt_counts(
-        &attempts,
-        GOVERNOR_SELECTOR_COUNT,
-        0,
-        TIMELOCK_SELECTOR_COUNT,
-    );
+    assert_source_attempt_counts(&attempts, GOVERNOR_SELECTOR_COUNT, 0, 0);
     assert_eq!(
         runner.store().checkpoint().expect("checkpoint").next_block,
         2
@@ -1951,5 +1946,3 @@ const TOKEN_DELEGATE_CHANGED_TOPIC0: &str =
     "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f";
 const GOVERNOR_SELECTOR_COUNT: usize = 1;
 const GOVERNOR_TOKEN_SELECTOR_COUNT: usize = 1;
-const TIMELOCK_SELECTOR_COUNT: usize = 1;
-const DATALENS_QUERY_SELECTOR_COUNT: usize = 2;

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -128,7 +128,7 @@ async fn test_run_path_processes_datalens_pages_into_postgres() -> Result<(), Bo
     run_indexer_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 1);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 2);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
     assert_table_count(&database.pool, "proposal_created", 1).await?;
     assert_table_count(&database.pool, "proposal", 1).await?;
     assert_table_count(&database.pool, "vote_cast", 1).await?;
@@ -366,7 +366,7 @@ async fn test_run_path_all_mode_resumes_existing_scope_and_starts_new_scope()
     run_indexer_all_contract_sets_command(&database.database_url, &datalens.endpoint).await?;
 
     assert_eq!(datalens.head_count.load(Ordering::Relaxed), 0);
-    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 2);
+    assert_eq!(datalens.query_count.load(Ordering::Relaxed), 1);
     assert_checkpoint_scope(&database.pool, CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_scope(&database.pool, SECOND_CONTRACT_SET_ID, 3, Some(2), Some(2)).await?;
     assert_checkpoint_row_count(&database.pool, 2).await?;

--- a/apps/indexer/tests/provisional_worker.rs
+++ b/apps/indexer/tests/provisional_worker.rs
@@ -47,7 +47,7 @@ fn test_provisional_worker_writes_segments_without_final_checkpoint_boundary() {
     let report = worker.run_once().expect("worker runs once");
 
     assert_eq!(report.segments_written, 1);
-    assert_eq!(reader.calls.len(), 2);
+    assert_eq!(reader.calls.len(), 1);
     assert!(
         reader
             .calls


### PR DESCRIPTION
## Summary
- combine governor, governor token, and optional timelock Datalens log selectors into one query plan per block-range chunk
- preserve source/address mapping so decode still routes each returned log by its address
- update warmup, client, planner, and runner tests for the reduced query count

## Why
DataLens coverage-index lookups on RustFS can take tens to hundreds of seconds for Arbitrum full-hit/empty ranges. DeGov previously issued multiple sequential selector queries for the same DAO chunk, multiplying that latency and hitting the 60s Datalens deadline even at chunk_size=1. This reduces the per-chunk lookup pressure without changing projection semantics.

## Validation
- cargo fmt --check
- cargo test -p degov-datalens-indexer --test datalens_planner --test datalens_warmup --test datalens_client --test indexer_runner
- cargo test -p degov-datalens-indexer --lib

## Deployment
No deployment or GitOps changes in this PR. Deploy only after the paired DataLens guard PR is merged and locally validated.