### PR TITLE
chore(release): bump version to 3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "degov-datalens-indexer"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["apps/indexer"]
 resolver = "3"
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@degov/web",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "scripts": {
     "postinstall": "prisma generate",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "degov",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "packageManager": "pnpm@10.32.1",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump the DeGov workspace, indexer package lock entry, and web package versions to 3.0.1 for the production release containing #1014 and #1015.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `pnpm install --filter @degov/web... --frozen-lockfile`
- `pnpm run test:web-scripts`: 78/78
- `git diff --check`