### PR TITLE
fix(indexer): reduce datalens filter log noise

### DIFF
--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
 use std::time::{Duration, Instant};
 
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use thiserror::Error;
 
 use crate::{
@@ -1400,7 +1400,7 @@ where
                     .map_err(|error| IndexerRunnerError::Normalize(error.to_string()))?;
             for log in logs {
                 if log.removed {
-                    info!(
+                    debug!(
                         "skipping removed Datalens EVM log before decode dao_code={} chain_id={} log_id={} block_number={}",
                         self.options.checkpoint_identity.dao_code,
                         self.options.checkpoint_identity.chain_id,
@@ -1410,7 +1410,7 @@ where
                     continue;
                 }
                 let Some(candidate_sources) = sources.get(&log.address) else {
-                    info!(
+                    debug!(
                         "skipping Datalens EVM log outside DAO address set dao_code={} chain_id={} log_id={} block_number={} address={}",
                         self.options.checkpoint_identity.dao_code,
                         self.options.checkpoint_identity.chain_id,


### PR DESCRIPTION
## Summary
- Lower per-row skip logs in the Datalens runner from `info` to `debug`.
- Keep scoped query/filter behavior unchanged.

## Verification
- `cargo fmt -p degov-datalens-indexer --check`
- `cargo test -p degov-datalens-indexer --test indexer_runner`
- `git diff --check`

## Context
The scoped Datalens query fix can encounter dense cached pages. Per-row skip logs should not be emitted at info level during normal indexing.