### PR TITLE
fix(web): hide total participation

### DIFF
--- a/apps/web/scripts/proposal-quorum-progress.test.ts
+++ b/apps/web/scripts/proposal-quorum-progress.test.ts
@@ -89,7 +89,7 @@ test("proposal quorum progress rejects duplicate counting mode buckets", () => {
   assert.equal(progress.currentVotes, 15n);
 });
 
-test("proposal vote summary distinguishes quorum progress from total participation", () => {
+test("proposal vote summary hides total participation while preserving quorum progress", () => {
   const currentVotesSource = readFileSync(
     new URL("../src/app/proposal/[id]/current-votes.tsx", import.meta.url),
     "utf8"
@@ -103,13 +103,10 @@ test("proposal vote summary distinguishes quorum progress from total participati
 
   assert.equal(typeof messages.currentVotes.quorumProgress, "string");
   assert.ok(messages.currentVotes.quorumProgress.length > 0);
-  assert.equal(typeof messages.currentVotes.totalParticipation, "string");
-  assert.ok(messages.currentVotes.totalParticipation.length > 0);
-  assert.notEqual(
-    messages.currentVotes.quorumProgress,
-    messages.currentVotes.totalParticipation
-  );
   assert.match(currentVotesSource, /t\("quorumProgress"\)/);
-  assert.match(currentVotesSource, /t\("totalParticipation"\)/);
-  assert.match(currentVotesSource, /formatTokenAmount\(totalVotesCast\)/);
+  assert.doesNotMatch(currentVotesSource, /t\("totalParticipation"\)/);
+  assert.doesNotMatch(
+    currentVotesSource,
+    /formatTokenAmount\(totalVotesCast\)/
+  );
 });

--- a/apps/web/src/app/proposal/[id]/current-votes.tsx
+++ b/apps/web/src/app/proposal/[id]/current-votes.tsx
@@ -28,13 +28,6 @@ const CurrentVotesSkeleton = () => {
           <Skeleton className="h-[18px] w-[120px]" />
         </div>
 
-        <div className="flex items-center justify-between gap-[10px]">
-          <span className="text-[14px] font-normal">
-            {t("totalParticipation")}
-          </span>
-          <Skeleton className="h-[18px] w-[80px]" />
-        </div>
-
         <div className="flex flex-col gap-[10px]">
           <div className="flex items-center justify-between gap-[10px]">
             <div className="flex items-center gap-[5px]">
@@ -163,13 +156,6 @@ export const CurrentVotes = ({
               required: formatTokenAmount(quorumRequired).formatted,
             })}
           </span>
-        </div>
-
-        <div className="flex items-center justify-between gap-[10px]">
-          <span className="text-[14px] font-normal">
-            {t("totalParticipation")}
-          </span>
-          <span>{formatTokenAmount(totalVotesCast).formatted}</span>
         </div>
 
         <div className="flex flex-col gap-[10px]">


### PR DESCRIPTION
## Summary

- hide the `Total participation` row from the Current Votes loading and rendered states
- preserve the #992 `COUNTING_MODE` quorum calculation and internal all-bucket total used by vote-distribution percentages
- update the focused regression test to require the row to stay hidden

Closes #1019

## Verification

- `pnpm test:web-scripts` (78/78)
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- `git diff --check`
- independent code review: no findings