### PR TITLE
fix(web): distinguish quorum from participation

### DIFF
--- a/apps/web/messages/en/proposal-detail.json
+++ b/apps/web/messages/en/proposal-detail.json
@@ -40,11 +40,12 @@
   },
   "currentVotes": {
     "title": "Current Votes",
-    "quorum": "Quorum",
+    "quorumProgress": "Quorum progress",
+    "totalParticipation": "Total participation",
     "majoritySupport": "Majority support",
     "yes": "Yes",
     "no": "No",
-    "participation": "{current} of {required}"
+    "quorumParticipation": "{current} of {required}"
   },
   "status": {
     "title": "Status",

--- a/apps/web/scripts/proposal-quorum-progress.test.ts
+++ b/apps/web/scripts/proposal-quorum-progress.test.ts
@@ -101,13 +101,13 @@ test("proposal vote summary distinguishes quorum progress from total participati
     )
   );
 
-  assert.equal(
+  assert.equal(typeof messages.currentVotes.quorumProgress, "string");
+  assert.ok(messages.currentVotes.quorumProgress.length > 0);
+  assert.equal(typeof messages.currentVotes.totalParticipation, "string");
+  assert.ok(messages.currentVotes.totalParticipation.length > 0);
+  assert.notEqual(
     messages.currentVotes.quorumProgress,
-    "Quorum progress"
-  );
-  assert.equal(
-    messages.currentVotes.totalParticipation,
-    "Total participation"
+    messages.currentVotes.totalParticipation
   );
   assert.match(currentVotesSource, /t\("quorumProgress"\)/);
   assert.match(currentVotesSource, /t\("totalParticipation"\)/);

--- a/apps/web/scripts/proposal-quorum-progress.test.ts
+++ b/apps/web/scripts/proposal-quorum-progress.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { getProposalQuorumProgress } from "../src/app/proposal/[id]/current-votes-calculation.ts";
@@ -27,4 +28,88 @@ test("proposal quorum progress counts against votes only when counting mode incl
 
   assert.equal(progress.currentVotes, 35n);
   assert.equal(progress.hasReachedQuorum, true);
+});
+
+test("proposal total participation counts every vote bucket", () => {
+  const progress = getProposalQuorumProgress({
+    forVotes: 10n,
+    againstVotes: 20n,
+    abstainVotes: 5n,
+    quorumRequired: 15n,
+    countingMode: "support=bravo&quorum=for,abstain",
+  });
+
+  assert.equal(progress.totalVotesCast, 35n);
+});
+
+test("proposal quorum progress uses the compatibility fallback without a counting mode", () => {
+  const progress = getProposalQuorumProgress({
+    forVotes: 10n,
+    againstVotes: 20n,
+    abstainVotes: 5n,
+    quorumRequired: 15n,
+  });
+
+  assert.equal(progress.currentVotes, 15n);
+});
+
+test("proposal quorum progress uses the compatibility fallback for a malformed counting mode", () => {
+  const progress = getProposalQuorumProgress({
+    forVotes: 10n,
+    againstVotes: 20n,
+    abstainVotes: 5n,
+    quorumRequired: 15n,
+    countingMode: "support=bravo&quorum=unknown",
+  });
+
+  assert.equal(progress.currentVotes, 15n);
+});
+
+test("proposal quorum progress rejects empty counting mode buckets", () => {
+  const progress = getProposalQuorumProgress({
+    forVotes: 10n,
+    againstVotes: 20n,
+    abstainVotes: 5n,
+    quorumRequired: 15n,
+    countingMode: "support=bravo&quorum=for,,against",
+  });
+
+  assert.equal(progress.currentVotes, 15n);
+});
+
+test("proposal quorum progress rejects duplicate counting mode buckets", () => {
+  const progress = getProposalQuorumProgress({
+    forVotes: 10n,
+    againstVotes: 20n,
+    abstainVotes: 5n,
+    quorumRequired: 15n,
+    countingMode: "support=bravo&quorum=for,for",
+  });
+
+  assert.equal(progress.currentVotes, 15n);
+});
+
+test("proposal vote summary distinguishes quorum progress from total participation", () => {
+  const currentVotesSource = readFileSync(
+    new URL("../src/app/proposal/[id]/current-votes.tsx", import.meta.url),
+    "utf8"
+  );
+  const messages = JSON.parse(
+    readFileSync(
+      new URL("../messages/en/proposal-detail.json", import.meta.url),
+      "utf8"
+    )
+  );
+
+  assert.equal(
+    messages.currentVotes.quorumProgress,
+    "Quorum progress"
+  );
+  assert.equal(
+    messages.currentVotes.totalParticipation,
+    "Total participation"
+  );
+  assert.match(currentVotesSource, /t\("quorumProgress"\)/);
+  assert.match(currentVotesSource, /t\("totalParticipation"\)/);
+  assert.match(currentVotesSource, /formatTokenAmount\(totalVotesCast\)/);
 });

--- a/apps/web/src/app/proposal/[id]/current-votes-calculation.ts
+++ b/apps/web/src/app/proposal/[id]/current-votes-calculation.ts
@@ -22,10 +22,11 @@ const parseQuorumBuckets = (countingMode?: string | null) => {
     .map((bucket) => bucket.trim().toLowerCase());
 
   if (
-    quorumBuckets.length === 0 ||
     new Set(quorumBuckets).size !== quorumBuckets.length ||
     quorumBuckets.some(
-      (bucket) => !["for", "against", "abstain"].includes(bucket)
+      (bucket) =>
+        bucket.length === 0 ||
+        !["for", "against", "abstain"].includes(bucket)
     )
   ) {
     return fallbackBuckets;

--- a/apps/web/src/app/proposal/[id]/current-votes-calculation.ts
+++ b/apps/web/src/app/proposal/[id]/current-votes-calculation.ts
@@ -16,11 +16,22 @@ const parseQuorumBuckets = (countingMode?: string | null) => {
     return fallbackBuckets;
   }
 
-  return quorumConfig
+  const quorumBuckets = quorumConfig
     .slice("quorum=".length)
     .split(",")
-    .map((bucket) => bucket.trim().toLowerCase())
-    .filter(Boolean);
+    .map((bucket) => bucket.trim().toLowerCase());
+
+  if (
+    quorumBuckets.length === 0 ||
+    new Set(quorumBuckets).size !== quorumBuckets.length ||
+    quorumBuckets.some(
+      (bucket) => !["for", "against", "abstain"].includes(bucket)
+    )
+  ) {
+    return fallbackBuckets;
+  }
+
+  return quorumBuckets;
 };
 
 export const getProposalQuorumProgress = ({
@@ -30,6 +41,7 @@ export const getProposalQuorumProgress = ({
   quorumRequired,
   countingMode,
 }: ProposalQuorumProgressInput) => {
+  const totalVotesCast = againstVotes + forVotes + abstainVotes;
   const quorumBuckets = parseQuorumBuckets(countingMode);
   const currentVotes = quorumBuckets.reduce((total, bucket) => {
     if (bucket === "for") return total + forVotes;
@@ -40,5 +52,5 @@ export const getProposalQuorumProgress = ({
   const hasReachedQuorum =
     quorumRequired === 0n ? false : currentVotes >= quorumRequired;
 
-  return { currentVotes, hasReachedQuorum };
+  return { currentVotes, hasReachedQuorum, totalVotesCast };
 };

--- a/apps/web/src/app/proposal/[id]/current-votes.tsx
+++ b/apps/web/src/app/proposal/[id]/current-votes.tsx
@@ -21,9 +21,18 @@ const CurrentVotesSkeleton = () => {
         <div className="flex items-center justify-between gap-[10px]">
           <div className="flex items-center gap-[5px]">
             <Skeleton className="h-[20px] w-[20px] rounded-full" />
-            <span className="text-[14px] font-normal">{t("quorum")}</span>
+            <span className="text-[14px] font-normal">
+              {t("quorumProgress")}
+            </span>
           </div>
           <Skeleton className="h-[18px] w-[120px]" />
+        </div>
+
+        <div className="flex items-center justify-between gap-[10px]">
+          <span className="text-[14px] font-normal">
+            {t("totalParticipation")}
+          </span>
+          <Skeleton className="h-[18px] w-[80px]" />
         </div>
 
         <div className="flex flex-col gap-[10px]">
@@ -92,16 +101,7 @@ export const CurrentVotes = ({
   const voteLabels = useTranslations("proposals.voteLabels");
   const formatTokenAmount = useFormatGovernanceTokenAmount();
 
-  const totalVotesCast = useMemo(() => {
-    const totalVotesCast =
-      proposalVotesData.againstVotes +
-      proposalVotesData.forVotes +
-      proposalVotesData.abstainVotes;
-
-    return totalVotesCast;
-  }, [proposalVotesData]);
-
-  const { currentVotes, hasReachedQuorum } = useMemo(
+  const { currentVotes, hasReachedQuorum, totalVotesCast } = useMemo(
     () =>
       getProposalQuorumProgress({
         ...proposalVotesData,
@@ -153,14 +153,23 @@ export const CurrentVotes = ({
                 className="rounded-full text-current"
               />
             )}
-            <span className="text-[14px] font-normal">{t("quorum")}</span>
+            <span className="text-[14px] font-normal">
+              {t("quorumProgress")}
+            </span>
           </div>
           <span className="flex items-center gap-[5px]">
-            {t("participation", {
+            {t("quorumParticipation", {
               current: formatTokenAmount(currentVotes).formatted,
               required: formatTokenAmount(quorumRequired).formatted,
             })}
           </span>
+        </div>
+
+        <div className="flex items-center justify-between gap-[10px]">
+          <span className="text-[14px] font-normal">
+            {t("totalParticipation")}
+          </span>
+          <span>{formatTokenAmount(totalVotesCast).formatted}</span>
         </div>
 
         <div className="flex flex-col gap-[10px]">


### PR DESCRIPTION
## Summary

- keep quorum progress aligned with each Governor contract's declared `COUNTING_MODE`
- add a separate `Total participation` value that always sums for, against, and abstain votes
- rename the quorum row to `Quorum progress` and retain the established for+abstain fallback for absent or malformed counting modes
- reject empty, duplicate, and unknown quorum buckets instead of producing misleading totals

## Why

Issue #992 conflates two valid but different metrics: contract-defined quorum contribution and all-bucket voter participation. Unconditionally adding against votes can disagree with the on-chain Governor result when `COUNTING_MODE` declares `quorum=for,abstain`.

## Validation

- strict TDD with expected RED failures
- focused quorum tests: 8/8
- `pnpm run test:web-scripts`: 78/78
- changed-file ESLint
- `pnpm --dir apps/web exec tsc --noEmit`
- `pnpm --dir apps/web run build`
- spec review: approved
- code-quality review: approved

Fixes #992.