### PR TITLE
fix(indexer): scope datalens log queries

### DIFF
--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -206,14 +206,15 @@ fn query_plans(
     } else {
         dao_topic0_filters_without_timelock()
     };
+    let selector_addresses = sources
+        .iter()
+        .map(|source| source.address.clone())
+        .collect();
 
     vec![query_plan(
         config,
-        sources.clone(),
-        sources
-            .iter()
-            .map(|source| source.address.clone())
-            .collect(),
+        sources,
+        selector_addresses,
         topics,
         from_block,
         to_block,

--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -209,8 +209,11 @@ fn query_plans(
 
     vec![query_plan(
         config,
-        sources,
-        Vec::new(),
+        sources.clone(),
+        sources
+            .iter()
+            .map(|source| source.address.clone())
+            .collect(),
         topics,
         from_block,
         to_block,

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -279,8 +279,7 @@ impl AdaptiveChunkSizer {
     pub fn record_chunk(&mut self, feedback: AdaptiveChunkFeedback) -> AdaptiveChunkSizingDecision {
         let previous_chunk_size = self.current_chunk_size;
         let full_cache_hit = feedback.has_only_full_cache_hits();
-        let dense_range = feedback.returned_row_count >= self.config.dense_returned_row_threshold
-            && !full_cache_hit;
+        let dense_range = feedback.returned_row_count >= self.config.dense_returned_row_threshold;
         let slow_local_processing = feedback.local_processing_write_duration
             > self.config.local_processing_shrink_threshold;
         let high_query_duration = feedback.read_duration
@@ -462,6 +461,16 @@ impl AdaptiveChunkFeedback {
                 .query_duration_max()
                 .is_some_and(|duration| duration > threshold)
     }
+}
+
+fn row_matches_address_sources(
+    row: &serde_json::Value,
+    sources: &BTreeMap<String, Vec<DaoLogSource>>,
+) -> bool {
+    row.get("address")
+        .and_then(serde_json::Value::as_str)
+        .map(|address| sources.contains_key(&address.to_ascii_lowercase()))
+        .unwrap_or(true)
 }
 
 fn shrink_chunk_size(chunk_size: u32, min_chunk_size: u32, shrink_factor_percent: u32) -> u32 {
@@ -1378,8 +1387,13 @@ where
                 });
             let rows = page_rows(page.rows)?;
             returned_row_count += rows.len();
-            let logs = normalize_evm_log_rows(self.options.checkpoint_identity.chain_id, rows)
-                .map_err(|error| IndexerRunnerError::Normalize(error.to_string()))?;
+            let scoped_rows = rows
+                .into_iter()
+                .filter(|row| row_matches_address_sources(row, &sources))
+                .collect::<Vec<_>>();
+            let logs =
+                normalize_evm_log_rows(self.options.checkpoint_identity.chain_id, scoped_rows)
+                    .map_err(|error| IndexerRunnerError::Normalize(error.to_string()))?;
             for log in logs {
                 if log.removed {
                     info!(
@@ -2126,5 +2140,33 @@ fn checkpoint(identity: IndexerCheckpointIdentity, start_block: i64) -> IndexerC
         last_error: None,
         lock_owner: None,
         locked_at: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_row_matches_address_sources_filters_rows_before_normalization() {
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            "0xabc0000000000000000000000000000000000000".to_owned(),
+            vec![DaoLogSource::Governor],
+        );
+
+        assert!(row_matches_address_sources(
+            &json!({"address": "0xABC0000000000000000000000000000000000000"}),
+            &sources,
+        ));
+        assert!(!row_matches_address_sources(
+            &json!({"address": "0xdef0000000000000000000000000000000000000"}),
+            &sources,
+        ));
+        assert!(row_matches_address_sources(
+            &json!({"block_number": 1}),
+            &sources
+        ));
     }
 }

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -469,7 +469,11 @@ fn row_matches_address_sources(
 ) -> bool {
     row.get("address")
         .and_then(serde_json::Value::as_str)
-        .map(|address| sources.contains_key(&address.to_ascii_lowercase()))
+        .map(|address| {
+            sources
+                .keys()
+                .any(|source| source.eq_ignore_ascii_case(address))
+        })
         .unwrap_or(true)
 }
 

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -32,7 +32,11 @@ fn test_plan_dao_log_queries_combines_sources_into_single_evm_log_selector() {
                 source: DaoLogSource::Timelock,
             },
         ],
-        &[],
+        &[
+            addresses.governor.clone(),
+            addresses.governor_token.clone(),
+            addresses.timelock.clone().expect("timelock"),
+        ],
         &topic0_union(&[
             GOVERNOR_TOPIC0_VALUES,
             TIMELOCK_TOPIC0_VALUES,
@@ -45,12 +49,20 @@ fn test_plan_dao_log_queries_combines_sources_into_single_evm_log_selector() {
 }
 
 #[test]
-fn test_plan_dao_log_queries_uses_broad_address_selector_for_reusable_datalens_cache() {
+fn test_plan_dao_log_queries_scopes_governance_selector_to_dao_addresses() {
     let config = config(1_000, DatalensFinality::DurableOnly);
-    let plans = plan_dao_log_queries(&config, &addresses(), 100, 199).expect("plans");
+    let addresses = addresses();
+    let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
     let evm_logs = plans[0].input.selector.evm_logs.as_ref().expect("evm logs");
-    assert!(evm_logs.addresses.is_empty());
+    assert_eq!(
+        evm_logs.addresses,
+        vec![
+            addresses.governor,
+            addresses.governor_token,
+            addresses.timelock.expect("timelock"),
+        ]
+    );
     assert_eq!(
         evm_logs.topics,
         vec![topic0_union(&[
@@ -82,7 +94,7 @@ fn test_plan_dao_log_queries_skips_timelock_when_not_configured() {
                 source: DaoLogSource::GovernorToken,
             },
         ],
-        &[],
+        &[addresses.governor.clone(), addresses.governor_token.clone()],
         &topic0_union(&[GOVERNOR_TOPIC0_VALUES, GOVERNOR_TOKEN_TOPIC0_VALUES]),
         100,
         199,
@@ -108,7 +120,8 @@ fn test_plan_dao_log_queries_chunks_ranges_by_config_limit() {
             .as_ref()
             .expect("evm logs")
             .addresses
-            .is_empty()
+            .len()
+            == 3
     }));
 }
 

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -34,7 +34,14 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
     ));
     assert_eq!(ensurer.requests.len(), 1);
     let request = &ensurer.requests[0];
-    assert!(request.selector.addresses.is_empty());
+    assert_eq!(
+        request.selector.addresses,
+        vec![
+            "0x1111111111111111111111111111111111111111",
+            "0x2222222222222222222222222222222222222222",
+            "0x3333333333333333333333333333333333333333",
+        ]
+    );
     assert_eq!(request.selector.topics.len(), 1);
     assert_eq!(request.selector.topics[0].len(), 24);
     for request in &ensurer.requests {
@@ -70,7 +77,7 @@ fn test_ensure_datalens_warmup_task_reuses_existing_matching_task() {
 }
 
 #[test]
-fn test_ensure_datalens_warmup_task_reuses_broad_selector_for_dao_address_mismatch() {
+fn test_ensure_datalens_warmup_task_creates_scoped_selector_for_dao_address_mismatch() {
     let config = config();
     let mut ensurer = MockWarmupEnsurer::default();
     let mut other_addresses = addresses();
@@ -82,9 +89,9 @@ fn test_ensure_datalens_warmup_task_reuses_broad_selector_for_dao_address_mismat
 
     assert!(matches!(
         second,
-        DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
+        DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 1);
+    assert_eq!(ensurer.created_tasks.len(), 2);
 }
 
 #[test]

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -882,7 +882,7 @@ fn test_adaptive_chunk_sizer_full_hit_high_duration_can_shrink_below_full_hit_fl
 }
 
 #[test]
-fn test_adaptive_chunk_sizer_full_hit_dense_rows_do_not_shrink_by_row_count() {
+fn test_adaptive_chunk_sizer_full_hit_dense_rows_shrink_by_row_count() {
     let mut sizer = AdaptiveChunkSizer::new(adaptive_config(100, 400)).expect("sizer");
 
     let dense = sizer.record_chunk(adaptive_feedback_with_rows(
@@ -891,8 +891,8 @@ fn test_adaptive_chunk_sizer_full_hit_dense_rows_do_not_shrink_by_row_count() {
         5_000,
     ));
 
-    assert_eq!(dense.current_chunk_size, 100);
-    assert_eq!(dense.reason, AdaptiveChunkSizingReason::Hold);
+    assert_eq!(dense.current_chunk_size, 50);
+    assert_eq!(dense.reason, AdaptiveChunkSizingReason::DenseReturnedRows);
 }
 
 #[test]


### PR DESCRIPTION
## Summary\n- scope DeGov Datalens EVM log selectors to the DAO contract addresses instead of using an empty address selector\n- filter out non-DAO-address rows before normalization as a defensive guard\n- shrink adaptive chunk size for dense FullHit chunks so cached high-row responses do not keep large ranges\n\n## Verification\n- cargo fmt -p degov-datalens-indexer\n- cargo test -p degov-datalens-indexer --test datalens_planner\n- cargo test -p degov-datalens-indexer --test indexer_runner\n- git diff --check