### PR TITLE
perf(indexer): optimize delegate profile provisional delta

### DIFF
--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -1419,21 +1419,26 @@ const MATERIALIZED_DELEGATE_PROFILES_SQL: &str = "WITH metric_stats AS (
          AND dao_code = $2
          AND lower(governor_address) = lower($3)
      ),
-     provisional_stats AS (
-       SELECT COUNT(DISTINCT lower(delegate_overlay.delegate))::int8 AS provisional_delta
+     overlay_delegates AS (
+       SELECT DISTINCT lower(delegate_overlay.delegate) AS delegate
        FROM degov_provisional_delegate_power_overlay delegate_overlay
        WHERE delegate_overlay.status = 'available'
+         AND delegate_overlay.source <> 'live-onchain'
          AND delegate_overlay.chain_id = $1
          AND delegate_overlay.dao_code = $2
          AND lower(delegate_overlay.governor_address) = lower($3)
          AND lower(delegate_overlay.delegate) <> '0x0000000000000000000000000000000000000000'
-         AND NOT EXISTS (
+     ),
+     provisional_stats AS (
+       SELECT COUNT(*)::int8 AS provisional_delta
+       FROM overlay_delegates overlay_delegate
+       WHERE NOT EXISTS (
            SELECT 1
            FROM delegate_profile durable_profile
            WHERE durable_profile.chain_id = $1
              AND durable_profile.dao_code = $2
              AND durable_profile.governor_address = lower($3)
-             AND durable_profile.delegate = lower(delegate_overlay.delegate)
+             AND durable_profile.delegate = overlay_delegate.delegate
          )
      )
      SELECT metric_stats.metric_row_count, metric_stats.metric_non_null_count,
@@ -1535,7 +1540,13 @@ mod tests {
         assert!(!normalized.contains(';'));
         assert!(normalized.contains("with metric_stats as"));
         assert!(normalized.contains("provisional_stats as"));
+        assert!(normalized.contains("overlay_delegates as"));
         assert!(normalized.contains("delegate_overlay.status = 'available'"));
+        assert!(normalized.contains("delegate_overlay.source <> 'live-onchain'"));
+        assert!(
+            normalized.contains("select distinct lower(delegate_overlay.delegate) as delegate")
+        );
+        assert!(normalized.contains("durable_profile.delegate = overlay_delegate.delegate"));
         assert!(!normalized.contains(" from delegate "));
         assert!(!normalized.contains(" join delegate "));
         assert!(!normalized.contains("count(distinct lower(to_delegate))"));

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -479,6 +479,21 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
 
     execute_concurrent_runtime_index(
         connection,
+        "provisional_delegate_profile_delta_nonlive_cover_idx",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_profile_delta_nonlive_cover_idx
+         ON degov_provisional_delegate_power_overlay (
+            chain_id, dao_code, lower(governor_address), lower(delegate)
+         )
+         INCLUDE (governor_address, delegate)
+         WHERE status = 'available'
+           AND source <> 'live-onchain'
+           AND lower(delegate) <> '0x0000000000000000000000000000000000000000'",
+    )
+    .await
+    .context("ensure non-live provisional delegate profile delta covering index")?;
+
+    execute_concurrent_runtime_index(
+        connection,
         "provisional_delegate_profile_delta_scope_idx",
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_profile_delta_scope_idx
          ON degov_provisional_delegate_power_overlay (
@@ -889,6 +904,11 @@ async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnecti
     )
     .await?;
     drop_invalid_runtime_index(connection, "provisional_delegate_live_graphql_scope_idx").await?;
+    drop_invalid_runtime_index(
+        connection,
+        "provisional_delegate_profile_delta_nonlive_cover_idx",
+    )
+    .await?;
     drop_invalid_runtime_index(connection, "provisional_delegate_profile_delta_scope_idx").await?;
     drop_invalid_runtime_index(connection, "provisional_contributor_live_graphql_scope_idx")
         .await?;

--- a/apps/indexer/tests/graphql_service.rs
+++ b/apps/indexer/tests/graphql_service.rs
@@ -544,7 +544,7 @@ async fn test_graphql_delegate_profiles_count_normalizes_governor_case_across_pa
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_graphql_delegate_profiles_count_adds_only_new_available_overlay_targets()
+async fn test_graphql_delegate_profiles_count_adds_only_distinct_nonlive_overlay_targets()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
     sqlx::query(
@@ -570,17 +570,21 @@ async fn test_graphql_delegate_profiles_count_adds_only_new_available_overlay_ta
           delegator, delegate, power, is_current, source, status
         ) VALUES
           ('overlay:new-a', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
-           '0xnew-a', '0xNeW', 1, TRUE, 'live-onchain', 'available'),
+           '0xnew-a', '0xNeW', 1, TRUE, 'provider', 'available'),
           ('overlay:new-b', 'lisk-second-contract-set', 1135, 'lisk', 'lisk-dao', '0xGOVERNOR',
-           '0xnew-b', '0xnew', 1, TRUE, 'live-onchain', 'available'),
+           '0xnew-b', '0xnew', 1, TRUE, 'safe-to-latest', 'available'),
+          ('overlay:new-c', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
+           '0xnew-c', '0xNEW', 1, TRUE, 'provider', 'available'),
           ('overlay:registry', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
-           '0xregistry', '0xDELEGATE', 1, TRUE, 'live-onchain', 'available'),
+           '0xregistry', '0xDELEGATE', 1, TRUE, 'provider', 'available'),
           ('overlay:zero', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
-           '0xzero', '0x0000000000000000000000000000000000000000', 1, TRUE, 'live-onchain', 'available'),
+           '0xzero', '0x0000000000000000000000000000000000000000', 1, TRUE, 'provider', 'available'),
           ('overlay:invalid', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
-           '0xinvalid', '0xinvalid', 1, TRUE, 'live-onchain', 'invalid'),
+           '0xinvalid', '0xinvalid', 1, TRUE, 'provider', 'invalid'),
           ('overlay:finalized', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
-           '0xfinalized', '0xfinalized', 1, TRUE, 'live-onchain', 'finalized')
+           '0xfinalized', '0xfinalized', 1, TRUE, 'provider', 'finalized'),
+          ('overlay:live-novel', $1, 1135, 'lisk', 'lisk-dao', '0xgovernor',
+           '0xlive', '0xnovel-live-only', 1, TRUE, 'live-onchain', 'available')
         "#,
     )
     .bind(CONTRACT_SET_ID)

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -187,13 +187,20 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
         "provisional_delegate_profile_delta_scope_idx",
     )
     .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
+        "provisional_delegate_profile_delta_nonlive_cover_idx",
+    )
+    .await?;
     assert_index_definition_contains(
         &database.pool,
         &database.schema,
-        "provisional_delegate_profile_delta_scope_idx",
+        "provisional_delegate_profile_delta_nonlive_cover_idx",
         &[
             "USING btree (chain_id, dao_code, lower(governor_address), lower(delegate))",
-            "WHERE (status = 'available'::text)",
+            "INCLUDE (governor_address, delegate)",
+            "WHERE ((status = 'available'::text) AND (source <> 'live-onchain'::text) AND (lower(delegate) <> '0x0000000000000000000000000000000000000000'::text))",
         ],
     )
     .await?;
@@ -751,7 +758,7 @@ async fn test_migration_repairs_and_plans_delegate_profile_delta_index()
     sqlx::query(
         "UPDATE pg_index
          SET indisvalid = false
-         WHERE indexrelid = 'provisional_delegate_profile_delta_scope_idx'::regclass",
+         WHERE indexrelid = 'provisional_delegate_profile_delta_nonlive_cover_idx'::regclass",
     )
     .execute(&database.pool)
     .await?;
@@ -759,7 +766,7 @@ async fn test_migration_repairs_and_plans_delegate_profile_delta_index()
     assert_index_is_valid(
         &database.pool,
         &database.schema,
-        "provisional_delegate_profile_delta_scope_idx",
+        "provisional_delegate_profile_delta_nonlive_cover_idx",
     )
     .await?;
 
@@ -768,18 +775,31 @@ async fn test_migration_repairs_and_plans_delegate_profile_delta_index()
         .await?;
     let plan: Vec<String> = sqlx::query_scalar(
         "EXPLAIN (COSTS OFF)
-         SELECT COUNT(DISTINCT lower(delegate_overlay.delegate))::int8
-         FROM degov_provisional_delegate_power_overlay delegate_overlay
-         WHERE delegate_overlay.status = 'available'
-           AND delegate_overlay.chain_id = 1135
-           AND delegate_overlay.dao_code = 'lisk-dao'
-           AND lower(delegate_overlay.governor_address) = lower('0xgovernor')",
+         WITH overlay_delegates AS (
+           SELECT DISTINCT lower(delegate_overlay.delegate) AS delegate
+           FROM degov_provisional_delegate_power_overlay delegate_overlay
+           WHERE delegate_overlay.status = 'available'
+             AND delegate_overlay.source <> 'live-onchain'
+             AND delegate_overlay.chain_id = 1135
+             AND delegate_overlay.dao_code = 'lisk-dao'
+             AND lower(delegate_overlay.governor_address) = lower('0xgovernor')
+             AND lower(delegate_overlay.delegate) <> '0x0000000000000000000000000000000000000000'
+         )
+         SELECT COUNT(*)::int8
+         FROM overlay_delegates overlay_delegate
+         WHERE NOT EXISTS (
+           SELECT 1 FROM delegate_profile durable_profile
+           WHERE durable_profile.chain_id = 1135
+             AND durable_profile.dao_code = 'lisk-dao'
+             AND durable_profile.governor_address = lower('0xgovernor')
+             AND durable_profile.delegate = overlay_delegate.delegate
+         )",
     )
     .fetch_all(&database.pool)
     .await?;
     let plan = plan.join("\n");
     assert!(
-        plan.contains("provisional_delegate_profile_delta_scope_idx"),
+        plan.contains("provisional_delegate_profile_delta_nonlive_cover_idx"),
         "expected logical-scope delta index in plan:\n{plan}"
     );
     assert!(
@@ -790,6 +810,136 @@ async fn test_migration_repairs_and_plans_delegate_profile_delta_index()
     database.cleanup().await?;
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delegate_profile_delta_plan_deduplicates_nonlive_targets_before_durable_probes()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+
+    apply_migrations(&database.pool).await?;
+    sqlx::query(
+        "INSERT INTO delegate_profile (chain_id, dao_code, governor_address, delegate)
+         VALUES (1135, 'lisk-dao', '0xgovernor', '0xprovider0000')",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO degov_provisional_delegate_power_overlay (
+           id, contract_set_id, chain_id, chain_name, dao_code, governor_address,
+           delegator, delegate, power, is_current, source, status
+         )
+         SELECT 'live:' || value, 'contract:' || (value % 7), 1135, 'lisk', 'lisk-dao',
+           CASE WHEN value % 2 = 0 THEN '0xgovernor' ELSE '0xGoVeRnOr' END,
+           '0xlive' || value, '0xlive-target' || value, 1, TRUE, 'live-onchain', 'available'
+         FROM generate_series(1, 5000) AS value",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO degov_provisional_delegate_power_overlay (
+           id, contract_set_id, chain_id, chain_name, dao_code, governor_address,
+           delegator, delegate, power, is_current, source, status
+         )
+         SELECT 'provider:' || value, 'contract:' || (value % 11), 1135, 'lisk', 'lisk-dao',
+           CASE WHEN value % 2 = 0 THEN '0xgovernor' ELSE '0xGoVeRnOr' END,
+           '0xprovider' || value, '0xprovider' || lpad((value % 4)::text, 4, '0'),
+           1, TRUE, 'provider', 'available'
+         FROM generate_series(1, 4000) AS value",
+    )
+    .execute(&database.pool)
+    .await?;
+    sqlx::query("VACUUM (ANALYZE) degov_provisional_delegate_power_overlay")
+        .execute(&database.pool)
+        .await?;
+    sqlx::query("VACUUM (ANALYZE) delegate_profile")
+        .execute(&database.pool)
+        .await?;
+    sqlx::query("SET enable_seqscan = off")
+        .execute(&database.pool)
+        .await?;
+    sqlx::query("SET enable_hashagg = off")
+        .execute(&database.pool)
+        .await?;
+
+    let explain: serde_json::Value = sqlx::query_scalar(
+        "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+         WITH overlay_delegates AS (
+           SELECT DISTINCT lower(delegate_overlay.delegate) AS delegate
+           FROM degov_provisional_delegate_power_overlay delegate_overlay
+           WHERE delegate_overlay.status = 'available'
+             AND delegate_overlay.source <> 'live-onchain'
+             AND delegate_overlay.chain_id = 1135
+             AND delegate_overlay.dao_code = 'lisk-dao'
+             AND lower(delegate_overlay.governor_address) = lower('0xgovernor')
+             AND lower(delegate_overlay.delegate) <> '0x0000000000000000000000000000000000000000'
+         )
+         SELECT COUNT(*)::int8
+         FROM overlay_delegates overlay_delegate
+         WHERE NOT EXISTS (
+           SELECT 1 FROM delegate_profile durable_profile
+           WHERE durable_profile.chain_id = 1135
+             AND durable_profile.dao_code = 'lisk-dao'
+             AND durable_profile.governor_address = lower('0xgovernor')
+             AND durable_profile.delegate = overlay_delegate.delegate
+         )",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    let root = &explain[0]["Plan"];
+    let nodes = collect_plan_nodes(root);
+    let overlay_scan = nodes
+        .iter()
+        .copied()
+        .find(|node| {
+            node["Node Type"] == "Index Only Scan"
+                && node["Index Name"] == "provisional_delegate_profile_delta_nonlive_cover_idx"
+        })
+        .unwrap_or_else(|| panic!("expected covering overlay index-only scan:\n{explain:#}"));
+    assert_eq!(overlay_scan["Heap Fetches"].as_u64(), Some(0));
+    assert!(
+        !nodes.iter().any(|node| {
+            node["Node Type"] == "Seq Scan"
+                && node["Relation Name"] == "degov_provisional_delegate_power_overlay"
+        }),
+        "unexpected overlay sequential scan:\n{explain:#}"
+    );
+    let anti_join = nodes
+        .iter()
+        .copied()
+        .find(|node| node["Join Type"] == "Anti")
+        .unwrap_or_else(|| panic!("expected anti-join:\n{explain:#}"));
+    assert!(
+        collect_plan_nodes(&anti_join["Plans"][0])
+            .iter()
+            .any(|node| node["Node Type"] == "Unique"),
+        "expected provider target deduplication before anti-join:\n{explain:#}"
+    );
+    let durable_probe = nodes
+        .iter()
+        .copied()
+        .find(|node| node["Relation Name"] == "delegate_profile")
+        .unwrap_or_else(|| panic!("expected durable delegate-profile probe:\n{explain:#}"));
+    assert!(
+        durable_probe["Actual Loops"]
+            .as_u64()
+            .is_some_and(|loops| loops <= 4),
+        "durable probes must be bounded by four distinct provider targets:\n{explain:#}"
+    );
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+fn collect_plan_nodes(plan: &serde_json::Value) -> Vec<&serde_json::Value> {
+    let mut nodes = vec![plan];
+    if let Some(children) = plan["Plans"].as_array() {
+        for child in children {
+            nodes.extend(collect_plan_nodes(child));
+        }
+    }
+    nodes
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -979,15 +1129,22 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
         "drop_invalid_runtime_index(connection, \"provisional_contributor_live_graphql_scope_idx\")"
     ));
     assert!(runtime_migration.contains(
-        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_profile_delta_scope_idx
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS provisional_delegate_profile_delta_nonlive_cover_idx
          ON degov_provisional_delegate_power_overlay (
             chain_id, dao_code, lower(governor_address), lower(delegate)
          )
-         WHERE status = 'available'"
+         INCLUDE (governor_address, delegate)
+         WHERE status = 'available'
+           AND source <> 'live-onchain'
+           AND lower(delegate) <> '0x0000000000000000000000000000000000000000'"
     ));
     assert!(runtime_migration.contains(
-        "drop_invalid_runtime_index(connection, \"provisional_delegate_profile_delta_scope_idx\")"
+        "drop_invalid_runtime_index(
+        connection,
+        \"provisional_delegate_profile_delta_nonlive_cover_idx\",
+    )"
     ));
+    assert!(runtime_migration.contains("provisional_delegate_profile_delta_scope_idx"));
     assert!(runtime_migration.contains("ON onchain_refresh_task (next_run_at, updated_at, id)"));
     assert!(runtime_migration.contains("WHERE status = 'pending'"));
     assert!(

--- a/apps/indexer/tests/onchain_refresh_worker.rs
+++ b/apps/indexer/tests/onchain_refresh_worker.rs
@@ -595,6 +595,59 @@ async fn test_onchain_refresh_worker_updates_contributors_tasks_and_metrics()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_onchain_refresh_worker_does_not_emit_live_delegate_without_durable_relation()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    seed_task(
+        &database.pool,
+        "task-one",
+        ACCOUNT_ONE,
+        "pending",
+        0,
+        true,
+        true,
+    )
+    .await?;
+    let reader = MockOnchainRefreshReader::new([(
+        "task-one",
+        OnchainRefreshReadValue {
+            task_id: "task-one".to_owned(),
+            balance: Some("17".to_owned()),
+            power: Some("11".to_owned()),
+            ..OnchainRefreshReadValue::default()
+        },
+    )]);
+    let worker = OnchainRefreshWorker::new(
+        database.pool.clone(),
+        OnchainRefreshWorkerConfig {
+            batch_size: 10,
+            apply_batch_size: 1_000,
+            max_attempts: 3,
+            deferred_drain_batch_size: 100,
+            debounce: Duration::from_secs(120),
+            lock_ttl: Duration::from_secs(60),
+            retry_delay: Duration::from_secs(30),
+            lock_owner: "test-worker".to_owned(),
+        },
+        reader,
+    );
+
+    let report = worker.run_once().await?;
+
+    assert_eq!(report.completed, 1, "{report:?}");
+    assert_table_count(
+        &database.pool,
+        "degov_provisional_delegate_power_overlay",
+        0,
+    )
+    .await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_onchain_refresh_worker_drains_data_metric_refresh_on_empty_work()
 -> Result<(), Box<dyn Error>> {
     let database = TestDatabase::connect().await?;
@@ -2646,6 +2699,37 @@ async fn test_refresh_live_power_overlays_writes_delegate_overlay_from_current_f
     assert_delegate_overlay(&database.pool, ACCOUNT_ONE, ACCOUNT_TWO, "23").await?;
     assert_table_count(&database.pool, "delegate", 1).await?;
     assert_table_count(&database.pool, "vote_power_checkpoint", 0).await?;
+
+    database.cleanup().await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_refresh_live_power_overlays_does_not_emit_delegate_without_durable_relation()
+-> Result<(), Box<dyn Error>> {
+    let database = TestDatabase::connect().await?;
+    let reader = LivePowerOverlayReader::new(
+        MethodValueChainTool::new("11", "23"),
+        BatchReadPlanConfig::default(),
+        ChainReadMethod::GetVotes,
+    );
+    let mut store = PostgresProvisionalPowerOverlayStore::new(database.pool.clone());
+
+    let written = refresh_live_power_overlays(
+        &reader,
+        &mut store,
+        &[task_for_chain("task-one", 46, ACCOUNT_ONE)],
+    )
+    .expect("refresh writes contributor overlay");
+
+    assert_eq!(written, 1);
+    assert_table_count(
+        &database.pool,
+        "degov_provisional_delegate_power_overlay",
+        0,
+    )
+    .await?;
 
     database.cleanup().await?;
 


### PR DESCRIPTION
## Summary

- exclude derived `live-onchain` overlays from the materialized delegate-profile provisional delta
- deduplicate normalized non-live targets before probing the durable registry
- add and repair a concurrent partial covering index while retaining the previous index for rolling rollback
- add PostgreSQL behavior, loader-contract, migration, and EXPLAIN JSON regression coverage

## Root cause

The materialized count still scanned all ENS live-power overlays. Those rows are derived from durable delegate relations and cannot add a new profile after registry initialization, but the query processed 117,057 rows and performed 117,057 durable registry probes. This made the count take several seconds.

## Validation

- strict RED/GREEN TDD evidence for SQL shape, live-only exclusion, index creation, and query plan
- GraphQL: 33/33
- migration: 18/18
- onchain refresh: 53/53
- PostgreSQL runtime: 36/36
- full Rust suite: passed
- Web scripts: 78/78
- Next.js production build: passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --all-targets`: passed with pre-existing warnings
- `git diff --check`: passed
- independent spec and quality reviews: approved, no Critical or Important findings

A pre-existing v4 parity fixture mismatch (26 tables versus stale expected 29) reproduces unchanged on base commit `4d1ce59e` and is outside this PR.

Relates to #920.
