### PR TITLE
perf(indexer): materialize delegate profile counts

### DIFF
--- a/apps/indexer/migrations/0011_delegate_profile_materialization.sql
+++ b/apps/indexer/migrations/0011_delegate_profile_materialization.sql
@@ -1,0 +1,16 @@
+ALTER TABLE data_metric
+  ADD COLUMN IF NOT EXISTS delegate_profiles_count INTEGER;
+
+CREATE TABLE IF NOT EXISTS delegate_profile (
+  chain_id INTEGER NOT NULL,
+  dao_code TEXT NOT NULL,
+  governor_address TEXT NOT NULL,
+  delegate TEXT NOT NULL,
+  PRIMARY KEY (chain_id, dao_code, governor_address, delegate),
+  CONSTRAINT delegate_profile_governor_address_normalized
+    CHECK (governor_address = lower(governor_address)),
+  CONSTRAINT delegate_profile_delegate_normalized
+    CHECK (delegate = lower(delegate)),
+  CONSTRAINT delegate_profile_delegate_nonzero
+    CHECK (delegate <> '0x0000000000000000000000000000000000000000')
+);

--- a/apps/indexer/reference/schema.graphql
+++ b/apps/indexer/reference/schema.graphql
@@ -618,6 +618,7 @@ type DataMetric @entity @index(fields: ["chainId", "governorAddress", "daoCode"]
   contributorCount: Int
   holdersCount: Int
   memberCount: Int
+  delegateProfilesCount: Int
 }
 
 

--- a/apps/indexer/src/delegate_profile.rs
+++ b/apps/indexer/src/delegate_profile.rs
@@ -1,0 +1,33 @@
+use sqlx::{Postgres, Transaction};
+
+pub(crate) const ZERO_DELEGATE_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+
+pub fn delegate_profile_scope_lock_key(
+    chain_id: i32,
+    dao_code: &str,
+    governor_address: &str,
+) -> String {
+    format!(
+        "degov_delegate_profile:{}:{}:{}",
+        chain_id,
+        dao_code,
+        governor_address.to_lowercase()
+    )
+}
+
+pub(crate) async fn acquire_delegate_profile_scope_lock(
+    transaction: &mut Transaction<'_, Postgres>,
+    chain_id: i32,
+    dao_code: &str,
+    governor_address: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(delegate_profile_scope_lock_key(
+            chain_id,
+            dao_code,
+            governor_address,
+        ))
+        .execute(&mut **transaction)
+        .await?;
+    Ok(())
+}

--- a/apps/indexer/src/graphql/filters.rs
+++ b/apps/indexer/src/graphql/filters.rs
@@ -362,6 +362,123 @@ pub(super) fn push_delegate_where<'a>(
     }
 }
 
+pub(super) fn push_delegate_profile_where<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    implicit_scope: &'a GraphqlScope,
+    where_: Option<&'a DelegateWhereInput>,
+) {
+    if !implicit_scope.is_empty() || where_.is_some() {
+        query.push(" WHERE ");
+        let mut has_condition = false;
+        push_delegate_profile_implicit_scope_filters(query, &mut has_condition, implicit_scope, "");
+        if let Some(where_) = where_ {
+            push_delegate_profile_filters(query, &mut has_condition, where_, "");
+        }
+        if !has_condition {
+            query.push("TRUE");
+        }
+    }
+}
+
+fn push_delegate_profile_implicit_scope_filters<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    scope: &'a GraphqlScope,
+    table_alias: &str,
+) {
+    if let Some(chain_id) = scope.chain_id {
+        push_column_eq(query, has_condition, table_alias, "chain_id", chain_id);
+    }
+    if let Some(governor_address) = &scope.governor_address {
+        push_normalized_address_eq(
+            query,
+            has_condition,
+            table_alias,
+            "governor_address",
+            governor_address,
+        );
+    }
+    if let Some(dao_code) = &scope.dao_code {
+        push_column_eq(query, has_condition, table_alias, "dao_code", dao_code);
+    }
+    if let Some(contract_set_id) = &scope.contract_set_id {
+        push_column_eq(
+            query,
+            has_condition,
+            table_alias,
+            "contract_set_id",
+            contract_set_id,
+        );
+    }
+}
+
+fn push_delegate_profile_filters<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    where_: &'a DelegateWhereInput,
+    table_alias: &str,
+) {
+    if let Some(chain_id) = where_.scope.chain_id_eq {
+        push_column_eq(query, has_condition, table_alias, "chain_id", chain_id);
+    }
+    if let Some(governor_address) = &where_.scope.governor_address_eq {
+        push_normalized_address_eq(
+            query,
+            has_condition,
+            table_alias,
+            "governor_address",
+            governor_address,
+        );
+    }
+    if let Some(dao_code) = &where_.scope.dao_code_eq {
+        push_column_eq(query, has_condition, table_alias, "dao_code", dao_code);
+    }
+    if let Some(from_delegate) = &where_.from_delegate_eq {
+        push_column_eq(
+            query,
+            has_condition,
+            table_alias,
+            "from_delegate",
+            from_delegate,
+        );
+    }
+    if let Some(to_delegate) = &where_.to_delegate_eq {
+        push_column_eq(
+            query,
+            has_condition,
+            table_alias,
+            "to_delegate",
+            to_delegate,
+        );
+    }
+    if let Some(is_current) = where_.is_current_eq {
+        push_column_eq(query, has_condition, table_alias, "is_current", is_current);
+    }
+    if let Some(power) = where_.power_lt {
+        push_and(query, has_condition);
+        push_qualified_column(query, table_alias, "power");
+        query.push(" < ").push_bind(power).push("::numeric");
+    }
+    if let Some(or) = &where_.or {
+        push_or_group(query, has_condition, or, |query, has_condition, filter| {
+            push_delegate_profile_filters(query, has_condition, filter, table_alias);
+        });
+    }
+}
+
+fn push_normalized_address_eq<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    table_alias: &str,
+    column: &str,
+    value: &'a str,
+) {
+    push_and(query, has_condition);
+    query.push("lower(");
+    push_qualified_column(query, table_alias, column);
+    query.push(") = lower(").push_bind(value).push(")");
+}
+
 pub(super) fn push_delegate_filters<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
     has_condition: &mut bool,

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -1312,7 +1312,7 @@ async fn count_realtime_delegate_profiles(
         ) delegate
         "#,
     );
-    push_delegate_where(&mut query, implicit_scope, where_);
+    push_delegate_profile_where(&mut query, implicit_scope, where_);
     if !implicit_scope.is_empty() || where_.is_some() {
         query.push(" AND ");
     } else {
@@ -1376,7 +1376,7 @@ fn materialized_delegate_profile_scope<'a>(
         || implicit_scope
             .governor_address
             .as_deref()
-            .is_some_and(|implicit| implicit != governor_address)
+            .is_some_and(|implicit| !implicit.eq_ignore_ascii_case(governor_address))
     {
         return None;
     }
@@ -1388,50 +1388,76 @@ fn materialized_delegate_profile_scope<'a>(
     })
 }
 
+#[derive(Debug, FromRow)]
+struct MaterializedDelegateProfileStats {
+    metric_row_count: i64,
+    metric_non_null_count: i64,
+    metric_min: Option<i32>,
+    metric_max: Option<i32>,
+    provisional_delta: i64,
+}
+
+impl MaterializedDelegateProfileStats {
+    fn validated_count(&self) -> Option<i32> {
+        let materialized_count = self.metric_min?;
+        (self.metric_row_count > 0
+            && self.metric_non_null_count == self.metric_row_count
+            && self.metric_max == Some(materialized_count)
+            && materialized_count >= 0)
+            .then_some(materialized_count)
+    }
+}
+
+const MATERIALIZED_DELEGATE_PROFILES_SQL: &str = "WITH metric_stats AS (
+       SELECT COUNT(*)::int8 AS metric_row_count,
+         COUNT(delegate_profiles_count)::int8 AS metric_non_null_count,
+         MIN(delegate_profiles_count) AS metric_min,
+         MAX(delegate_profiles_count) AS metric_max
+       FROM data_metric
+       WHERE id = 'global'
+         AND chain_id = $1
+         AND dao_code = $2
+         AND lower(governor_address) = lower($3)
+     ),
+     provisional_stats AS (
+       SELECT COUNT(DISTINCT lower(delegate_overlay.delegate))::int8 AS provisional_delta
+       FROM degov_provisional_delegate_power_overlay delegate_overlay
+       WHERE delegate_overlay.status = 'available'
+         AND delegate_overlay.chain_id = $1
+         AND delegate_overlay.dao_code = $2
+         AND lower(delegate_overlay.governor_address) = lower($3)
+         AND lower(delegate_overlay.delegate) <> '0x0000000000000000000000000000000000000000'
+         AND NOT EXISTS (
+           SELECT 1
+           FROM delegate_profile durable_profile
+           WHERE durable_profile.chain_id = $1
+             AND durable_profile.dao_code = $2
+             AND durable_profile.governor_address = lower($3)
+             AND durable_profile.delegate = lower(delegate_overlay.delegate)
+         )
+     )
+     SELECT metric_stats.metric_row_count, metric_stats.metric_non_null_count,
+       metric_stats.metric_min, metric_stats.metric_max,
+       provisional_stats.provisional_delta
+     FROM metric_stats
+     CROSS JOIN provisional_stats";
+
 async fn count_materialized_delegate_profiles(
     pool: &PgPool,
     scope: DelegateProfileScope<'_>,
 ) -> GraphqlResult<Option<i64>> {
-    let materialized_count: Option<i32> = sqlx::query_scalar(
-        "SELECT MAX(delegate_profiles_count)
-         FROM data_metric
-         WHERE id = 'global'
-           AND chain_id = $1
-           AND dao_code = $2
-           AND lower(governor_address) = lower($3)",
-    )
-    .bind(scope.chain_id)
-    .bind(scope.dao_code)
-    .bind(scope.governor_address)
-    .fetch_one(pool)
-    .await?;
-    let Some(materialized_count) = materialized_count else {
+    let stats: MaterializedDelegateProfileStats =
+        sqlx::query_as(MATERIALIZED_DELEGATE_PROFILES_SQL)
+            .bind(scope.chain_id)
+            .bind(scope.dao_code)
+            .bind(scope.governor_address)
+            .fetch_one(pool)
+            .await?;
+    let Some(materialized_count) = stats.validated_count() else {
         return Ok(None);
     };
 
-    let provisional_delta: i64 = sqlx::query_scalar(
-        "SELECT COUNT(DISTINCT lower(delegate_overlay.delegate))::int8
-         FROM degov_provisional_delegate_power_overlay delegate_overlay
-         WHERE delegate_overlay.status = 'available'
-           AND delegate_overlay.chain_id = $1
-           AND delegate_overlay.dao_code = $2
-           AND lower(delegate_overlay.governor_address) = lower($3)
-           AND lower(delegate_overlay.delegate) <> '0x0000000000000000000000000000000000000000'
-           AND NOT EXISTS (
-             SELECT 1
-             FROM delegate_profile durable_profile
-             WHERE durable_profile.chain_id = $1
-               AND durable_profile.dao_code = $2
-               AND durable_profile.governor_address = lower($3)
-               AND durable_profile.delegate = lower(delegate_overlay.delegate)
-           )",
-    )
-    .bind(scope.chain_id)
-    .bind(scope.dao_code)
-    .bind(scope.governor_address)
-    .fetch_one(pool)
-    .await?;
-    let provisional_delta = i32::try_from(provisional_delta).map_err(|_| {
+    let provisional_delta = i32::try_from(stats.provisional_delta).map_err(|_| {
         async_graphql::Error::new("delegateProfilesCount provisional delta exceeds GraphQL Int")
     })?;
     let total = materialized_count
@@ -1497,6 +1523,43 @@ pub(super) async fn count_delegate_mappings(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_materialized_delegate_profile_sql_is_one_snapshot_without_durable_delegate_scan() {
+        let normalized = MATERIALIZED_DELEGATE_PROFILES_SQL
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_ascii_lowercase();
+
+        assert!(!normalized.contains(';'));
+        assert!(normalized.contains("with metric_stats as"));
+        assert!(normalized.contains("provisional_stats as"));
+        assert!(normalized.contains("delegate_overlay.status = 'available'"));
+        assert!(!normalized.contains(" from delegate "));
+        assert!(!normalized.contains(" join delegate "));
+        assert!(!normalized.contains("count(distinct lower(to_delegate))"));
+    }
+
+    #[test]
+    fn test_materialized_delegate_profile_stats_fail_closed() {
+        let stats = |metric_row_count, metric_non_null_count, metric_min, metric_max| {
+            MaterializedDelegateProfileStats {
+                metric_row_count,
+                metric_non_null_count,
+                metric_min,
+                metric_max,
+                provisional_delta: 0,
+            }
+        };
+
+        assert_eq!(stats(0, 0, None, None).validated_count(), None);
+        assert_eq!(stats(2, 0, None, None).validated_count(), None);
+        assert_eq!(stats(2, 1, Some(7), Some(7)).validated_count(), None);
+        assert_eq!(stats(2, 2, Some(4), Some(7)).validated_count(), None);
+        assert_eq!(stats(2, 2, Some(-1), Some(-1)).validated_count(), None);
+        assert_eq!(stats(2, 2, Some(7), Some(7)).validated_count(), Some(7));
+    }
 
     #[test]
     fn test_indexer_status_provisional_height_matches_contract_dataset_key() {

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -451,7 +451,8 @@ pub(super) async fn query_data_metrics(
           power_sum::text AS power_sum,
           COALESCE(contributor_count, member_count) AS contributor_count,
           COALESCE(holders_count, member_count) AS holders_count,
-          COALESCE(member_count, holders_count, contributor_count) AS member_count
+          COALESCE(member_count, holders_count, contributor_count) AS member_count,
+          delegate_profiles_count
         FROM (
           SELECT data_metric.id, data_metric.contract_set_id, data_metric.chain_id,
             data_metric.dao_code, data_metric.governor_address, data_metric.token_address,
@@ -493,7 +494,7 @@ pub(super) async fn query_data_metrics(
               ELSE data_metric.votes_weight_abstain_sum
             END AS votes_weight_abstain_sum,
             data_metric.power_sum, data_metric.contributor_count, data_metric.holders_count,
-            data_metric.member_count
+            data_metric.member_count, data_metric.delegate_profiles_count
           FROM data_metric
           LEFT JOIN LATERAL (
             SELECT count(*)::INTEGER AS proposals_count
@@ -1264,12 +1265,11 @@ pub(super) async fn count_delegates(
     Ok(total)
 }
 
-pub(super) async fn count_delegate_profiles(
+async fn count_realtime_delegate_profiles(
     pool: &PgPool,
     implicit_scope: &GraphqlScope,
     where_: Option<&DelegateWhereInput>,
 ) -> GraphqlResult<i64> {
-    // TODO: switch this realtime count to dataMetrics/materialized metrics.
     let mut query = QueryBuilder::<Postgres>::new(
         r#"
         SELECT COUNT(DISTINCT lower(to_delegate))::int8 AS total
@@ -1321,6 +1321,138 @@ pub(super) async fn count_delegate_profiles(
     query.push("lower(to_delegate) <> '0x0000000000000000000000000000000000000000'");
     let (total,): (i64,) = query.build_query_as().fetch_one(pool).await?;
     Ok(total)
+}
+
+#[derive(Copy, Clone, Debug)]
+struct DelegateProfileScope<'a> {
+    chain_id: i32,
+    dao_code: &'a str,
+    governor_address: &'a str,
+}
+
+fn materialized_delegate_profile_scope<'a>(
+    implicit_scope: &GraphqlScope,
+    where_: Option<&'a DelegateWhereInput>,
+) -> Option<DelegateProfileScope<'a>> {
+    if implicit_scope.contract_set_id.is_some() {
+        return None;
+    }
+
+    let DelegateWhereInput {
+        scope,
+        from_delegate_eq,
+        to_delegate_eq,
+        is_current_eq,
+        power_lt,
+        or,
+    } = where_?;
+    if from_delegate_eq.is_some()
+        || to_delegate_eq.is_some()
+        || is_current_eq.is_some()
+        || power_lt.is_some()
+        || or.is_some()
+    {
+        return None;
+    }
+
+    let ScopeWhereInput {
+        chain_id_eq,
+        governor_address_eq,
+        dao_code_eq,
+    } = scope;
+    let chain_id = (*chain_id_eq)?;
+    let dao_code = dao_code_eq.as_deref().filter(|value| !value.is_empty())?;
+    let governor_address = governor_address_eq
+        .as_deref()
+        .filter(|value| !value.is_empty())?;
+
+    if implicit_scope
+        .chain_id
+        .is_some_and(|implicit| implicit != chain_id)
+        || implicit_scope
+            .dao_code
+            .as_deref()
+            .is_some_and(|implicit| implicit != dao_code)
+        || implicit_scope
+            .governor_address
+            .as_deref()
+            .is_some_and(|implicit| implicit != governor_address)
+    {
+        return None;
+    }
+
+    Some(DelegateProfileScope {
+        chain_id,
+        dao_code,
+        governor_address,
+    })
+}
+
+async fn count_materialized_delegate_profiles(
+    pool: &PgPool,
+    scope: DelegateProfileScope<'_>,
+) -> GraphqlResult<Option<i64>> {
+    let materialized_count: Option<i32> = sqlx::query_scalar(
+        "SELECT MAX(delegate_profiles_count)
+         FROM data_metric
+         WHERE id = 'global'
+           AND chain_id = $1
+           AND dao_code = $2
+           AND lower(governor_address) = lower($3)",
+    )
+    .bind(scope.chain_id)
+    .bind(scope.dao_code)
+    .bind(scope.governor_address)
+    .fetch_one(pool)
+    .await?;
+    let Some(materialized_count) = materialized_count else {
+        return Ok(None);
+    };
+
+    let provisional_delta: i64 = sqlx::query_scalar(
+        "SELECT COUNT(DISTINCT lower(delegate_overlay.delegate))::int8
+         FROM degov_provisional_delegate_power_overlay delegate_overlay
+         WHERE delegate_overlay.status = 'available'
+           AND delegate_overlay.chain_id = $1
+           AND delegate_overlay.dao_code = $2
+           AND lower(delegate_overlay.governor_address) = lower($3)
+           AND lower(delegate_overlay.delegate) <> '0x0000000000000000000000000000000000000000'
+           AND NOT EXISTS (
+             SELECT 1
+             FROM delegate_profile durable_profile
+             WHERE durable_profile.chain_id = $1
+               AND durable_profile.dao_code = $2
+               AND durable_profile.governor_address = lower($3)
+               AND durable_profile.delegate = lower(delegate_overlay.delegate)
+           )",
+    )
+    .bind(scope.chain_id)
+    .bind(scope.dao_code)
+    .bind(scope.governor_address)
+    .fetch_one(pool)
+    .await?;
+    let provisional_delta = i32::try_from(provisional_delta).map_err(|_| {
+        async_graphql::Error::new("delegateProfilesCount provisional delta exceeds GraphQL Int")
+    })?;
+    let total = materialized_count
+        .checked_add(provisional_delta)
+        .ok_or_else(|| async_graphql::Error::new("delegateProfilesCount exceeds GraphQL Int"))?;
+
+    Ok(Some(i64::from(total)))
+}
+
+pub(super) async fn count_delegate_profiles(
+    pool: &PgPool,
+    implicit_scope: &GraphqlScope,
+    where_: Option<&DelegateWhereInput>,
+) -> GraphqlResult<i64> {
+    if let Some(scope) = materialized_delegate_profile_scope(implicit_scope, where_)
+        && let Some(total) = count_materialized_delegate_profiles(pool, scope).await?
+    {
+        return Ok(total);
+    }
+
+    count_realtime_delegate_profiles(pool, implicit_scope, where_).await
 }
 
 pub(super) async fn count_delegate_mappings(

--- a/apps/indexer/src/graphql/types.rs
+++ b/apps/indexer/src/graphql/types.rs
@@ -149,6 +149,7 @@ pub struct DataMetric {
     pub(super) contributor_count: Option<i32>,
     pub(super) holders_count: Option<i32>,
     pub(super) member_count: Option<i32>,
+    pub(super) delegate_profiles_count: Option<i32>,
 }
 
 #[derive(Clone, Debug, FromRow, SimpleObject)]

--- a/apps/indexer/src/lib.rs
+++ b/apps/indexer/src/lib.rs
@@ -3,6 +3,7 @@ pub mod checkpoint;
 pub mod config;
 pub mod datalens;
 pub mod decode;
+mod delegate_profile;
 pub mod error;
 pub mod graphql;
 pub mod metrics;
@@ -13,6 +14,8 @@ pub mod runner;
 pub mod runtime;
 pub mod runtime_config;
 pub mod store;
+
+pub use crate::delegate_profile::delegate_profile_scope_lock_key;
 
 pub use crate::chain::tool::{
     BatchReadPlanConfig, BlockReadMode, ChainContracts, ChainReadExecutionReport, ChainReadFailure,

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -1,9 +1,10 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use degov_datalens_indexer::runtime::{
+    DelegateProfileBackfillOptions, DelegateProfileBackfillSelection, DelegateProfileScope,
     TimelockProposalLinkBackfillOptions, migrate, refresh_proposal_reference_fields,
-    refresh_proposal_titles, repair_invalid_runtime_indexes, repair_timelock_proposal_links,
-    run_graphql, run_indexer, run_worker, smoke_datalens,
+    refresh_proposal_titles, repair_delegate_profiles, repair_invalid_runtime_indexes,
+    repair_timelock_proposal_links, run_graphql, run_indexer, run_worker, smoke_datalens,
 };
 
 #[derive(Debug, Parser)]
@@ -40,6 +41,25 @@ enum Command {
         batch_size: usize,
         #[arg(long, default_value_t = 20)]
         max_batches: usize,
+    },
+    #[command(group(
+        clap::ArgGroup::new("delegate_profile_selection")
+            .required(true)
+            .args(["all_scopes", "chain_id"])
+    ))]
+    RepairDelegateProfiles {
+        #[arg(long, conflicts_with_all = ["chain_id", "dao_code", "governor_address"])]
+        all_scopes: bool,
+        #[arg(long, requires_all = ["dao_code", "governor_address"])]
+        chain_id: Option<i32>,
+        #[arg(long, requires_all = ["chain_id", "governor_address"])]
+        dao_code: Option<String>,
+        #[arg(long, requires_all = ["chain_id", "dao_code"])]
+        governor_address: Option<String>,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        max_scopes: Option<usize>,
     },
 }
 
@@ -109,6 +129,45 @@ async fn main() -> anyhow::Result<()> {
             );
             Ok(())
         }
+        Command::RepairDelegateProfiles {
+            all_scopes,
+            chain_id,
+            dao_code,
+            governor_address,
+            dry_run,
+            max_scopes,
+        } => {
+            let selection = if all_scopes {
+                DelegateProfileBackfillSelection::AllScopes
+            } else {
+                let (Some(chain_id), Some(dao_code), Some(governor_address)) =
+                    (chain_id, dao_code, governor_address)
+                else {
+                    anyhow::bail!(
+                        "delegate profile repair requires --all-scopes or a complete logical scope"
+                    );
+                };
+                DelegateProfileBackfillSelection::Scope(DelegateProfileScope::new(
+                    chain_id,
+                    dao_code,
+                    governor_address,
+                )?)
+            };
+            let report = repair_delegate_profiles(DelegateProfileBackfillOptions {
+                selection,
+                dry_run,
+                max_scopes,
+            })
+            .await?;
+            log::info!(
+                "delegate profile repair completed dry_run={} scopes_processed={} profiles_inserted={} metric_rows_updated={}",
+                report.dry_run,
+                report.scopes_processed,
+                report.profiles_inserted,
+                report.metric_rows_updated
+            );
+            Ok(())
+        }
     }
 }
 
@@ -118,4 +177,83 @@ fn init_logging() -> anyhow::Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init()
         .map_err(|error| anyhow::anyhow!("initialize tracing subscriber: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Command};
+    use clap::Parser;
+
+    #[test]
+    fn test_repair_delegate_profiles_parses_scoped_canary() {
+        let cli = Cli::try_parse_from([
+            "degov-datalens-indexer",
+            "repair-delegate-profiles",
+            "--chain-id",
+            "1",
+            "--dao-code",
+            "dao-a",
+            "--governor-address",
+            "0xGovernorA",
+            "--dry-run",
+        ])
+        .expect("scoped delegate profile repair parses");
+
+        assert!(matches!(
+            cli.command,
+            Command::RepairDelegateProfiles {
+                all_scopes: false,
+                chain_id: Some(1),
+                dao_code: Some(ref dao_code),
+                governor_address: Some(ref governor_address),
+                dry_run: true,
+                max_scopes: None,
+            } if dao_code == "dao-a" && governor_address == "0xGovernorA"
+        ));
+    }
+
+    #[test]
+    fn test_repair_delegate_profiles_requires_explicit_scope_selection() {
+        assert!(
+            Cli::try_parse_from(["degov-datalens-indexer", "repair-delegate-profiles"]).is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "degov-datalens-indexer",
+                "repair-delegate-profiles",
+                "--all-scopes",
+                "--chain-id",
+                "1",
+                "--dao-code",
+                "dao-a",
+                "--governor-address",
+                "0xgovernora",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_repair_delegate_profiles_parses_all_scopes_limit() {
+        let cli = Cli::try_parse_from([
+            "degov-datalens-indexer",
+            "repair-delegate-profiles",
+            "--all-scopes",
+            "--max-scopes",
+            "25",
+        ])
+        .expect("all-scope delegate profile repair parses");
+
+        assert!(matches!(
+            cli.command,
+            Command::RepairDelegateProfiles {
+                all_scopes: true,
+                chain_id: None,
+                dao_code: None,
+                governor_address: None,
+                dry_run: false,
+                max_scopes: Some(25),
+            }
+        ));
+    }
 }

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -160,11 +160,13 @@ async fn main() -> anyhow::Result<()> {
             })
             .await?;
             log::info!(
-                "delegate profile repair completed dry_run={} scopes_processed={} profiles_inserted={} metric_rows_updated={}",
+                "delegate profile repair completed dry_run={} scopes_processed={} profiles_inserted={} metric_rows_updated={} profiles_would_insert={} metric_rows_would_update={}",
                 report.dry_run,
                 report.scopes_processed,
                 report.profiles_inserted,
-                report.metric_rows_updated
+                report.metric_rows_updated,
+                report.profiles_would_insert,
+                report.metric_rows_would_update
             );
             Ok(())
         }

--- a/apps/indexer/src/onchain/refresh.rs
+++ b/apps/indexer/src/onchain/refresh.rs
@@ -22,6 +22,7 @@ use crate::{
     MulticallReadGroup, PartialChainReadFailureReport, ProvisionalContributorPowerOverlayWrite,
     ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
     ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, ReadRequirement,
+    delegate_profile::acquire_delegate_profile_scope_lock,
     store::postgres::{
         drain_deferred_onchain_refresh_tasks, drain_deferred_onchain_refresh_tasks_for_scope,
         repair_missing_onchain_refresh_contributor_coverage,
@@ -4133,6 +4134,15 @@ async fn refresh_data_metric_scope(
     transaction: &mut Transaction<'_, Postgres>,
     scope: &DataMetricRefreshScope,
 ) -> Result<(), sqlx::Error> {
+    if let Some(dao_code) = &scope.dao_code {
+        acquire_delegate_profile_scope_lock(
+            transaction,
+            scope.chain_id,
+            dao_code,
+            &scope.governor_address,
+        )
+        .await?;
+    }
     let metric_id = data_metric_id(
         scope.chain_id,
         &scope.governor_address,
@@ -4140,9 +4150,24 @@ async fn refresh_data_metric_scope(
     );
 
     sqlx::query(
-        "INSERT INTO data_metric (
+        "WITH rollout AS (
+            SELECT COALESCE(bool_or(delegate_profiles_count IS NOT NULL), FALSE) AS initialized
+            FROM data_metric
+            WHERE id = 'global'
+              AND chain_id = $3
+              AND dao_code IS NOT DISTINCT FROM $4
+              AND lower(governor_address) = lower($5)
+         ), profile_count AS (
+            SELECT count(*)::INTEGER AS value
+            FROM delegate_profile
+            WHERE chain_id = $3
+              AND dao_code IS NOT DISTINCT FROM $4
+              AND governor_address = lower($5)
+         )
+         INSERT INTO data_metric (
             id, contract_set_id, chain_id, dao_code, governor_address, token_address,
-            power_sum, contributor_count, holders_count, member_count
+            power_sum, contributor_count, holders_count, member_count,
+            delegate_profiles_count
          )
          SELECT
             $1, $2, $3, $4, $5, $6,
@@ -4154,7 +4179,9 @@ async fn refresh_data_metric_scope(
                     ELSE count(*)
                 END
             )::INTEGER,
-            count(*)::INTEGER
+            count(*)::INTEGER,
+            (SELECT CASE WHEN rollout.initialized THEN profile_count.value END
+             FROM rollout, profile_count)
          FROM contributor
          WHERE contract_set_id = $2 AND chain_id = $3 AND governor_address = $5 AND dao_code IS NOT DISTINCT FROM $4
          ON CONFLICT ON CONSTRAINT data_metric_scope_unique DO UPDATE
@@ -4162,7 +4189,11 @@ async fn refresh_data_metric_scope(
              power_sum = EXCLUDED.power_sum,
              contributor_count = EXCLUDED.contributor_count,
              holders_count = EXCLUDED.holders_count,
-             member_count = EXCLUDED.member_count",
+             member_count = EXCLUDED.member_count,
+             delegate_profiles_count = COALESCE(
+                 EXCLUDED.delegate_profiles_count,
+                 data_metric.delegate_profiles_count
+             )",
     )
     .bind(metric_id)
     .bind(&scope.contract_set_id)

--- a/apps/indexer/src/runtime/delegate_profile_backfill.rs
+++ b/apps/indexer/src/runtime/delegate_profile_backfill.rs
@@ -1,9 +1,7 @@
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use thiserror::Error;
 
-use super::migrate::apply_migrations;
-
-const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+use crate::delegate_profile::{ZERO_DELEGATE_ADDRESS, acquire_delegate_profile_scope_lock};
 
 #[derive(Debug, Error)]
 pub enum DelegateProfileBackfillError {
@@ -22,8 +20,8 @@ pub enum DelegateProfileBackfillError {
     #[error("connect to DeGov indexer Postgres: {0}")]
     Connect(#[source] sqlx::Error),
 
-    #[error("apply DeGov indexer migrations: {0}")]
-    Migration(String),
+    #[error("delegate profile backfill preflight failed: {0}")]
+    Preflight(String),
 
     #[error("{operation}: {source}")]
     Database {
@@ -91,17 +89,29 @@ pub struct DelegateProfileBackfillOptions {
     pub max_scopes: Option<usize>,
 }
 
+fn validate_options(
+    options: &DelegateProfileBackfillOptions,
+) -> Result<(), DelegateProfileBackfillError> {
+    if options.max_scopes == Some(0) {
+        return Err(DelegateProfileBackfillError::InvalidMaxScopes);
+    }
+    Ok(())
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DelegateProfileBackfillReport {
     pub scopes_processed: usize,
     pub profiles_inserted: usize,
     pub metric_rows_updated: usize,
+    pub profiles_would_insert: usize,
+    pub metric_rows_would_update: usize,
     pub dry_run: bool,
 }
 
 pub async fn repair_delegate_profiles(
     options: DelegateProfileBackfillOptions,
 ) -> Result<DelegateProfileBackfillReport, DelegateProfileBackfillError> {
+    validate_options(&options)?;
     let database_url = std::env::var("DEGOV_INDEXER_DATABASE_URL")
         .map_err(|_| DelegateProfileBackfillError::MissingDatabaseUrl)?;
     let pool = PgPoolOptions::new()
@@ -109,9 +119,6 @@ pub async fn repair_delegate_profiles(
         .connect(&database_url)
         .await
         .map_err(DelegateProfileBackfillError::Connect)?;
-    apply_migrations(&pool)
-        .await
-        .map_err(|error| DelegateProfileBackfillError::Migration(error.to_string()))?;
 
     repair_delegate_profiles_with_pool(&pool, options).await
 }
@@ -120,9 +127,8 @@ pub async fn repair_delegate_profiles_with_pool(
     pool: &PgPool,
     options: DelegateProfileBackfillOptions,
 ) -> Result<DelegateProfileBackfillReport, DelegateProfileBackfillError> {
-    if options.max_scopes == Some(0) {
-        return Err(DelegateProfileBackfillError::InvalidMaxScopes);
-    }
+    validate_options(&options)?;
+    preflight_delegate_profile_backfill(pool).await?;
 
     let scopes = resolve_scopes(pool, &options).await?;
     let mut report = DelegateProfileBackfillReport {
@@ -134,38 +140,16 @@ pub async fn repair_delegate_profiles_with_pool(
         let mut transaction = pool.begin().await.map_err(|source| {
             database_error("begin delegate profile backfill scope transaction", source)
         })?;
-        let lock_key = format!(
-            "degov_delegate_profile:{}:{}:{}",
-            scope.chain_id, scope.dao_code, scope.governor_address
-        );
-        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
-            .bind(lock_key)
-            .execute(&mut *transaction)
-            .await
-            .map_err(|source| {
-                database_error("acquire delegate profile backfill scope lock", source)
-            })?;
-
-        let insert_result = sqlx::query(
-            "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
-             SELECT $1, $2, $3, lower(delegate.to_delegate)
-             FROM delegate
-             WHERE delegate.chain_id = $1
-               AND delegate.dao_code = $2
-               AND lower(delegate.governor_address) = $3
-               AND lower(delegate.to_delegate) <> $4
-             GROUP BY lower(delegate.to_delegate)
-             ON CONFLICT DO NOTHING",
+        acquire_delegate_profile_scope_lock(
+            &mut transaction,
+            scope.chain_id,
+            &scope.dao_code,
+            &scope.governor_address,
         )
-        .bind(scope.chain_id)
-        .bind(&scope.dao_code)
-        .bind(&scope.governor_address)
-        .bind(ZERO_ADDRESS)
-        .execute(&mut *transaction)
         .await
-        .map_err(|source| database_error("insert delegate profiles", source))?;
+        .map_err(|source| database_error("acquire delegate profile backfill scope lock", source))?;
 
-        let registry_count: i64 = sqlx::query_scalar(
+        let existing_registry_count: i64 = sqlx::query_scalar(
             "SELECT count(*)
              FROM delegate_profile
              WHERE chain_id = $1 AND dao_code = $2 AND governor_address = $3",
@@ -176,6 +160,29 @@ pub async fn repair_delegate_profiles_with_pool(
         .fetch_one(&mut *transaction)
         .await
         .map_err(|source| database_error("count delegate profiles", source))?;
+        let profiles_would_insert: i64 = sqlx::query_scalar(
+            "SELECT count(DISTINCT lower(delegate.to_delegate))
+             FROM delegate
+             WHERE delegate.chain_id = $1
+               AND delegate.dao_code = $2
+               AND lower(delegate.governor_address) = $3
+               AND lower(delegate.to_delegate) <> $4
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM delegate_profile
+                 WHERE delegate_profile.chain_id = $1
+                   AND delegate_profile.dao_code = $2
+                   AND delegate_profile.governor_address = $3
+                   AND delegate_profile.delegate = lower(delegate.to_delegate)
+               )",
+        )
+        .bind(scope.chain_id)
+        .bind(&scope.dao_code)
+        .bind(&scope.governor_address)
+        .bind(ZERO_DELEGATE_ADDRESS)
+        .fetch_one(&mut *transaction)
+        .await
+        .map_err(|source| database_error("count missing delegate profiles", source))?;
         let historical_count: i64 = sqlx::query_scalar(
             "SELECT count(DISTINCT lower(delegate.to_delegate))
              FROM delegate
@@ -187,23 +194,23 @@ pub async fn repair_delegate_profiles_with_pool(
         .bind(scope.chain_id)
         .bind(&scope.dao_code)
         .bind(&scope.governor_address)
-        .bind(ZERO_ADDRESS)
+        .bind(ZERO_DELEGATE_ADDRESS)
         .fetch_one(&mut *transaction)
         .await
         .map_err(|source| database_error("verify delegate profile history", source))?;
-        if registry_count != historical_count {
+        let expected_registry_count = existing_registry_count + profiles_would_insert;
+        if expected_registry_count != historical_count {
             return Err(DelegateProfileBackfillError::Verification {
                 scope: scope_label(&scope),
-                registry_count,
+                registry_count: expected_registry_count,
                 historical_count,
             });
         }
-        let registry_count = i32::try_from(registry_count)
+        let registry_count = i32::try_from(expected_registry_count)
             .map_err(|_| DelegateProfileBackfillError::MetricCountOutOfRange)?;
-
-        let update_result = sqlx::query(
-            "UPDATE data_metric
-             SET delegate_profiles_count = $4
+        let metric_rows_would_update: i64 = sqlx::query_scalar(
+            "SELECT count(*)
+             FROM data_metric
              WHERE id = 'global'
                AND chain_id = $1
                AND dao_code = $2
@@ -212,14 +219,13 @@ pub async fn repair_delegate_profiles_with_pool(
         .bind(scope.chain_id)
         .bind(&scope.dao_code)
         .bind(&scope.governor_address)
-        .bind(registry_count)
-        .execute(&mut *transaction)
+        .fetch_one(&mut *transaction)
         .await
-        .map_err(|source| database_error("update delegate profile metric", source))?;
+        .map_err(|source| database_error("count delegate profile metric rows", source))?;
 
         report.scopes_processed += 1;
-        report.profiles_inserted += rows_affected(insert_result.rows_affected())?;
-        report.metric_rows_updated += rows_affected(update_result.rows_affected())?;
+        report.profiles_would_insert += i64_rows(profiles_would_insert)?;
+        report.metric_rows_would_update += i64_rows(metric_rows_would_update)?;
 
         if options.dry_run {
             transaction.rollback().await.map_err(|source| {
@@ -229,6 +235,41 @@ pub async fn repair_delegate_profiles_with_pool(
                 )
             })?;
         } else {
+            let insert_result = sqlx::query(
+                "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+                 SELECT $1, $2, $3, lower(delegate.to_delegate)
+                 FROM delegate
+                 WHERE delegate.chain_id = $1
+                   AND delegate.dao_code = $2
+                   AND lower(delegate.governor_address) = $3
+                   AND lower(delegate.to_delegate) <> $4
+                 GROUP BY lower(delegate.to_delegate)
+                 ON CONFLICT DO NOTHING",
+            )
+            .bind(scope.chain_id)
+            .bind(&scope.dao_code)
+            .bind(&scope.governor_address)
+            .bind(ZERO_DELEGATE_ADDRESS)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|source| database_error("insert delegate profiles", source))?;
+            let update_result = sqlx::query(
+                "UPDATE data_metric
+                 SET delegate_profiles_count = $4
+                 WHERE id = 'global'
+                   AND chain_id = $1
+                   AND dao_code = $2
+                   AND lower(governor_address) = $3",
+            )
+            .bind(scope.chain_id)
+            .bind(&scope.dao_code)
+            .bind(&scope.governor_address)
+            .bind(registry_count)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|source| database_error("update delegate profile metric", source))?;
+            report.profiles_inserted += rows_affected(insert_result.rows_affected())?;
+            report.metric_rows_updated += rows_affected(update_result.rows_affected())?;
             transaction.commit().await.map_err(|source| {
                 database_error("commit delegate profile backfill scope transaction", source)
             })?;
@@ -242,7 +283,7 @@ async fn resolve_scopes(
     pool: &PgPool,
     options: &DelegateProfileBackfillOptions,
 ) -> Result<Vec<DelegateProfileScope>, DelegateProfileBackfillError> {
-    let mut scopes = match &options.selection {
+    let scopes = match &options.selection {
         DelegateProfileBackfillSelection::Scope(scope) => vec![scope.clone()],
         DelegateProfileBackfillSelection::AllScopes => {
             let rows: Vec<(i32, String, String)> = sqlx::query_as(
@@ -261,8 +302,10 @@ async fn resolve_scopes(
                      AND dao_code IS NOT NULL
                      AND governor_address IS NOT NULL
                  ) logical_scope
-                 ORDER BY chain_id, dao_code, governor_address",
+                 ORDER BY chain_id, dao_code, governor_address
+                 LIMIT $1",
             )
+            .bind(i64::try_from(options.max_scopes.unwrap_or(usize::MAX)).unwrap_or(i64::MAX))
             .fetch_all(pool)
             .await
             .map_err(|source| {
@@ -276,11 +319,68 @@ async fn resolve_scopes(
         }
     };
 
-    if let Some(max_scopes) = options.max_scopes {
-        scopes.truncate(max_scopes);
-    }
-
     Ok(scopes)
+}
+
+async fn preflight_delegate_profile_backfill(
+    pool: &PgPool,
+) -> Result<(), DelegateProfileBackfillError> {
+    let catalog_ready: bool = sqlx::query_scalar(
+        "SELECT
+           to_regclass('delegate_profile') IS NOT NULL
+           AND EXISTS (
+             SELECT 1 FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name = 'data_metric'
+               AND column_name = 'delegate_profiles_count'
+           )
+           AND (
+             SELECT count(*) = 4
+             FROM pg_constraint
+             WHERE conrelid = to_regclass('delegate_profile')
+               AND conname IN (
+                 'delegate_profile_pkey',
+                 'delegate_profile_governor_address_normalized',
+                 'delegate_profile_delegate_normalized',
+                 'delegate_profile_delegate_nonzero'
+               )
+               AND convalidated
+           )
+           AND EXISTS (
+             SELECT 1
+             FROM pg_class index_class
+             JOIN pg_index ON pg_index.indexrelid = index_class.oid
+             WHERE index_class.oid = to_regclass('delegate_profile_backfill_scope_target_idx')
+               AND pg_index.indisvalid
+               AND pg_index.indisready
+           )",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(|source| database_error("check delegate profile backfill prerequisites", source))?;
+    let migration_table_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('_sqlx_migrations') IS NOT NULL")
+            .fetch_one(pool)
+            .await
+            .map_err(|source| database_error("check SQLx migration history", source))?;
+    let migration_ready = if migration_table_exists {
+        sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM _sqlx_migrations WHERE version = 11 AND success)",
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(|source| database_error("check delegate profile migration version", source))?
+    } else {
+        false
+    };
+
+    if catalog_ready && migration_ready {
+        Ok(())
+    } else {
+        Err(DelegateProfileBackfillError::Preflight(
+            "migration 0011 and valid delegate_profile_backfill_scope_target_idx are required; run `degov-datalens-indexer migrate` first".to_owned(),
+        ))
+    }
 }
 
 fn scope_label(scope: &DelegateProfileScope) -> String {
@@ -291,6 +391,10 @@ fn scope_label(scope: &DelegateProfileScope) -> String {
 }
 
 fn rows_affected(value: u64) -> Result<usize, DelegateProfileBackfillError> {
+    usize::try_from(value).map_err(|_| DelegateProfileBackfillError::RowCountOutOfRange)
+}
+
+fn i64_rows(value: i64) -> Result<usize, DelegateProfileBackfillError> {
     usize::try_from(value).map_err(|_| DelegateProfileBackfillError::RowCountOutOfRange)
 }
 

--- a/apps/indexer/src/runtime/delegate_profile_backfill.rs
+++ b/apps/indexer/src/runtime/delegate_profile_backfill.rs
@@ -39,6 +39,19 @@ pub enum DelegateProfileBackfillError {
         historical_count: i64,
     },
 
+    #[error(
+        "delegate profile metric verification failed for {scope}: expected_count={expected_count} intended_replicas={intended_replicas} actual_replicas={actual_replicas} populated_replicas={populated_replicas} min_count={min_count:?} max_count={max_count:?}"
+    )]
+    MetricVerification {
+        scope: String,
+        expected_count: i32,
+        intended_replicas: u64,
+        actual_replicas: i64,
+        populated_replicas: i64,
+        min_count: Option<i32>,
+        max_count: Option<i32>,
+    },
+
     #[error("delegate profile count exceeds data_metric INTEGER range")]
     MetricCountOutOfRange,
 
@@ -299,8 +312,47 @@ pub async fn repair_delegate_profiles_with_pool(
             .execute(&mut *transaction)
             .await
             .map_err(|source| database_error("update delegate profile metric", source))?;
+            let (actual_replicas, populated_replicas, min_count, max_count): (
+                i64,
+                i64,
+                Option<i32>,
+                Option<i32>,
+            ) = sqlx::query_as(
+                "SELECT
+                   count(*),
+                   count(delegate_profiles_count),
+                   min(delegate_profiles_count),
+                   max(delegate_profiles_count)
+                 FROM data_metric
+                 WHERE id = 'global'
+                   AND chain_id = $1
+                   AND dao_code = $2
+                   AND lower(governor_address) = $3",
+            )
+            .bind(scope.chain_id)
+            .bind(&scope.dao_code)
+            .bind(&scope.governor_address)
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(|source| database_error("verify delegate profile metric replicas", source))?;
+            let intended_replicas = update_result.rows_affected();
+            let replicas_match = u64::try_from(actual_replicas) == Ok(intended_replicas)
+                && populated_replicas == actual_replicas
+                && min_count == Some(verified_registry_count)
+                && max_count == Some(verified_registry_count);
+            if !replicas_match {
+                return Err(DelegateProfileBackfillError::MetricVerification {
+                    scope: scope_label(&scope),
+                    expected_count: verified_registry_count,
+                    intended_replicas,
+                    actual_replicas,
+                    populated_replicas,
+                    min_count,
+                    max_count,
+                });
+            }
             report.profiles_inserted += rows_affected(insert_result.rows_affected())?;
-            report.metric_rows_updated += rows_affected(update_result.rows_affected())?;
+            report.metric_rows_updated += rows_affected(intended_replicas)?;
             transaction.commit().await.map_err(|source| {
                 database_error("commit delegate profile backfill scope transaction", source)
             })?;

--- a/apps/indexer/src/runtime/delegate_profile_backfill.rs
+++ b/apps/indexer/src/runtime/delegate_profile_backfill.rs
@@ -1,7 +1,7 @@
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use thiserror::Error;
 
-use crate::delegate_profile::{ZERO_DELEGATE_ADDRESS, acquire_delegate_profile_scope_lock};
+use crate::delegate_profile::acquire_delegate_profile_scope_lock;
 
 #[derive(Debug, Error)]
 pub enum DelegateProfileBackfillError {
@@ -166,7 +166,7 @@ pub async fn repair_delegate_profiles_with_pool(
              WHERE delegate.chain_id = $1
                AND delegate.dao_code = $2
                AND lower(delegate.governor_address) = $3
-               AND lower(delegate.to_delegate) <> $4
+               AND lower(delegate.to_delegate) <> '0x0000000000000000000000000000000000000000'
                AND NOT EXISTS (
                  SELECT 1
                  FROM delegate_profile
@@ -179,7 +179,6 @@ pub async fn repair_delegate_profiles_with_pool(
         .bind(scope.chain_id)
         .bind(&scope.dao_code)
         .bind(&scope.governor_address)
-        .bind(ZERO_DELEGATE_ADDRESS)
         .fetch_one(&mut *transaction)
         .await
         .map_err(|source| database_error("count missing delegate profiles", source))?;
@@ -189,12 +188,11 @@ pub async fn repair_delegate_profiles_with_pool(
              WHERE delegate.chain_id = $1
                AND delegate.dao_code = $2
                AND lower(delegate.governor_address) = $3
-               AND lower(delegate.to_delegate) <> $4",
+               AND lower(delegate.to_delegate) <> '0x0000000000000000000000000000000000000000'",
         )
         .bind(scope.chain_id)
         .bind(&scope.dao_code)
         .bind(&scope.governor_address)
-        .bind(ZERO_DELEGATE_ADDRESS)
         .fetch_one(&mut *transaction)
         .await
         .map_err(|source| database_error("verify delegate profile history", source))?;
@@ -242,14 +240,13 @@ pub async fn repair_delegate_profiles_with_pool(
                  WHERE delegate.chain_id = $1
                    AND delegate.dao_code = $2
                    AND lower(delegate.governor_address) = $3
-                   AND lower(delegate.to_delegate) <> $4
+                   AND lower(delegate.to_delegate) <> '0x0000000000000000000000000000000000000000'
                  GROUP BY lower(delegate.to_delegate)
                  ON CONFLICT DO NOTHING",
             )
             .bind(scope.chain_id)
             .bind(&scope.dao_code)
             .bind(&scope.governor_address)
-            .bind(ZERO_DELEGATE_ADDRESS)
             .execute(&mut *transaction)
             .await
             .map_err(|source| database_error("insert delegate profiles", source))?;
@@ -270,12 +267,11 @@ pub async fn repair_delegate_profiles_with_pool(
                  WHERE delegate.chain_id = $1
                    AND delegate.dao_code = $2
                    AND lower(delegate.governor_address) = $3
-                   AND lower(delegate.to_delegate) <> $4",
+                   AND lower(delegate.to_delegate) <> '0x0000000000000000000000000000000000000000'",
             )
             .bind(scope.chain_id)
             .bind(&scope.dao_code)
             .bind(&scope.governor_address)
-            .bind(ZERO_DELEGATE_ADDRESS)
             .fetch_one(&mut *transaction)
             .await
             .map_err(|source| database_error("verify inserted delegate profile history", source))?;
@@ -386,8 +382,17 @@ async fn preflight_delegate_profile_backfill(
              FROM pg_class index_class
              JOIN pg_index ON pg_index.indexrelid = index_class.oid
              WHERE index_class.oid = to_regclass('delegate_profile_backfill_scope_target_idx')
+               AND pg_index.indrelid = to_regclass('delegate')
                AND pg_index.indisvalid
                AND pg_index.indisready
+               AND pg_index.indnkeyatts = 4
+               AND pg_index.indnatts = 4
+               AND pg_get_indexdef(index_class.oid, 1, TRUE) = 'chain_id'
+               AND pg_get_indexdef(index_class.oid, 2, TRUE) = 'dao_code'
+               AND pg_get_indexdef(index_class.oid, 3, TRUE) = 'lower(governor_address)'
+               AND pg_get_indexdef(index_class.oid, 4, TRUE) = 'lower(to_delegate)'
+               AND pg_get_expr(pg_index.indpred, pg_index.indrelid, TRUE) =
+                 'chain_id IS NOT NULL AND dao_code IS NOT NULL AND governor_address IS NOT NULL AND lower(to_delegate) <> ''0x0000000000000000000000000000000000000000''::text'
            )",
     )
     .fetch_one(pool)

--- a/apps/indexer/src/runtime/delegate_profile_backfill.rs
+++ b/apps/indexer/src/runtime/delegate_profile_backfill.rs
@@ -1,0 +1,299 @@
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use thiserror::Error;
+
+use super::migrate::apply_migrations;
+
+const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+
+#[derive(Debug, Error)]
+pub enum DelegateProfileBackfillError {
+    #[error("delegate profile backfill dao_code must not be empty")]
+    EmptyDaoCode,
+
+    #[error("delegate profile backfill governor_address must not be empty")]
+    EmptyGovernorAddress,
+
+    #[error("delegate profile backfill max_scopes must be greater than zero")]
+    InvalidMaxScopes,
+
+    #[error("missing required Datalens configuration field DEGOV_INDEXER_DATABASE_URL")]
+    MissingDatabaseUrl,
+
+    #[error("connect to DeGov indexer Postgres: {0}")]
+    Connect(#[source] sqlx::Error),
+
+    #[error("apply DeGov indexer migrations: {0}")]
+    Migration(String),
+
+    #[error("{operation}: {source}")]
+    Database {
+        operation: &'static str,
+        #[source]
+        source: sqlx::Error,
+    },
+
+    #[error(
+        "delegate profile verification failed for {scope}: registry_count={registry_count} historical_count={historical_count}"
+    )]
+    Verification {
+        scope: String,
+        registry_count: i64,
+        historical_count: i64,
+    },
+
+    #[error("delegate profile count exceeds data_metric INTEGER range")]
+    MetricCountOutOfRange,
+
+    #[error("delegate profile backfill row count exceeds usize")]
+    RowCountOutOfRange,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateProfileScope {
+    pub chain_id: i32,
+    pub dao_code: String,
+    pub governor_address: String,
+}
+
+impl DelegateProfileScope {
+    pub fn new(
+        chain_id: i32,
+        dao_code: impl Into<String>,
+        governor_address: impl Into<String>,
+    ) -> Result<Self, DelegateProfileBackfillError> {
+        let dao_code = dao_code.into();
+        let governor_address = governor_address.into().to_lowercase();
+        if dao_code.is_empty() {
+            return Err(DelegateProfileBackfillError::EmptyDaoCode);
+        }
+        if governor_address.is_empty() {
+            return Err(DelegateProfileBackfillError::EmptyGovernorAddress);
+        }
+
+        Ok(Self {
+            chain_id,
+            dao_code,
+            governor_address,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DelegateProfileBackfillSelection {
+    Scope(DelegateProfileScope),
+    AllScopes,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateProfileBackfillOptions {
+    pub selection: DelegateProfileBackfillSelection,
+    pub dry_run: bool,
+    pub max_scopes: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DelegateProfileBackfillReport {
+    pub scopes_processed: usize,
+    pub profiles_inserted: usize,
+    pub metric_rows_updated: usize,
+    pub dry_run: bool,
+}
+
+pub async fn repair_delegate_profiles(
+    options: DelegateProfileBackfillOptions,
+) -> Result<DelegateProfileBackfillReport, DelegateProfileBackfillError> {
+    let database_url = std::env::var("DEGOV_INDEXER_DATABASE_URL")
+        .map_err(|_| DelegateProfileBackfillError::MissingDatabaseUrl)?;
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .map_err(DelegateProfileBackfillError::Connect)?;
+    apply_migrations(&pool)
+        .await
+        .map_err(|error| DelegateProfileBackfillError::Migration(error.to_string()))?;
+
+    repair_delegate_profiles_with_pool(&pool, options).await
+}
+
+pub async fn repair_delegate_profiles_with_pool(
+    pool: &PgPool,
+    options: DelegateProfileBackfillOptions,
+) -> Result<DelegateProfileBackfillReport, DelegateProfileBackfillError> {
+    if options.max_scopes == Some(0) {
+        return Err(DelegateProfileBackfillError::InvalidMaxScopes);
+    }
+
+    let scopes = resolve_scopes(pool, &options).await?;
+    let mut report = DelegateProfileBackfillReport {
+        dry_run: options.dry_run,
+        ..DelegateProfileBackfillReport::default()
+    };
+
+    for scope in scopes {
+        let mut transaction = pool.begin().await.map_err(|source| {
+            database_error("begin delegate profile backfill scope transaction", source)
+        })?;
+        let lock_key = format!(
+            "degov_delegate_profile:{}:{}:{}",
+            scope.chain_id, scope.dao_code, scope.governor_address
+        );
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind(lock_key)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|source| {
+                database_error("acquire delegate profile backfill scope lock", source)
+            })?;
+
+        let insert_result = sqlx::query(
+            "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+             SELECT $1, $2, $3, lower(delegate.to_delegate)
+             FROM delegate
+             WHERE delegate.chain_id = $1
+               AND delegate.dao_code = $2
+               AND lower(delegate.governor_address) = $3
+               AND lower(delegate.to_delegate) <> $4
+             GROUP BY lower(delegate.to_delegate)
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(scope.chain_id)
+        .bind(&scope.dao_code)
+        .bind(&scope.governor_address)
+        .bind(ZERO_ADDRESS)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|source| database_error("insert delegate profiles", source))?;
+
+        let registry_count: i64 = sqlx::query_scalar(
+            "SELECT count(*)
+             FROM delegate_profile
+             WHERE chain_id = $1 AND dao_code = $2 AND governor_address = $3",
+        )
+        .bind(scope.chain_id)
+        .bind(&scope.dao_code)
+        .bind(&scope.governor_address)
+        .fetch_one(&mut *transaction)
+        .await
+        .map_err(|source| database_error("count delegate profiles", source))?;
+        let historical_count: i64 = sqlx::query_scalar(
+            "SELECT count(DISTINCT lower(delegate.to_delegate))
+             FROM delegate
+             WHERE delegate.chain_id = $1
+               AND delegate.dao_code = $2
+               AND lower(delegate.governor_address) = $3
+               AND lower(delegate.to_delegate) <> $4",
+        )
+        .bind(scope.chain_id)
+        .bind(&scope.dao_code)
+        .bind(&scope.governor_address)
+        .bind(ZERO_ADDRESS)
+        .fetch_one(&mut *transaction)
+        .await
+        .map_err(|source| database_error("verify delegate profile history", source))?;
+        if registry_count != historical_count {
+            return Err(DelegateProfileBackfillError::Verification {
+                scope: scope_label(&scope),
+                registry_count,
+                historical_count,
+            });
+        }
+        let registry_count = i32::try_from(registry_count)
+            .map_err(|_| DelegateProfileBackfillError::MetricCountOutOfRange)?;
+
+        let update_result = sqlx::query(
+            "UPDATE data_metric
+             SET delegate_profiles_count = $4
+             WHERE id = 'global'
+               AND chain_id = $1
+               AND dao_code = $2
+               AND lower(governor_address) = $3",
+        )
+        .bind(scope.chain_id)
+        .bind(&scope.dao_code)
+        .bind(&scope.governor_address)
+        .bind(registry_count)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|source| database_error("update delegate profile metric", source))?;
+
+        report.scopes_processed += 1;
+        report.profiles_inserted += rows_affected(insert_result.rows_affected())?;
+        report.metric_rows_updated += rows_affected(update_result.rows_affected())?;
+
+        if options.dry_run {
+            transaction.rollback().await.map_err(|source| {
+                database_error(
+                    "roll back delegate profile dry run scope transaction",
+                    source,
+                )
+            })?;
+        } else {
+            transaction.commit().await.map_err(|source| {
+                database_error("commit delegate profile backfill scope transaction", source)
+            })?;
+        }
+    }
+
+    Ok(report)
+}
+
+async fn resolve_scopes(
+    pool: &PgPool,
+    options: &DelegateProfileBackfillOptions,
+) -> Result<Vec<DelegateProfileScope>, DelegateProfileBackfillError> {
+    let mut scopes = match &options.selection {
+        DelegateProfileBackfillSelection::Scope(scope) => vec![scope.clone()],
+        DelegateProfileBackfillSelection::AllScopes => {
+            let rows: Vec<(i32, String, String)> = sqlx::query_as(
+                "SELECT chain_id, dao_code, governor_address
+                 FROM (
+                   SELECT chain_id, dao_code, lower(governor_address) AS governor_address
+                   FROM data_metric
+                   WHERE id = 'global'
+                     AND chain_id IS NOT NULL
+                     AND dao_code IS NOT NULL
+                     AND governor_address IS NOT NULL
+                   UNION
+                   SELECT chain_id, dao_code, lower(governor_address) AS governor_address
+                   FROM delegate
+                   WHERE chain_id IS NOT NULL
+                     AND dao_code IS NOT NULL
+                     AND governor_address IS NOT NULL
+                 ) logical_scope
+                 ORDER BY chain_id, dao_code, governor_address",
+            )
+            .fetch_all(pool)
+            .await
+            .map_err(|source| {
+                database_error("discover delegate profile backfill scopes", source)
+            })?;
+            rows.into_iter()
+                .map(|(chain_id, dao_code, governor_address)| {
+                    DelegateProfileScope::new(chain_id, dao_code, governor_address)
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        }
+    };
+
+    if let Some(max_scopes) = options.max_scopes {
+        scopes.truncate(max_scopes);
+    }
+
+    Ok(scopes)
+}
+
+fn scope_label(scope: &DelegateProfileScope) -> String {
+    format!(
+        "chain_id={} dao_code={} governor_address={}",
+        scope.chain_id, scope.dao_code, scope.governor_address
+    )
+}
+
+fn rows_affected(value: u64) -> Result<usize, DelegateProfileBackfillError> {
+    usize::try_from(value).map_err(|_| DelegateProfileBackfillError::RowCountOutOfRange)
+}
+
+fn database_error(operation: &'static str, source: sqlx::Error) -> DelegateProfileBackfillError {
+    DelegateProfileBackfillError::Database { operation, source }
+}

--- a/apps/indexer/src/runtime/delegate_profile_backfill.rs
+++ b/apps/indexer/src/runtime/delegate_profile_backfill.rs
@@ -40,12 +40,13 @@ pub enum DelegateProfileBackfillError {
     },
 
     #[error(
-        "delegate profile metric verification failed for {scope}: expected_count={expected_count} intended_replicas={intended_replicas} actual_replicas={actual_replicas} populated_replicas={populated_replicas} min_count={min_count:?} max_count={max_count:?}"
+        "delegate profile metric verification failed for {scope}: expected_count={expected_count} intended_replicas={intended_replicas} updated_replicas={updated_replicas} actual_replicas={actual_replicas} populated_replicas={populated_replicas} min_count={min_count:?} max_count={max_count:?}"
     )]
     MetricVerification {
         scope: String,
         expected_count: i32,
         intended_replicas: u64,
+        updated_replicas: u64,
         actual_replicas: i64,
         populated_replicas: i64,
         min_count: Option<i32>,
@@ -233,10 +234,12 @@ pub async fn repair_delegate_profiles_with_pool(
         .fetch_one(&mut *transaction)
         .await
         .map_err(|source| database_error("count delegate profile metric rows", source))?;
+        let intended_metric_replicas = u64::try_from(metric_rows_would_update)
+            .map_err(|_| DelegateProfileBackfillError::RowCountOutOfRange)?;
 
         report.scopes_processed += 1;
         report.profiles_would_insert += i64_rows(profiles_would_insert)?;
-        report.metric_rows_would_update += i64_rows(metric_rows_would_update)?;
+        report.metric_rows_would_update += rows_affected(intended_metric_replicas)?;
 
         if options.dry_run {
             transaction.rollback().await.map_err(|source| {
@@ -335,16 +338,18 @@ pub async fn repair_delegate_profiles_with_pool(
             .fetch_one(&mut *transaction)
             .await
             .map_err(|source| database_error("verify delegate profile metric replicas", source))?;
-            let intended_replicas = update_result.rows_affected();
-            let replicas_match = u64::try_from(actual_replicas) == Ok(intended_replicas)
-                && populated_replicas == actual_replicas
+            let updated_replicas = update_result.rows_affected();
+            let replicas_match = updated_replicas == intended_metric_replicas
+                && u64::try_from(actual_replicas) == Ok(intended_metric_replicas)
+                && u64::try_from(populated_replicas) == Ok(intended_metric_replicas)
                 && min_count == Some(verified_registry_count)
                 && max_count == Some(verified_registry_count);
             if !replicas_match {
                 return Err(DelegateProfileBackfillError::MetricVerification {
                     scope: scope_label(&scope),
                     expected_count: verified_registry_count,
-                    intended_replicas,
+                    intended_replicas: intended_metric_replicas,
+                    updated_replicas,
                     actual_replicas,
                     populated_replicas,
                     min_count,
@@ -352,7 +357,7 @@ pub async fn repair_delegate_profiles_with_pool(
                 });
             }
             report.profiles_inserted += rows_affected(insert_result.rows_affected())?;
-            report.metric_rows_updated += rows_affected(intended_replicas)?;
+            report.metric_rows_updated += rows_affected(updated_replicas)?;
             transaction.commit().await.map_err(|source| {
                 database_error("commit delegate profile backfill scope transaction", source)
             })?;

--- a/apps/indexer/src/runtime/delegate_profile_backfill.rs
+++ b/apps/indexer/src/runtime/delegate_profile_backfill.rs
@@ -206,7 +206,7 @@ pub async fn repair_delegate_profiles_with_pool(
                 historical_count,
             });
         }
-        let registry_count = i32::try_from(expected_registry_count)
+        let _planned_registry_count = i32::try_from(expected_registry_count)
             .map_err(|_| DelegateProfileBackfillError::MetricCountOutOfRange)?;
         let metric_rows_would_update: i64 = sqlx::query_scalar(
             "SELECT count(*)
@@ -253,6 +253,41 @@ pub async fn repair_delegate_profiles_with_pool(
             .execute(&mut *transaction)
             .await
             .map_err(|source| database_error("insert delegate profiles", source))?;
+            let actual_registry_count: i64 = sqlx::query_scalar(
+                "SELECT count(*)
+                 FROM delegate_profile
+                 WHERE chain_id = $1 AND dao_code = $2 AND governor_address = $3",
+            )
+            .bind(scope.chain_id)
+            .bind(&scope.dao_code)
+            .bind(&scope.governor_address)
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(|source| database_error("verify inserted delegate profiles", source))?;
+            let actual_historical_count: i64 = sqlx::query_scalar(
+                "SELECT count(DISTINCT lower(delegate.to_delegate))
+                 FROM delegate
+                 WHERE delegate.chain_id = $1
+                   AND delegate.dao_code = $2
+                   AND lower(delegate.governor_address) = $3
+                   AND lower(delegate.to_delegate) <> $4",
+            )
+            .bind(scope.chain_id)
+            .bind(&scope.dao_code)
+            .bind(&scope.governor_address)
+            .bind(ZERO_DELEGATE_ADDRESS)
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(|source| database_error("verify inserted delegate profile history", source))?;
+            if actual_registry_count != actual_historical_count {
+                return Err(DelegateProfileBackfillError::Verification {
+                    scope: scope_label(&scope),
+                    registry_count: actual_registry_count,
+                    historical_count: actual_historical_count,
+                });
+            }
+            let verified_registry_count = i32::try_from(actual_registry_count)
+                .map_err(|_| DelegateProfileBackfillError::MetricCountOutOfRange)?;
             let update_result = sqlx::query(
                 "UPDATE data_metric
                  SET delegate_profiles_count = $4
@@ -264,7 +299,7 @@ pub async fn repair_delegate_profiles_with_pool(
             .bind(scope.chain_id)
             .bind(&scope.dao_code)
             .bind(&scope.governor_address)
-            .bind(registry_count)
+            .bind(verified_registry_count)
             .execute(&mut *transaction)
             .await
             .map_err(|source| database_error("update delegate profile metric", source))?;

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -361,6 +361,19 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
     .await
     .context("ensure current delegate power refresh index")?;
 
+    execute_concurrent_runtime_index(
+        connection,
+        "delegate_profile_backfill_scope_target_idx",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_profile_backfill_scope_target_idx
+         ON delegate (chain_id, dao_code, lower(governor_address), lower(to_delegate))
+         WHERE chain_id IS NOT NULL
+           AND dao_code IS NOT NULL
+           AND governor_address IS NOT NULL
+           AND lower(to_delegate) <> '0x0000000000000000000000000000000000000000'",
+    )
+    .await
+    .context("ensure delegate profile backfill scope target index")?;
+
     sqlx::query(
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_mapping_to_lookup_idx
          ON delegate_mapping (contract_set_id, \"to\") INCLUDE (id, power)",
@@ -848,6 +861,7 @@ async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnecti
     drop_invalid_runtime_index(connection, "delegate_rolling_metadata_preload_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_current_from_scope_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_current_power_refresh_idx").await?;
+    drop_invalid_runtime_index(connection, "delegate_profile_backfill_scope_target_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_mapping_to_lookup_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_mapping_effective_count_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_mapping_positive_count_idx").await?;

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -479,6 +479,18 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
 
     execute_concurrent_runtime_index(
         connection,
+        "provisional_delegate_profile_delta_scope_idx",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_profile_delta_scope_idx
+         ON degov_provisional_delegate_power_overlay (
+            chain_id, dao_code, lower(governor_address), lower(delegate)
+         )
+         WHERE status = 'available'",
+    )
+    .await
+    .context("ensure provisional delegate profile delta scope index")?;
+
+    execute_concurrent_runtime_index(
+        connection,
         "provisional_contributor_live_graphql_scope_idx",
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_contributor_live_graphql_scope_idx
          ON degov_provisional_contributor_power_overlay (
@@ -877,6 +889,7 @@ async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnecti
     )
     .await?;
     drop_invalid_runtime_index(connection, "provisional_delegate_live_graphql_scope_idx").await?;
+    drop_invalid_runtime_index(connection, "provisional_delegate_profile_delta_scope_idx").await?;
     drop_invalid_runtime_index(connection, "provisional_contributor_live_graphql_scope_idx")
         .await?;
 

--- a/apps/indexer/src/runtime/mod.rs
+++ b/apps/indexer/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod datalens;
+pub mod delegate_profile_backfill;
 pub mod graphql;
 pub mod indexer;
 pub mod migrate;
@@ -8,6 +9,11 @@ pub mod timelock_proposal_link_backfill;
 pub mod worker;
 
 pub use datalens::smoke_datalens;
+pub use delegate_profile_backfill::{
+    DelegateProfileBackfillError, DelegateProfileBackfillOptions, DelegateProfileBackfillReport,
+    DelegateProfileBackfillSelection, DelegateProfileScope, repair_delegate_profiles,
+    repair_delegate_profiles_with_pool,
+};
 pub use graphql::run_graphql;
 pub use indexer::run_indexer;
 pub use migrate::{

--- a/apps/indexer/src/store/postgres/runner_store.rs
+++ b/apps/indexer/src/store/postgres/runner_store.rs
@@ -271,16 +271,14 @@ async fn write_projection_batch(
     onchain_refresh_debounce: Duration,
     onchain_refresh_deferred_drain_batch_size: usize,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
-    if let Some(token) = &batch.token {
-        for (chain_id, dao_code, governor_address) in delegate_profile_scopes(token) {
-            acquire_delegate_profile_scope_lock(
-                transaction,
-                chain_id,
-                &dao_code,
-                &governor_address,
-            )
+    let delegate_profile_scopes = batch
+        .token
+        .as_ref()
+        .map(delegate_profile_scopes)
+        .unwrap_or_default();
+    for (chain_id, dao_code, governor_address) in &delegate_profile_scopes {
+        acquire_delegate_profile_scope_lock(transaction, *chain_id, dao_code, governor_address)
             .await?;
-        }
     }
     if let Some(proposal) = &batch.proposal {
         write_proposal_batch_rows(transaction, proposal).await?;
@@ -290,7 +288,7 @@ async fn write_projection_batch(
     }
     let inserted_operation_ids = if let Some(token) = &batch.token {
         let inserted_operation_ids = write_token_batch_rows(transaction, token).await?;
-        maintain_delegate_profiles(transaction, token, &inserted_operation_ids).await?;
+        insert_delegate_profiles(transaction, token, &inserted_operation_ids).await?;
         inserted_operation_ids
     } else {
         Vec::new()
@@ -309,6 +307,7 @@ async fn write_projection_batch(
     if let Some(vote) = &batch.vote {
         refresh_vote_data_metric(transaction, &vote.contributor_vote_signals).await?;
     }
+    synchronize_delegate_profile_metrics(transaction, &delegate_profile_scopes).await?;
     if let Some(token) = &batch.token {
         upsert_onchain_refresh_tasks(
             transaction,

--- a/apps/indexer/src/store/postgres/runner_store.rs
+++ b/apps/indexer/src/store/postgres/runner_store.rs
@@ -1,11 +1,13 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt,
     future::Future,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use sqlx::{PgPool, Postgres, QueryBuilder, Row, Transaction};
+
+use crate::delegate_profile::{ZERO_DELEGATE_ADDRESS, acquire_delegate_profile_scope_lock};
 
 use crate::{
     AdaptiveChunkSizingDecision, CheckpointRepository, ContributorVoteSignalWrite, DataMetricWrite,
@@ -269,6 +271,17 @@ async fn write_projection_batch(
     onchain_refresh_debounce: Duration,
     onchain_refresh_deferred_drain_batch_size: usize,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
+    if let Some(token) = &batch.token {
+        for (chain_id, dao_code, governor_address) in delegate_profile_scopes(token) {
+            acquire_delegate_profile_scope_lock(
+                transaction,
+                chain_id,
+                &dao_code,
+                &governor_address,
+            )
+            .await?;
+        }
+    }
     if let Some(proposal) = &batch.proposal {
         write_proposal_batch_rows(transaction, proposal).await?;
     }
@@ -276,7 +289,9 @@ async fn write_projection_batch(
         write_vote_batch_rows(transaction, vote).await?;
     }
     let inserted_operation_ids = if let Some(token) = &batch.token {
-        write_token_batch_rows(transaction, token).await?
+        let inserted_operation_ids = write_token_batch_rows(transaction, token).await?;
+        maintain_delegate_profiles(transaction, token, &inserted_operation_ids).await?;
+        inserted_operation_ids
     } else {
         Vec::new()
     };

--- a/apps/indexer/src/store/postgres/runner_store.rs
+++ b/apps/indexer/src/store/postgres/runner_store.rs
@@ -271,11 +271,7 @@ async fn write_projection_batch(
     onchain_refresh_debounce: Duration,
     onchain_refresh_deferred_drain_batch_size: usize,
 ) -> Result<(), PostgresIndexerRunnerStoreError> {
-    let delegate_profile_scopes = batch
-        .token
-        .as_ref()
-        .map(delegate_profile_scopes)
-        .unwrap_or_default();
+    let delegate_profile_scopes = delegate_profile_scopes(batch);
     for (chain_id, dao_code, governor_address) in &delegate_profile_scopes {
         acquire_delegate_profile_scope_lock(transaction, *chain_id, dao_code, governor_address)
             .await?;

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -64,20 +64,37 @@ fn recompute_delegate_count_effective_chunk_size() -> usize {
 }
 
 fn delegate_profile_scopes(batch: &TokenProjectionBatch) -> BTreeSet<(i32, String, String)> {
-    batch
-        .delegate_changed
-        .iter()
-        .map(|row| {
-            (
-                row.common.chain_id,
-                row.common.dao_code.clone(),
-                row.common.governor_address.to_lowercase(),
-            )
-        })
-        .collect()
+    let mut scopes = BTreeSet::new();
+    for operation in &batch.operations {
+        insert_delegate_profile_scope(&mut scopes, token_operation_common(operation));
+    }
+    for row in &batch.delegate_changed {
+        insert_delegate_profile_scope(&mut scopes, &row.common);
+    }
+    for row in &batch.delegate_votes_changed {
+        insert_delegate_profile_scope(&mut scopes, &row.common);
+    }
+    for row in &batch.token_transfers {
+        insert_delegate_profile_scope(&mut scopes, &row.common);
+    }
+    for row in &batch.delegate_rollings {
+        insert_delegate_profile_scope(&mut scopes, &row.common);
+    }
+    scopes
 }
 
-async fn maintain_delegate_profiles(
+fn insert_delegate_profile_scope(
+    scopes: &mut BTreeSet<(i32, String, String)>,
+    common: &TokenEventCommon,
+) {
+    scopes.insert((
+        common.chain_id,
+        common.dao_code.clone(),
+        common.governor_address.to_lowercase(),
+    ));
+}
+
+async fn insert_delegate_profiles(
     transaction: &mut Transaction<'_, Postgres>,
     batch: &TokenProjectionBatch,
     inserted_operation_keys: &[(String, String)],
@@ -122,12 +139,13 @@ async fn maintain_delegate_profiles(
     query.push(" ON CONFLICT DO NOTHING");
     query.build().execute(&mut **transaction).await?;
 
-    let scopes = profiles
-        .iter()
-        .map(|(chain_id, dao_code, governor_address, _)| {
-            (*chain_id, dao_code.as_str(), governor_address.as_str())
-        })
-        .collect::<BTreeSet<_>>();
+    Ok(())
+}
+
+async fn synchronize_delegate_profile_metrics(
+    transaction: &mut Transaction<'_, Postgres>,
+    scopes: &BTreeSet<(i32, String, String)>,
+) -> Result<(), PostgresIndexerRunnerStoreError> {
     for (chain_id, dao_code, governor_address) in scopes {
         sqlx::query(
             "WITH rollout AS (
@@ -151,7 +169,7 @@ async fn maintain_delegate_profiles(
                AND data_metric.dao_code = $2
                AND lower(data_metric.governor_address) = $3",
         )
-        .bind(chain_id)
+        .bind(*chain_id)
         .bind(dao_code)
         .bind(governor_address)
         .execute(&mut **transaction)

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -63,34 +63,92 @@ fn recompute_delegate_count_effective_chunk_size() -> usize {
     )
 }
 
-fn delegate_profile_scopes(batch: &TokenProjectionBatch) -> BTreeSet<(i32, String, String)> {
+fn delegate_profile_scopes(batch: &IndexerProjectionBatch) -> BTreeSet<(i32, String, String)> {
     let mut scopes = BTreeSet::new();
-    for operation in &batch.operations {
-        insert_delegate_profile_scope(&mut scopes, token_operation_common(operation));
+    if let Some(token) = &batch.token {
+        for operation in &token.operations {
+            let common = token_operation_common(operation);
+            insert_delegate_profile_scope(
+                &mut scopes,
+                common.chain_id,
+                &common.dao_code,
+                &common.governor_address,
+            );
+        }
+        for row in &token.delegate_changed {
+            insert_token_delegate_profile_scope(&mut scopes, &row.common);
+        }
+        for row in &token.delegate_votes_changed {
+            insert_token_delegate_profile_scope(&mut scopes, &row.common);
+        }
+        for row in &token.token_transfers {
+            insert_token_delegate_profile_scope(&mut scopes, &row.common);
+        }
+        for row in &token.delegate_rollings {
+            insert_token_delegate_profile_scope(&mut scopes, &row.common);
+        }
     }
-    for row in &batch.delegate_changed {
-        insert_delegate_profile_scope(&mut scopes, &row.common);
+    if let Some(proposal) = &batch.proposal {
+        for row in &proposal.proposals {
+            insert_delegate_profile_scope(
+                &mut scopes,
+                row.chain_id,
+                &row.dao_code,
+                &row.governor_address,
+            );
+        }
+        for row in &proposal.data_metrics {
+            insert_delegate_profile_scope(
+                &mut scopes,
+                row.chain_id,
+                &row.dao_code,
+                &row.governor_address,
+            );
+        }
     }
-    for row in &batch.delegate_votes_changed {
-        insert_delegate_profile_scope(&mut scopes, &row.common);
-    }
-    for row in &batch.token_transfers {
-        insert_delegate_profile_scope(&mut scopes, &row.common);
-    }
-    for row in &batch.delegate_rollings {
-        insert_delegate_profile_scope(&mut scopes, &row.common);
+    if let Some(vote) = &batch.vote {
+        for row in &vote.contributor_vote_signals {
+            insert_delegate_profile_scope(
+                &mut scopes,
+                row.chain_id,
+                &row.dao_code,
+                &row.governor_address,
+            );
+        }
+        for row in &vote.data_metrics {
+            insert_delegate_profile_scope(
+                &mut scopes,
+                row.chain_id,
+                &row.dao_code,
+                &row.governor_address,
+            );
+        }
     }
     scopes
 }
 
-fn insert_delegate_profile_scope(
+fn insert_token_delegate_profile_scope(
     scopes: &mut BTreeSet<(i32, String, String)>,
     common: &TokenEventCommon,
 ) {
-    scopes.insert((
+    insert_delegate_profile_scope(
+        scopes,
         common.chain_id,
-        common.dao_code.clone(),
-        common.governor_address.to_lowercase(),
+        &common.dao_code,
+        &common.governor_address,
+    );
+}
+
+fn insert_delegate_profile_scope(
+    scopes: &mut BTreeSet<(i32, String, String)>,
+    chain_id: i32,
+    dao_code: &str,
+    governor_address: &str,
+) {
+    scopes.insert((
+        chain_id,
+        dao_code.to_owned(),
+        governor_address.to_lowercase(),
     ));
 }
 

--- a/apps/indexer/src/store/postgres/token.rs
+++ b/apps/indexer/src/store/postgres/token.rs
@@ -63,6 +63,104 @@ fn recompute_delegate_count_effective_chunk_size() -> usize {
     )
 }
 
+fn delegate_profile_scopes(batch: &TokenProjectionBatch) -> BTreeSet<(i32, String, String)> {
+    batch
+        .delegate_changed
+        .iter()
+        .map(|row| {
+            (
+                row.common.chain_id,
+                row.common.dao_code.clone(),
+                row.common.governor_address.to_lowercase(),
+            )
+        })
+        .collect()
+}
+
+async fn maintain_delegate_profiles(
+    transaction: &mut Transaction<'_, Postgres>,
+    batch: &TokenProjectionBatch,
+    inserted_operation_keys: &[(String, String)],
+) -> Result<(), PostgresIndexerRunnerStoreError> {
+    let inserted_operation_keys = inserted_operation_keys
+        .iter()
+        .map(|(contract_set_id, id)| (contract_set_id.as_str(), id.as_str()))
+        .collect::<HashSet<_>>();
+    let profiles = batch
+        .delegate_changed
+        .iter()
+        .filter(|row| {
+            inserted_operation_keys.contains(&(row.common.contract_set_id.as_str(), row.id.as_str()))
+        })
+        .filter_map(|row| {
+            let delegate = row.to_delegate.to_lowercase();
+            (delegate != ZERO_DELEGATE_ADDRESS).then(|| {
+                (
+                    row.common.chain_id,
+                    row.common.dao_code.clone(),
+                    row.common.governor_address.to_lowercase(),
+                    delegate,
+                )
+            })
+        })
+        .collect::<BTreeSet<_>>();
+
+    if profiles.is_empty() {
+        return Ok(());
+    }
+
+    let mut query = QueryBuilder::<Postgres>::new(
+        "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate) ",
+    );
+    query.push_values(&profiles, |mut values, profile| {
+        values
+            .push_bind(profile.0)
+            .push_bind(&profile.1)
+            .push_bind(&profile.2)
+            .push_bind(&profile.3);
+    });
+    query.push(" ON CONFLICT DO NOTHING");
+    query.build().execute(&mut **transaction).await?;
+
+    let scopes = profiles
+        .iter()
+        .map(|(chain_id, dao_code, governor_address, _)| {
+            (*chain_id, dao_code.as_str(), governor_address.as_str())
+        })
+        .collect::<BTreeSet<_>>();
+    for (chain_id, dao_code, governor_address) in scopes {
+        sqlx::query(
+            "WITH rollout AS (
+               SELECT COALESCE(bool_or(delegate_profiles_count IS NOT NULL), FALSE) AS initialized
+               FROM data_metric
+               WHERE id = 'global'
+                 AND chain_id = $1
+                 AND dao_code = $2
+                 AND lower(governor_address) = $3
+             ), profile_count AS (
+               SELECT count(*)::INTEGER AS value
+               FROM delegate_profile
+               WHERE chain_id = $1 AND dao_code = $2 AND governor_address = $3
+             )
+             UPDATE data_metric
+             SET delegate_profiles_count = profile_count.value
+             FROM rollout, profile_count
+             WHERE rollout.initialized
+               AND data_metric.id = 'global'
+               AND data_metric.chain_id = $1
+               AND data_metric.dao_code = $2
+               AND lower(data_metric.governor_address) = $3",
+        )
+        .bind(chain_id)
+        .bind(dao_code)
+        .bind(governor_address)
+        .execute(&mut **transaction)
+        .await?;
+    }
+
+    Ok(())
+}
+
 fn chunk_count(row_count: usize, chunk_size: usize) -> usize {
     if row_count == 0 {
         0

--- a/apps/indexer/tests/delegate_profile_backfill.rs
+++ b/apps/indexer/tests/delegate_profile_backfill.rs
@@ -141,6 +141,38 @@ async fn test_backfill_preflight_rejects_missing_runtime_index() -> Result<(), B
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_backfill_preflight_rejects_wrong_runtime_index_definition()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_schema_migrations(&database.pool).await?;
+    sqlx::query(
+        "CREATE INDEX delegate_profile_backfill_scope_target_idx
+         ON delegate (chain_id)",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    let error = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::AllScopes,
+            dry_run: true,
+            max_scopes: Some(1),
+        },
+    )
+    .await
+    .expect_err("backfill rejects a valid index with the wrong definition");
+
+    assert!(
+        error
+            .to_string()
+            .contains("delegate_profile_backfill_scope_target_idx")
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_scoped_backfill_deduplicates_and_repairs_metric_drift() -> Result<(), Box<dyn Error>>
 {
     let database = TestDatabase::connect().await?;

--- a/apps/indexer/tests/delegate_profile_backfill.rs
+++ b/apps/indexer/tests/delegate_profile_backfill.rs
@@ -7,7 +7,7 @@ use std::{
 
 use degov_datalens_indexer::runtime::{
     DelegateProfileBackfillOptions, DelegateProfileBackfillSelection, DelegateProfileScope,
-    apply_migrations, repair_delegate_profiles_with_pool,
+    apply_migrations, apply_schema_migrations, repair_delegate_profiles_with_pool,
 };
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
@@ -59,6 +59,84 @@ impl TestDatabase {
         .await?;
         Ok(())
     }
+}
+
+impl Drop for TestDatabase {
+    fn drop(&mut self) {
+        let pool = self.pool.clone();
+        let schema = self.schema.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            tokio::task::block_in_place(|| {
+                handle.block_on(async move {
+                    let _ = sqlx::query(&format!(r#"DROP SCHEMA IF EXISTS "{schema}" CASCADE"#))
+                        .execute(&pool)
+                        .await;
+                });
+            });
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_options_and_dry_run_do_not_apply_pending_schema() -> Result<(), Box<dyn Error>>
+{
+    let database = TestDatabase::connect().await?;
+    let invalid = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::AllScopes,
+            dry_run: true,
+            max_scopes: Some(0),
+        },
+    )
+    .await
+    .expect_err("zero max scopes is rejected before preflight");
+    assert!(invalid.to_string().contains("max_scopes"));
+
+    let preflight = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::AllScopes,
+            dry_run: true,
+            max_scopes: Some(1),
+        },
+    )
+    .await
+    .expect_err("dry run does not apply pending schema");
+    assert!(preflight.to_string().contains("preflight"));
+    let data_metric_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('data_metric') IS NOT NULL")
+            .fetch_one(&database.pool)
+            .await?;
+    assert!(!data_metric_exists);
+
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backfill_preflight_rejects_missing_runtime_index() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_schema_migrations(&database.pool).await?;
+
+    let error = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::AllScopes,
+            dry_run: true,
+            max_scopes: Some(1),
+        },
+    )
+    .await
+    .expect_err("backfill requires its runtime index");
+
+    assert!(
+        error
+            .to_string()
+            .contains("delegate_profile_backfill_scope_target_idx")
+    );
+    database.cleanup().await?;
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -207,8 +285,10 @@ async fn test_all_scopes_dry_run_rolls_back_each_scope() -> Result<(), Box<dyn E
     .await?;
 
     assert_eq!(report.scopes_processed, 3);
-    assert_eq!(report.profiles_inserted, 3);
-    assert_eq!(report.metric_rows_updated, 2);
+    assert_eq!(report.profiles_inserted, 0);
+    assert_eq!(report.metric_rows_updated, 0);
+    assert_eq!(report.profiles_would_insert, 3);
+    assert_eq!(report.metric_rows_would_update, 2);
     assert_eq!(
         sqlx::query_scalar::<_, i64>("SELECT count(*) FROM delegate_profile")
             .fetch_one(&database.pool)
@@ -218,6 +298,56 @@ async fn test_all_scopes_dry_run_rolls_back_each_scope() -> Result<(), Box<dyn E
     assert_eq!(metric_counts(&database.pool, "dao-a").await?, vec![None]);
     assert_eq!(metric_counts(&database.pool, "dao-b").await?, vec![None]);
 
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backfill_detects_registry_corruption_without_updating_metric()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_migrations(&database.pool).await?;
+    seed_global_metric(&database.pool, "scope-a", 1, "dao-a", "0xgovernora").await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a",
+        "delegate-a",
+        1,
+        "dao-a",
+        "0xgovernora",
+        "0xdelegate1",
+    )
+    .await?;
+    sqlx::query(
+        "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+         VALUES (1, 'dao-a', '0xgovernora', '0xcorrupt')",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 99 WHERE dao_code = 'dao-a'")
+        .execute(&database.pool)
+        .await?;
+
+    let error = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::Scope(DelegateProfileScope::new(
+                1,
+                "dao-a",
+                "0xgovernora",
+            )?),
+            dry_run: false,
+            max_scopes: None,
+        },
+    )
+    .await
+    .expect_err("registry corruption fails verification");
+
+    assert!(error.to_string().contains("verification failed"));
+    assert_eq!(
+        metric_counts(&database.pool, "dao-a").await?,
+        vec![Some(99)]
+    );
     database.cleanup().await?;
     Ok(())
 }

--- a/apps/indexer/tests/delegate_profile_backfill.rs
+++ b/apps/indexer/tests/delegate_profile_backfill.rs
@@ -6,8 +6,9 @@ use std::{
 };
 
 use degov_datalens_indexer::runtime::{
-    DelegateProfileBackfillOptions, DelegateProfileBackfillSelection, DelegateProfileScope,
-    apply_migrations, apply_schema_migrations, repair_delegate_profiles_with_pool,
+    DelegateProfileBackfillError, DelegateProfileBackfillOptions, DelegateProfileBackfillSelection,
+    DelegateProfileScope, apply_migrations, apply_schema_migrations,
+    repair_delegate_profiles_with_pool,
 };
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use tokio::sync::{Mutex, MutexGuard};
@@ -348,6 +349,90 @@ async fn test_backfill_detects_registry_corruption_without_updating_metric()
         metric_counts(&database.pool, "dao-a").await?,
         vec![Some(99)]
     );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backfill_verifies_actual_registry_after_insert_before_publishing_metric()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_migrations(&database.pool).await?;
+    seed_global_metric(&database.pool, "scope-a", 1, "dao-a", "0xgovernora").await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a",
+        "delegate-a",
+        1,
+        "dao-a",
+        "0xgovernora",
+        "0xdelegate1",
+    )
+    .await?;
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 99 WHERE dao_code = 'dao-a'")
+        .execute(&database.pool)
+        .await?;
+    sqlx::query(
+        "CREATE FUNCTION inject_delegate_profile_corruption() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+         BEGIN
+           IF NEW.delegate <> '0x0000000000000000000000000000000000000bad' THEN
+             INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+             VALUES (
+               NEW.chain_id,
+               NEW.dao_code,
+               NEW.governor_address,
+               '0x0000000000000000000000000000000000000bad'
+             );
+           END IF;
+           RETURN NEW;
+         END
+         $$",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "CREATE TRIGGER inject_delegate_profile_corruption
+         AFTER INSERT ON delegate_profile
+         FOR EACH ROW EXECUTE FUNCTION inject_delegate_profile_corruption()",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    let error = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::Scope(DelegateProfileScope::new(
+                1,
+                "dao-a",
+                "0xgovernora",
+            )?),
+            dry_run: false,
+            max_scopes: None,
+        },
+    )
+    .await
+    .expect_err("post-write registry corruption fails verification");
+
+    assert!(matches!(
+        error,
+        DelegateProfileBackfillError::Verification {
+            registry_count: 2,
+            historical_count: 1,
+            ..
+        }
+    ));
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT count(*) FROM delegate_profile")
+            .fetch_one(&database.pool)
+            .await?,
+        0
+    );
+    assert_eq!(
+        metric_counts(&database.pool, "dao-a").await?,
+        vec![Some(99)]
+    );
+
     database.cleanup().await?;
     Ok(())
 }

--- a/apps/indexer/tests/delegate_profile_backfill.rs
+++ b/apps/indexer/tests/delegate_profile_backfill.rs
@@ -1,0 +1,306 @@
+use std::{
+    env,
+    error::Error,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use degov_datalens_indexer::runtime::{
+    DelegateProfileBackfillOptions, DelegateProfileBackfillSelection, DelegateProfileScope,
+    apply_migrations, repair_delegate_profiles_with_pool,
+};
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use tokio::sync::{Mutex, MutexGuard};
+
+const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+static SCHEMA_COUNTER: AtomicU64 = AtomicU64::new(0);
+static DATABASE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+struct TestDatabase {
+    _guard: MutexGuard<'static, ()>,
+    pool: PgPool,
+    schema: String,
+}
+
+impl TestDatabase {
+    async fn connect() -> Result<Self, Box<dyn Error>> {
+        let guard = DATABASE_TEST_LOCK.lock().await;
+        let database_url = env::var("DEGOV_INDEXER_TEST_DATABASE_URL")
+            .map_err(|_| "DEGOV_INDEXER_TEST_DATABASE_URL is required")?;
+        let schema = unique_schema_name();
+        let setup_pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await?;
+        sqlx::query(&format!(r#"CREATE SCHEMA "{schema}""#))
+            .execute(&setup_pool)
+            .await?;
+        setup_pool.close().await;
+
+        let database_url = database_url_with_search_path(&database_url, &schema);
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&database_url)
+            .await?;
+
+        Ok(Self {
+            _guard: guard,
+            pool,
+            schema,
+        })
+    }
+
+    async fn cleanup(&self) -> Result<(), sqlx::Error> {
+        sqlx::query(&format!(
+            r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+            self.schema
+        ))
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scoped_backfill_deduplicates_and_repairs_metric_drift() -> Result<(), Box<dyn Error>>
+{
+    let database = TestDatabase::connect().await?;
+    apply_migrations(&database.pool).await?;
+    seed_global_metric(&database.pool, "scope-a-v1", 1, "dao-a", "0xGovernorA").await?;
+    seed_global_metric(&database.pool, "scope-a-v2", 1, "dao-a", "0xgovernora").await?;
+    seed_global_metric(&database.pool, "scope-b", 1, "dao-b", "0xgovernorb").await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a-v1",
+        "delegate-1",
+        1,
+        "dao-a",
+        "0xGovernorA",
+        "0xDELEGATE1",
+    )
+    .await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a-v2",
+        "delegate-2",
+        1,
+        "dao-a",
+        "0xgovernora",
+        "0xdelegate1",
+    )
+    .await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a-v2",
+        "delegate-3",
+        1,
+        "dao-a",
+        "0xgovernora",
+        "0xDelegate2",
+    )
+    .await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a-v1",
+        "delegate-zero",
+        1,
+        "dao-a",
+        "0xGovernorA",
+        ZERO_ADDRESS,
+    )
+    .await?;
+    seed_delegate(
+        &database.pool,
+        "scope-b",
+        "delegate-other",
+        1,
+        "dao-b",
+        "0xgovernorb",
+        "0xdelegate3",
+    )
+    .await?;
+    let options = DelegateProfileBackfillOptions {
+        selection: DelegateProfileBackfillSelection::Scope(DelegateProfileScope::new(
+            1,
+            "dao-a",
+            "0xGOVERNORA",
+        )?),
+        dry_run: false,
+        max_scopes: None,
+    };
+    let first = repair_delegate_profiles_with_pool(&database.pool, options.clone()).await?;
+
+    assert_eq!(first.scopes_processed, 1);
+    assert_eq!(first.profiles_inserted, 2);
+    assert_eq!(first.metric_rows_updated, 2);
+    assert_eq!(
+        profile_delegates(&database.pool, "dao-a").await?,
+        vec!["0xdelegate1", "0xdelegate2"]
+    );
+    assert_eq!(
+        metric_counts(&database.pool, "dao-a").await?,
+        vec![Some(2), Some(2)]
+    );
+    assert_eq!(metric_counts(&database.pool, "dao-b").await?, vec![None]);
+
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 99 WHERE dao_code = 'dao-a'")
+        .execute(&database.pool)
+        .await?;
+    let second = repair_delegate_profiles_with_pool(&database.pool, options).await?;
+
+    assert_eq!(second.profiles_inserted, 0);
+    assert_eq!(second.metric_rows_updated, 2);
+    assert_eq!(
+        metric_counts(&database.pool, "dao-a").await?,
+        vec![Some(2), Some(2)]
+    );
+
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_all_scopes_dry_run_rolls_back_each_scope() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_migrations(&database.pool).await?;
+    seed_global_metric(&database.pool, "scope-a", 1, "dao-a", "0xgovernora").await?;
+    seed_global_metric(&database.pool, "scope-b", 2, "dao-b", "0xgovernorb").await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a",
+        "delegate-a",
+        1,
+        "dao-a",
+        "0xgovernora",
+        "0xdelegate1",
+    )
+    .await?;
+    seed_delegate(
+        &database.pool,
+        "scope-b",
+        "delegate-b",
+        2,
+        "dao-b",
+        "0xgovernorb",
+        "0xdelegate2",
+    )
+    .await?;
+    seed_delegate(
+        &database.pool,
+        "scope-c",
+        "delegate-c",
+        3,
+        "dao-c",
+        "0xgovernorc",
+        "0xdelegate3",
+    )
+    .await?;
+
+    let report = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::AllScopes,
+            dry_run: true,
+            max_scopes: None,
+        },
+    )
+    .await?;
+
+    assert_eq!(report.scopes_processed, 3);
+    assert_eq!(report.profiles_inserted, 3);
+    assert_eq!(report.metric_rows_updated, 2);
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT count(*) FROM delegate_profile")
+            .fetch_one(&database.pool)
+            .await?,
+        0
+    );
+    assert_eq!(metric_counts(&database.pool, "dao-a").await?, vec![None]);
+    assert_eq!(metric_counts(&database.pool, "dao-b").await?, vec![None]);
+
+    database.cleanup().await?;
+    Ok(())
+}
+
+async fn seed_global_metric(
+    pool: &PgPool,
+    contract_set_id: &str,
+    chain_id: i32,
+    dao_code: &str,
+    governor_address: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO data_metric (id, contract_set_id, chain_id, dao_code, governor_address)
+         VALUES ('global', $1, $2, $3, $4)",
+    )
+    .bind(contract_set_id)
+    .bind(chain_id)
+    .bind(dao_code)
+    .bind(governor_address)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn seed_delegate(
+    pool: &PgPool,
+    contract_set_id: &str,
+    id: &str,
+    chain_id: i32,
+    dao_code: &str,
+    governor_address: &str,
+    to_delegate: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO delegate (
+           id, contract_set_id, chain_id, dao_code, governor_address, from_delegate, to_delegate,
+           block_number, block_timestamp, transaction_hash, is_current, power
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, 1, 1, $1, true, 0)",
+    )
+    .bind(id)
+    .bind(contract_set_id)
+    .bind(chain_id)
+    .bind(dao_code)
+    .bind(governor_address)
+    .bind(format!("0xfrom{id}"))
+    .bind(to_delegate)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn profile_delegates(pool: &PgPool, dao_code: &str) -> Result<Vec<String>, sqlx::Error> {
+    sqlx::query_scalar(
+        "SELECT delegate FROM delegate_profile WHERE dao_code = $1 ORDER BY delegate",
+    )
+    .bind(dao_code)
+    .fetch_all(pool)
+    .await
+}
+
+async fn metric_counts(pool: &PgPool, dao_code: &str) -> Result<Vec<Option<i32>>, sqlx::Error> {
+    sqlx::query("SELECT delegate_profiles_count FROM data_metric WHERE dao_code = $1 ORDER BY contract_set_id")
+        .bind(dao_code)
+        .fetch_all(pool)
+        .await
+        .map(|rows| rows.into_iter().map(|row| row.get("delegate_profiles_count")).collect())
+}
+
+fn unique_schema_name() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_millis();
+    let counter = SCHEMA_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!(
+        "degov_delegate_profile_test_{}_{}_{}",
+        std::process::id(),
+        now,
+        counter
+    )
+}
+
+fn database_url_with_search_path(database_url: &str, schema: &str) -> String {
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    format!("{database_url}{separator}options=-csearch_path%3D{schema}")
+}

--- a/apps/indexer/tests/delegate_profile_backfill.rs
+++ b/apps/indexer/tests/delegate_profile_backfill.rs
@@ -469,6 +469,136 @@ async fn test_backfill_verifies_actual_registry_after_insert_before_publishing_m
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backfill_rejects_uniform_post_update_metric_drift() -> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_migrations(&database.pool).await?;
+    seed_global_metric(&database.pool, "scope-a-v1", 1, "dao-a", "0xgovernora").await?;
+    seed_global_metric(&database.pool, "scope-a-v2", 1, "dao-a", "0xgovernora").await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a-v1",
+        "delegate-a",
+        1,
+        "dao-a",
+        "0xgovernora",
+        "0xdelegate1",
+    )
+    .await?;
+    sqlx::query(
+        "CREATE FUNCTION corrupt_delegate_profile_metric() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+         BEGIN
+           NEW.delegate_profiles_count := 99;
+           RETURN NEW;
+         END
+         $$",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "CREATE TRIGGER corrupt_delegate_profile_metric
+         BEFORE UPDATE OF delegate_profiles_count ON data_metric
+         FOR EACH ROW EXECUTE FUNCTION corrupt_delegate_profile_metric()",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    let error = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::Scope(DelegateProfileScope::new(
+                1,
+                "dao-a",
+                "0xgovernora",
+            )?),
+            dry_run: false,
+            max_scopes: None,
+        },
+    )
+    .await
+    .expect_err("post-update metric drift fails verification");
+
+    assert!(error.to_string().contains("metric verification failed"));
+    assert_eq!(
+        metric_counts(&database.pool, "dao-a").await?,
+        vec![None, None]
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT count(*) FROM delegate_profile")
+            .fetch_one(&database.pool)
+            .await?,
+        0
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backfill_rejects_replica_introduced_during_metric_update()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_migrations(&database.pool).await?;
+    seed_global_metric(&database.pool, "scope-a-v1", 1, "dao-a", "0xgovernora").await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a-v1",
+        "delegate-a",
+        1,
+        "dao-a",
+        "0xgovernora",
+        "0xdelegate1",
+    )
+    .await?;
+    sqlx::query(
+        "CREATE FUNCTION introduce_delegate_profile_metric_replica() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+         BEGIN
+           INSERT INTO data_metric (
+             id, contract_set_id, chain_id, dao_code, governor_address, delegate_profiles_count
+           ) VALUES ('global', 'scope-a-v2', 1, 'dao-a', '0xgovernora', NULL)
+           ON CONFLICT DO NOTHING;
+           RETURN NULL;
+         END
+         $$",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "CREATE TRIGGER introduce_delegate_profile_metric_replica
+         AFTER UPDATE OF delegate_profiles_count ON data_metric
+         FOR EACH STATEMENT EXECUTE FUNCTION introduce_delegate_profile_metric_replica()",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    let error = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::Scope(DelegateProfileScope::new(
+                1,
+                "dao-a",
+                "0xgovernora",
+            )?),
+            dry_run: false,
+            max_scopes: None,
+        },
+    )
+    .await
+    .expect_err("a metric replica introduced during update fails verification");
+
+    assert!(error.to_string().contains("metric verification failed"));
+    assert_eq!(metric_counts(&database.pool, "dao-a").await?, vec![None]);
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT count(*) FROM delegate_profile")
+            .fetch_one(&database.pool)
+            .await?,
+        0
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
 async fn seed_global_metric(
     pool: &PgPool,
     contract_set_id: &str,

--- a/apps/indexer/tests/delegate_profile_backfill.rs
+++ b/apps/indexer/tests/delegate_profile_backfill.rs
@@ -599,6 +599,77 @@ async fn test_backfill_rejects_replica_introduced_during_metric_update()
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backfill_rejects_update_that_skips_an_intended_metric_replica()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_migrations(&database.pool).await?;
+    seed_global_metric(&database.pool, "scope-a-v1", 1, "dao-a", "0xgovernora").await?;
+    seed_global_metric(&database.pool, "scope-a-v2", 1, "dao-a", "0xgovernora").await?;
+    seed_delegate(
+        &database.pool,
+        "scope-a-v1",
+        "delegate-a",
+        1,
+        "dao-a",
+        "0xgovernora",
+        "0xdelegate1",
+    )
+    .await?;
+    sqlx::query(
+        "CREATE FUNCTION skip_one_delegate_profile_metric() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+         BEGIN
+           IF OLD.contract_set_id = 'scope-a-v2' THEN
+             RETURN NULL;
+           END IF;
+           RETURN NEW;
+         END
+         $$",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "CREATE TRIGGER skip_one_delegate_profile_metric
+         BEFORE UPDATE OF delegate_profiles_count ON data_metric
+         FOR EACH ROW EXECUTE FUNCTION skip_one_delegate_profile_metric()",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    let error = repair_delegate_profiles_with_pool(
+        &database.pool,
+        DelegateProfileBackfillOptions {
+            selection: DelegateProfileBackfillSelection::Scope(DelegateProfileScope::new(
+                1,
+                "dao-a",
+                "0xgovernora",
+            )?),
+            dry_run: false,
+            max_scopes: None,
+        },
+    )
+    .await
+    .expect_err("skipping an intended replica fails verification");
+
+    let message = error.to_string();
+    assert!(message.contains("intended_replicas=2"), "{message}");
+    assert!(message.contains("updated_replicas=1"), "{message}");
+    assert!(message.contains("actual_replicas=2"), "{message}");
+    assert_eq!(
+        metric_counts(&database.pool, "dao-a").await?,
+        vec![None, None]
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT count(*) FROM delegate_profile")
+            .fetch_one(&database.pool)
+            .await?,
+        0
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
 async fn seed_global_metric(
     pool: &PgPool,
     contract_set_id: &str,

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -772,18 +772,30 @@ async fn test_graphql_delegate_profiles_count_falls_back_for_null_or_filtered_sc
 #[test]
 fn test_graphql_delegate_profile_fast_path_uses_one_database_query() {
     let source = include_str!("../src/graphql/query.rs");
-    let start = source
+    let sql_start = source
         .find("const MATERIALIZED_DELEGATE_PROFILES_SQL")
         .expect("materialized delegate profile combined statement");
-    let end = source[start..]
+    let fast_path_start = source[sql_start..]
+        .find("async fn count_materialized_delegate_profiles")
+        .map(|offset| sql_start + offset)
+        .expect("materialized delegate profile fast path");
+    let fast_path_end = source[fast_path_start..]
         .find("pub(super) async fn count_delegate_profiles")
-        .map(|offset| start + offset)
+        .map(|offset| fast_path_start + offset)
         .expect("public delegate profile count function");
-    let fast_path = &source[start..end];
+    let combined_sql = source[sql_start..fast_path_start]
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    let fast_path = &source[fast_path_start..fast_path_end];
 
     assert_eq!(fast_path.matches(".fetch_one(pool)").count(), 1);
     assert_eq!(fast_path.matches("sqlx::query_as").count(), 1);
     assert!(!fast_path.contains("sqlx::query_scalar"));
+    assert!(!combined_sql.contains(" from delegate "));
+    assert!(!combined_sql.contains(" join delegate "));
+    assert!(!combined_sql.contains("count(distinct lower(to_delegate))"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -322,12 +322,12 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_graphql_delegate_profiles_count_uses_logical_scope_materialized_max()
+async fn test_graphql_delegate_profiles_count_uses_replicated_logical_scope_metric()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     sqlx::query(
         "UPDATE data_metric
-         SET delegate_profiles_count = 4
+         SET delegate_profiles_count = 7
          WHERE contract_set_id = $1 AND id = 'global'",
     )
     .bind(CONTRACT_SET_ID)
@@ -377,11 +377,165 @@ async fn test_graphql_delegate_profiles_count_uses_logical_scope_materialized_ma
     );
     let data = response.data.into_json()?;
     assert_eq!(data["delegateProfilesCount"], 7);
-    assert_eq!(data["dataMetrics"][0]["delegateProfilesCount"], 4);
+    assert_eq!(data["dataMetrics"][0]["delegateProfilesCount"], 7);
     assert_eq!(data["dataMetrics"][1]["delegateProfilesCount"], 7);
     assert_eq!(
         data["eventMetric"][0]["delegateProfilesCount"],
         serde_json::Value::Null
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_delegate_profiles_count_falls_back_for_invalid_metric_replicas()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    sqlx::query(
+        "INSERT INTO data_metric (
+           id, contract_set_id, chain_id, dao_code, governor_address, delegate_profiles_count
+         ) VALUES ('global', 'lisk-second-contract-set', 1135, 'lisk-dao', '0xgovernor', 7)",
+    )
+    .execute(&database.pool)
+    .await?;
+    let schema = graphql::build_schema(database.pool.clone());
+    let request = || {
+        Request::new(
+            r#"
+            query InvalidMaterializedDelegateProfiles {
+              delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+              })
+            }
+            "#,
+        )
+    };
+
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = CASE contract_set_id WHEN $1 THEN 4 ELSE 7 END
+         WHERE id = 'global' AND chain_id = 1135 AND dao_code = 'lisk-dao'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    let drift = schema.execute(request()).await;
+    assert!(
+        drift.errors.is_empty(),
+        "unexpected errors: {:?}",
+        drift.errors
+    );
+    assert_eq!(drift.data.into_json()?["delegateProfilesCount"], 2);
+
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = CASE contract_set_id WHEN $1 THEN 4 ELSE NULL END
+         WHERE id = 'global' AND chain_id = 1135 AND dao_code = 'lisk-dao'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    let mixed_null = schema.execute(request()).await;
+    assert!(
+        mixed_null.errors.is_empty(),
+        "unexpected errors: {:?}",
+        mixed_null.errors
+    );
+    assert_eq!(mixed_null.data.into_json()?["delegateProfilesCount"], 2);
+
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = -1
+         WHERE id = 'global' AND chain_id = 1135 AND dao_code = 'lisk-dao'",
+    )
+    .execute(&database.pool)
+    .await?;
+    let negative = schema.execute(request()).await;
+    assert!(
+        negative.errors.is_empty(),
+        "unexpected errors: {:?}",
+        negative.errors
+    );
+    assert_eq!(negative.data.into_json()?["delegateProfilesCount"], 2);
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_delegate_profiles_count_normalizes_governor_case_across_paths()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = 7
+         WHERE contract_set_id = $1 AND id = 'global'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    let schema = graphql::build_schema(database.pool.clone());
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query MixedCaseGovernorDelegateProfiles {
+              materialized: delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xGoVeRnOr"
+              })
+              realtime: delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xGoVeRnOr"
+                fromDelegate_eq: "0xdelegator"
+              })
+            }
+            "#,
+        ))
+        .await;
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+    let data = response.data.into_json()?;
+    assert_eq!(data["materialized"], 7);
+    assert_eq!(data["realtime"], 1);
+
+    let implicit_schema = graphql::build_schema_with_scope(
+        database.pool.clone(),
+        graphql::GraphqlScope {
+            governor_address: Some("0xgovernor".to_owned()),
+            ..graphql::GraphqlScope::default()
+        },
+    );
+    let implicit_response = implicit_schema
+        .execute(Request::new(
+            r#"
+            query ImplicitMixedCaseGovernorDelegateProfiles {
+              delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xGoVeRnOr"
+              })
+            }
+            "#,
+        ))
+        .await;
+    assert!(
+        implicit_response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        implicit_response.errors
+    );
+    assert_eq!(
+        implicit_response.data.into_json()?["delegateProfilesCount"],
+        7
     );
 
     database.cleanup().await?;
@@ -616,20 +770,20 @@ async fn test_graphql_delegate_profiles_count_falls_back_for_null_or_filtered_sc
 }
 
 #[test]
-fn test_graphql_delegate_profile_fast_path_source_does_not_scan_delegate() {
+fn test_graphql_delegate_profile_fast_path_uses_one_database_query() {
     let source = include_str!("../src/graphql/query.rs");
     let start = source
-        .find("async fn count_materialized_delegate_profiles")
-        .expect("materialized delegate profile count helper");
+        .find("const MATERIALIZED_DELEGATE_PROFILES_SQL")
+        .expect("materialized delegate profile combined statement");
     let end = source[start..]
         .find("pub(super) async fn count_delegate_profiles")
         .map(|offset| start + offset)
         .expect("public delegate profile count function");
     let fast_path = &source[start..end];
 
-    assert!(fast_path.contains("MAX(delegate_profiles_count)"));
-    assert!(!fast_path.contains("FROM delegate\n"));
-    assert!(!fast_path.contains("COUNT(DISTINCT lower(to_delegate))"));
+    assert_eq!(fast_path.matches(".fetch_one(pool)").count(), 1);
+    assert_eq!(fast_path.matches("sqlx::query_as").count(), 1);
+    assert!(!fast_path.contains("sqlx::query_scalar"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -322,6 +322,317 @@ async fn test_graphql_schema_serves_current_web_compatibility_queries() -> Resul
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_delegate_profiles_count_uses_logical_scope_materialized_max()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = 4
+         WHERE contract_set_id = $1 AND id = 'global'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO data_metric (
+           id, contract_set_id, chain_id, dao_code, governor_address, delegate_profiles_count
+         ) VALUES ('global', 'lisk-second-contract-set', 1135, 'lisk-dao', '0xgovernor', 7)",
+    )
+    .execute(&database.pool)
+    .await?;
+    let schema = graphql::build_schema(database.pool.clone());
+
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query MaterializedDelegateProfiles {
+              delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+              })
+              dataMetrics(
+                where: {
+                  id_eq: "global"
+                  chainId_eq: 1135
+                  daoCode_eq: "lisk-dao"
+                  governorAddress_eq: "0xgovernor"
+                }
+                orderBy: id_ASC
+              ) {
+                delegateProfilesCount
+              }
+              eventMetric: dataMetrics(where: { id_eq: "0000000800-proposal" }) {
+                delegateProfilesCount
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+    let data = response.data.into_json()?;
+    assert_eq!(data["delegateProfilesCount"], 7);
+    assert_eq!(data["dataMetrics"][0]["delegateProfilesCount"], 4);
+    assert_eq!(data["dataMetrics"][1]["delegateProfilesCount"], 7);
+    assert_eq!(
+        data["eventMetric"][0]["delegateProfilesCount"],
+        serde_json::Value::Null
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_delegate_profiles_count_adds_only_new_available_overlay_targets()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = 7
+         WHERE contract_set_id = $1 AND id = 'global'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+         VALUES
+           (1135, 'lisk-dao', '0xgovernor', '0xdelegate'),
+           (1135, 'lisk-dao', '0xgovernor', '0xformer')",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO degov_provisional_delegate_power_overlay (
+          id, contract_set_id, chain_id, chain_name, dao_code, governor_address,
+          delegator, delegate, power, is_current, source, status
+        ) VALUES
+          ('overlay:new-a', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
+           '0xnew-a', '0xNeW', 1, TRUE, 'live-onchain', 'available'),
+          ('overlay:new-b', 'lisk-second-contract-set', 1135, 'lisk', 'lisk-dao', '0xGOVERNOR',
+           '0xnew-b', '0xnew', 1, TRUE, 'live-onchain', 'available'),
+          ('overlay:registry', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
+           '0xregistry', '0xDELEGATE', 1, TRUE, 'live-onchain', 'available'),
+          ('overlay:zero', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
+           '0xzero', '0x0000000000000000000000000000000000000000', 1, TRUE, 'live-onchain', 'available'),
+          ('overlay:invalid', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
+           '0xinvalid', '0xinvalid', 1, TRUE, 'live-onchain', 'invalid'),
+          ('overlay:finalized', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
+           '0xfinalized', '0xfinalized', 1, TRUE, 'live-onchain', 'finalized')
+        "#,
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    let schema = graphql::build_schema(database.pool.clone());
+
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query OverlayDelegateProfiles {
+              delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+              })
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+    assert_eq!(response.data.into_json()?["delegateProfilesCount"], 8);
+
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = $1
+         WHERE contract_set_id = $2 AND id = 'global'",
+    )
+    .bind(i32::MAX)
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    let overflow_response = schema
+        .execute(Request::new(
+            r#"
+            query OverflowingDelegateProfiles {
+              delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+              })
+            }
+            "#,
+        ))
+        .await;
+    assert_eq!(overflow_response.errors.len(), 1);
+    assert!(
+        overflow_response.errors[0]
+            .message
+            .contains("delegateProfilesCount exceeds GraphQL Int")
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graphql_delegate_profiles_count_falls_back_for_null_or_filtered_scopes()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = NULL
+         WHERE contract_set_id = $1 AND id = 'global'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    let schema = graphql::build_schema(database.pool.clone());
+
+    let null_metric_response = schema
+        .execute(Request::new(
+            r#"
+            query NullMetricDelegateProfileFallback {
+              delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+              })
+            }
+            "#,
+        ))
+        .await;
+    assert!(
+        null_metric_response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        null_metric_response.errors
+    );
+    assert_eq!(
+        null_metric_response.data.into_json()?["delegateProfilesCount"],
+        2
+    );
+
+    sqlx::query(
+        "UPDATE data_metric
+         SET delegate_profiles_count = 99
+         WHERE contract_set_id = $1 AND id = 'global'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .execute(&database.pool)
+    .await?;
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query FilteredDelegateProfileFallbacks {
+              incomplete: delegateProfilesCount(where: { daoCode_eq: "lisk-dao" })
+              from: delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+                fromDelegate_eq: "0xdelegator"
+              })
+              current: delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+                isCurrent_eq: true
+              })
+              power: delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+                power_lt: 1
+              })
+              recursive: delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+                OR: [{ toDelegate_eq: "0xformer" }]
+              })
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+    let data = response.data.into_json()?;
+    assert_eq!(data["incomplete"], 2);
+    assert_eq!(data["from"], 1);
+    assert_eq!(data["current"], 1);
+    assert_eq!(data["power"], 1);
+    assert_eq!(data["recursive"], 1);
+
+    let contract_scoped_schema = graphql::build_schema_with_scope(
+        database.pool.clone(),
+        graphql::GraphqlScope {
+            contract_set_id: Some(CONTRACT_SET_ID.to_owned()),
+            ..graphql::GraphqlScope::default()
+        },
+    );
+    let contract_scoped_response = contract_scoped_schema
+        .execute(Request::new(
+            r#"
+            query ContractScopedDelegateProfileFallback {
+              delegateProfilesCount(where: {
+                chainId_eq: 1135
+                daoCode_eq: "lisk-dao"
+                governorAddress_eq: "0xgovernor"
+              })
+            }
+            "#,
+        ))
+        .await;
+    assert!(
+        contract_scoped_response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        contract_scoped_response.errors
+    );
+    assert_eq!(
+        contract_scoped_response.data.into_json()?["delegateProfilesCount"],
+        2
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[test]
+fn test_graphql_delegate_profile_fast_path_source_does_not_scan_delegate() {
+    let source = include_str!("../src/graphql/query.rs");
+    let start = source
+        .find("async fn count_materialized_delegate_profiles")
+        .expect("materialized delegate profile count helper");
+    let end = source[start..]
+        .find("pub(super) async fn count_delegate_profiles")
+        .map(|offset| start + offset)
+        .expect("public delegate profile count function");
+    let fast_path = &source[start..end];
+
+    assert!(fast_path.contains("MAX(delegate_profiles_count)"));
+    assert!(!fast_path.contains("FROM delegate\n"));
+    assert!(!fast_path.contains("COUNT(DISTINCT lower(to_delegate))"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_nested_voters_filter_by_exact_punctuated_id() -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     let schema = graphql::build_schema_with_scope(

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -184,6 +184,22 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "provisional_delegate_profile_delta_scope_idx",
+    )
+    .await?;
+    assert_index_definition_contains(
+        &database.pool,
+        &database.schema,
+        "provisional_delegate_profile_delta_scope_idx",
+        &[
+            "USING btree (chain_id, dao_code, lower(governor_address), lower(delegate))",
+            "WHERE (status = 'available'::text)",
+        ],
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "delegate_mapping_positive_count_idx",
     )
     .await?;
@@ -727,6 +743,56 @@ async fn test_migration_repairs_invalid_runtime_index() -> Result<(), Box<dyn Er
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_migration_repairs_and_plans_delegate_profile_delta_index()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    sqlx::query(
+        "UPDATE pg_index
+         SET indisvalid = false
+         WHERE indexrelid = 'provisional_delegate_profile_delta_scope_idx'::regclass",
+    )
+    .execute(&database.pool)
+    .await?;
+    apply_migrations(&database.pool).await?;
+    assert_index_is_valid(
+        &database.pool,
+        &database.schema,
+        "provisional_delegate_profile_delta_scope_idx",
+    )
+    .await?;
+
+    sqlx::query("SET enable_seqscan = off")
+        .execute(&database.pool)
+        .await?;
+    let plan: Vec<String> = sqlx::query_scalar(
+        "EXPLAIN (COSTS OFF)
+         SELECT COUNT(DISTINCT lower(delegate_overlay.delegate))::int8
+         FROM degov_provisional_delegate_power_overlay delegate_overlay
+         WHERE delegate_overlay.status = 'available'
+           AND delegate_overlay.chain_id = 1135
+           AND delegate_overlay.dao_code = 'lisk-dao'
+           AND lower(delegate_overlay.governor_address) = lower('0xgovernor')",
+    )
+    .fetch_all(&database.pool)
+    .await?;
+    let plan = plan.join("\n");
+    assert!(
+        plan.contains("provisional_delegate_profile_delta_scope_idx"),
+        "expected logical-scope delta index in plan:\n{plan}"
+    );
+    assert!(
+        !plan.contains("Seq Scan on degov_provisional_delegate_power_overlay"),
+        "unexpected overlay sequential scan:\n{plan}"
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_migration_rebuilds_invalid_deferred_candidate_scope_drain_index()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -911,6 +977,16 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     ));
     assert!(runtime_migration.contains(
         "drop_invalid_runtime_index(connection, \"provisional_contributor_live_graphql_scope_idx\")"
+    ));
+    assert!(runtime_migration.contains(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_profile_delta_scope_idx
+         ON degov_provisional_delegate_power_overlay (
+            chain_id, dao_code, lower(governor_address), lower(delegate)
+         )
+         WHERE status = 'available'"
+    ));
+    assert!(runtime_migration.contains(
+        "drop_invalid_runtime_index(connection, \"provisional_delegate_profile_delta_scope_idx\")"
     ));
     assert!(runtime_migration.contains("ON onchain_refresh_task (next_run_at, updated_at, id)"));
     assert!(runtime_migration.contains("WHERE status = 'pending'"));

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -178,6 +178,12 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "delegate_profile_backfill_scope_target_idx",
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "delegate_mapping_positive_count_idx",
     )
     .await?;
@@ -935,6 +941,31 @@ fn test_graphql_and_worker_use_schema_only_migrations() {
     assert!(!worker_runtime.contains("use super::migrate::apply_migrations"));
     assert!(!graphql_runtime.contains("apply_migrations(&pool).await?"));
     assert!(!worker_runtime.contains("apply_migrations(&pool).await?"));
+}
+
+#[test]
+fn test_delegate_profile_backfill_uses_runtime_index_and_read_only_preflight() {
+    let runtime_migration = include_str!("../src/runtime/migrate.rs");
+    let backfill = include_str!("../src/runtime/delegate_profile_backfill.rs");
+
+    assert!(runtime_migration.contains(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS delegate_profile_backfill_scope_target_idx"
+    ));
+    assert!(
+        runtime_migration.contains(
+            "ON delegate (chain_id, dao_code, lower(governor_address), lower(to_delegate))"
+        )
+    );
+    assert!(backfill.contains("LIMIT $1"));
+    assert!(!backfill.contains("apply_migrations"));
+    assert!(
+        backfill
+            .find("validate_options")
+            .expect("option validation exists")
+            < backfill
+                .find("std::env::var")
+                .expect("database lookup exists")
+    );
 }
 
 #[test]

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -49,6 +49,7 @@ const REQUIRED_TABLES: &[&str] = &[
     "timelock_role_event",
     "timelock_min_delay_change",
     "data_metric",
+    "delegate_profile",
     "delegate_rolling",
     "delegate",
     "contributor",
@@ -148,6 +149,20 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     for table_name in REQUIRED_TABLES {
         assert_table_exists(&database.pool, &database.schema, table_name).await?;
     }
+    assert_column_exists(
+        &database.pool,
+        &database.schema,
+        "data_metric",
+        "delegate_profiles_count",
+    )
+    .await?;
+    assert_primary_key_columns(
+        &database.pool,
+        &database.schema,
+        "delegate_profile",
+        &["chain_id", "dao_code", "governor_address", "delegate"],
+    )
+    .await?;
     assert_index_exists(
         &database.pool,
         &database.schema,
@@ -335,6 +350,61 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
 
     database.cleanup().await?;
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delegate_profile_migration_rerun_preserves_materialized_data()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    apply_schema_migrations(&database.pool).await?;
+    sqlx::query(
+        "INSERT INTO data_metric (
+           id, contract_set_id, chain_id, dao_code, governor_address, delegate_profiles_count
+         ) VALUES ('global', 'scope-a', 1, 'dao-a', '0xgovernora', 1)",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+         VALUES (1, 'dao-a', '0xgovernora', '0xdelegate1')",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    assert!(
+        sqlx::query(
+            "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+             VALUES (1, 'dao-a', '0xGovernorA', '0xdelegate2')",
+        )
+        .execute(&database.pool)
+        .await
+        .is_err()
+    );
+    assert!(
+        sqlx::query(
+            "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+             VALUES (1, 'dao-a', '0xgovernora', '0x0000000000000000000000000000000000000000')",
+        )
+        .execute(&database.pool)
+        .await
+        .is_err()
+    );
+
+    apply_schema_migrations(&database.pool).await?;
+
+    let profile_count: i64 = sqlx::query_scalar("SELECT count(*) FROM delegate_profile")
+        .fetch_one(&database.pool)
+        .await?;
+    let metric_count: Option<i32> = sqlx::query_scalar(
+        "SELECT delegate_profiles_count FROM data_metric WHERE contract_set_id = 'scope-a'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(profile_count, 1);
+    assert_eq!(metric_count, Some(1));
+
+    database.cleanup().await?;
     Ok(())
 }
 
@@ -772,7 +842,8 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
             "0007_checkpoint_adaptive_chunk_state.sql",
             "0008_indexer_latest_head.sql",
             "0009_provisional_proposal_event_fields.sql",
-            "0010_provisional_vote_overlays.sql"
+            "0010_provisional_vote_overlays.sql",
+            "0011_delegate_profile_materialization.sql"
         ]
     );
 
@@ -995,6 +1066,62 @@ async fn assert_table_exists(
     .await?;
 
     assert!(exists, "expected table {schema}.{table_name} to exist");
+
+    Ok(())
+}
+
+async fn assert_column_exists(
+    pool: &PgPool,
+    schema: &str,
+    table_name: &str,
+    column_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+           SELECT 1
+           FROM information_schema.columns
+           WHERE table_schema = $1 AND table_name = $2 AND column_name = $3
+         )",
+    )
+    .bind(schema)
+    .bind(table_name)
+    .bind(column_name)
+    .fetch_one(pool)
+    .await?;
+
+    assert!(
+        exists,
+        "expected column {schema}.{table_name}.{column_name} to exist"
+    );
+
+    Ok(())
+}
+
+async fn assert_primary_key_columns(
+    pool: &PgPool,
+    schema: &str,
+    table_name: &str,
+    expected: &[&str],
+) -> Result<(), Box<dyn Error>> {
+    let columns: Vec<String> = sqlx::query_scalar(
+        "SELECT attribute.attname
+         FROM pg_constraint constraint_definition
+         JOIN pg_class table_definition ON table_definition.oid = constraint_definition.conrelid
+         JOIN pg_namespace namespace ON namespace.oid = table_definition.relnamespace
+         JOIN unnest(constraint_definition.conkey) WITH ORDINALITY key(attnum, ordinal) ON TRUE
+         JOIN pg_attribute attribute
+           ON attribute.attrelid = table_definition.oid AND attribute.attnum = key.attnum
+         WHERE constraint_definition.contype = 'p'
+           AND namespace.nspname = $1
+           AND table_definition.relname = $2
+         ORDER BY key.ordinal",
+    )
+    .bind(schema)
+    .bind(table_name)
+    .fetch_all(pool)
+    .await?;
+
+    assert_eq!(columns, expected);
 
     Ok(())
 }

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -473,6 +473,9 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     )
     .await?;
     seed_data_metric_with_scope(&database.pool, "demo-dao", "7", 7, 7).await?;
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 5 WHERE dao_code = 'demo-dao'")
+        .execute(&database.pool)
+        .await?;
     seed_final_delegate_with_scope(
         &database.pool,
         "demo-dao",
@@ -562,6 +565,12 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
     assert_completed_task(&database.pool, "task-one", 1).await?;
     assert_completed_task(&database.pool, "task-two", 2).await?;
     assert_data_metric_counts(&database.pool, "7", 7, 7, 7, 7).await?;
+    let delegate_profiles_count: Option<i32> = sqlx::query_scalar(
+        "SELECT delegate_profiles_count FROM data_metric WHERE dao_code = 'demo-dao'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(delegate_profiles_count, Some(5));
     assert_table_count(&database.pool, "onchain_refresh_data_metric_task", 1).await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_ONE, "3", "11", "8").await?;
     assert_power_checkpoint(&database.pool, ACCOUNT_TWO, "0", "5", "5").await?;

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -20,9 +20,11 @@ use degov_datalens_indexer::{
     OnchainRefreshWorker, OnchainRefreshWorkerConfig, PartialChainReadFailureReport,
     PostgresProvisionalPowerOverlayStore, ProvisionalContributorPowerOverlayWrite,
     ProvisionalDelegatePowerOverlayRelation, ProvisionalDelegatePowerOverlayWrite,
-    ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, refresh_live_power_overlays,
+    ProvisionalPowerOverlayScope, ProvisionalPowerOverlayStore, delegate_profile_scope_lock_key,
+    refresh_live_power_overlays,
     runtime::{
-        apply_migrations,
+        DelegateProfileBackfillOptions, DelegateProfileBackfillSelection, DelegateProfileScope,
+        apply_migrations, repair_delegate_profiles_with_pool,
         worker::{OnchainRefreshWorkerBatchScope, OnchainRefreshWorkerScopeSchedule},
     },
 };
@@ -394,6 +396,7 @@ struct TestDatabase {
     _guard: MutexGuard<'static, ()>,
     pool: PgPool,
     schema: String,
+    database_url: String,
 }
 
 impl TestDatabase {
@@ -401,20 +404,24 @@ impl TestDatabase {
         let guard = DATABASE_TEST_LOCK.lock().await;
         let database_url = env::var("DEGOV_INDEXER_TEST_DATABASE_URL")
             .map_err(|_| "DEGOV_INDEXER_TEST_DATABASE_URL is required")?;
-        let pool = PgPoolOptions::new()
+        let setup_pool = PgPoolOptions::new()
             .max_connections(1)
             .connect(&database_url)
             .await?;
         let schema = unique_schema_name();
 
         sqlx::query("DROP SCHEMA IF EXISTS squid_processor CASCADE")
-            .execute(&pool)
+            .execute(&setup_pool)
             .await?;
         sqlx::query(&format!(r#"CREATE SCHEMA "{schema}""#))
-            .execute(&pool)
+            .execute(&setup_pool)
             .await?;
-        sqlx::query(&format!(r#"SET search_path TO "{schema}""#))
-            .execute(&pool)
+        setup_pool.close().await;
+
+        let database_url = database_url_with_search_path(&database_url, &schema);
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .connect(&database_url)
             .await?;
         apply_migrations(&pool).await?;
 
@@ -422,6 +429,7 @@ impl TestDatabase {
             _guard: guard,
             pool,
             schema,
+            database_url,
         })
     }
 
@@ -653,6 +661,146 @@ async fn test_onchain_refresh_worker_waits_for_quiet_data_metric_refresh_task()
 
     database.cleanup().await?;
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_data_metric_refresh_waits_for_backfill_scope_lock_and_publishes_exact_metric()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_data_metric_with_scope(&database.pool, "scope-v1", "0", 0, 0).await?;
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 1")
+        .execute(&database.pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+         VALUES (46, 'demo-dao', $1, $2)",
+    )
+    .bind(GOVERNOR)
+    .bind(ACCOUNT_TWO)
+    .execute(&database.pool)
+    .await?;
+    seed_data_metric_refresh_task_with_scope(&database.pool, "scope-v2").await?;
+
+    let mut backfill_transaction = database.pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(delegate_profile_scope_lock_key(46, "demo-dao", GOVERNOR))
+        .execute(&mut *backfill_transaction)
+        .await?;
+    let worker_pool = named_test_pool(&database.database_url, "refresh-after-backfill").await?;
+    let worker = test_data_metric_refresh_worker(worker_pool);
+    let worker_future = worker.run_once();
+    tokio::pin!(worker_future);
+
+    tokio::select! {
+        result = &mut worker_future => {
+            result?;
+            return Err("refresh completed while backfill owned the logical scope lock".into());
+        }
+        result = wait_for_advisory_lock(&database.pool, "refresh-after-backfill") => result?,
+    }
+    backfill_transaction.commit().await?;
+    let report = worker_future.await?;
+
+    assert_eq!(report.data_metric_refreshes, 1);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool).await?,
+        vec![Some(1), Some(1)]
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backfill_waits_for_data_metric_refresh_scope_lock_and_repairs_new_replica()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_data_metric_with_scope(&database.pool, "scope-v1", "0", 0, 0).await?;
+    seed_final_delegate_with_scope(
+        &database.pool,
+        "scope-v1",
+        "demo-dao",
+        46,
+        ACCOUNT_ONE,
+        ACCOUNT_TWO,
+        "1",
+    )
+    .await?;
+    seed_data_metric_refresh_task_with_scope(&database.pool, "scope-v2").await?;
+
+    const INSERT_GATE: i64 = 920_002;
+    sqlx::query(
+        "CREATE FUNCTION wait_before_refresh_metric_insert() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+         BEGIN
+           IF NEW.contract_set_id = 'scope-v2' THEN
+             PERFORM pg_advisory_xact_lock(920002);
+           END IF;
+           RETURN NEW;
+         END
+         $$",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "CREATE TRIGGER wait_before_refresh_metric_insert
+         BEFORE INSERT ON data_metric
+         FOR EACH ROW EXECUTE FUNCTION wait_before_refresh_metric_insert()",
+    )
+    .execute(&database.pool)
+    .await?;
+    let mut gate_transaction = database.pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(INSERT_GATE)
+        .execute(&mut *gate_transaction)
+        .await?;
+
+    let worker_pool = named_test_pool(&database.database_url, "refresh-before-backfill").await?;
+    let worker = test_data_metric_refresh_worker(worker_pool);
+    let worker_future = worker.run_once();
+    tokio::pin!(worker_future);
+    tokio::select! {
+        result = &mut worker_future => {
+            result?;
+            return Err("refresh completed before reaching the insert gate".into());
+        }
+        result = wait_for_advisory_lock(&database.pool, "refresh-before-backfill") => result?,
+    }
+    let repair_pool = named_test_pool(&database.database_url, "backfill-after-refresh").await?;
+    let repair_future = async move {
+        repair_delegate_profiles_with_pool(
+            &repair_pool,
+            DelegateProfileBackfillOptions {
+                selection: DelegateProfileBackfillSelection::Scope(DelegateProfileScope::new(
+                    46, "demo-dao", GOVERNOR,
+                )?),
+                dry_run: false,
+                max_scopes: None,
+            },
+        )
+        .await
+    };
+    tokio::pin!(repair_future);
+
+    tokio::select! {
+        result = &mut repair_future => {
+            result?;
+            return Err("backfill completed while refresh owned the logical scope lock".into());
+        }
+        result = wait_for_advisory_lock(&database.pool, "backfill-after-refresh") => result?,
+    }
+    gate_transaction.commit().await?;
+    let (worker_report, backfill_report) = tokio::join!(&mut worker_future, &mut repair_future);
+    let worker_report = worker_report?;
+    let backfill_report = backfill_report?;
+
+    assert_eq!(worker_report.data_metric_refreshes, 1);
+    assert_eq!(backfill_report.metric_rows_updated, 2);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool).await?,
+        vec![Some(1), Some(1)]
+    );
+    database.cleanup().await?;
     Ok(())
 }
 
@@ -3352,6 +3500,95 @@ async fn seed_data_metric_refresh_task(pool: &PgPool) -> Result<(), sqlx::Error>
     Ok(())
 }
 
+async fn seed_data_metric_refresh_task_with_scope(
+    pool: &PgPool,
+    contract_set_id: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO onchain_refresh_data_metric_task (
+            id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+            created_at, updated_at
+         ) VALUES ($1, $2, 46, 'demo-dao', $3, $4, 10000, 10000)",
+    )
+    .bind(format!("{contract_set_id}:46:demo-dao:{GOVERNOR}"))
+    .bind(contract_set_id)
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+fn test_data_metric_refresh_worker(pool: PgPool) -> OnchainRefreshWorker<MockOnchainRefreshReader> {
+    OnchainRefreshWorker::new(
+        pool,
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        MockOnchainRefreshReader::from_values(BTreeMap::new()),
+    )
+}
+
+async fn named_test_pool(
+    database_url: &str,
+    application_name: &str,
+) -> Result<PgPool, sqlx::Error> {
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(database_url)
+        .await?;
+    sqlx::query("SELECT set_config('application_name', $1, FALSE)")
+        .bind(application_name)
+        .execute(&pool)
+        .await?;
+    Ok(pool)
+}
+
+async fn wait_for_advisory_lock(
+    pool: &PgPool,
+    application_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                   SELECT 1 FROM pg_stat_activity
+                   WHERE application_name = $1 AND wait_event = 'advisory'
+                 )",
+            )
+            .bind(application_name)
+            .fetch_one(pool)
+            .await?;
+            if waiting {
+                return Ok::<_, sqlx::Error>(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| "connection did not wait on advisory lock")??;
+    Ok(())
+}
+
+async fn delegate_profile_metric_counts(pool: &PgPool) -> Result<Vec<Option<i32>>, sqlx::Error> {
+    sqlx::query_scalar(
+        "SELECT delegate_profiles_count
+         FROM data_metric
+         WHERE chain_id = 46 AND dao_code = 'demo-dao' AND lower(governor_address) = $1
+         ORDER BY contract_set_id",
+    )
+    .bind(GOVERNOR)
+    .fetch_all(pool)
+    .await
+}
+
 async fn seed_recent_data_metric_refresh_task(pool: &PgPool) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO onchain_refresh_data_metric_task (
@@ -4124,6 +4361,11 @@ fn unique_schema_name() -> String {
         millis,
         sequence
     )
+}
+
+fn database_url_with_search_path(database_url: &str, schema: &str) -> String {
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    format!("{database_url}{separator}options=-csearch_path%3D{schema}")
 }
 
 fn unix_time_millis_for_test() -> i64 {

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -14,17 +14,20 @@ use std::{
 
 use degov_datalens_indexer::{
     BatchReadPlanConfig, CallExecutedEvent, CallScheduledEvent, ChainContracts, ChainReadMethod,
-    DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS, DecodedGovernorEvent, DecodedTimelockEvent,
-    DecodedTokenEvent, DelegateChangedEvent, DelegateVotesChangedEvent, GovernanceTokenStandard,
-    IndexerProjectionBatch, IndexerRunnerStore, IndexerRunnerTransaction, NormalizedEvmLog,
-    PostgresIndexerRunnerStore, ProposalCreatedEvent, ProposalExtendedEvent,
-    ProposalProjectionContext, ProposalProjectionEvent, ProposalQueuedEvent,
+    CheckpointRepository, DEFAULT_ONCHAIN_REFRESH_DEFERRED_DRAIN_ROWS, DecodedGovernorEvent,
+    DecodedTimelockEvent, DecodedTokenEvent, DelegateChangedEvent, DelegateVotesChangedEvent,
+    GovernanceTokenStandard, IndexerCheckpointIdentity, IndexerProjectionBatch, IndexerRunnerStore,
+    IndexerRunnerTransaction, NormalizedEvmLog, PostgresIndexerRunnerStore, ProposalCreatedEvent,
+    ProposalExtendedEvent, ProposalProjectionContext, ProposalProjectionEvent, ProposalQueuedEvent,
     TimelockProjectionContext, TimelockProjectionEvent, TimelockProposalLinkContext,
     TokenEventCommon, TokenProjectionBatch, TokenProjectionContext, TokenProjectionEvent,
     TokenTransferEvent, TokenTransferWrite, VoteCastEvent, VoteProjectionContext,
-    VoteProjectionEvent, delegate_profile_scope_lock_key, project_proposal_events,
-    project_timelock_events, project_timelock_events_with_proposal_links, project_token_events,
-    project_vote_events, runtime::apply_migrations,
+    VoteProjectionEvent, project_proposal_events, project_timelock_events,
+    project_timelock_events_with_proposal_links, project_token_events, project_vote_events,
+    runtime::{
+        DelegateProfileBackfillOptions, DelegateProfileBackfillSelection, DelegateProfileScope,
+        apply_migrations, repair_delegate_profiles_with_pool,
+    },
 };
 use ethabi::{Token, encode};
 use serde_json::{Value, json};
@@ -1332,31 +1335,126 @@ async fn test_postgres_token_projection_waits_for_delegate_profile_backfill_lock
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_empty_global_metric(&database.pool).await?;
+    sqlx::query(
+        "INSERT INTO data_metric (
+           id, contract_set_id, chain_id, dao_code, governor_address,
+           token_address, delegate_profiles_count
+         ) VALUES ('global', 'scope-v2', 1, 'demo-dao', $1, $2, 0)",
+    )
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .execute(&database.pool)
+    .await?;
     sqlx::query("UPDATE data_metric SET delegate_profiles_count = 0 WHERE id = 'global'")
         .execute(&database.pool)
         .await?;
-    let mut backfill_transaction = database.pool.begin().await?;
-    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
-        .bind(delegate_profile_scope_lock_key(1, "demo-dao", GOVERNOR))
-        .execute(&mut *backfill_transaction)
+    sqlx::query(
+        "INSERT INTO delegate (
+           id, contract_set_id, chain_id, dao_code, governor_address, token_address,
+           contract_address, log_index, transaction_index, from_delegate, to_delegate,
+           block_number, block_timestamp, transaction_hash, is_current, power
+         ) VALUES (
+           'profile-race-history', $1, 1, 'demo-dao', $2, $3,
+           $3, 0, 0, $4, $5, 1, 1, '0xprofile-race-history', FALSE, 0
+         )",
+    )
+    .bind(CONTRACT_SET_ID)
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .bind(ZERO_ADDRESS)
+    .bind(DELEGATE)
+    .execute(&database.pool)
+    .await?;
+
+    const REPAIR_GATE_LOCK: i64 = 9_202_026;
+    sqlx::query(&format!(
+        "CREATE FUNCTION wait_for_delegate_profile_repair_gate() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+         BEGIN
+           IF NEW.delegate = '{DELEGATE}' THEN
+             PERFORM pg_advisory_xact_lock({REPAIR_GATE_LOCK});
+           END IF;
+           RETURN NEW;
+         END
+         $$"
+    ))
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "CREATE TRIGGER wait_for_delegate_profile_repair_gate
+         BEFORE INSERT ON delegate_profile
+         FOR EACH ROW EXECUTE FUNCTION wait_for_delegate_profile_repair_gate()",
+    )
+    .execute(&database.pool)
+    .await?;
+
+    let controller_pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database.database_url)
         .await?;
+    let mut controller = controller_pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1::BIGINT)")
+        .bind(REPAIR_GATE_LOCK)
+        .execute(&mut *controller)
+        .await?;
+
+    let repair_pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database.database_url)
+        .await?;
+    let repair_application_name = format!("{}_repair", database.schema);
+    sqlx::query("SELECT set_config('application_name', $1, FALSE)")
+        .bind(&repair_application_name)
+        .execute(&repair_pool)
+        .await?;
+    let repair = tokio::spawn(async move {
+        repair_delegate_profiles_with_pool(
+            &repair_pool,
+            DelegateProfileBackfillOptions {
+                selection: DelegateProfileBackfillSelection::Scope(
+                    DelegateProfileScope::new(1, "demo-dao", GOVERNOR)
+                        .map_err(|error| error.to_string())?,
+                ),
+                dry_run: false,
+                max_scopes: None,
+            },
+        )
+        .await
+        .map_err(|error| error.to_string())
+    });
+    wait_for_advisory_lock(&database.pool, &repair_application_name).await?;
 
     let writer_pool = PgPoolOptions::new()
         .max_connections(1)
         .connect(&database.database_url)
         .await?;
+    let writer_application_name = format!("{}_writer", database.schema);
+    sqlx::query("SELECT set_config('application_name', $1, FALSE)")
+        .bind(&writer_application_name)
+        .execute(&writer_pool)
+        .await?;
     let batch = project_token_events(
         &token_projection_context(),
         vec![TokenProjectionEvent {
-            log: normalized_token_log("profile-race", 4, 0, 1),
+            log: normalized_token_log("profile-race-writer", 4, 0, 1),
             event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
                 delegator: DELEGATOR.to_owned(),
-                from_delegate: ZERO_ADDRESS.to_owned(),
-                to_delegate: DELEGATE.to_owned(),
+                from_delegate: DELEGATE.to_owned(),
+                to_delegate: SECOND_DELEGATE.to_owned(),
             }),
         }],
     )
     .map_err(|error| format!("race profile projection failed: {error:?}"))?;
+    let checkpoint_identity = IndexerCheckpointIdentity {
+        dao_code: "demo-dao".to_owned(),
+        chain_id: 1,
+        contract_set_id: CONTRACT_SET_ID.to_owned(),
+        stream_id: "governor-and-token-logs".to_owned(),
+        data_source_version: "datalens-v1".to_owned(),
+    };
+    CheckpointRepository::new(database.pool.clone())
+        .read_or_create(&checkpoint_identity, 1)
+        .await?;
     let mut writer = tokio::spawn(async move {
         let mut store = PostgresIndexerRunnerStore::new(writer_pool);
         let mut transaction = store
@@ -1368,19 +1466,28 @@ async fn test_postgres_token_projection_waits_for_delegate_profile_backfill_lock
                 ..IndexerProjectionBatch::default()
             })
             .map_err(|error| error.to_string())?;
+        transaction
+            .advance_checkpoint(&checkpoint_identity, 4, Some(4))
+            .map_err(|error| error.to_string())?;
         transaction.commit().map_err(|error| error.to_string())
     });
 
-    assert!(
-        timeout(Duration::from_millis(200), &mut writer)
-            .await
-            .is_err()
-    );
-    backfill_transaction.commit().await?;
-    timeout(Duration::from_secs(5), writer)
+    let writer_waited =
+        wait_for_writer_lock_or_completion(&database.pool, &writer_application_name, &writer)
+            .await?;
+    controller.commit().await?;
+    timeout(Duration::from_secs(5), repair)
+        .await
+        .map_err(|_| "repair did not resume after gate release")??
+        .map_err(|error| format!("repair failed after gate release: {error}"))?;
+    timeout(Duration::from_secs(5), &mut writer)
         .await
         .map_err(|_| "writer did not resume after backfill lock release")??
         .map_err(|error| format!("writer failed after lock release: {error}"))?;
+    assert!(
+        writer_waited,
+        "writer completed while the real repair held the scope lock"
+    );
 
     let historical_count: i64 = sqlx::query_scalar(
         "SELECT count(DISTINCT lower(to_delegate)) FROM delegate
@@ -1391,15 +1498,88 @@ async fn test_postgres_token_projection_waits_for_delegate_profile_backfill_lock
     .bind(ZERO_ADDRESS)
     .fetch_one(&database.pool)
     .await?;
-    assert_eq!(historical_count, 1);
-    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 1);
+    assert_eq!(historical_count, 2);
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 2);
     assert_eq!(
         delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
-        vec![Some(1)]
+        vec![Some(2), Some(2)]
     );
+    let operation_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM delegate_changed
+         WHERE contract_set_id = $1 AND id = 'profile-race-writer'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(operation_count, 1);
+    let checkpoint: (String, String) = sqlx::query_as(
+        "SELECT processed_height::TEXT, next_block::TEXT
+         FROM degov_indexer_checkpoint
+         WHERE contract_set_id = $1 AND dao_code = 'demo-dao'",
+    )
+    .bind(CONTRACT_SET_ID)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(checkpoint, ("4".to_owned(), "5".to_owned()));
 
     database.cleanup().await?;
     Ok(())
+}
+
+async fn wait_for_advisory_lock(
+    pool: &PgPool,
+    application_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                   SELECT 1 FROM pg_stat_activity
+                   WHERE application_name = $1 AND wait_event = 'advisory'
+                 )",
+            )
+            .bind(application_name)
+            .fetch_one(pool)
+            .await?;
+            if waiting {
+                return Ok::<_, sqlx::Error>(());
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| "connection did not wait on advisory lock")??;
+    Ok(())
+}
+
+async fn wait_for_writer_lock_or_completion(
+    pool: &PgPool,
+    application_name: &str,
+    writer: &tokio::task::JoinHandle<Result<(), String>>,
+) -> Result<bool, Box<dyn Error>> {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if writer.is_finished() {
+                return Ok::<_, sqlx::Error>(false);
+            }
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                   SELECT 1 FROM pg_stat_activity
+                   WHERE application_name = $1 AND wait_event = 'advisory'
+                 )",
+            )
+            .bind(application_name)
+            .fetch_one(pool)
+            .await?;
+            if waiting {
+                return Ok(true);
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| "writer neither completed nor waited on the scope lock")?
+    .map_err(Into::into)
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -844,6 +844,9 @@ async fn test_postgres_data_metric_event_rows_are_idempotent_and_keep_global()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     seed_global_metric(&database.pool).await?;
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 5 WHERE id = 'global'")
+        .execute(&database.pool)
+        .await?;
     let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
     let proposal_batch = project_proposal_events(
         &proposal_projection_context(),
@@ -965,6 +968,11 @@ async fn test_postgres_data_metric_event_rows_are_idempotent_and_keep_global()
         .fetch_one(&database.pool)
         .await?;
     assert_eq!(global.get::<String, _>("id"), "global");
+    let delegate_profiles_count: Option<i32> =
+        sqlx::query_scalar("SELECT delegate_profiles_count FROM data_metric WHERE id = 'global'")
+            .fetch_one(&database.pool)
+            .await?;
+    assert_eq!(delegate_profiles_count, Some(5));
 
     database.cleanup().await?;
 

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -975,7 +975,7 @@ async fn test_postgres_data_metric_event_rows_are_idempotent_and_keep_global()
         sqlx::query_scalar("SELECT delegate_profiles_count FROM data_metric WHERE id = 'global'")
             .fetch_one(&database.pool)
             .await?;
-    assert_eq!(delegate_profiles_count, Some(5));
+    assert_eq!(delegate_profiles_count, Some(0));
 
     database.cleanup().await?;
 
@@ -1504,6 +1504,146 @@ async fn test_postgres_delegate_profile_metric_keeps_new_contract_set_null_befor
     )?;
 
     assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 1);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![None, None]
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_delegate_profile_metric_syncs_proposal_only_new_contract_set()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_initialized_delegate_profile_scope(&database.pool).await?;
+    let proposal_batch = project_proposal_events(
+        &proposal_projection_context_with_scope(
+            "scope-v2", 1, GOVERNOR, TOKEN, TIMELOCK, "demo-dao",
+        ),
+        vec![ProposalProjectionEvent {
+            log: normalized_log("profile-proposal-only", 1, 0, 1),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "921".to_owned(),
+                proposer: PROPOSER.to_owned(),
+                targets: vec![TARGET.to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["proposalOnly()".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "10".to_owned(),
+                vote_end: "20".to_owned(),
+                description: "Proposal-only rollout".to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("proposal-only projection failed: {error:?}"))?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            proposal: Some(proposal_batch),
+            token: None,
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![Some(1), Some(1)]
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_delegate_profile_metric_syncs_vote_only_new_contract_set()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_initialized_delegate_profile_scope(&database.pool).await?;
+    sqlx::query(
+        "INSERT INTO proposal (
+           id, contract_set_id, chain_id, dao_code, governor_address, proposal_id,
+           proposer, targets, values, signatures, calldatas, vote_start, vote_end,
+           description, block_number, block_timestamp, transaction_hash, title,
+           vote_start_timestamp, vote_end_timestamp, clock_mode, quorum, decimals
+         ) VALUES (
+           'profile-vote-only-proposal', 'scope-v2', 1, 'demo-dao', $1, '921',
+           $2, ARRAY[]::TEXT[], ARRAY[]::TEXT[], ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+           10, 20, 'Vote-only rollout fixture', 1, 1, '0xprofile-vote-only-proposal',
+           'Vote-only rollout fixture', 10, 20, 'blocknumber', 0, 18
+         )",
+    )
+    .bind(GOVERNOR)
+    .bind(PROPOSER)
+    .execute(&database.pool)
+    .await?;
+    let vote_batch = project_vote_events(
+        &vote_projection_context_with_scope("scope-v2", 1, GOVERNOR, TOKEN, TIMELOCK, "demo-dao"),
+        vec![VoteProjectionEvent {
+            log: normalized_log("profile-vote-only", 1, 0, 1),
+            event: DecodedGovernorEvent::VoteCast(VoteCastEvent {
+                voter: RECEIVER.to_owned(),
+                proposal_id: "921".to_owned(),
+                support: 1,
+                weight: "10".to_owned(),
+                reason: "rollout".to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("vote-only projection failed: {error:?}"))?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            vote: Some(vote_batch),
+            token: None,
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![Some(1), Some(1)]
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_delegate_profile_metric_keeps_proposal_only_scope_null_before_backfill()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_empty_global_metric(&database.pool).await?;
+    let proposal_batch = project_proposal_events(
+        &proposal_projection_context_with_scope(
+            "scope-v2", 1, GOVERNOR, TOKEN, TIMELOCK, "demo-dao",
+        ),
+        vec![ProposalProjectionEvent {
+            log: normalized_log("profile-proposal-only-uninitialized", 1, 0, 1),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "922".to_owned(),
+                proposer: PROPOSER.to_owned(),
+                targets: vec![TARGET.to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["uninitialized()".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "10".to_owned(),
+                vote_end: "20".to_owned(),
+                description: "Uninitialized proposal-only rollout".to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("uninitialized proposal-only projection failed: {error:?}"))?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            proposal: Some(proposal_batch),
+            token: None,
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
     assert_eq!(
         delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
         vec![None, None]

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -1253,12 +1253,29 @@ async fn test_postgres_token_projection_materializes_delegate_profiles_after_rol
     apply_projection_batch(
         &mut store,
         IndexerProjectionBatch {
-            token: Some(incremental),
+            token: Some(incremental.clone()),
             ..IndexerProjectionBatch::default()
         },
     )?;
 
     assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 2);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![Some(2), Some(2)]
+    );
+    sqlx::query(
+        "UPDATE data_metric SET delegate_profiles_count = 0
+         WHERE contract_set_id = 'scope-v2' AND id = 'global'",
+    )
+    .execute(&database.pool)
+    .await?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(incremental),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
     assert_eq!(
         delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
         vec![Some(2), Some(2)]
@@ -1326,6 +1343,171 @@ async fn test_postgres_token_projection_materializes_delegate_profiles_after_rol
     transaction.rollback()?;
     assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 2);
 
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_delegate_profile_metric_syncs_new_contract_set_after_first_delegate()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_initialized_delegate_profile_scope(&database.pool).await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let batch = project_token_events(
+        &token_projection_context_with_scope("scope-v2", "demo-dao", GOVERNOR),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("profile-rollout-new-delegate", 1, 0, 1),
+            event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: DELEGATOR.to_owned(),
+                from_delegate: ZERO_ADDRESS.to_owned(),
+                to_delegate: SECOND_DELEGATE.to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("new-contract delegate projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 2);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![Some(2), Some(2)]
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_delegate_profile_metric_syncs_zero_only_batch() -> Result<(), Box<dyn Error>>
+{
+    let database = TestDatabase::connect().await?;
+    seed_initialized_delegate_profile_scope(&database.pool).await?;
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 0 WHERE id = 'global'")
+        .execute(&database.pool)
+        .await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let batch = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("profile-rollout-zero-only", 1, 0, 1),
+            event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: DELEGATOR.to_owned(),
+                from_delegate: DELEGATE.to_owned(),
+                to_delegate: ZERO_ADDRESS.to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("zero-only delegate projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 1);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![Some(1)]
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_delegate_profile_metric_syncs_transfer_batch_after_metric_creation()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_initialized_delegate_profile_scope(&database.pool).await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let token_batch = project_token_events(
+        &token_projection_context_with_scope("scope-v2", "demo-dao", GOVERNOR),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("profile-rollout-transfer", 1, 0, 1),
+            event: DecodedTokenEvent::Transfer(TokenTransferEvent {
+                from: ZERO_ADDRESS.to_owned(),
+                to: RECEIVER.to_owned(),
+                value: "10".to_owned(),
+                standard: GovernanceTokenStandard::Erc20,
+            }),
+        }],
+    )
+    .map_err(|error| format!("transfer-only projection failed: {error:?}"))?;
+    let proposal_batch = project_proposal_events(
+        &proposal_projection_context_with_scope(
+            "scope-v2", 1, GOVERNOR, TOKEN, TIMELOCK, "demo-dao",
+        ),
+        vec![ProposalProjectionEvent {
+            log: normalized_log("profile-rollout-proposal", 1, 0, 2),
+            event: DecodedGovernorEvent::ProposalCreated(ProposalCreatedEvent {
+                proposal_id: "920".to_owned(),
+                proposer: PROPOSER.to_owned(),
+                targets: vec![TARGET.to_owned()],
+                values: vec!["0".to_owned()],
+                signatures: vec!["sync()".to_owned()],
+                calldatas: vec!["0x".to_owned()],
+                vote_start: "10".to_owned(),
+                vote_end: "20".to_owned(),
+                description: "Profile rollout".to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("metric-creating proposal projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            proposal: Some(proposal_batch),
+            token: Some(token_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 1);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![Some(1), Some(1)]
+    );
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_delegate_profile_metric_keeps_new_contract_set_null_before_backfill()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_empty_global_metric(&database.pool).await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let batch = project_token_events(
+        &token_projection_context_with_scope("scope-v2", "demo-dao", GOVERNOR),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("profile-rollout-uninitialized", 1, 0, 1),
+            event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: DELEGATOR.to_owned(),
+                from_delegate: ZERO_ADDRESS.to_owned(),
+                to_delegate: DELEGATE.to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("uninitialized delegate projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 1);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![None, None]
+    );
     database.cleanup().await?;
     Ok(())
 }
@@ -4521,6 +4703,22 @@ async fn seed_empty_global_metric(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    Ok(())
+}
+
+async fn seed_initialized_delegate_profile_scope(pool: &PgPool) -> Result<(), sqlx::Error> {
+    seed_empty_global_metric(pool).await?;
+    sqlx::query(
+        "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+         VALUES (1, 'demo-dao', $1, $2)",
+    )
+    .bind(GOVERNOR)
+    .bind(DELEGATE)
+    .execute(pool)
+    .await?;
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 1 WHERE id = 'global'")
+        .execute(pool)
+        .await?;
     Ok(())
 }
 

--- a/apps/indexer/tests/postgres_runtime_run.rs
+++ b/apps/indexer/tests/postgres_runtime_run.rs
@@ -22,9 +22,9 @@ use degov_datalens_indexer::{
     TimelockProjectionContext, TimelockProjectionEvent, TimelockProposalLinkContext,
     TokenEventCommon, TokenProjectionBatch, TokenProjectionContext, TokenProjectionEvent,
     TokenTransferEvent, TokenTransferWrite, VoteCastEvent, VoteProjectionContext,
-    VoteProjectionEvent, project_proposal_events, project_timelock_events,
-    project_timelock_events_with_proposal_links, project_token_events, project_vote_events,
-    runtime::apply_migrations,
+    VoteProjectionEvent, delegate_profile_scope_lock_key, project_proposal_events,
+    project_timelock_events, project_timelock_events_with_proposal_links, project_token_events,
+    project_vote_events, runtime::apply_migrations,
 };
 use ethabi::{Token, encode};
 use serde_json::{Value, json};
@@ -1151,6 +1151,254 @@ async fn test_postgres_data_metric_event_snapshots_follow_mixed_batch_event_orde
 
     database.cleanup().await?;
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_projection_materializes_delegate_profiles_after_rollout()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_empty_global_metric(&database.pool).await?;
+    sqlx::query(
+        "INSERT INTO data_metric (
+           id, contract_set_id, chain_id, dao_code, governor_address, token_address
+         ) VALUES ('global', 'scope-v2', 1, 'demo-dao', $1, $2)",
+    )
+    .bind(GOVERNOR)
+    .bind(TOKEN)
+    .execute(&database.pool)
+    .await?;
+    let mut store = PostgresIndexerRunnerStore::new(database.pool.clone());
+    let initial = project_token_events(
+        &token_projection_context(),
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("profile-initial", 1, 0, 1),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: DELEGATOR.to_owned(),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: DELEGATE.to_uppercase(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("profile-duplicate", 1, 0, 2),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: RECEIVER.to_owned(),
+                    from_delegate: ZERO_ADDRESS.to_owned(),
+                    to_delegate: DELEGATE.to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("profile-zero", 1, 0, 3),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: TARGET.to_owned(),
+                    from_delegate: DELEGATE.to_owned(),
+                    to_delegate: ZERO_ADDRESS.to_owned(),
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("initial profile projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(initial.clone()),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(initial),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 1);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![None, None]
+    );
+
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 1 WHERE contract_set_id = $1")
+        .bind(CONTRACT_SET_ID)
+        .execute(&database.pool)
+        .await?;
+    let second_scope = token_projection_context_with_scope("scope-v2", "demo-dao", GOVERNOR);
+    let incremental = project_token_events(
+        &second_scope,
+        vec![
+            TokenProjectionEvent {
+                log: normalized_token_log("profile-new", 2, 0, 1),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: TARGET.to_owned(),
+                    from_delegate: DELEGATE.to_owned(),
+                    to_delegate: SECOND_DELEGATE.to_owned(),
+                }),
+            },
+            TokenProjectionEvent {
+                log: normalized_token_log("profile-old-target", 2, 0, 2),
+                event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                    delegator: RECEIVER.to_owned(),
+                    from_delegate: SECOND_DELEGATE.to_owned(),
+                    to_delegate: DELEGATE.to_owned(),
+                }),
+            },
+        ],
+    )
+    .map_err(|error| format!("incremental profile projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(incremental),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 2);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![Some(2), Some(2)]
+    );
+
+    sqlx::query(
+        "INSERT INTO data_metric (
+           id, contract_set_id, chain_id, dao_code, governor_address,
+           token_address, delegate_profiles_count
+         ) VALUES ('global', 'scope-other', 1, 'dao-other', $1, $2, 0)",
+    )
+    .bind(SECOND_GOVERNOR)
+    .bind(TOKEN)
+    .execute(&database.pool)
+    .await?;
+    let other_scope =
+        token_projection_context_with_scope("scope-other", "dao-other", SECOND_GOVERNOR);
+    let other_batch = project_token_events(
+        &other_scope,
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("profile-other-scope", 3, 0, 1),
+            event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: DELEGATOR.to_owned(),
+                from_delegate: ZERO_ADDRESS.to_owned(),
+                to_delegate: DELEGATE.to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("other profile projection failed: {error:?}"))?;
+    apply_projection_batch(
+        &mut store,
+        IndexerProjectionBatch {
+            token: Some(other_batch),
+            ..IndexerProjectionBatch::default()
+        },
+    )?;
+    assert_eq!(
+        delegate_profile_count(&database.pool, "dao-other").await?,
+        1
+    );
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "dao-other").await?,
+        vec![Some(1)]
+    );
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 2);
+
+    let rollback_target = "0x0000000000000000000000000000000000000c05";
+    let rollback_batch = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("profile-rollback", 3, 0, 1),
+            event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: TARGET.to_owned(),
+                from_delegate: SECOND_DELEGATE.to_owned(),
+                to_delegate: rollback_target.to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("rollback profile projection failed: {error:?}"))?;
+    let mut transaction = store.begin_transaction()?;
+    transaction.apply_projection_batch(&IndexerProjectionBatch {
+        token: Some(rollback_batch),
+        ..IndexerProjectionBatch::default()
+    })?;
+    transaction.rollback()?;
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 2);
+
+    database.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_postgres_token_projection_waits_for_delegate_profile_backfill_lock()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_empty_global_metric(&database.pool).await?;
+    sqlx::query("UPDATE data_metric SET delegate_profiles_count = 0 WHERE id = 'global'")
+        .execute(&database.pool)
+        .await?;
+    let mut backfill_transaction = database.pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(delegate_profile_scope_lock_key(1, "demo-dao", GOVERNOR))
+        .execute(&mut *backfill_transaction)
+        .await?;
+
+    let writer_pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database.database_url)
+        .await?;
+    let batch = project_token_events(
+        &token_projection_context(),
+        vec![TokenProjectionEvent {
+            log: normalized_token_log("profile-race", 4, 0, 1),
+            event: DecodedTokenEvent::DelegateChanged(DelegateChangedEvent {
+                delegator: DELEGATOR.to_owned(),
+                from_delegate: ZERO_ADDRESS.to_owned(),
+                to_delegate: DELEGATE.to_owned(),
+            }),
+        }],
+    )
+    .map_err(|error| format!("race profile projection failed: {error:?}"))?;
+    let mut writer = tokio::spawn(async move {
+        let mut store = PostgresIndexerRunnerStore::new(writer_pool);
+        let mut transaction = store
+            .begin_transaction()
+            .map_err(|error| error.to_string())?;
+        transaction
+            .apply_projection_batch(&IndexerProjectionBatch {
+                token: Some(batch),
+                ..IndexerProjectionBatch::default()
+            })
+            .map_err(|error| error.to_string())?;
+        transaction.commit().map_err(|error| error.to_string())
+    });
+
+    assert!(
+        timeout(Duration::from_millis(200), &mut writer)
+            .await
+            .is_err()
+    );
+    backfill_transaction.commit().await?;
+    timeout(Duration::from_secs(5), writer)
+        .await
+        .map_err(|_| "writer did not resume after backfill lock release")??
+        .map_err(|error| format!("writer failed after lock release: {error}"))?;
+
+    let historical_count: i64 = sqlx::query_scalar(
+        "SELECT count(DISTINCT lower(to_delegate)) FROM delegate
+         WHERE chain_id = 1 AND dao_code = 'demo-dao' AND lower(governor_address) = $1
+           AND lower(to_delegate) <> $2",
+    )
+    .bind(GOVERNOR)
+    .bind(ZERO_ADDRESS)
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(historical_count, 1);
+    assert_eq!(delegate_profile_count(&database.pool, "demo-dao").await?, 1);
+    assert_eq!(
+        delegate_profile_metric_counts(&database.pool, "demo-dao").await?,
+        vec![Some(1)]
+    );
+
+    database.cleanup().await?;
     Ok(())
 }
 
@@ -4025,6 +4273,41 @@ fn token_projection_context() -> TokenProjectionContext {
         },
         current_power_method: ChainReadMethod::GetVotes,
     }
+}
+
+fn token_projection_context_with_scope(
+    contract_set_id: &str,
+    dao_code: &str,
+    governor_address: &str,
+) -> TokenProjectionContext {
+    TokenProjectionContext {
+        contract_set_id: contract_set_id.to_owned(),
+        dao_code: dao_code.to_owned(),
+        governor_address: governor_address.to_owned(),
+        ..token_projection_context()
+    }
+}
+
+async fn delegate_profile_count(pool: &PgPool, dao_code: &str) -> Result<i64, sqlx::Error> {
+    sqlx::query_scalar("SELECT count(*) FROM delegate_profile WHERE dao_code = $1")
+        .bind(dao_code)
+        .fetch_one(pool)
+        .await
+}
+
+async fn delegate_profile_metric_counts(
+    pool: &PgPool,
+    dao_code: &str,
+) -> Result<Vec<Option<i32>>, sqlx::Error> {
+    sqlx::query_scalar(
+        "SELECT delegate_profiles_count
+         FROM data_metric
+         WHERE id = 'global' AND dao_code = $1
+         ORDER BY contract_set_id",
+    )
+    .bind(dao_code)
+    .fetch_all(pool)
+    .await
 }
 
 async fn seed_global_metric(pool: &PgPool) -> Result<(), sqlx::Error> {


### PR DESCRIPTION
## Summary

- materialize historical onchain delegate profiles per logical DAO scope and replicate the count into `data_metric`
- add race-safe migration, repair/dry-run tooling, runtime synchronization, and exact post-write verification
- serve the common GraphQL delegate-profile count from a single materialized snapshot while preserving realtime fallbacks for unsupported or invalid scopes

## Why

Issue #920 identified that the ENS delegate-page total needs historical onchain delegate-profile semantics. The realtime `COUNT(DISTINCT ...)` path was correct but too expensive for a frequently requested metric and did not provide a durable backfill/recompute contract.

This change makes the onchain historical count explicit and incrementally maintained. Tally's 20 known offchain-only profiles remain intentionally outside this onchain metric.

## Correctness and rollout safety

- normalized logical scope registry deduplicates addresses across contract sets and excludes the zero address
- advisory locks coordinate live token/proposal/vote writers, refresh workers, and repair transactions
- repair verifies registry/history parity and every intended metric replica before commit
- pre-rollout scopes stay nullable; initialized scopes publish or heal exact replica values
- invalid, drifted, mixed-null, filtered, or incomplete metric scopes fail closed to the realtime compatibility path

## Validation

- complete indexer CI-equivalent build/test/convention/compatibility job
- 10 delegate-profile backfill integration tests
- 51 onchain refresh integration tests, including both real-PostgreSQL lock orderings
- 33 GraphQL integration tests
- 17 migration integration tests
- 36 PostgreSQL runtime integration tests
- web script tests: 78/78
- Next.js production build
- independent spec and code-quality reviews approved with no Critical or Important findings

Deployment, backfill, live latency, query-plan, and production backup/restore evidence will be recorded on #920 after the merged immutable image is promoted through staging and production.
