### PR TITLE
fix(indexer): restore Square proposal cursor compatibility

### DIFF
--- a/apps/indexer/src/graphql/filters.rs
+++ b/apps/indexer/src/graphql/filters.rs
@@ -34,6 +34,29 @@ pub(super) fn push_proposal_filters<'a>(
     table_alias: &str,
 ) {
     push_scope_filters(query, has_condition, &where_.scope, table_alias);
+    if let Some(block_number) = &where_.block_number_eq {
+        push_numeric_column_comparison(
+            query,
+            has_condition,
+            table_alias,
+            "block_number",
+            " = ",
+            block_number,
+        );
+    }
+    if let Some(block_number) = &where_.block_number_gt {
+        push_numeric_column_comparison(
+            query,
+            has_condition,
+            table_alias,
+            "block_number",
+            " > ",
+            block_number,
+        );
+    }
+    if let Some(id) = &where_.id_gt {
+        push_column_comparison(query, has_condition, table_alias, "id", " > ", id);
+    }
     if let Some(proposal_id) = &where_.proposal_id_eq {
         push_proposal_id_eq(query, has_condition, table_alias, proposal_id);
     }
@@ -85,6 +108,26 @@ pub(super) fn push_proposal_filters<'a>(
         push_implicit_scope_filters(query, &mut nested_has_condition, implicit_scope, "v", true);
         push_vote_cast_group_filters(query, &mut nested_has_condition, voters_some, "v");
         query.push(")");
+    }
+    if let Some(timestamp) = &where_.vote_end_timestamp_gte {
+        push_millisecond_timestamp_comparison(
+            query,
+            has_condition,
+            table_alias,
+            "vote_end_timestamp",
+            " >= ",
+            timestamp,
+        );
+    }
+    if let Some(timestamp) = &where_.vote_end_timestamp_lt {
+        push_millisecond_timestamp_comparison(
+            query,
+            has_condition,
+            table_alias,
+            "vote_end_timestamp",
+            " < ",
+            timestamp,
+        );
     }
     if let Some(or) = &where_.or {
         push_or_group(query, has_condition, or, |query, has_condition, filter| {
@@ -513,6 +556,54 @@ pub(super) fn push_numeric_column_eq<'a>(
     query.push(" = ").push_bind(value).push("::numeric");
 }
 
+fn push_column_comparison<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    table_alias: &str,
+    column: &str,
+    operator: &'static str,
+    value: &'a str,
+) {
+    push_and(query, has_condition);
+    push_qualified_column(query, table_alias, column);
+    query.push(operator).push_bind(value);
+}
+
+fn push_numeric_column_comparison<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    table_alias: &str,
+    column: &str,
+    operator: &'static str,
+    value: &'a str,
+) {
+    push_and(query, has_condition);
+    push_qualified_column(query, table_alias, column);
+    query.push(operator).push_bind(value).push("::numeric");
+}
+
+fn push_millisecond_timestamp_comparison<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    table_alias: &str,
+    column: &str,
+    operator: &'static str,
+    value: &'a str,
+) {
+    push_and(query, has_condition);
+    query.push("(CASE WHEN ");
+    push_qualified_column(query, table_alias, column);
+    query.push(" < 1000000000000 THEN ");
+    push_qualified_column(query, table_alias, column);
+    query.push(" * 1000 ELSE ");
+    push_qualified_column(query, table_alias, column);
+    query
+        .push(" END)")
+        .push(operator)
+        .push_bind(value)
+        .push("::numeric");
+}
+
 fn push_proposal_id_eq<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
     has_condition: &mut bool,
@@ -560,5 +651,35 @@ pub(super) fn push_and(query: &mut QueryBuilder<'_, Postgres>, has_condition: &m
         query.push(" AND ");
     } else {
         *has_condition = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_proposal_where_binds_numeric_cursor_values() {
+        let untrusted_value = "800) OR TRUE --";
+        let where_ = ProposalWhereInput {
+            block_number_eq: Some(untrusted_value.to_owned()),
+            block_number_gt: Some("799".to_owned()),
+            id_gt: Some("proposal:cursor".to_owned()),
+            vote_end_timestamp_gte: Some("1700002000000".to_owned()),
+            vote_end_timestamp_lt: Some("1700002400000".to_owned()),
+            ..ProposalWhereInput::default()
+        };
+        let mut query = QueryBuilder::<Postgres>::new("SELECT * FROM proposal");
+        let scope = GraphqlScope::default();
+
+        push_proposal_where(&mut query, &scope, Some(&where_));
+
+        let sql = query.sql();
+        assert!(!sql.contains(untrusted_value));
+        assert!(sql.contains("proposal.block_number = $1::numeric"));
+        assert!(sql.contains("proposal.block_number > $2::numeric"));
+        assert!(sql.contains("proposal.id > $3"));
+        assert!(sql.contains("proposal.vote_end_timestamp") && sql.contains(">= $4::numeric"));
+        assert!(sql.contains("proposal.vote_end_timestamp") && sql.contains("< $5::numeric"));
     }
 }

--- a/apps/indexer/src/graphql/filters.rs
+++ b/apps/indexer/src/graphql/filters.rs
@@ -154,6 +154,9 @@ pub(super) fn push_vote_cast_group_filters<'a>(
     where_: &'a VoteCastGroupWhereInput,
     table_alias: &str,
 ) {
+    if let Some(id) = &where_.id_eq {
+        push_column_eq(query, has_condition, table_alias, "id", id);
+    }
     if let Some(voter) = &where_.voter_eq {
         push_column_eq(query, has_condition, table_alias, "voter", voter);
     }
@@ -686,5 +689,21 @@ mod tests {
             sql.contains("proposal.vote_end_timestamp") && sql.contains(">= $4::numeric(78,0)")
         );
         assert!(sql.contains("proposal.vote_end_timestamp") && sql.contains("< $5::numeric(78,0)"));
+    }
+
+    #[test]
+    fn test_push_vote_cast_group_filters_binds_id() {
+        let untrusted_id = "vote:101:2') OR TRUE --";
+        let where_ = VoteCastGroupWhereInput {
+            id_eq: Some(untrusted_id.to_owned()),
+            ..VoteCastGroupWhereInput::default()
+        };
+        let mut query = QueryBuilder::<Postgres>::new("SELECT * FROM vote_cast_group WHERE ");
+        let mut has_condition = false;
+
+        push_vote_cast_group_filters(&mut query, &mut has_condition, &where_, "vote_cast_group");
+
+        assert!(!query.sql().contains(untrusted_id));
+        assert!(query.sql().contains("vote_cast_group.id = $1"));
     }
 }

--- a/apps/indexer/src/graphql/filters.rs
+++ b/apps/indexer/src/graphql/filters.rs
@@ -579,7 +579,10 @@ fn push_numeric_column_comparison<'a>(
 ) {
     push_and(query, has_condition);
     push_qualified_column(query, table_alias, column);
-    query.push(operator).push_bind(value).push("::numeric");
+    query
+        .push(operator)
+        .push_bind(value)
+        .push("::numeric(78,0)");
 }
 
 fn push_millisecond_timestamp_comparison<'a>(
@@ -601,7 +604,7 @@ fn push_millisecond_timestamp_comparison<'a>(
         .push(" END)")
         .push(operator)
         .push_bind(value)
-        .push("::numeric");
+        .push("::numeric(78,0)");
 }
 
 fn push_proposal_id_eq<'a>(
@@ -676,10 +679,12 @@ mod tests {
 
         let sql = query.sql();
         assert!(!sql.contains(untrusted_value));
-        assert!(sql.contains("proposal.block_number = $1::numeric"));
-        assert!(sql.contains("proposal.block_number > $2::numeric"));
+        assert!(sql.contains("proposal.block_number = $1::numeric(78,0)"));
+        assert!(sql.contains("proposal.block_number > $2::numeric(78,0)"));
         assert!(sql.contains("proposal.id > $3"));
-        assert!(sql.contains("proposal.vote_end_timestamp") && sql.contains(">= $4::numeric"));
-        assert!(sql.contains("proposal.vote_end_timestamp") && sql.contains("< $5::numeric"));
+        assert!(
+            sql.contains("proposal.vote_end_timestamp") && sql.contains(">= $4::numeric(78,0)")
+        );
+        assert!(sql.contains("proposal.vote_end_timestamp") && sql.contains("< $5::numeric(78,0)"));
     }
 }

--- a/apps/indexer/src/graphql/order.rs
+++ b/apps/indexer/src/graphql/order.rs
@@ -23,6 +23,12 @@ pub(super) fn push_proposal_order(
         query,
         order_by.unwrap_or(&[ProposalOrderByInput::IdAsc]),
         |order| match order {
+            ProposalOrderByInput::BlockNumberAscNullsFirst => {
+                "proposal.block_number ASC NULLS FIRST"
+            }
+            ProposalOrderByInput::BlockTimestampAscNullsFirst => {
+                "proposal.block_timestamp ASC NULLS FIRST"
+            }
             ProposalOrderByInput::BlockTimestampDescNullsLast => {
                 "proposal.block_timestamp DESC NULLS LAST"
             }
@@ -153,5 +159,29 @@ pub(super) fn push_order<T>(
     let mut separated = query.separated(", ");
     for order in order_by {
         separated.push(to_sql(order));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_proposal_order_uses_qualified_compatibility_fragments() {
+        let mut query = QueryBuilder::<Postgres>::new("SELECT * FROM proposal");
+
+        push_proposal_order(
+            &mut query,
+            Some(&[
+                ProposalOrderByInput::BlockNumberAscNullsFirst,
+                ProposalOrderByInput::BlockTimestampAscNullsFirst,
+                ProposalOrderByInput::IdAsc,
+            ]),
+        );
+
+        assert_eq!(
+            query.sql(),
+            "SELECT * FROM proposal ORDER BY proposal.block_number ASC NULLS FIRST, proposal.block_timestamp ASC NULLS FIRST, proposal.id ASC"
+        );
     }
 }

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -6,6 +6,53 @@ use super::order::*;
 use super::pagination::push_page;
 use super::types::*;
 
+const PROPOSAL_NUMERIC_INPUT_ERROR: &str =
+    "must be a canonical non-negative base-10 integer with at most 78 digits";
+
+fn validate_proposal_where(where_: Option<&ProposalWhereInput>) -> GraphqlResult<()> {
+    let Some(where_) = where_ else {
+        return Ok(());
+    };
+
+    for (field, value) in [
+        ("blockNumber_eq", where_.block_number_eq.as_deref()),
+        ("blockNumber_gt", where_.block_number_gt.as_deref()),
+        (
+            "voteEndTimestamp_gte",
+            where_.vote_end_timestamp_gte.as_deref(),
+        ),
+        (
+            "voteEndTimestamp_lt",
+            where_.vote_end_timestamp_lt.as_deref(),
+        ),
+    ] {
+        if value.is_some_and(|value| !is_canonical_numeric_78(value)) {
+            return Err(async_graphql::Error::new(format!(
+                "ProposalWhereInput.{field} {PROPOSAL_NUMERIC_INPUT_ERROR}"
+            )));
+        }
+    }
+
+    if let Some(or) = &where_.or {
+        for filter in or {
+            validate_proposal_where(Some(filter))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn is_canonical_numeric_78(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() || bytes.len() > 78 {
+        return false;
+    }
+    if bytes == b"0" {
+        return true;
+    }
+    matches!(bytes[0], b'1'..=b'9') && bytes[1..].iter().all(u8::is_ascii_digit)
+}
+
 pub(super) async fn query_indexer_status(
     pool: &PgPool,
     implicit_scope: &GraphqlScope,
@@ -37,6 +84,7 @@ pub(super) async fn query_proposals(
     offset: Option<i32>,
     limit: Option<i32>,
 ) -> GraphqlResult<Vec<Proposal>> {
+    validate_proposal_where(where_)?;
     let mut query = QueryBuilder::<Postgres>::new(
         r#"
         SELECT id, contract_set_id, chain_id, dao_code, governor_address, proposal_id, proposer,
@@ -214,6 +262,7 @@ pub(super) async fn count_proposals(
     implicit_scope: &GraphqlScope,
     where_: Option<&ProposalWhereInput>,
 ) -> GraphqlResult<i64> {
+    validate_proposal_where(where_)?;
     let mut query = QueryBuilder::<Postgres>::new(
         r#"
         SELECT COUNT(*)::int8 AS total
@@ -1326,5 +1375,28 @@ mod tests {
         assert!(
             sql.contains("split_part(degov_indexer_checkpoint.contract_set_id, 'dataset=', 2)")
         );
+    }
+
+    #[test]
+    fn test_canonical_numeric_78_accepts_boundaries_and_rejects_other_forms() {
+        assert!(is_canonical_numeric_78("0"));
+        assert!(is_canonical_numeric_78("9223372036854775808"));
+        assert!(is_canonical_numeric_78(&"9".repeat(78)));
+
+        for invalid in [
+            "",
+            "not-a-number",
+            "NaN",
+            "1.5",
+            "1e3",
+            "-1",
+            "+1",
+            " 1",
+            "1 ",
+            "01",
+            &"9".repeat(79),
+        ] {
+            assert!(!is_canonical_numeric_78(invalid), "accepted {invalid:?}");
+        }
     }
 }

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -221,7 +221,9 @@ pub(super) async fn count_proposals(
           SELECT proposal.id, proposal.contract_set_id, proposal.chain_id,
             proposal.dao_code, proposal.governor_address, proposal.proposal_id,
             COALESCE(proposal_overlay.proposer, proposal.proposer) AS proposer,
-            COALESCE(proposal_overlay.description, proposal.description) AS description
+            COALESCE(proposal_overlay.description, proposal.description) AS description,
+            proposal.block_number,
+            COALESCE(proposal_overlay.vote_end_timestamp, proposal.vote_end_timestamp) AS vote_end_timestamp
           FROM proposal
           LEFT JOIN degov_provisional_proposal_overlay proposal_overlay
             ON proposal_overlay.contract_set_id = proposal.contract_set_id
@@ -235,7 +237,9 @@ pub(super) async fn count_proposals(
           SELECT proposal_overlay.id, proposal_overlay.contract_set_id, proposal_overlay.chain_id,
             proposal_overlay.dao_code, proposal_overlay.governor_address, proposal_overlay.proposal_id,
             COALESCE(proposal_overlay.proposer, '') AS proposer,
-            COALESCE(proposal_overlay.description, '') AS description
+            COALESCE(proposal_overlay.description, '') AS description,
+            COALESCE(proposal_overlay.block_number, proposal_overlay.anchor_block_number, 0) AS block_number,
+            COALESCE(proposal_overlay.vote_end_timestamp, 0) AS vote_end_timestamp
           FROM degov_provisional_proposal_overlay proposal_overlay
           WHERE proposal_overlay.status = 'available'
             AND proposal_overlay.source <> 'live-onchain'

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -447,6 +447,8 @@ pub struct ProposalWhereInput {
 #[derive(Clone, Debug, Default, InputObject)]
 #[graphql(rename_fields = "camelCase")]
 pub struct VoteCastGroupWhereInput {
+    #[graphql(name = "id_eq")]
+    pub(super) id_eq: Option<String>,
     #[graphql(name = "voter_eq")]
     pub(super) voter_eq: Option<String>,
     #[graphql(name = "support_eq")]

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -422,6 +422,12 @@ pub struct ScopeWhereInput {
 pub struct ProposalWhereInput {
     #[graphql(flatten)]
     pub(super) scope: ScopeWhereInput,
+    #[graphql(name = "blockNumber_eq")]
+    pub(super) block_number_eq: Option<String>,
+    #[graphql(name = "blockNumber_gt")]
+    pub(super) block_number_gt: Option<String>,
+    #[graphql(name = "id_gt")]
+    pub(super) id_gt: Option<String>,
     #[graphql(name = "proposalId_eq")]
     pub(super) proposal_id_eq: Option<String>,
     #[graphql(name = "proposer_eq")]
@@ -430,6 +436,10 @@ pub struct ProposalWhereInput {
     pub(super) description_contains_insensitive: Option<String>,
     #[graphql(name = "voters_some")]
     pub(super) voters_some: Option<VoteCastGroupWhereInput>,
+    #[graphql(name = "voteEndTimestamp_gte")]
+    pub(super) vote_end_timestamp_gte: Option<String>,
+    #[graphql(name = "voteEndTimestamp_lt")]
+    pub(super) vote_end_timestamp_lt: Option<String>,
     #[graphql(name = "OR")]
     pub(super) or: Option<Vec<ProposalWhereInput>>,
 }
@@ -552,6 +562,10 @@ pub struct DelegateMappingWhereInput {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Enum)]
 #[graphql(rename_items = "camelCase")]
 pub enum ProposalOrderByInput {
+    #[graphql(name = "blockNumber_ASC_NULLS_FIRST")]
+    BlockNumberAscNullsFirst,
+    #[graphql(name = "blockTimestamp_ASC_NULLS_FIRST")]
+    BlockTimestampAscNullsFirst,
     #[graphql(name = "blockTimestamp_DESC_NULLS_LAST")]
     BlockTimestampDescNullsLast,
     #[graphql(name = "id_ASC")]

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -909,6 +909,121 @@ async fn test_graphql_proposal_fields_prefer_provisional_overlay_and_fallback_to
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_proposal_cursor_filters_and_ascending_orders() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    sqlx::query(
+        "UPDATE proposal
+         SET block_number = 800, vote_end_timestamp = 1700002100
+         WHERE id = 'proposal:1135:0xgovernor:102'",
+    )
+    .execute(&database.pool)
+    .await?;
+    seed_provisional_only_proposal_overlay(&database.pool).await?;
+    let schema = graphql::build_schema(database.pool.clone());
+
+    let request = Request::new(
+        r#"
+            query ProposalCursorCompatibility(
+              $sameBlock: ProposalWhereInput
+              $incremental: ProposalWhereInput
+              $window: ProposalWhereInput
+              $page: ProposalWhereInput
+              $beyondInt: ProposalWhereInput
+            ) {
+              sameBlock: proposals(
+                where: $sameBlock
+                orderBy: [blockNumber_ASC_NULLS_FIRST, id_ASC]
+              ) {
+                id
+                blockNumber
+              }
+              incremental: proposals(
+                where: $incremental
+                orderBy: [blockNumber_ASC_NULLS_FIRST, id_ASC]
+              ) {
+                id
+                blockNumber
+              }
+              window: proposals(
+                where: $window
+                orderBy: [blockTimestamp_ASC_NULLS_FIRST, id_ASC]
+              ) {
+                id
+                blockTimestamp
+                voteEndTimestamp
+              }
+              byTimestamp: proposals(
+                orderBy: [blockTimestamp_ASC_NULLS_FIRST, id_ASC]
+              ) {
+                id
+                blockTimestamp
+              }
+              page: proposalsPage(where: $page, orderBy: [id_ASC], limit: 10) {
+                totalCount
+                items { id }
+              }
+              beyondInt: proposals(where: $beyondInt) { id }
+            }
+        "#,
+    )
+    .variables(async_graphql::Variables::from_json(json!({
+        "sameBlock": {
+            "blockNumber_eq": "800",
+            "id_gt": "proposal:1135:0xgovernor:101"
+        },
+        "incremental": {
+            "OR": [
+                { "blockNumber_gt": "800" },
+                {
+                    "blockNumber_eq": "800",
+                    "id_gt": "proposal:1135:0xgovernor:101"
+                }
+            ]
+        },
+        "window": {
+            "voteEndTimestamp_gte": "1700002000000",
+            "voteEndTimestamp_lt": "1700002400000"
+        },
+        "page": {
+            "blockNumber_gt": "800",
+            "voteEndTimestamp_gte": "1700002400000",
+            "voteEndTimestamp_lt": "1700002400001"
+        },
+        "beyondInt": { "blockNumber_gt": "9223372036854775808" }
+    })));
+    let response = schema.execute(request).await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+
+    let data = response.data.into_json()?;
+    assert_eq!(data["sameBlock"][0]["id"], "proposal:1135:0xgovernor:102");
+    assert_eq!(data["sameBlock"][0]["blockNumber"], "800");
+    assert_eq!(
+        data["sameBlock"].as_array().expect("same block rows").len(),
+        1
+    );
+    assert_eq!(data["incremental"][0]["id"], "proposal:1135:0xgovernor:102");
+    assert_eq!(data["incremental"][1]["id"], "overlay:proposal:999");
+    assert_eq!(data["window"][0]["id"], "proposal:1135:0xgovernor:101");
+    assert_eq!(data["window"][1]["id"], "proposal:1135:0xgovernor:102");
+    assert_eq!(data["window"].as_array().expect("window rows").len(), 2);
+    assert_eq!(data["byTimestamp"][0]["id"], "proposal:1135:0xgovernor:101");
+    assert_eq!(data["byTimestamp"][1]["id"], "proposal:1135:0xgovernor:102");
+    assert_eq!(data["byTimestamp"][2]["id"], "overlay:proposal:999");
+    assert_eq!(data["page"]["totalCount"], 1);
+    assert_eq!(data["page"]["items"][0]["id"], "overlay:proposal:999");
+    assert_eq!(data["beyondInt"].as_array().expect("bigint rows").len(), 0);
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_schema_applies_implicit_scope_to_queries_and_pages()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -322,6 +322,68 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_nested_voters_filter_by_exact_punctuated_id() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let schema = graphql::build_schema_with_scope(
+        database.pool.clone(),
+        graphql::GraphqlScope {
+            dao_code: Some("lisk-dao".to_owned()),
+            chain_id: Some(1135),
+            governor_address: Some("0xgovernor".to_owned()),
+            contract_set_id: Some(CONTRACT_SET_ID.to_owned()),
+        },
+    );
+
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query NestedVoteIdFilter {
+              proposals(where: { proposalId_eq: "101" }) {
+                exact: voters(where: { id_eq: "vote:101:2" }) {
+                  id
+                  voter
+                  support
+                }
+                recursive: voters(
+                  where: {
+                    OR: [
+                      { id_eq: "vote:missing" }
+                      { id_eq: "vote:101:2", voter_eq: "0xvoter2", support_eq: 0 }
+                    ]
+                  }
+                ) {
+                  id
+                }
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+    let data = response.data.into_json()?;
+    assert_eq!(data["proposals"][0]["exact"][0]["id"], "vote:101:2");
+    assert_eq!(data["proposals"][0]["exact"][0]["voter"], "0xvoter2");
+    assert_eq!(data["proposals"][0]["exact"][0]["support"], 0);
+    assert_eq!(
+        data["proposals"][0]["exact"]
+            .as_array()
+            .expect("exact voters")
+            .len(),
+        1
+    );
+    assert_eq!(data["proposals"][0]["recursive"][0]["id"], "vote:101:2");
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_schema_rejects_removed_connection_fields() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     let schema = graphql::build_schema(database.pool.clone());

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -929,6 +929,8 @@ async fn test_graphql_proposal_cursor_filters_and_ascending_orders() -> Result<(
               $window: ProposalWhereInput
               $page: ProposalWhereInput
               $beyondInt: ProposalWhereInput
+              $zero: ProposalWhereInput
+              $maxNumeric: ProposalWhereInput
             ) {
               sameBlock: proposals(
                 where: $sameBlock
@@ -963,6 +965,8 @@ async fn test_graphql_proposal_cursor_filters_and_ascending_orders() -> Result<(
                 items { id }
               }
               beyondInt: proposals(where: $beyondInt) { id }
+              zero: proposals(where: $zero) { id }
+              maxNumeric: proposals(where: $maxNumeric) { id }
             }
         "#,
     )
@@ -989,7 +993,9 @@ async fn test_graphql_proposal_cursor_filters_and_ascending_orders() -> Result<(
             "voteEndTimestamp_gte": "1700002400000",
             "voteEndTimestamp_lt": "1700002400001"
         },
-        "beyondInt": { "blockNumber_gt": "9223372036854775808" }
+        "beyondInt": { "blockNumber_gt": "9223372036854775808" },
+        "zero": { "blockNumber_eq": "0" },
+        "maxNumeric": { "blockNumber_gt": "9".repeat(78) }
     })));
     let response = schema.execute(request).await;
 
@@ -1017,8 +1023,128 @@ async fn test_graphql_proposal_cursor_filters_and_ascending_orders() -> Result<(
     assert_eq!(data["page"]["totalCount"], 1);
     assert_eq!(data["page"]["items"][0]["id"], "overlay:proposal:999");
     assert_eq!(data["beyondInt"].as_array().expect("bigint rows").len(), 0);
+    assert_eq!(data["zero"].as_array().expect("zero rows").len(), 0);
+    assert_eq!(
+        data["maxNumeric"]
+            .as_array()
+            .expect("max numeric rows")
+            .len(),
+        0
+    );
 
     database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_proposal_numeric_filters_reject_noncanonical_values_before_sql()
+-> Result<(), Box<dyn Error>> {
+    let pool = PgPoolOptions::new()
+        .acquire_timeout(Duration::from_millis(100))
+        .connect_lazy("postgres://127.0.0.1:1/degov")?;
+    let schema = graphql::build_schema(pool);
+    let invalid_values = [
+        ("blockNumber_eq", ""),
+        ("blockNumber_eq", "not-a-number"),
+        ("blockNumber_gt", "NaN"),
+        ("blockNumber_gt", "1.5"),
+        ("voteEndTimestamp_gte", "1e3"),
+        ("voteEndTimestamp_lt", "-1"),
+        ("voteEndTimestamp_gte", " 1"),
+        ("voteEndTimestamp_lt", "01"),
+    ];
+
+    for (field, value) in invalid_values {
+        let mut where_value = serde_json::Map::new();
+        where_value.insert(field.to_owned(), json!(value));
+        let response = schema
+            .execute(
+                Request::new(
+                    r#"
+                    query InvalidProposalNumeric($where: ProposalWhereInput) {
+                      proposals(where: $where) { id }
+                    }
+                    "#,
+                )
+                .variables(async_graphql::Variables::from_json(json!({
+                    "where": where_value
+                }))),
+            )
+            .await;
+
+        assert_eq!(response.errors.len(), 1, "field {field}, value {value:?}");
+        assert!(
+            response.errors[0]
+                .message
+                .contains(&format!("ProposalWhereInput.{field}")),
+            "unexpected error for field {field}, value {value:?}: {:?}",
+            response.errors
+        );
+        assert!(
+            response.errors[0]
+                .message
+                .contains("canonical non-negative base-10 integer with at most 78 digits"),
+            "unexpected error for field {field}, value {value:?}: {:?}",
+            response.errors
+        );
+    }
+
+    let response = schema
+        .execute(
+            Request::new(
+                r#"
+                query InvalidProposalNumeric($where: ProposalWhereInput) {
+                  proposals(where: $where) { id }
+                }
+                "#,
+            )
+            .variables(async_graphql::Variables::from_json(json!({
+                "where": { "blockNumber_gt": "9".repeat(79) }
+            }))),
+        )
+        .await;
+    assert_eq!(response.errors.len(), 1);
+    assert!(
+        response.errors[0]
+            .message
+            .contains("ProposalWhereInput.blockNumber_gt"),
+        "unexpected error: {:?}",
+        response.errors
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_proposals_page_rejects_recursive_invalid_numeric_before_count_sql()
+-> Result<(), Box<dyn Error>> {
+    let pool = PgPoolOptions::new()
+        .acquire_timeout(Duration::from_millis(100))
+        .connect_lazy("postgres://127.0.0.1:1/degov")?;
+    let schema = graphql::build_schema(pool);
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query InvalidProposalPageNumeric {
+              proposalsPage(
+                where: { OR: [{ blockNumber_gt: "800" }, { voteEndTimestamp_lt: "NaN" }] }
+              ) {
+                totalCount
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert_eq!(response.errors.len(), 1);
+    assert!(
+        response.errors[0]
+            .message
+            .contains("ProposalWhereInput.voteEndTimestamp_lt"),
+        "unexpected error: {:?}",
+        response.errors
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- restore bounded proposal cursor filters and deterministic block/id ordering required by DeGov Square
- validate numeric cursor and timestamp inputs before binding them as PostgreSQL numeric values
- add the nested voter ID filter needed for exact vote lookup without restoring the removed top-level vote query

## Root cause

Square proposal, vote-end, and vote tracking queries still depend on provider-side cursor/filter contracts that were removed during the Datalens schema migration. Production jobs therefore fail GraphQL validation and cannot advance their cursors.

## Validation

- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://datalens:datalens@127.0.0.1:55439/datalens_test cargo test --locked -p degov-datalens-indexer`
- `cargo build --locked -p degov-datalens-indexer`
- Rust convention checks and compatibility preflight tests
- `cargo fmt --all --check`

Provider half of #1011. The Square consumer update will be deployed only after this schema is live.