### PR TITLE
perf(indexer): reduce governance indexing latency

### DIFF
--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -206,14 +206,15 @@ fn query_plans(
     } else {
         dao_topic0_filters_without_timelock()
     };
+    let selector_addresses = sources
+        .iter()
+        .map(|source| source.address.clone())
+        .collect();
 
     vec![query_plan(
         config,
-        sources.clone(),
-        sources
-            .iter()
-            .map(|source| source.address.clone())
-            .collect(),
+        sources,
+        selector_addresses,
         topics,
         from_block,
         to_block,

--- a/apps/indexer/src/datalens/planner.rs
+++ b/apps/indexer/src/datalens/planner.rs
@@ -209,8 +209,11 @@ fn query_plans(
 
     vec![query_plan(
         config,
-        sources,
-        Vec::new(),
+        sources.clone(),
+        sources
+            .iter()
+            .map(|source| source.address.clone())
+            .collect(),
         topics,
         from_block,
         to_block,

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -147,6 +147,7 @@ pub use runtime_config::{
     ContractSetConcurrencyLimit, GraphqlRuntimeConfig, IndexerContractSetMode,
     IndexerContractSetRuntimeConfig, IndexerRuntimeConfig, IndexerTargetHeight,
     MetricsRuntimeConfig, OnchainRefreshRuntimeConfig, OnchainRefreshScopeMode,
-    ProvisionalRuntimeConfig, datalens_retry_config, onchain_refresh_debounce_from_env,
-    onchain_refresh_worker_enabled, parse_bool_env_value, parse_i64_env_value, required_env,
+    ProvisionalRuntimeConfig, RealtimeRuntimeConfig, datalens_retry_config,
+    onchain_refresh_debounce_from_env, onchain_refresh_worker_enabled, parse_bool_env_value,
+    parse_i64_env_value, required_env,
 };

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -279,8 +279,7 @@ impl AdaptiveChunkSizer {
     pub fn record_chunk(&mut self, feedback: AdaptiveChunkFeedback) -> AdaptiveChunkSizingDecision {
         let previous_chunk_size = self.current_chunk_size;
         let full_cache_hit = feedback.has_only_full_cache_hits();
-        let dense_range = feedback.returned_row_count >= self.config.dense_returned_row_threshold
-            && !full_cache_hit;
+        let dense_range = feedback.returned_row_count >= self.config.dense_returned_row_threshold;
         let slow_local_processing = feedback.local_processing_write_duration
             > self.config.local_processing_shrink_threshold;
         let high_query_duration = feedback.read_duration
@@ -462,6 +461,16 @@ impl AdaptiveChunkFeedback {
                 .query_duration_max()
                 .is_some_and(|duration| duration > threshold)
     }
+}
+
+fn row_matches_address_sources(
+    row: &serde_json::Value,
+    sources: &BTreeMap<String, Vec<DaoLogSource>>,
+) -> bool {
+    row.get("address")
+        .and_then(serde_json::Value::as_str)
+        .map(|address| sources.contains_key(&address.to_ascii_lowercase()))
+        .unwrap_or(true)
 }
 
 fn shrink_chunk_size(chunk_size: u32, min_chunk_size: u32, shrink_factor_percent: u32) -> u32 {
@@ -1378,8 +1387,13 @@ where
                 });
             let rows = page_rows(page.rows)?;
             returned_row_count += rows.len();
-            let logs = normalize_evm_log_rows(self.options.checkpoint_identity.chain_id, rows)
-                .map_err(|error| IndexerRunnerError::Normalize(error.to_string()))?;
+            let scoped_rows = rows
+                .into_iter()
+                .filter(|row| row_matches_address_sources(row, &sources))
+                .collect::<Vec<_>>();
+            let logs =
+                normalize_evm_log_rows(self.options.checkpoint_identity.chain_id, scoped_rows)
+                    .map_err(|error| IndexerRunnerError::Normalize(error.to_string()))?;
             for log in logs {
                 if log.removed {
                     info!(
@@ -2126,5 +2140,33 @@ fn checkpoint(identity: IndexerCheckpointIdentity, start_block: i64) -> IndexerC
         last_error: None,
         lock_owner: None,
         locked_at: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_row_matches_address_sources_filters_rows_before_normalization() {
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            "0xabc0000000000000000000000000000000000000".to_owned(),
+            vec![DaoLogSource::Governor],
+        );
+
+        assert!(row_matches_address_sources(
+            &json!({"address": "0xABC0000000000000000000000000000000000000"}),
+            &sources,
+        ));
+        assert!(!row_matches_address_sources(
+            &json!({"address": "0xdef0000000000000000000000000000000000000"}),
+            &sources,
+        ));
+        assert!(row_matches_address_sources(
+            &json!({"block_number": 1}),
+            &sources
+        ));
     }
 }

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -469,7 +469,11 @@ fn row_matches_address_sources(
 ) -> bool {
     row.get("address")
         .and_then(serde_json::Value::as_str)
-        .map(|address| sources.contains_key(&address.to_ascii_lowercase()))
+        .map(|address| {
+            sources
+                .keys()
+                .any(|source| source.eq_ignore_ascii_case(address))
+        })
         .unwrap_or(true)
 }
 

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -31,7 +31,10 @@ use crate::{
     required_env,
 };
 
-use super::{datalens::verify_datalens, migrate::apply_migrations};
+use super::{
+    datalens::verify_datalens,
+    migrate::{apply_runtime_maintenance, apply_schema_migrations},
+};
 
 pub async fn run_indexer() -> Result<()> {
     let config = DatalensConfig::from_env().context("load Datalens configuration")?;
@@ -57,14 +60,21 @@ pub async fn run_indexer() -> Result<()> {
         .connect(&database_url)
         .await
         .context("connect to DeGov indexer Postgres")?;
-    apply_migrations(&pool).await?;
-    let _metrics_server = crate::metrics::spawn_metrics_server(
-        pool.clone(),
-        MetricsRuntimeConfig::from_env().context("load metrics runtime configuration")?,
+    apply_schema_migrations(&pool).await?;
+    let _metrics_server = run_post_schema_startup(
+        || spawn_realtime_worker_if_enabled(&runtime, &config, pool.clone()),
+        || async {
+            crate::metrics::spawn_metrics_server(
+                pool.clone(),
+                MetricsRuntimeConfig::from_env().context("load metrics runtime configuration")?,
+            )
+            .await
+            .context("start DeGov indexer metrics service")
+        },
+        || ensure_warmup_on_startup(&runtime, &config),
+        || apply_runtime_maintenance(&pool),
     )
-    .await
-    .context("start DeGov indexer metrics service")?;
-    ensure_warmup_on_startup(&runtime, &config).await?;
+    .await?;
     let datalens_query_gate = if runtime.datalens_query_concurrency.is_limited() {
         Some(
             DatalensQueryConcurrencyGate::new(runtime.datalens_query_concurrency)
@@ -110,6 +120,36 @@ pub async fn run_indexer() -> Result<()> {
 
         sleep(runtime.poll_interval).await;
     }
+}
+
+async fn run_post_schema_startup<
+    MetricsServer,
+    StartMetrics,
+    StartMetricsFuture,
+    EnsureWarmup,
+    EnsureWarmupFuture,
+    ApplyRuntimeMaintenance,
+    ApplyRuntimeMaintenanceFuture,
+>(
+    start_realtime: impl FnOnce() -> Result<()>,
+    start_metrics: StartMetrics,
+    ensure_warmup: EnsureWarmup,
+    apply_runtime_maintenance: ApplyRuntimeMaintenance,
+) -> Result<MetricsServer>
+where
+    StartMetrics: FnOnce() -> StartMetricsFuture,
+    StartMetricsFuture: Future<Output = Result<MetricsServer>>,
+    EnsureWarmup: FnOnce() -> EnsureWarmupFuture,
+    EnsureWarmupFuture: Future<Output = Result<()>>,
+    ApplyRuntimeMaintenance: FnOnce() -> ApplyRuntimeMaintenanceFuture,
+    ApplyRuntimeMaintenanceFuture: Future<Output = Result<()>>,
+{
+    start_realtime()?;
+    let metrics_server = start_metrics().await?;
+    ensure_warmup().await?;
+    apply_runtime_maintenance().await?;
+
+    Ok(metrics_server)
 }
 
 fn spawn_realtime_worker_if_enabled(
@@ -2192,6 +2232,57 @@ mod tests {
             .await
             .expect("realtime pass signals startup before its lease is polled");
         handle
+    }
+
+    #[tokio::test]
+    async fn test_post_schema_startup_starts_realtime_before_runtime_maintenance() {
+        let (realtime_started_tx, realtime_started_rx) = tokio::sync::oneshot::channel();
+        let (maintenance_started_tx, maintenance_started_rx) = tokio::sync::oneshot::channel();
+        let release_maintenance = Arc::new(tokio::sync::Semaphore::new(0));
+        let release_maintenance_for_startup = release_maintenance.clone();
+
+        let startup = task::spawn(async move {
+            run_post_schema_startup(
+                || {
+                    realtime_started_tx
+                        .send(())
+                        .expect("realtime startup signal is received");
+                    Ok(())
+                },
+                || async { Ok(()) },
+                || async { Ok(()) },
+                || async move {
+                    maintenance_started_tx
+                        .send(())
+                        .expect("runtime maintenance startup signal is received");
+                    let _permit = release_maintenance_for_startup
+                        .acquire()
+                        .await
+                        .expect("runtime maintenance release semaphore remains open");
+                    Ok(())
+                },
+            )
+            .await
+        });
+
+        timeout(Duration::from_secs(1), realtime_started_rx)
+            .await
+            .expect("realtime startup begins promptly after schema migration")
+            .expect("realtime startup signal is sent");
+        timeout(Duration::from_secs(1), maintenance_started_rx)
+            .await
+            .expect("runtime maintenance begins after realtime startup")
+            .expect("runtime maintenance startup signal is sent");
+        assert!(
+            !startup.is_finished(),
+            "runtime maintenance remains independent from already-started realtime work"
+        );
+
+        release_maintenance.add_permits(1);
+        startup
+            .await
+            .expect("post-schema startup task joins")
+            .expect("post-schema startup succeeds");
     }
 
     #[test]

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -4,12 +4,9 @@ use anyhow as runtime_anyhow;
 use datalens_sdk::RetryConfig;
 use runtime_anyhow::{Context, Result, bail};
 use sqlx::postgres::PgPoolOptions;
-use tokio::{
-    runtime::Handle,
-    sync::Semaphore,
-    task,
-    time::{sleep, timeout},
-};
+#[cfg(test)]
+use tokio::time::timeout;
+use tokio::{runtime::Handle, sync::Semaphore, task, time::sleep};
 
 use crate::runner::IndexerRunnerProgress;
 use crate::{
@@ -208,47 +205,8 @@ async fn run_realtime_cycle(
     passes: &mut RealtimePassRegistry<RealtimeContractSetPassReport>,
     observed_heads: &mut BTreeMap<String, i64>,
 ) {
-    for contract_set in contract_sets {
-        let contract_set = contract_set.clone();
-        let previous_head = observed_heads.get(&contract_set.contract_set_id).copied();
-        let pass_key = contract_set.contract_set_id.clone();
-        let dao_code = contract_set.dao_code.clone();
-        let chain_id = contract_set.contract.chain_id;
-        let contract_set_id = contract_set.contract_set_id.clone();
-        if !passes.contains(&pass_key)
-            && !passes.has_capacity(
-                chain_id,
-                runtime.realtime.max_in_flight,
-                runtime.realtime.per_chain_max_in_flight,
-            )
-        {
-            log::debug!(
-                "Datalens realtime cycle skipped because realtime pass capacity is reached dao_code={} chain_id={} active_passes={} active_chain_passes={} max_in_flight={} per_chain_max_in_flight={}",
-                dao_code,
-                chain_id,
-                passes.len(),
-                passes.chain_active_count(chain_id),
-                runtime.realtime.max_in_flight,
-                runtime.realtime.per_chain_max_in_flight
-            );
-            continue;
-        }
-        match poll_realtime_pass_with_runtime(passes, &pass_key, chain_id, &runtime.realtime, {
-            let runtime = runtime.clone();
-            let pool = pool.clone();
-            let realtime_datalens_config = realtime_datalens_config.clone();
-            move || {
-                run_realtime_contract_set_pass(
-                    runtime,
-                    contract_set,
-                    pool,
-                    realtime_datalens_config,
-                    previous_head,
-                )
-            }
-        })
-        .await
-        {
+    for completed_pass in passes.reap_finished().await {
+        match completed_pass.result {
             RealtimePassPoll::Completed(report) => {
                 let observed_head = realtime_observed_head_after_pass(&report);
                 if let Some(observed_head) = observed_head {
@@ -269,28 +227,159 @@ async fn run_realtime_cycle(
                     report.provisional.vote_overlays_written
                 );
             }
-            RealtimePassPoll::TimedOut => log::warn!(
-                "Datalens realtime cycle timed out; retaining the in-flight pass and skipping the same chain until it completes dao_code={} chain_id={} contract_set_id={} pass_timeout_ms={}",
+            RealtimePassPoll::Failed(error) => log::warn!(
+                "Datalens realtime pass failed chain_id={} contract_set_id={} error={error:#}",
+                completed_pass.chain_id,
+                completed_pass.key
+            ),
+            #[cfg(test)]
+            RealtimePassPoll::TimedOut | RealtimePassPoll::InFlight => {
+                unreachable!("a finished realtime pass must complete or fail")
+            }
+        }
+    }
+
+    for timed_out_pass in passes.mark_timed_out(runtime.realtime.pass_timeout) {
+        log::warn!(
+            "Datalens realtime pass lease timed out; retaining the in-flight pass until it completes contract_set_id={} chain_id={} pass_timeout_ms={}",
+            timed_out_pass.key,
+            timed_out_pass.chain_id,
+            runtime.realtime.pass_timeout.as_millis()
+        );
+    }
+
+    let schedule_order = realtime_schedule_order(
+        contract_sets,
+        passes.last_started_keys(),
+        passes.last_started_chain_id(),
+        |contract_set| contract_set.contract_set_id.as_str(),
+        |contract_set| contract_set.contract.chain_id,
+    );
+    for contract_set_index in schedule_order {
+        let contract_set = contract_sets[contract_set_index].clone();
+        let previous_head = observed_heads.get(&contract_set.contract_set_id).copied();
+        let pass_key = contract_set.contract_set_id.clone();
+        let dao_code = contract_set.dao_code.clone();
+        let chain_id = contract_set.contract.chain_id;
+        let contract_set_id = contract_set.contract_set_id.clone();
+        if !passes.try_start(
+            &pass_key,
+            chain_id,
+            runtime.realtime.max_in_flight,
+            runtime.realtime.per_chain_max_in_flight,
+            {
+                let runtime = runtime.clone();
+                let pool = pool.clone();
+                let realtime_datalens_config = realtime_datalens_config.clone();
+                move || {
+                    run_realtime_contract_set_pass(
+                        runtime,
+                        contract_set,
+                        pool,
+                        realtime_datalens_config,
+                        previous_head,
+                    )
+                }
+            },
+        ) {
+            if passes.contains(&pass_key) {
+                log::debug!(
+                    "Datalens realtime cycle skipped an in-flight pass dao_code={} chain_id={} contract_set_id={}",
+                    dao_code,
+                    chain_id,
+                    contract_set_id
+                );
+            } else {
+                log::debug!(
+                    "Datalens realtime cycle skipped because realtime pass capacity is reached dao_code={} chain_id={} active_passes={} active_chain_passes={} max_in_flight={} per_chain_max_in_flight={}",
+                    dao_code,
+                    chain_id,
+                    passes.len(),
+                    passes.chain_active_count(chain_id),
+                    runtime.realtime.max_in_flight,
+                    runtime.realtime.per_chain_max_in_flight
+                );
+            }
+        } else {
+            log::debug!(
+                "Datalens realtime pass started dao_code={} chain_id={} contract_set_id={} active_passes={} active_chain_passes={}",
                 dao_code,
                 chain_id,
                 contract_set_id,
-                runtime.realtime.pass_timeout.as_millis()
-            ),
-            RealtimePassPoll::InFlight => log::debug!(
-                "Datalens realtime cycle skipped an in-flight chain dao_code={} chain_id={} contract_set_id={}",
-                dao_code,
-                chain_id,
-                contract_set_id
-            ),
-            RealtimePassPoll::Failed(error) => {
-                log::warn!("Datalens realtime cycle failed error={error:#}")
-            }
+                passes.len(),
+                passes.chain_active_count(chain_id)
+            );
         }
     }
 }
 
 fn realtime_observed_head_after_pass(report: &RealtimeContractSetPassReport) -> Option<i64> {
     (!report.provisional.current_head_race).then_some(report.latest_head)
+}
+
+fn realtime_schedule_order<T>(
+    items: &[T],
+    last_started_keys: &BTreeMap<i32, String>,
+    last_started_chain_id: Option<i32>,
+    key: impl for<'a> Fn(&'a T) -> &'a str,
+    chain_id: impl Fn(&T) -> i32,
+) -> Vec<usize> {
+    let mut chain_lengths = BTreeMap::new();
+    let mut chain_order = Vec::new();
+    for item in items {
+        let chain_id = chain_id(item);
+        let chain_length = chain_lengths.entry(chain_id).or_insert(0usize);
+        if *chain_length == 0 {
+            chain_order.push(chain_id);
+        }
+        *chain_length += 1;
+    }
+    let global_chain_start = last_started_chain_id
+        .and_then(|last_started_chain_id| {
+            chain_order
+                .iter()
+                .position(|chain_id| *chain_id == last_started_chain_id)
+        })
+        .map(|last_started_chain_index| (last_started_chain_index + 1) % chain_order.len())
+        .unwrap_or(0);
+    let global_chain_ranks = chain_order
+        .iter()
+        .enumerate()
+        .map(|(chain_index, chain_id)| {
+            (
+                *chain_id,
+                (chain_index + chain_order.len() - global_chain_start) % chain_order.len(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let mut chain_ordinals = BTreeMap::new();
+    let mut candidates = Vec::with_capacity(items.len());
+    let mut last_started_ordinals = BTreeMap::new();
+    for (index, item) in items.iter().enumerate() {
+        let chain_id = chain_id(item);
+        let ordinal = chain_ordinals.entry(chain_id).or_insert(0usize);
+        if last_started_keys
+            .get(&chain_id)
+            .is_some_and(|last_started_key| key(item) == last_started_key)
+        {
+            last_started_ordinals.insert(chain_id, *ordinal);
+        }
+        candidates.push((index, chain_id, *ordinal));
+        *ordinal += 1;
+    }
+
+    candidates.sort_by_key(|(index, chain_id, ordinal)| {
+        let rank = last_started_ordinals
+            .get(chain_id)
+            .map(|last_started_ordinal| {
+                (ordinal + chain_lengths[chain_id] - last_started_ordinal - 1)
+                    % chain_lengths[chain_id]
+            })
+            .unwrap_or(*ordinal);
+        (rank, global_chain_ranks[chain_id], *index)
+    });
+    candidates.into_iter().map(|(index, _, _)| index).collect()
 }
 
 async fn run_realtime_contract_set_pass(
@@ -366,22 +455,58 @@ struct RealtimeContractSetPassReport {
 
 struct RealtimePassRegistry<T> {
     passes: BTreeMap<String, RealtimePass<T>>,
+    last_started_keys: BTreeMap<i32, String>,
+    last_started_chain_id: Option<i32>,
 }
 
 struct RealtimePass<T> {
     chain_id: i32,
+    started_at: tokio::time::Instant,
+    timeout_logged: bool,
     handle: task::JoinHandle<Result<T>>,
+}
+
+impl<T> RealtimePass<T> {
+    fn new(chain_id: i32, handle: task::JoinHandle<Result<T>>) -> Self {
+        Self {
+            chain_id,
+            started_at: tokio::time::Instant::now(),
+            timeout_logged: false,
+            handle,
+        }
+    }
+}
+
+struct RealtimePassCompletion<T> {
+    key: String,
+    chain_id: i32,
+    result: RealtimePassPoll<T>,
+}
+
+struct RealtimePassTimeout {
+    key: String,
+    chain_id: i32,
 }
 
 impl<T> Default for RealtimePassRegistry<T> {
     fn default() -> Self {
         Self {
             passes: BTreeMap::new(),
+            last_started_keys: BTreeMap::new(),
+            last_started_chain_id: None,
         }
     }
 }
 
 impl<T> RealtimePassRegistry<T> {
+    fn last_started_keys(&self) -> &BTreeMap<i32, String> {
+        &self.last_started_keys
+    }
+
+    fn last_started_chain_id(&self) -> Option<i32> {
+        self.last_started_chain_id
+    }
+
     fn contains(&self, key: &str) -> bool {
         self.passes.contains_key(key)
     }
@@ -405,15 +530,100 @@ impl<T> RealtimePassRegistry<T> {
     ) -> bool {
         self.len() < max_in_flight && self.chain_active_count(chain_id) < per_chain_max_in_flight
     }
+
+    fn try_start<F, Fut>(
+        &mut self,
+        key: &str,
+        chain_id: i32,
+        max_in_flight: usize,
+        per_chain_max_in_flight: usize,
+        start: F,
+    ) -> bool
+    where
+        T: Send + 'static,
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T>> + Send + 'static,
+    {
+        if self.contains(key)
+            || !self.has_capacity(chain_id, max_in_flight, per_chain_max_in_flight)
+        {
+            return false;
+        }
+
+        self.passes.insert(
+            key.to_owned(),
+            RealtimePass::new(chain_id, task::spawn(start())),
+        );
+        self.last_started_keys.insert(chain_id, key.to_owned());
+        self.last_started_chain_id = Some(chain_id);
+        true
+    }
+
+    async fn reap_finished(&mut self) -> Vec<RealtimePassCompletion<T>>
+    where
+        T: Send + 'static,
+    {
+        let finished_keys = self
+            .passes
+            .iter()
+            .filter_map(|(key, pass)| pass.handle.is_finished().then_some(key.clone()))
+            .collect::<Vec<_>>();
+        let mut completions = Vec::with_capacity(finished_keys.len());
+
+        for key in finished_keys {
+            let pass = self
+                .passes
+                .remove(&key)
+                .expect("finished realtime pass remains registered");
+            let chain_id = pass.chain_id;
+            let result = match pass.handle.await {
+                Ok(Ok(report)) => RealtimePassPoll::Completed(report),
+                Ok(Err(error)) => RealtimePassPoll::Failed(error),
+                Err(error) => RealtimePassPoll::Failed(
+                    runtime_anyhow::Error::new(error).context("join Datalens realtime pass"),
+                ),
+            };
+            completions.push(RealtimePassCompletion {
+                key,
+                chain_id,
+                result,
+            });
+        }
+
+        completions
+    }
+
+    fn mark_timed_out(&mut self, timeout_duration: Duration) -> Vec<RealtimePassTimeout> {
+        let now = tokio::time::Instant::now();
+
+        self.passes
+            .iter_mut()
+            .filter_map(|(key, pass)| {
+                (!pass.timeout_logged
+                    && !pass.handle.is_finished()
+                    && now.duration_since(pass.started_at) >= timeout_duration)
+                    .then(|| {
+                        pass.timeout_logged = true;
+                        RealtimePassTimeout {
+                            key: key.clone(),
+                            chain_id: pass.chain_id,
+                        }
+                    })
+            })
+            .collect()
+    }
 }
 
 enum RealtimePassPoll<T> {
     Completed(T),
-    TimedOut,
-    InFlight,
     Failed(runtime_anyhow::Error),
+    #[cfg(test)]
+    TimedOut,
+    #[cfg(test)]
+    InFlight,
 }
 
+#[cfg(test)]
 async fn poll_realtime_pass<T, F, Fut>(
     registry: &mut RealtimePassRegistry<T>,
     key: &str,
@@ -437,19 +647,16 @@ where
 
     match poll_realtime_pass_handle(&mut pass, timeout_duration).await {
         RealtimePassPoll::TimedOut => {
-            registry.passes.insert(
-                key.to_owned(),
-                RealtimePass {
-                    chain_id,
-                    handle: pass,
-                },
-            );
+            registry
+                .passes
+                .insert(key.to_owned(), RealtimePass::new(chain_id, pass));
             RealtimePassPoll::TimedOut
         }
         result => result,
     }
 }
 
+#[cfg(test)]
 async fn poll_realtime_pass_handle<T>(
     pass: &mut task::JoinHandle<Result<T>>,
     timeout_duration: Duration,
@@ -467,6 +674,7 @@ where
     }
 }
 
+#[cfg(test)]
 async fn poll_realtime_pass_with_runtime<T, F, Fut>(
     registry: &mut RealtimePassRegistry<T>,
     key: &str,
@@ -2258,13 +2466,9 @@ mod tests {
         assert!(matches!(first, RealtimePassPoll::TimedOut));
         assert!(started_at.elapsed() < Duration::from_millis(100));
         assert_eq!(starts.load(Ordering::SeqCst), 1);
-        registry.passes.insert(
-            "demo-dao:1".to_owned(),
-            RealtimePass {
-                chain_id: 1,
-                handle: pass,
-            },
-        );
+        registry
+            .passes
+            .insert("demo-dao:1".to_owned(), RealtimePass::new(1, pass));
 
         let second = poll_realtime_pass(
             &mut registry,
@@ -2312,18 +2516,238 @@ mod tests {
             let mut pass = start_blocked_realtime_pass(starts.clone(), release.clone()).await;
             let result = poll_realtime_pass_handle(&mut pass, Duration::from_millis(5)).await;
             assert!(matches!(result, RealtimePassPoll::TimedOut));
-            registry.passes.insert(
-                key.to_owned(),
-                RealtimePass {
-                    chain_id: 1,
-                    handle: pass,
-                },
-            );
+            registry
+                .passes
+                .insert(key.to_owned(), RealtimePass::new(1, pass));
         }
 
         assert_eq!(starts.load(Ordering::SeqCst), 2);
         assert_eq!(registry.len(), 2);
         release.add_permits(2);
+    }
+
+    #[tokio::test]
+    async fn test_realtime_scheduler_starts_two_distinct_passes_at_global_capacity_two() {
+        let starts = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let mut registry = RealtimePassRegistry::default();
+
+        assert!(registry.try_start("dao-a:1", 1, 2, 1, {
+            let starts = starts.clone();
+            let release = release.clone();
+            move || async move {
+                starts.fetch_add(1, Ordering::SeqCst);
+                let _permit = release
+                    .acquire()
+                    .await
+                    .expect("release semaphore remains open");
+                Ok::<_, runtime_anyhow::Error>(())
+            }
+        },));
+        assert!(registry.try_start("dao-b:2", 2, 2, 1, {
+            let starts = starts.clone();
+            let release = release.clone();
+            move || async move {
+                starts.fetch_add(1, Ordering::SeqCst);
+                let _permit = release
+                    .acquire()
+                    .await
+                    .expect("release semaphore remains open");
+                Ok::<_, runtime_anyhow::Error>(())
+            }
+        },));
+
+        tokio::time::timeout(Duration::from_millis(100), async {
+            while starts.load(Ordering::SeqCst) != 2 {
+                task::yield_now().await;
+            }
+        })
+        .await
+        .expect("both admitted realtime passes start without waiting for a lease");
+        assert_eq!(registry.len(), 2);
+        release.add_permits(2);
+    }
+
+    #[tokio::test]
+    async fn test_realtime_scheduler_respects_per_chain_capacity_when_starting_passes() {
+        let starts = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let mut registry = RealtimePassRegistry::default();
+
+        assert!(registry.try_start("dao-a:1", 1, 2, 1, {
+            let starts = starts.clone();
+            let release = release.clone();
+            move || async move {
+                starts.fetch_add(1, Ordering::SeqCst);
+                let _permit = release
+                    .acquire()
+                    .await
+                    .expect("release semaphore remains open");
+                Ok::<_, runtime_anyhow::Error>(())
+            }
+        },));
+        assert!(!registry.try_start("dao-b:1", 1, 2, 1, || async {
+            panic!("per-chain capacity must prevent a second realtime pass")
+        }));
+
+        tokio::time::timeout(Duration::from_millis(100), async {
+            while starts.load(Ordering::SeqCst) != 1 {
+                task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the admitted realtime pass starts");
+        assert_eq!(registry.len(), 1);
+        release.add_permits(1);
+    }
+
+    #[tokio::test]
+    async fn test_realtime_scheduler_rotates_same_chain_admission_after_a_pass_completes() {
+        let keys = ["dao-a:1", "dao-b:1"];
+        let mut registry = RealtimePassRegistry::default();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        assert!(registry.try_start("dao-a:1", 1, 1, 1, move || async move {
+            started_tx
+                .send(())
+                .expect("first realtime pass start signal is received");
+            Ok::<_, runtime_anyhow::Error>(())
+        }));
+        started_rx
+            .await
+            .expect("first realtime pass starts before it is reaped");
+
+        let completed = tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                let completed = registry.reap_finished().await;
+                if !completed.is_empty() {
+                    return completed;
+                }
+                task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first realtime pass completes");
+        assert_eq!(completed.len(), 1);
+
+        let next_start = realtime_schedule_order(
+            &keys,
+            registry.last_started_keys(),
+            registry.last_started_chain_id(),
+            |key| *key,
+            |_| 1,
+        )[0];
+        assert_eq!(keys[next_start], "dao-b:1");
+        assert!(registry.try_start(keys[next_start], 1, 1, 1, || async {
+            Ok::<_, runtime_anyhow::Error>(())
+        }));
+    }
+
+    #[test]
+    fn test_realtime_scheduler_keeps_waiting_chain_work_ahead_of_a_restarted_peer() {
+        let contract_sets = [
+            ("dao-a:1", 1),
+            ("dao-c:2", 2),
+            ("dao-b:1", 1),
+            ("dao-d:2", 2),
+        ];
+        let last_started_keys =
+            BTreeMap::from([(1, "dao-a:1".to_owned()), (2, "dao-d:2".to_owned())]);
+
+        let order = realtime_schedule_order(
+            &contract_sets,
+            &last_started_keys,
+            None,
+            |(key, _)| *key,
+            |(_, chain_id)| *chain_id,
+        );
+
+        let waiting_chain_work = order
+            .iter()
+            .position(|index| *index == 2)
+            .expect("waiting same-chain work is scheduled");
+        let restarted_peer = order
+            .iter()
+            .position(|index| *index == 0)
+            .expect("previously started same-chain work is scheduled");
+
+        assert!(waiting_chain_work < restarted_peer);
+    }
+
+    #[tokio::test]
+    async fn test_realtime_scheduler_rotates_global_capacity_between_grouped_chains() {
+        let contract_sets = [
+            ("dao-a:1", 1),
+            ("dao-b:1", 1),
+            ("dao-c:2", 2),
+            ("dao-d:2", 2),
+        ];
+        let mut registry = RealtimePassRegistry::default();
+        assert!(registry.try_start("dao-a:1", 1, 1, 1, || async {
+            Ok::<_, runtime_anyhow::Error>(())
+        }));
+        tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                if !registry.reap_finished().await.is_empty() {
+                    return;
+                }
+                task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first chain pass completes");
+
+        let after_chain_one = realtime_schedule_order(
+            &contract_sets,
+            registry.last_started_keys(),
+            registry.last_started_chain_id(),
+            |(key, _)| *key,
+            |(_, chain_id)| *chain_id,
+        );
+        assert_eq!(after_chain_one[0], 2);
+        assert!(registry.try_start("dao-c:2", 2, 1, 1, || async {
+            Ok::<_, runtime_anyhow::Error>(())
+        }));
+        tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                if !registry.reap_finished().await.is_empty() {
+                    return;
+                }
+                task::yield_now().await;
+            }
+        })
+        .await
+        .expect("second chain pass completes");
+
+        let after_chain_two = realtime_schedule_order(
+            &contract_sets,
+            registry.last_started_keys(),
+            registry.last_started_chain_id(),
+            |(key, _)| *key,
+            |(_, chain_id)| *chain_id,
+        );
+        assert_eq!(after_chain_two[0], 1);
+    }
+
+    #[test]
+    fn test_realtime_scheduler_interleaves_chains_after_global_rotation() {
+        let contract_sets = [
+            ("dao-a:1", 1),
+            ("dao-b:1", 1),
+            ("dao-c:2", 2),
+            ("dao-d:2", 2),
+        ];
+        let last_started_keys = BTreeMap::from([(1, "dao-a:1".to_owned())]);
+
+        let order = realtime_schedule_order(
+            &contract_sets,
+            &last_started_keys,
+            Some(1),
+            |(key, _)| *key,
+            |(_, chain_id)| *chain_id,
+        );
+
+        assert_eq!(order, vec![2, 1, 3, 0]);
     }
 
     #[tokio::test]
@@ -2334,13 +2758,9 @@ mod tests {
             start_blocked_realtime_pass(Arc::new(AtomicUsize::new(0)), release.clone()).await;
         let first = poll_realtime_pass_handle(&mut pass, Duration::from_millis(5)).await;
         assert!(matches!(first, RealtimePassPoll::TimedOut));
-        registry.passes.insert(
-            "dao-a:1".to_owned(),
-            RealtimePass {
-                chain_id: 1,
-                handle: pass,
-            },
-        );
+        registry
+            .passes
+            .insert("dao-a:1".to_owned(), RealtimePass::new(1, pass));
         assert!(!registry.has_capacity(1, 2, 1));
         release.add_permits(1);
     }

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -4,7 +4,12 @@ use anyhow as runtime_anyhow;
 use datalens_sdk::RetryConfig;
 use runtime_anyhow::{Context, Result, bail};
 use sqlx::postgres::PgPoolOptions;
-use tokio::{runtime::Handle, sync::Semaphore, task, time::sleep};
+use tokio::{
+    runtime::Handle,
+    sync::Semaphore,
+    task,
+    time::{sleep, timeout},
+};
 
 use crate::runner::IndexerRunnerProgress;
 use crate::{
@@ -72,6 +77,8 @@ pub async fn run_indexer() -> Result<()> {
         None
     };
 
+    spawn_realtime_worker_if_enabled(&runtime, &config, pool.clone())?;
+
     loop {
         let contract_sets = runtime
             .configured_contract_sets(&config)
@@ -106,6 +113,373 @@ pub async fn run_indexer() -> Result<()> {
 
         sleep(runtime.poll_interval).await;
     }
+}
+
+fn spawn_realtime_worker_if_enabled(
+    runtime: &IndexerRuntimeConfig,
+    config: &DatalensConfig,
+    pool: sqlx::PgPool,
+) -> Result<()> {
+    if !realtime_worker_is_eligible(
+        runtime.run_once,
+        runtime.realtime.enabled,
+        runtime.provisional.enabled,
+        &runtime.realtime.dao_codes,
+    ) {
+        log::info!(
+            "Datalens realtime worker is inert run_once={} enabled={} provisional_enabled={}",
+            runtime.run_once,
+            runtime.realtime.enabled,
+            runtime.provisional.enabled
+        );
+        return Ok(());
+    }
+    let Some(realtime_datalens_config) = realtime_datalens_config(&runtime.realtime, config) else {
+        log::warn!(
+            "Datalens realtime worker is inert because DEGOV_REALTIME_DATALENS_APPLICATION must differ from DATALENS_APPLICATION and DEGOV_REALTIME_DATALENS_TOKEN is required"
+        );
+        return Ok(());
+    };
+
+    let contract_sets = runtime
+        .configured_contract_sets(config)
+        .context("select configured realtime contract sets")?;
+    let configured_dao_codes = contract_sets
+        .iter()
+        .map(|contract_set| contract_set.dao_code.clone())
+        .collect::<Vec<_>>();
+    if !realtime_worker_has_configured_dao_match(&configured_dao_codes, &runtime.realtime.dao_codes)
+    {
+        log::warn!(
+            "Datalens realtime worker is inert because no configured DAO matches DEGOV_REALTIME_DAO_CODES dao_codes={:?}",
+            runtime.realtime.dao_codes
+        );
+        return Ok(());
+    }
+    let contract_sets = contract_sets
+        .into_iter()
+        .filter(|contract_set| {
+            is_realtime_dao_allowlisted(&contract_set.dao_code, &runtime.realtime.dao_codes)
+        })
+        .collect::<Vec<_>>();
+    if contract_sets.is_empty() {
+        log::warn!(
+            "Datalens realtime worker is inert because no configured DAO matches DEGOV_REALTIME_DAO_CODES dao_codes={:?}",
+            runtime.realtime.dao_codes
+        );
+        return Ok(());
+    }
+
+    let runtime = runtime.clone();
+    task::spawn(async move {
+        run_realtime_worker_loop(runtime, contract_sets, pool, realtime_datalens_config).await;
+    });
+    Ok(())
+}
+
+async fn run_realtime_worker_loop(
+    runtime: IndexerRuntimeConfig,
+    contract_sets: Vec<DatalensRuntimeContractSet>,
+    pool: sqlx::PgPool,
+    realtime_datalens_config: DatalensConfig,
+) {
+    let mut passes = RealtimePassRegistry::default();
+    let mut observed_heads = BTreeMap::new();
+
+    loop {
+        run_realtime_cycle(
+            &runtime,
+            &contract_sets,
+            pool.clone(),
+            &realtime_datalens_config,
+            &mut passes,
+            &mut observed_heads,
+        )
+        .await;
+        sleep(runtime.realtime.poll_interval).await;
+    }
+}
+
+async fn run_realtime_cycle(
+    runtime: &IndexerRuntimeConfig,
+    contract_sets: &[DatalensRuntimeContractSet],
+    pool: sqlx::PgPool,
+    realtime_datalens_config: &DatalensConfig,
+    passes: &mut RealtimePassRegistry<RealtimeContractSetPassReport>,
+    observed_heads: &mut BTreeMap<String, i64>,
+) {
+    for contract_set in contract_sets {
+        let contract_set = contract_set.clone();
+        let previous_head = observed_heads.get(&contract_set.contract_set_id).copied();
+        let pass_key = contract_set.contract_set_id.clone();
+        let dao_code = contract_set.dao_code.clone();
+        let chain_id = contract_set.contract.chain_id;
+        let contract_set_id = contract_set.contract_set_id.clone();
+        if !passes.contains(&pass_key)
+            && !passes.has_capacity(
+                chain_id,
+                runtime.realtime.max_in_flight,
+                runtime.realtime.per_chain_max_in_flight,
+            )
+        {
+            log::debug!(
+                "Datalens realtime cycle skipped because realtime pass capacity is reached dao_code={} chain_id={} active_passes={} active_chain_passes={} max_in_flight={} per_chain_max_in_flight={}",
+                dao_code,
+                chain_id,
+                passes.len(),
+                passes.chain_active_count(chain_id),
+                runtime.realtime.max_in_flight,
+                runtime.realtime.per_chain_max_in_flight
+            );
+            continue;
+        }
+        match poll_realtime_pass_with_runtime(passes, &pass_key, chain_id, &runtime.realtime, {
+            let runtime = runtime.clone();
+            let pool = pool.clone();
+            let realtime_datalens_config = realtime_datalens_config.clone();
+            move || {
+                run_realtime_contract_set_pass(
+                    runtime,
+                    contract_set,
+                    pool,
+                    realtime_datalens_config,
+                    previous_head,
+                )
+            }
+        })
+        .await
+        {
+            RealtimePassPoll::Completed(report) => {
+                let observed_head = realtime_observed_head_after_pass(&report);
+                if let Some(observed_head) = observed_head {
+                    observed_heads.insert(report.contract_set_id.clone(), observed_head);
+                }
+                log::info!(
+                    "Datalens realtime cycle completed dao_code={} chain_id={} contract_set_id={} range_start_block={:?} range_end_block={:?} latest_head={} current_head_race={} segments_written={:?} proposal_overlays_written={:?} proposal_event_overlays_written={:?} vote_overlays_written={:?}",
+                    report.dao_code,
+                    report.chain_id,
+                    report.contract_set_id,
+                    report.range.map(|range| range.0),
+                    report.range.map(|range| range.1),
+                    report.latest_head,
+                    report.provisional.current_head_race,
+                    report.provisional.segments_written,
+                    report.provisional.proposal_overlays_written,
+                    report.provisional.proposal_event_overlays_written,
+                    report.provisional.vote_overlays_written
+                );
+            }
+            RealtimePassPoll::TimedOut => log::warn!(
+                "Datalens realtime cycle timed out; retaining the in-flight pass and skipping the same chain until it completes dao_code={} chain_id={} contract_set_id={} pass_timeout_ms={}",
+                dao_code,
+                chain_id,
+                contract_set_id,
+                runtime.realtime.pass_timeout.as_millis()
+            ),
+            RealtimePassPoll::InFlight => log::debug!(
+                "Datalens realtime cycle skipped an in-flight chain dao_code={} chain_id={} contract_set_id={}",
+                dao_code,
+                chain_id,
+                contract_set_id
+            ),
+            RealtimePassPoll::Failed(error) => {
+                log::warn!("Datalens realtime cycle failed error={error:#}")
+            }
+        }
+    }
+}
+
+fn realtime_observed_head_after_pass(report: &RealtimeContractSetPassReport) -> Option<i64> {
+    (!report.provisional.current_head_race).then_some(report.latest_head)
+}
+
+async fn run_realtime_contract_set_pass(
+    runtime: IndexerRuntimeConfig,
+    contract_set: DatalensRuntimeContractSet,
+    pool: sqlx::PgPool,
+    realtime_datalens_config: DatalensConfig,
+    previous_head: Option<i64>,
+) -> Result<RealtimeContractSetPassReport> {
+    let dao_code = contract_set.dao_code.clone();
+    let chain_id = contract_set.contract.chain_id;
+    let contract_set_id = contract_set.contract_set_id.clone();
+    task::spawn_blocking(move || -> Result<_> {
+        let mut contract_runtime = runtime
+            .for_configured_contract_set_at_target(&contract_set, contract_set.contract.start_block)
+            .context("build realtime contract set runtime")?;
+        contract_runtime.provisional = runtime.provisional.clone();
+        let config = realtime_datalens_config_for_contract_set(
+            &realtime_datalens_config,
+            &contract_set.config,
+        );
+        let mut client = DatalensNativeClient::from_config_with_retry_config(
+            &config,
+            datalens_retry_config(contract_runtime.query_max_attempts),
+        )
+        .context("create Datalens realtime client")?;
+        let latest_head = client
+            .latest_head_height(&config)
+            .context("resolve Datalens realtime latest head")?;
+        let range = plan_realtime_tail_range(
+            previous_head,
+            latest_head,
+            contract_runtime.start_block,
+            runtime.realtime.tail_window_blocks,
+        );
+        let provisional = match range {
+            Some((from_block, to_block)) => {
+                let mut store = PostgresProvisionalSegmentStore::new(pool);
+                run_provisional_worker_for_range(
+                    &contract_runtime,
+                    &config,
+                    &contract_set.addresses,
+                    from_block,
+                    to_block,
+                    latest_head,
+                    &mut client,
+                    &mut store,
+                )?
+            }
+            None => ProvisionalWorkerRunReport::default(),
+        };
+        Ok(RealtimeContractSetPassReport {
+            dao_code,
+            chain_id,
+            contract_set_id,
+            latest_head,
+            range,
+            provisional,
+        })
+    })
+    .await
+    .context("join Datalens realtime blocking pass")?
+}
+
+struct RealtimeContractSetPassReport {
+    dao_code: String,
+    chain_id: i32,
+    contract_set_id: String,
+    latest_head: i64,
+    range: Option<(i64, i64)>,
+    provisional: ProvisionalWorkerRunReport,
+}
+
+struct RealtimePassRegistry<T> {
+    passes: BTreeMap<String, RealtimePass<T>>,
+}
+
+struct RealtimePass<T> {
+    chain_id: i32,
+    handle: task::JoinHandle<Result<T>>,
+}
+
+impl<T> Default for RealtimePassRegistry<T> {
+    fn default() -> Self {
+        Self {
+            passes: BTreeMap::new(),
+        }
+    }
+}
+
+impl<T> RealtimePassRegistry<T> {
+    fn contains(&self, key: &str) -> bool {
+        self.passes.contains_key(key)
+    }
+
+    fn len(&self) -> usize {
+        self.passes.len()
+    }
+
+    fn chain_active_count(&self, chain_id: i32) -> usize {
+        self.passes
+            .values()
+            .filter(|pass| pass.chain_id == chain_id)
+            .count()
+    }
+
+    fn has_capacity(
+        &self,
+        chain_id: i32,
+        max_in_flight: usize,
+        per_chain_max_in_flight: usize,
+    ) -> bool {
+        self.len() < max_in_flight && self.chain_active_count(chain_id) < per_chain_max_in_flight
+    }
+}
+
+enum RealtimePassPoll<T> {
+    Completed(T),
+    TimedOut,
+    InFlight,
+    Failed(runtime_anyhow::Error),
+}
+
+async fn poll_realtime_pass<T, F, Fut>(
+    registry: &mut RealtimePassRegistry<T>,
+    key: &str,
+    chain_id: i32,
+    timeout_duration: Duration,
+    start: F,
+) -> RealtimePassPoll<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>> + Send + 'static,
+{
+    let mut pass = match registry.passes.remove(key) {
+        Some(pass) if pass.handle.is_finished() => pass.handle,
+        Some(pass) => {
+            registry.passes.insert(key.to_owned(), pass);
+            return RealtimePassPoll::InFlight;
+        }
+        None => task::spawn(start()),
+    };
+
+    match poll_realtime_pass_handle(&mut pass, timeout_duration).await {
+        RealtimePassPoll::TimedOut => {
+            registry.passes.insert(
+                key.to_owned(),
+                RealtimePass {
+                    chain_id,
+                    handle: pass,
+                },
+            );
+            RealtimePassPoll::TimedOut
+        }
+        result => result,
+    }
+}
+
+async fn poll_realtime_pass_handle<T>(
+    pass: &mut task::JoinHandle<Result<T>>,
+    timeout_duration: Duration,
+) -> RealtimePassPoll<T>
+where
+    T: Send + 'static,
+{
+    match timeout(timeout_duration, pass).await {
+        Ok(Ok(Ok(report))) => RealtimePassPoll::Completed(report),
+        Ok(Ok(Err(error))) => RealtimePassPoll::Failed(error),
+        Ok(Err(error)) => RealtimePassPoll::Failed(
+            runtime_anyhow::Error::new(error).context("join Datalens realtime pass"),
+        ),
+        Err(_) => RealtimePassPoll::TimedOut,
+    }
+}
+
+async fn poll_realtime_pass_with_runtime<T, F, Fut>(
+    registry: &mut RealtimePassRegistry<T>,
+    key: &str,
+    chain_id: i32,
+    runtime: &crate::RealtimeRuntimeConfig,
+    start: F,
+) -> RealtimePassPoll<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>> + Send + 'static,
+{
+    poll_realtime_pass(registry, key, chain_id, runtime.pass_timeout, start).await
 }
 
 async fn run_configured_contract_sets_pass(
@@ -1185,11 +1559,47 @@ where
         );
         return Ok(ProvisionalWorkerRunReport {
             latest_height: Some(latest_height),
+            current_head_race: false,
             segments_written: None,
             proposal_overlays_written: None,
             proposal_event_overlays_written: None,
             vote_overlays_written: None,
         });
+    };
+    run_provisional_worker_for_range(
+        runtime,
+        config,
+        contracts,
+        from_block,
+        to_block,
+        latest_height,
+        reader,
+        store,
+    )
+}
+
+fn run_provisional_worker_for_range<R, S>(
+    runtime: &IndexerContractSetRuntimeConfig,
+    config: &DatalensConfig,
+    contracts: &DaoContractAddresses,
+    from_block: i64,
+    to_block: i64,
+    latest_height: i64,
+    reader: &mut R,
+    store: &mut S,
+) -> Result<ProvisionalWorkerRunReport>
+where
+    R: DatalensProvisionalLogQueryReader,
+    S: DatalensProvisionalSegmentStore
+        + ProvisionalProposalOverlayStore
+        + ProvisionalVoteOverlayStore,
+{
+    let Some(chain_id) = config.chain.network_id else {
+        bail!(
+            "missing Datalens chain network_id for provisional worker dao_code={} contract_set_id={}",
+            runtime.dao_code,
+            runtime.checkpoint_contract_set_id
+        );
     };
     let options = ProvisionalWorkerOptions {
         datalens_config: config.clone(),
@@ -1219,6 +1629,7 @@ where
                 );
                 return Ok(ProvisionalWorkerRunReport {
                     latest_height: Some(latest_height),
+                    current_head_race: true,
                     segments_written: None,
                     proposal_overlays_written: None,
                     proposal_event_overlays_written: None,
@@ -1246,6 +1657,7 @@ where
 
     Ok(ProvisionalWorkerRunReport {
         latest_height: Some(latest_height),
+        current_head_race: false,
         segments_written: Some(report.segments_written),
         proposal_overlays_written: Some(report.proposal_overlays_written),
         proposal_event_overlays_written: Some(report.proposal_event_overlays_written),
@@ -1256,6 +1668,7 @@ where
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ProvisionalWorkerRunReport {
     latest_height: Option<i64>,
+    current_head_race: bool,
     segments_written: Option<usize>,
     proposal_overlays_written: Option<usize>,
     proposal_event_overlays_written: Option<usize>,
@@ -1278,6 +1691,80 @@ fn provisional_tail_range(
             .max(runtime.start_block),
         latest_height,
     ))
+}
+
+fn plan_realtime_tail_range(
+    previous_head: Option<i64>,
+    latest_head: i64,
+    start_block: i64,
+    tail_window_blocks: i64,
+) -> Option<(i64, i64)> {
+    if previous_head.is_some_and(|head| latest_head <= head) || latest_head < start_block {
+        return None;
+    }
+
+    let tail_start = latest_head
+        .saturating_sub(tail_window_blocks.saturating_sub(1))
+        .max(start_block);
+    let from_block = previous_head
+        .map(|head| head.saturating_add(1))
+        .unwrap_or(tail_start)
+        .max(tail_start);
+
+    (from_block <= latest_head).then_some((from_block, latest_head))
+}
+
+fn is_realtime_dao_allowlisted(dao_code: &str, dao_codes: &[String]) -> bool {
+    dao_codes.iter().any(|allowed| allowed == dao_code)
+}
+
+fn realtime_worker_is_eligible(
+    run_once: bool,
+    realtime_enabled: bool,
+    provisional_enabled: bool,
+    dao_codes: &[String],
+) -> bool {
+    !run_once && realtime_enabled && provisional_enabled && !dao_codes.is_empty()
+}
+
+fn realtime_datalens_config(
+    realtime: &crate::RealtimeRuntimeConfig,
+    durable_config: &DatalensConfig,
+) -> Option<DatalensConfig> {
+    let application = realtime.datalens_application.as_ref()?.trim();
+    let token = realtime.datalens_token.as_ref()?;
+    if application.is_empty()
+        || application == durable_config.application
+        || token.expose_secret().trim().is_empty()
+    {
+        return None;
+    }
+
+    let mut config = durable_config.clone();
+    config.application = application.to_owned();
+    config.bearer_token = token.clone();
+    config.timeout = realtime.query_timeout;
+    Some(config)
+}
+
+fn realtime_datalens_config_for_contract_set(
+    realtime_config: &DatalensConfig,
+    contract_set_config: &DatalensConfig,
+) -> DatalensConfig {
+    let mut config = contract_set_config.clone();
+    config.application = realtime_config.application.clone();
+    config.bearer_token = realtime_config.bearer_token.clone();
+    config.timeout = realtime_config.timeout;
+    config
+}
+
+fn realtime_worker_has_configured_dao_match(
+    configured_dao_codes: &[String],
+    allowlist: &[String],
+) -> bool {
+    configured_dao_codes
+        .iter()
+        .any(|dao_code| is_realtime_dao_allowlisted(dao_code, allowlist))
 }
 
 fn provisional_worker_error_to_anyhow(error: ProvisionalWorkerError) -> runtime_anyhow::Error {
@@ -1459,7 +1946,7 @@ mod tests {
             Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use datalens_sdk::native::QueryInput;
@@ -1470,10 +1957,34 @@ mod tests {
         DatalensProvisionalSegmentWrite, DatasetKeyConfig, GovernanceTokenStandard,
         ProvisionalProposalEventOverlayWrite, ProvisionalProposalOverlayWrite,
         ProvisionalRuntimeConfig, ProvisionalTimelockOperationOverlayWrite,
-        ProvisionalVoteCastGroupOverlayWrite, QueryLimitConfig, SecretString,
+        ProvisionalVoteCastGroupOverlayWrite, QueryLimitConfig, RealtimeRuntimeConfig,
+        SecretString,
     };
 
     use super::*;
+
+    async fn start_blocked_realtime_pass(
+        starts: Arc<AtomicUsize>,
+        release: Arc<tokio::sync::Semaphore>,
+    ) -> task::JoinHandle<Result<()>> {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let handle = task::spawn(async move {
+            starts.fetch_add(1, Ordering::SeqCst);
+            started_tx
+                .send(())
+                .expect("realtime pass start signal is received");
+            let _permit = release
+                .acquire()
+                .await
+                .expect("release semaphore remains open");
+            Ok::<_, runtime_anyhow::Error>(())
+        });
+
+        started_rx
+            .await
+            .expect("realtime pass signals startup before its lease is polled");
+        handle
+    }
 
     #[test]
     fn test_resolve_contract_set_max_chunks_per_run_adapts_all_mode_from_remaining_blocks() {
@@ -1586,6 +2097,254 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_realtime_tail_planner_uses_latest_tail_on_first_observation() {
+        assert_eq!(
+            plan_realtime_tail_range(None, 105, 100, 8),
+            Some((100, 105))
+        );
+    }
+
+    #[test]
+    fn test_realtime_tail_planner_uses_only_new_blocks_after_first_observation() {
+        assert_eq!(
+            plan_realtime_tail_range(Some(105), 108, 100, 8),
+            Some((106, 108))
+        );
+    }
+
+    #[test]
+    fn test_realtime_tail_planner_bounds_large_recovery_gap_to_tail_window() {
+        assert_eq!(
+            plan_realtime_tail_range(Some(100), 200, 1, 8),
+            Some((193, 200))
+        );
+    }
+
+    #[test]
+    fn test_realtime_tail_planner_skips_unchanged_or_regressed_heads() {
+        assert_eq!(plan_realtime_tail_range(Some(105), 105, 100, 8), None);
+        assert_eq!(plan_realtime_tail_range(Some(105), 104, 100, 8), None);
+    }
+
+    #[test]
+    fn test_realtime_tail_planner_never_precedes_start_block() {
+        assert_eq!(
+            plan_realtime_tail_range(None, 102, 100, 8),
+            Some((100, 102))
+        );
+    }
+
+    #[test]
+    fn test_realtime_allowlist_only_selects_explicit_configured_dao_codes() {
+        let allowlist = vec!["demo-dao".to_owned()];
+
+        assert!(is_realtime_dao_allowlisted("demo-dao", &allowlist));
+        assert!(!is_realtime_dao_allowlisted("other-dao", &allowlist));
+    }
+
+    #[test]
+    fn test_realtime_empty_allowlist_is_inert() {
+        assert!(!is_realtime_dao_allowlisted("demo-dao", &[]));
+    }
+
+    #[test]
+    fn test_realtime_datalens_config_requires_application_distinct_from_durable() {
+        let durable = datalens_config();
+        let shared_application = RealtimeRuntimeConfig {
+            datalens_application: Some(durable.application.clone()),
+            datalens_token: Some(SecretString::new("dedicated-realtime-token")),
+            query_timeout: Duration::from_secs(5),
+            ..Default::default()
+        };
+        let realtime = RealtimeRuntimeConfig {
+            datalens_application: Some("degov-realtime".to_owned()),
+            datalens_token: Some(SecretString::new("dedicated-realtime-token")),
+            query_timeout: Duration::from_secs(5),
+            ..Default::default()
+        };
+
+        assert!(realtime_datalens_config(&shared_application, &durable).is_none());
+        let dedicated = realtime_datalens_config(&realtime, &durable)
+            .expect("dedicated realtime Datalens configuration is complete");
+
+        assert_eq!(dedicated.application, "degov-realtime");
+        assert_eq!(
+            dedicated.bearer_token.expose_secret(),
+            "dedicated-realtime-token"
+        );
+        assert_eq!(dedicated.timeout, Duration::from_secs(5));
+        assert_eq!(durable.application, "degov-test");
+        assert_eq!(
+            durable.bearer_token.expose_secret(),
+            "unit-test-redacted-value"
+        );
+        assert_eq!(durable.timeout, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_realtime_worker_gating_requires_long_running_provisional_allowlisted_mode() {
+        let dao_codes = vec!["demo-dao".to_owned()];
+
+        assert!(realtime_worker_is_eligible(false, true, true, &dao_codes));
+        assert!(!realtime_worker_is_eligible(true, true, true, &dao_codes));
+        assert!(!realtime_worker_is_eligible(false, false, true, &dao_codes));
+        assert!(!realtime_worker_is_eligible(false, true, false, &dao_codes));
+        assert!(!realtime_worker_is_eligible(false, true, true, &[]));
+    }
+
+    #[test]
+    fn test_realtime_worker_gating_rejects_unmatched_allowlist() {
+        let configured = vec!["other-dao".to_owned()];
+        let allowlist = vec!["demo-dao".to_owned()];
+
+        assert!(!realtime_worker_has_configured_dao_match(
+            &configured,
+            &allowlist
+        ));
+    }
+
+    #[test]
+    fn test_realtime_current_head_race_keeps_observed_head_unadvanced_for_tail_retry() {
+        let report = RealtimeContractSetPassReport {
+            dao_code: "demo-dao".to_owned(),
+            chain_id: 1,
+            contract_set_id: "demo-dao:1".to_owned(),
+            latest_head: 105,
+            range: Some((100, 105)),
+            provisional: ProvisionalWorkerRunReport {
+                current_head_race: true,
+                ..Default::default()
+            },
+        };
+
+        let observed_head = realtime_observed_head_after_pass(&report);
+
+        assert_eq!(observed_head, None);
+        assert_eq!(
+            plan_realtime_tail_range(observed_head, 106, 100, 8),
+            Some((100, 106))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_realtime_pass_lease_allows_completion_after_query_deadline() {
+        let mut registry = RealtimePassRegistry::default();
+        let realtime = RealtimeRuntimeConfig {
+            query_timeout: Duration::from_millis(5),
+            pass_timeout: Duration::from_millis(20),
+            ..Default::default()
+        };
+
+        let result =
+            poll_realtime_pass_with_runtime(&mut registry, "demo-dao:1", 1, &realtime, || async {
+                sleep(Duration::from_millis(10)).await;
+                Ok::<_, runtime_anyhow::Error>(())
+            })
+            .await;
+
+        assert!(matches!(result, RealtimePassPoll::Completed(())));
+    }
+
+    #[tokio::test]
+    async fn test_realtime_pass_registry_times_out_without_starting_an_overlapping_pass() {
+        let starts = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let mut registry = RealtimePassRegistry::default();
+
+        let mut pass = start_blocked_realtime_pass(starts.clone(), release.clone()).await;
+        let started_at = Instant::now();
+        let first = poll_realtime_pass_handle(&mut pass, Duration::from_millis(5)).await;
+        assert!(matches!(first, RealtimePassPoll::TimedOut));
+        assert!(started_at.elapsed() < Duration::from_millis(100));
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
+        registry.passes.insert(
+            "demo-dao:1".to_owned(),
+            RealtimePass {
+                chain_id: 1,
+                handle: pass,
+            },
+        );
+
+        let second = poll_realtime_pass(
+            &mut registry,
+            "demo-dao:1",
+            1,
+            Duration::from_millis(5),
+            || async { panic!("an in-flight chain must not start another realtime pass") },
+        )
+        .await;
+        assert!(matches!(second, RealtimePassPoll::InFlight));
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+        release.add_permits(1);
+        let completed = tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                let result = poll_realtime_pass(
+                    &mut registry,
+                    "demo-dao:1",
+                    1,
+                    Duration::from_millis(5),
+                    || async {
+                        panic!("completed pass must be collected before a new pass can start")
+                    },
+                )
+                .await;
+                if !matches!(result, RealtimePassPoll::InFlight) {
+                    return result;
+                }
+                task::yield_now().await;
+            }
+        })
+        .await
+        .expect("timed out pass eventually completes");
+        assert!(matches!(completed, RealtimePassPoll::Completed(())));
+    }
+
+    #[tokio::test]
+    async fn test_realtime_pass_registry_allows_two_distinct_daos_on_one_chain_at_capacity_two() {
+        let starts = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let mut registry = RealtimePassRegistry::default();
+
+        for key in ["dao-a:1", "dao-b:1"] {
+            assert!(registry.has_capacity(1, 2, 2));
+            let mut pass = start_blocked_realtime_pass(starts.clone(), release.clone()).await;
+            let result = poll_realtime_pass_handle(&mut pass, Duration::from_millis(5)).await;
+            assert!(matches!(result, RealtimePassPoll::TimedOut));
+            registry.passes.insert(
+                key.to_owned(),
+                RealtimePass {
+                    chain_id: 1,
+                    handle: pass,
+                },
+            );
+        }
+
+        assert_eq!(starts.load(Ordering::SeqCst), 2);
+        assert_eq!(registry.len(), 2);
+        release.add_permits(2);
+    }
+
+    #[tokio::test]
+    async fn test_realtime_pass_registry_rejects_second_dao_when_per_chain_capacity_is_one() {
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let mut registry = RealtimePassRegistry::default();
+        let mut pass =
+            start_blocked_realtime_pass(Arc::new(AtomicUsize::new(0)), release.clone()).await;
+        let first = poll_realtime_pass_handle(&mut pass, Duration::from_millis(5)).await;
+        assert!(matches!(first, RealtimePassPoll::TimedOut));
+        registry.passes.insert(
+            "dao-a:1".to_owned(),
+            RealtimePass {
+                chain_id: 1,
+                handle: pass,
+            },
+        );
+        assert!(!registry.has_capacity(1, 2, 1));
+        release.add_permits(1);
+    }
+
     #[tokio::test]
     async fn test_resolve_contract_set_target_height_keeps_fixed_numeric_target_without_datalens() {
         let runtime = IndexerRuntimeConfig {
@@ -1612,6 +2371,7 @@ mod tests {
                 enabled: false,
                 finality: DatalensProvisionalFinality::SafeToLatest,
             },
+            realtime: Default::default(),
         };
         let config = DatalensConfig {
             endpoint: "http://127.0.0.1:1".to_owned(),
@@ -1718,6 +2478,46 @@ mod tests {
         assert_eq!(store.writes[0].segment_finality, "safe_to_latest");
         assert_eq!(store.writes[0].range_start_block, 21);
         assert_eq!(store.writes[0].range_end_block, 25);
+    }
+
+    #[test]
+    fn test_provisional_worker_range_path_reuses_safe_to_latest_projection() {
+        let runtime = contract_runtime(ProvisionalRuntimeConfig {
+            enabled: true,
+            finality: DatalensProvisionalFinality::SafeToLatest,
+        });
+        let config = datalens_config();
+        let contracts = dao_contracts();
+        let mut reader =
+            RecordingProvisionalReader::with_segments(vec![DatalensProvisionalCacheSegment {
+                source: "provider".to_owned(),
+                finality: "safe_to_latest".to_owned(),
+                range_start_block: 17,
+                range_end_block: 19,
+                anchor_block_number: Some(19),
+                anchor_block_hash: Some("0xanchor".to_owned()),
+                anchor_parent_hash: Some("0xparent".to_owned()),
+                anchor_block_timestamp: Some(1_700_000_000),
+            }]);
+        let mut store = RecordingProvisionalSegmentStore::default();
+
+        let result = run_provisional_worker_for_range(
+            &runtime,
+            &config,
+            &contracts,
+            17,
+            19,
+            19,
+            &mut reader,
+            &mut store,
+        )
+        .expect("range path writes provisional overlays");
+
+        assert_eq!(result.segments_written, Some(1));
+        assert_eq!(reader.latest_head_calls, 0);
+        assert_eq!(reader.ranges, vec![(17, 19)]);
+        assert_eq!(reader.finalities, vec![Some("safe_to_latest".to_owned())]);
+        assert_eq!(store.writes.len(), 1);
     }
 
     #[test]
@@ -2710,6 +3510,7 @@ mod tests {
                 enabled: false,
                 finality: DatalensProvisionalFinality::SafeToLatest,
             },
+            realtime: Default::default(),
         }
     }
 

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -84,8 +84,6 @@ pub async fn run_indexer() -> Result<()> {
         None
     };
 
-    spawn_realtime_worker_if_enabled(&runtime, &config, pool.clone())?;
-
     loop {
         let contract_sets = runtime
             .configured_contract_sets(&config)
@@ -2190,6 +2188,7 @@ async fn resolve_contract_set_target_height(
 #[cfg(test)]
 mod tests {
     use std::{
+        fs,
         sync::{
             Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
@@ -2238,12 +2237,15 @@ mod tests {
     async fn test_post_schema_startup_starts_realtime_before_runtime_maintenance() {
         let (realtime_started_tx, realtime_started_rx) = tokio::sync::oneshot::channel();
         let (maintenance_started_tx, maintenance_started_rx) = tokio::sync::oneshot::channel();
+        let realtime_start_count = Arc::new(AtomicUsize::new(0));
+        let realtime_start_count_for_startup = realtime_start_count.clone();
         let release_maintenance = Arc::new(tokio::sync::Semaphore::new(0));
         let release_maintenance_for_startup = release_maintenance.clone();
 
         let startup = task::spawn(async move {
             run_post_schema_startup(
                 || {
+                    realtime_start_count_for_startup.fetch_add(1, Ordering::SeqCst);
                     realtime_started_tx
                         .send(())
                         .expect("realtime startup signal is received");
@@ -2283,6 +2285,28 @@ mod tests {
             .await
             .expect("post-schema startup task joins")
             .expect("post-schema startup succeeds");
+        assert_eq!(realtime_start_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_run_indexer_starts_realtime_worker_once_in_post_schema_startup() {
+        let indexer_runtime = fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/runtime/indexer.rs"
+        ))
+        .expect("read indexer runtime source");
+
+        let worker_start_call = [
+            "spawn_realtime_worker_if_enabled",
+            "(&runtime, &config, pool.clone())",
+        ]
+        .concat();
+
+        assert_eq!(
+            indexer_runtime.matches(&worker_start_call).count(),
+            1,
+            "run_indexer delegates the realtime worker start to post-schema startup exactly once"
+        );
     }
 
     #[test]

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -50,18 +50,19 @@ pub async fn repair_invalid_runtime_indexes() -> Result<()> {
 }
 
 pub async fn apply_migrations(pool: &PgPool) -> Result<()> {
+    apply_schema_migrations(pool).await?;
+    apply_runtime_maintenance(pool).await
+}
+
+pub async fn apply_runtime_maintenance(pool: &PgPool) -> Result<()> {
     let mut connection = pool
         .acquire()
         .await
-        .context("acquire DeGov indexer migration connection")?;
+        .context("acquire DeGov indexer runtime maintenance connection")?;
 
     acquire_runtime_migration_lock(&mut connection).await?;
 
     let result: Result<()> = async {
-        MIGRATOR
-            .run(&mut *connection)
-            .await
-            .context("apply Datalens-native DeGov indexer init migration")?;
         drop_invalid_runtime_indexes_for_connection(&mut connection).await?;
         ensure_runtime_indexes(&mut connection).await?;
         repair_delegate_effective_counts_once(&mut connection).await?;
@@ -295,13 +296,14 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure scoped processing onchain refresh retry index")?;
 
-    sqlx::query(
-        "CREATE INDEX IF NOT EXISTS onchain_refresh_deferred_candidate_scope_drain_idx
+    execute_concurrent_runtime_index(
+        connection,
+        "onchain_refresh_deferred_candidate_scope_drain_idx",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_deferred_candidate_scope_drain_idx
          ON onchain_refresh_deferred_candidate (
             chain_id, contract_set_id, dao_code, next_run_at, updated_at, id
          )",
     )
-    .execute(&mut *connection)
     .await
     .context("ensure scoped onchain refresh deferred drain index")?;
 

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -833,6 +833,11 @@ async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnecti
     drop_invalid_runtime_index(connection, "onchain_refresh_task_processing_retry_idx").await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_processing_lock_retry_idx")
         .await?;
+    drop_invalid_runtime_index(
+        connection,
+        "onchain_refresh_deferred_candidate_scope_drain_idx",
+    )
+    .await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_pending_scope_claim_idx").await?;
     drop_invalid_runtime_index(connection, "onchain_refresh_task_failed_scope_retry_idx").await?;
     drop_invalid_runtime_index(

--- a/apps/indexer/src/runtime/mod.rs
+++ b/apps/indexer/src/runtime/mod.rs
@@ -11,7 +11,8 @@ pub use datalens::smoke_datalens;
 pub use graphql::run_graphql;
 pub use indexer::run_indexer;
 pub use migrate::{
-    apply_migrations, apply_schema_migrations, migrate, repair_invalid_runtime_indexes,
+    apply_migrations, apply_runtime_maintenance, apply_schema_migrations, migrate,
+    repair_invalid_runtime_indexes,
 };
 pub use proposal_reference_fields::refresh_proposal_reference_fields;
 pub use proposal_title_refresh::refresh_proposal_titles;

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -1,4 +1,10 @@
-use std::{collections::BTreeMap, env, net::SocketAddr, path::Path, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env,
+    net::SocketAddr,
+    path::Path,
+    time::Duration,
+};
 
 use anyhow as runtime_anyhow;
 use datalens_sdk::RetryConfig;
@@ -36,6 +42,105 @@ pub struct MetricsRuntimeConfig {
 pub struct ProvisionalRuntimeConfig {
     pub enabled: bool,
     pub finality: DatalensProvisionalFinality,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RealtimeRuntimeConfig {
+    pub enabled: bool,
+    pub dao_codes: Vec<String>,
+    pub datalens_application: Option<String>,
+    pub datalens_token: Option<SecretString>,
+    pub poll_interval: Duration,
+    pub tail_window_blocks: i64,
+    pub max_in_flight: usize,
+    pub per_chain_max_in_flight: usize,
+    pub query_timeout: Duration,
+    pub pass_timeout: Duration,
+}
+
+impl Default for RealtimeRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dao_codes: Vec::new(),
+            datalens_application: None,
+            datalens_token: None,
+            poll_interval: Duration::from_millis(3_000),
+            tail_window_blocks: 8,
+            max_in_flight: 1,
+            per_chain_max_in_flight: 1,
+            query_timeout: Duration::from_millis(5_000),
+            pass_timeout: Duration::from_millis(15_000),
+        }
+    }
+}
+
+impl RealtimeRuntimeConfig {
+    pub fn from_env() -> Result<Self> {
+        let defaults = Self::default();
+        let poll_interval_ms = optional_env_u64("DEGOV_REALTIME_POLL_INTERVAL_MS")?
+            .unwrap_or(defaults.poll_interval.as_millis() as u64);
+        if poll_interval_ms < 2_000 {
+            bail!("DEGOV_REALTIME_POLL_INTERVAL_MS must be at least 2000");
+        }
+
+        let tail_window_blocks = optional_env_i64("DEGOV_REALTIME_TAIL_WINDOW_BLOCKS")?
+            .unwrap_or(defaults.tail_window_blocks);
+        if tail_window_blocks <= 0 {
+            bail!("DEGOV_REALTIME_TAIL_WINDOW_BLOCKS must be greater than zero");
+        }
+
+        let max_in_flight =
+            optional_env_usize("DEGOV_REALTIME_MAX_IN_FLIGHT")?.unwrap_or(defaults.max_in_flight);
+        if max_in_flight == 0 {
+            bail!("DEGOV_REALTIME_MAX_IN_FLIGHT must be greater than zero");
+        }
+
+        let per_chain_max_in_flight = optional_env_usize("DEGOV_REALTIME_PER_CHAIN_MAX_IN_FLIGHT")?
+            .unwrap_or(defaults.per_chain_max_in_flight);
+        if per_chain_max_in_flight == 0 {
+            bail!("DEGOV_REALTIME_PER_CHAIN_MAX_IN_FLIGHT must be greater than zero");
+        }
+
+        let query_timeout_ms = optional_env_u64("DEGOV_REALTIME_QUERY_TIMEOUT_MS")?
+            .unwrap_or(defaults.query_timeout.as_millis() as u64);
+        if query_timeout_ms == 0 {
+            bail!("DEGOV_REALTIME_QUERY_TIMEOUT_MS must be greater than zero");
+        }
+
+        let pass_timeout_ms = optional_env_u64("DEGOV_REALTIME_PASS_TIMEOUT_MS")?
+            .unwrap_or(defaults.pass_timeout.as_millis() as u64);
+        if pass_timeout_ms < query_timeout_ms {
+            bail!(
+                "DEGOV_REALTIME_PASS_TIMEOUT_MS must be at least DEGOV_REALTIME_QUERY_TIMEOUT_MS"
+            );
+        }
+
+        Ok(Self {
+            enabled: optional_env_bool("DEGOV_REALTIME_WORKER_ENABLED")?
+                .unwrap_or(defaults.enabled),
+            dao_codes: optional_env("DEGOV_REALTIME_DAO_CODES")?
+                .map(|value| {
+                    value
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|dao_code| !dao_code.is_empty())
+                        .map(ToOwned::to_owned)
+                        .collect::<BTreeSet<_>>()
+                        .into_iter()
+                        .collect()
+                })
+                .unwrap_or_default(),
+            datalens_application: optional_env("DEGOV_REALTIME_DATALENS_APPLICATION")?,
+            datalens_token: optional_env("DEGOV_REALTIME_DATALENS_TOKEN")?.map(SecretString::new),
+            poll_interval: Duration::from_millis(poll_interval_ms),
+            tail_window_blocks,
+            max_in_flight,
+            per_chain_max_in_flight,
+            query_timeout: Duration::from_millis(query_timeout_ms),
+            pass_timeout: Duration::from_millis(pass_timeout_ms),
+        })
+    }
 }
 
 impl ProvisionalRuntimeConfig {
@@ -202,6 +307,7 @@ pub struct IndexerRuntimeConfig {
     pub onchain_refresh_deferred_drain_batch_size: usize,
     pub proposal_timestamp_backfill: ProposalTimestampBackfillConfig,
     pub provisional: ProvisionalRuntimeConfig,
+    pub realtime: RealtimeRuntimeConfig,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -424,6 +530,7 @@ impl IndexerRuntimeConfig {
                 onchain_refresh_deferred_drain_batch_size_from_env()?,
             proposal_timestamp_backfill: load_proposal_timestamp_backfill_config()?,
             provisional: ProvisionalRuntimeConfig::from_env()?,
+            realtime: RealtimeRuntimeConfig::from_env()?,
             poll_interval,
             run_once,
             max_chunks_per_run: optional_env_u64("DEGOV_INDEXER_MAX_CHUNKS_PER_RUN")?,

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -38,6 +38,141 @@ fn test_onchain_refresh_worker_enabled_rejects_ambiguous_values() {
 }
 
 #[test]
+fn test_indexer_runtime_config_defaults_realtime_worker_to_disabled() {
+    with_env_vars!(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("test-dao")),
+            ("DEGOV_REALTIME_WORKER_ENABLED", None::<&str>),
+            ("DEGOV_REALTIME_DAO_CODES", None::<&str>),
+            ("DEGOV_REALTIME_POLL_INTERVAL_MS", None::<&str>),
+            ("DEGOV_REALTIME_TAIL_WINDOW_BLOCKS", None::<&str>),
+            ("DEGOV_REALTIME_MAX_IN_FLIGHT", None::<&str>),
+            ("DEGOV_REALTIME_PER_CHAIN_MAX_IN_FLIGHT", None::<&str>,),
+            ("DEGOV_REALTIME_QUERY_TIMEOUT_MS", None::<&str>),
+            ("DEGOV_REALTIME_PASS_TIMEOUT_MS", None::<&str>),
+            ("DEGOV_REALTIME_DATALENS_APPLICATION", None::<&str>),
+            ("DEGOV_REALTIME_DATALENS_TOKEN", None::<&str>),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert!(!config.realtime.enabled);
+            assert!(config.realtime.dao_codes.is_empty());
+            assert_eq!(config.realtime.poll_interval, Duration::from_millis(3_000));
+            assert_eq!(config.realtime.tail_window_blocks, 8);
+            assert_eq!(config.realtime.max_in_flight, 1);
+            assert_eq!(config.realtime.per_chain_max_in_flight, 1);
+            assert_eq!(config.realtime.query_timeout, Duration::from_millis(5_000));
+            assert_eq!(config.realtime.pass_timeout, Duration::from_millis(15_000));
+            assert_eq!(config.realtime.datalens_application, None);
+            assert_eq!(config.realtime.datalens_token, None);
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_parses_realtime_dao_allowlist() {
+    with_env_vars!(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("test-dao")),
+            ("DEGOV_REALTIME_WORKER_ENABLED", Some("true")),
+            (
+                "DEGOV_REALTIME_DAO_CODES",
+                Some(" demo-dao, test-dao, demo-dao , ,\ttest-dao "),
+            ),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(
+                config.realtime.dao_codes,
+                vec!["demo-dao".to_owned(), "test-dao".to_owned()]
+            );
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_accepts_realtime_worker_overrides() {
+    with_env_vars!(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("test-dao")),
+            ("DEGOV_REALTIME_WORKER_ENABLED", Some("true")),
+            ("DEGOV_REALTIME_POLL_INTERVAL_MS", Some("2500")),
+            ("DEGOV_REALTIME_TAIL_WINDOW_BLOCKS", Some("12")),
+            ("DEGOV_REALTIME_MAX_IN_FLIGHT", Some("3")),
+            ("DEGOV_REALTIME_PER_CHAIN_MAX_IN_FLIGHT", Some("2")),
+            ("DEGOV_REALTIME_QUERY_TIMEOUT_MS", Some("7500")),
+            ("DEGOV_REALTIME_PASS_TIMEOUT_MS", Some("15000")),
+            (
+                "DEGOV_REALTIME_DATALENS_APPLICATION",
+                Some("degov-realtime"),
+            ),
+            ("DEGOV_REALTIME_DATALENS_TOKEN", Some("realtime-test-token")),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert!(config.realtime.enabled);
+            assert_eq!(config.realtime.poll_interval, Duration::from_millis(2_500));
+            assert_eq!(config.realtime.tail_window_blocks, 12);
+            assert_eq!(config.realtime.max_in_flight, 3);
+            assert_eq!(config.realtime.per_chain_max_in_flight, 2);
+            assert_eq!(config.realtime.query_timeout, Duration::from_millis(7_500));
+            assert_eq!(config.realtime.pass_timeout, Duration::from_millis(15_000));
+            assert_eq!(
+                config.realtime.datalens_application.as_deref(),
+                Some("degov-realtime")
+            );
+            assert_eq!(
+                config
+                    .realtime
+                    .datalens_token
+                    .as_ref()
+                    .map(degov_datalens_indexer::SecretString::expose_secret),
+                Some("realtime-test-token")
+            );
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_rejects_invalid_realtime_worker_boundaries() {
+    for (name, value) in [
+        ("DEGOV_REALTIME_POLL_INTERVAL_MS", "0"),
+        ("DEGOV_REALTIME_POLL_INTERVAL_MS", "1999"),
+        ("DEGOV_REALTIME_TAIL_WINDOW_BLOCKS", "0"),
+        ("DEGOV_REALTIME_MAX_IN_FLIGHT", "0"),
+        ("DEGOV_REALTIME_PER_CHAIN_MAX_IN_FLIGHT", "0"),
+        ("DEGOV_REALTIME_QUERY_TIMEOUT_MS", "0"),
+        ("DEGOV_REALTIME_PASS_TIMEOUT_MS", "0"),
+        ("DEGOV_REALTIME_PASS_TIMEOUT_MS", "4999"),
+    ] {
+        with_env_vars!(
+            [
+                ("DEGOV_INDEXER_DAO_CODE", Some("test-dao")),
+                ("DEGOV_REALTIME_WORKER_ENABLED", Some("true")),
+                ("DEGOV_REALTIME_POLL_INTERVAL_MS", None::<&str>),
+                ("DEGOV_REALTIME_TAIL_WINDOW_BLOCKS", None::<&str>),
+                ("DEGOV_REALTIME_MAX_IN_FLIGHT", None::<&str>),
+                ("DEGOV_REALTIME_PER_CHAIN_MAX_IN_FLIGHT", None::<&str>,),
+                ("DEGOV_REALTIME_QUERY_TIMEOUT_MS", None::<&str>),
+                ("DEGOV_REALTIME_PASS_TIMEOUT_MS", None::<&str>),
+                ("DEGOV_REALTIME_DATALENS_APPLICATION", None::<&str>),
+                ("DEGOV_REALTIME_DATALENS_TOKEN", None::<&str>),
+                (name, Some(value)),
+            ],
+            || {
+                let error = IndexerRuntimeConfig::from_env()
+                    .expect_err("invalid realtime worker boundary is rejected");
+
+                assert!(error.to_string().contains(name));
+            },
+        );
+    }
+}
+
+#[test]
 fn test_onchain_refresh_runtime_config_defaults_debounce() {
     with_env_vars!(
         [
@@ -947,6 +1082,7 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
             enabled: true,
             finality: DatalensProvisionalFinality::LatestOnly,
         },
+        realtime: Default::default(),
     };
     let selected = config
         .configured_contract_sets(Some("lisk-dao"))
@@ -1035,6 +1171,7 @@ fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
             enabled: false,
             finality: DatalensProvisionalFinality::SafeToLatest,
         },
+        realtime: Default::default(),
     };
     let selected = config
         .configured_contract_sets(Some("lisk-dao"))
@@ -1078,6 +1215,7 @@ fn test_indexer_runtime_latest_target_height_does_not_skip_all_mode_contract_set
             enabled: false,
             finality: DatalensProvisionalFinality::SafeToLatest,
         },
+        realtime: Default::default(),
     };
 
     assert!(!runtime.should_skip_contract_set_start_after_target(568752));

--- a/apps/indexer/tests/datalens_planner.rs
+++ b/apps/indexer/tests/datalens_planner.rs
@@ -32,7 +32,11 @@ fn test_plan_dao_log_queries_combines_sources_into_single_evm_log_selector() {
                 source: DaoLogSource::Timelock,
             },
         ],
-        &[],
+        &[
+            addresses.governor.clone(),
+            addresses.governor_token.clone(),
+            addresses.timelock.clone().expect("timelock"),
+        ],
         &topic0_union(&[
             GOVERNOR_TOPIC0_VALUES,
             TIMELOCK_TOPIC0_VALUES,
@@ -45,12 +49,20 @@ fn test_plan_dao_log_queries_combines_sources_into_single_evm_log_selector() {
 }
 
 #[test]
-fn test_plan_dao_log_queries_uses_broad_address_selector_for_reusable_datalens_cache() {
+fn test_plan_dao_log_queries_scopes_governance_selector_to_dao_addresses() {
     let config = config(1_000, DatalensFinality::DurableOnly);
-    let plans = plan_dao_log_queries(&config, &addresses(), 100, 199).expect("plans");
+    let addresses = addresses();
+    let plans = plan_dao_log_queries(&config, &addresses, 100, 199).expect("plans");
 
     let evm_logs = plans[0].input.selector.evm_logs.as_ref().expect("evm logs");
-    assert!(evm_logs.addresses.is_empty());
+    assert_eq!(
+        evm_logs.addresses,
+        vec![
+            addresses.governor,
+            addresses.governor_token,
+            addresses.timelock.expect("timelock"),
+        ]
+    );
     assert_eq!(
         evm_logs.topics,
         vec![topic0_union(&[
@@ -82,7 +94,7 @@ fn test_plan_dao_log_queries_skips_timelock_when_not_configured() {
                 source: DaoLogSource::GovernorToken,
             },
         ],
-        &[],
+        &[addresses.governor.clone(), addresses.governor_token.clone()],
         &topic0_union(&[GOVERNOR_TOPIC0_VALUES, GOVERNOR_TOKEN_TOPIC0_VALUES]),
         100,
         199,
@@ -108,7 +120,8 @@ fn test_plan_dao_log_queries_chunks_ranges_by_config_limit() {
             .as_ref()
             .expect("evm logs")
             .addresses
-            .is_empty()
+            .len()
+            == 3
     }));
 }
 

--- a/apps/indexer/tests/datalens_warmup.rs
+++ b/apps/indexer/tests/datalens_warmup.rs
@@ -34,7 +34,14 @@ fn test_ensure_datalens_warmup_task_submits_follow_query_when_enabled() {
     ));
     assert_eq!(ensurer.requests.len(), 1);
     let request = &ensurer.requests[0];
-    assert!(request.selector.addresses.is_empty());
+    assert_eq!(
+        request.selector.addresses,
+        vec![
+            "0x1111111111111111111111111111111111111111",
+            "0x2222222222222222222222222222222222222222",
+            "0x3333333333333333333333333333333333333333",
+        ]
+    );
     assert_eq!(request.selector.topics.len(), 1);
     assert_eq!(request.selector.topics[0].len(), 24);
     for request in &ensurer.requests {
@@ -70,7 +77,7 @@ fn test_ensure_datalens_warmup_task_reuses_existing_matching_task() {
 }
 
 #[test]
-fn test_ensure_datalens_warmup_task_reuses_broad_selector_for_dao_address_mismatch() {
+fn test_ensure_datalens_warmup_task_creates_scoped_selector_for_dao_address_mismatch() {
     let config = config();
     let mut ensurer = MockWarmupEnsurer::default();
     let mut other_addresses = addresses();
@@ -82,9 +89,9 @@ fn test_ensure_datalens_warmup_task_reuses_broad_selector_for_dao_address_mismat
 
     assert!(matches!(
         second,
-        DatalensWarmupEnsureOutcome::Submitted { created: false, .. }
+        DatalensWarmupEnsureOutcome::Submitted { created: true, .. }
     ));
-    assert_eq!(ensurer.created_tasks.len(), 1);
+    assert_eq!(ensurer.created_tasks.len(), 2);
 }
 
 #[test]

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -882,7 +882,7 @@ fn test_adaptive_chunk_sizer_full_hit_high_duration_can_shrink_below_full_hit_fl
 }
 
 #[test]
-fn test_adaptive_chunk_sizer_full_hit_dense_rows_do_not_shrink_by_row_count() {
+fn test_adaptive_chunk_sizer_full_hit_dense_rows_shrink_by_row_count() {
     let mut sizer = AdaptiveChunkSizer::new(adaptive_config(100, 400)).expect("sizer");
 
     let dense = sizer.record_chunk(adaptive_feedback_with_rows(
@@ -891,8 +891,8 @@ fn test_adaptive_chunk_sizer_full_hit_dense_rows_do_not_shrink_by_row_count() {
         5_000,
     ));
 
-    assert_eq!(dense.current_chunk_size, 100);
-    assert_eq!(dense.reason, AdaptiveChunkSizingReason::Hold);
+    assert_eq!(dense.current_chunk_size, 50);
+    assert_eq!(dense.reason, AdaptiveChunkSizingReason::DenseReturnedRows);
 }
 
 #[test]

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -669,6 +669,42 @@ async fn test_schema_only_migration_creates_worker_owned_task_table() -> Result<
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_schema_only_migration_creates_realtime_overlay_tables_and_scope_constraints()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_schema_migrations(&database.pool).await?;
+
+    for table_name in [
+        "degov_provisional_segment",
+        "degov_provisional_contributor_power_overlay",
+        "degov_provisional_delegate_power_overlay",
+        "degov_provisional_proposal_overlay",
+        "degov_provisional_timelock_operation_overlay",
+        "degov_provisional_vote_cast_group_overlay",
+        "degov_provisional_proposal_event_overlay",
+    ] {
+        assert_table_exists(&database.pool, &database.schema, table_name).await?;
+    }
+
+    for constraint_name in [
+        "degov_provisional_segment_scope_unique",
+        "degov_provisional_contributor_power_overlay_scope_unique",
+        "degov_provisional_delegate_power_overlay_scope_unique",
+        "degov_provisional_proposal_overlay_scope_unique",
+        "degov_provisional_timelock_operation_overlay_scope_unique",
+        "degov_provisional_vote_cast_group_overlay_scope_unique",
+        "degov_provisional_proposal_event_overlay_scope_unique",
+    ] {
+        assert_constraint_exists(&database.pool, &database.schema, constraint_name).await?;
+    }
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
 #[test]
 fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
 -> Result<(), Box<dyn Error>> {
@@ -728,6 +764,9 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("onchain_refresh_task_pending_scope_claim_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_failed_scope_retry_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_processing_scope_retry_idx"));
+    assert!(runtime_migration.contains(
+        "execute_concurrent_runtime_index(\n        connection,\n        \"onchain_refresh_deferred_candidate_scope_drain_idx\",\n        \"CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_deferred_candidate_scope_drain_idx"
+    ));
     assert!(runtime_migration.contains("contributor_onchain_refresh_coverage_scope_idx"));
     assert!(runtime_migration.contains("release_runtime_migration_lock"));
     assert!(runtime_migration.contains(
@@ -912,6 +951,35 @@ async fn assert_table_exists(
     .await?;
 
     assert!(exists, "expected table {schema}.{table_name} to exist");
+
+    Ok(())
+}
+
+async fn assert_constraint_exists(
+    pool: &PgPool,
+    schema: &str,
+    constraint_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    let exists: bool = sqlx::query_scalar(
+        r#"
+        SELECT EXISTS (
+          SELECT 1
+          FROM pg_constraint
+          JOIN pg_namespace ON pg_namespace.oid = pg_constraint.connamespace
+          WHERE pg_namespace.nspname = $1
+            AND pg_constraint.conname = $2
+        )
+        "#,
+    )
+    .bind(schema)
+    .bind(constraint_name)
+    .fetch_one(pool)
+    .await?;
+
+    assert!(
+        exists,
+        "expected constraint {schema}.{constraint_name} to exist"
+    );
 
     Ok(())
 }

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -651,6 +651,50 @@ async fn test_migration_repairs_invalid_runtime_index() -> Result<(), Box<dyn Er
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_migration_rebuilds_invalid_deferred_candidate_scope_drain_index()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    sqlx::query("DROP INDEX onchain_refresh_deferred_candidate_scope_drain_idx")
+        .execute(&database.pool)
+        .await?;
+    sqlx::query(
+        "CREATE INDEX onchain_refresh_deferred_candidate_scope_drain_idx
+         ON onchain_refresh_deferred_candidate (id)",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "UPDATE pg_index
+         SET indisvalid = false
+         WHERE indexrelid = 'onchain_refresh_deferred_candidate_scope_drain_idx'::regclass",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    apply_migrations(&database.pool).await?;
+
+    assert_index_is_valid(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_deferred_candidate_scope_drain_idx",
+    )
+    .await?;
+    assert_index_definition_contains(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_deferred_candidate_scope_drain_idx",
+        &["chain_id, contract_set_id, dao_code, next_run_at, updated_at, id"],
+    )
+    .await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_schema_only_migration_creates_worker_owned_task_table() -> Result<(), Box<dyn Error>>
 {
     let database = TestDatabase::connect().await?;


### PR DESCRIPTION
## Summary

- add a provisional realtime fast lane for newly confirmed governance events while durable indexing continues independently
- schedule realtime passes fairly with bounded global and per-chain concurrency
- start realtime processing immediately after schema safety migrations, before slower runtime maintenance
- make runtime index maintenance safe for concurrent startup and repair invalid concurrent indexes

## Root cause

Realtime indexing was blocked behind startup runtime maintenance, including a slow PostgreSQL index build. A restart could therefore delay the first realtime cycle by more than 90 seconds even though the query path was otherwise ready.

## Impact

On the `helixbox-nue` staging deployment, startup-to-first-realtime-cycle dropped from about 93.5 seconds to 4.25 seconds. A fresh Demo DAO canary measured:

- proposal: queryable 20.739 seconds after confirmation was observed
- vote: queryable 16.830 seconds after confirmation was observed

Both measurements meet the 10–30 second target.

## Validation

- `cargo test -p degov-datalens-indexer --locked --lib` — 159 passed
- `cargo test -p degov-datalens-indexer --locked --test migration_schema` with PostgreSQL 17 — 14 passed
- `cargo check -p degov-datalens-indexer --locked`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- staging GraphQL confirmed the fresh proposal and vote; indexer containers remained Ready with zero restarts

Closes #1012