### PR TITLE
feat(playground): add GTK faucet flow

### DIFF
--- a/apps/web/messages/en/faucet.json
+++ b/apps/web/messages/en/faucet.json
@@ -1,0 +1,18 @@
+{
+  "eyebrow": "Base Playground",
+  "title": "Get ready to govern",
+  "description": "Claim 10 GTK, then delegate the voting power to yourself. You can use it to create, vote on, and execute a Playground proposal.",
+  "claimTitle": "Claim your test governance tokens",
+  "claimDescription": "Each wallet can claim 10 GTK once.",
+  "claim": "Claim 10 GTK",
+  "claimed": "10 GTK claimed",
+  "connectWallet": "Connect wallet",
+  "switchNetwork": "Switch to {network}",
+  "notConfigured": "The Faucet contract has not been configured for this DAO yet.",
+  "delegateTitle": "Activate your voting power",
+  "delegateDescription": "GTK only counts toward governance after you delegate it. Delegate to your own wallet to continue.",
+  "delegate": "Delegate to myself",
+  "delegated": "Voting power activated",
+  "viewTransaction": "View transaction",
+  "gasNotice": "This Playground runs on Base Mainnet. Your wallet needs a small amount of ETH to pay gas for claiming, delegating, and governance transactions."
+}

--- a/apps/web/scripts/playground-faucet.test.ts
+++ b/apps/web/scripts/playground-faucet.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { getPlaygroundFaucetAddress } from "../src/utils/playground-faucet.ts";
+
+const FAUCET = "0x1234567890AbcdEF1234567890aBcdef12345678";
+
+test("resolves the Faucet from Registry faucetAddress params", () => {
+  assert.equal(
+    getPlaygroundFaucetAddress({
+      code: "playground-dao",
+      apps: [
+        {
+          name: "Faucet",
+          description: "Claim GTK",
+          icon: "/faucet.svg",
+          link: "/faucet",
+          params: { faucetAddress: FAUCET },
+        },
+      ],
+    }),
+    FAUCET
+  );
+});
+
+test("supports the generic Registry contract param", () => {
+  assert.equal(
+    getPlaygroundFaucetAddress({
+      code: "playground-dao",
+      apps: [
+        {
+          name: "Faucet",
+          description: "Claim GTK",
+          icon: "/faucet.svg",
+          link: "/faucet",
+          params: { contract: FAUCET },
+        },
+      ],
+    }),
+    FAUCET
+  );
+});
+
+test("does not expose the Faucet to other DAOs or malformed addresses", () => {
+  const app = {
+    name: "Faucet",
+    description: "Claim GTK",
+    icon: "/faucet.svg",
+    link: "/faucet",
+    params: { faucetAddress: FAUCET },
+  };
+
+  assert.equal(
+    getPlaygroundFaucetAddress({ code: "another-dao", apps: [app] }),
+    undefined
+  );
+  assert.equal(
+    getPlaygroundFaucetAddress({
+      code: "playground-dao",
+      apps: [{ ...app, params: { faucetAddress: "not-an-address" } }],
+    }),
+    undefined
+  );
+});
+
+test("does not treat another app contract as the Faucet", () => {
+  assert.equal(
+    getPlaygroundFaucetAddress({
+      code: "playground-dao",
+      apps: [
+        {
+          name: "Another app",
+          description: "Not a Faucet",
+          icon: "/app.svg",
+          link: "/another-app",
+          params: { contract: FAUCET },
+        },
+      ],
+    }),
+    undefined
+  );
+});
+
+test("Faucet page reads its address from Registry config", () => {
+  const source = readFileSync(
+    path.join(import.meta.dirname, "../src/app/faucet/page.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /getPlaygroundFaucetAddress\(daoConfig\)/);
+  assert.doesNotMatch(source, /0x[0-9a-fA-F]{40}/);
+});

--- a/apps/web/src/app/[locale]/faucet/page.tsx
+++ b/apps/web/src/app/[locale]/faucet/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../faucet/page";

--- a/apps/web/src/app/faucet/page.tsx
+++ b/apps/web/src/app/faucet/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { Check, CircleAlert, ExternalLink, Vote } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import {
+  useAccount,
+  useReadContract,
+  useWaitForTransactionReceipt,
+  useWriteContract,
+} from "wagmi";
+
+import NotFound from "@/components/not-found";
+import { Button } from "@/components/ui/button";
+import { playgroundFaucetAbi } from "@/config/abi/playground-faucet";
+import { abi as tokenAbi } from "@/config/abi/token";
+import { useConnectWalletStatus } from "@/hooks/useConnectWalletStatus";
+import { useContractGuard } from "@/hooks/useContractGuard";
+import { useDaoConfig } from "@/hooks/useDaoConfig";
+import { useDelegate } from "@/hooks/useDelegate";
+import {
+  getPlaygroundFaucetAddress,
+  PLAYGROUND_DAO_CODE,
+} from "@/utils/playground-faucet";
+
+import type { BaseError } from "viem";
+
+function TransactionLink({ hash }: { hash: `0x${string}` }) {
+  const daoConfig = useDaoConfig();
+  const t = useTranslations("faucet");
+  const explorer = daoConfig?.chain?.explorers?.[0];
+
+  if (!explorer) return null;
+
+  return (
+    <a
+      href={`${explorer}/tx/${hash}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-sm font-semibold underline underline-offset-4"
+    >
+      {t("viewTransaction")}
+      <ExternalLink aria-hidden="true" className="size-4" />
+    </a>
+  );
+}
+
+function getErrorMessage(error: Error | null): string | undefined {
+  if (!error) return undefined;
+  return (error as BaseError).shortMessage ?? error.message;
+}
+
+export default function FaucetPage() {
+  const t = useTranslations("faucet");
+  const daoConfig = useDaoConfig();
+  const faucetAddress = getPlaygroundFaucetAddress(daoConfig);
+  const { address } = useAccount();
+  const { isConnected, isCorrectNetwork, errorMessage } =
+    useConnectWalletStatus();
+  const { validateBeforeExecution } = useContractGuard();
+  const { delegate, isPending: isDelegating } = useDelegate();
+  const [claimHash, setClaimHash] = useState<`0x${string}`>();
+  const [claimErrorState, setClaimErrorState] = useState<string>();
+  const [delegateHash, setDelegateHash] = useState<`0x${string}`>();
+  const [delegateError, setDelegateError] = useState<string>();
+
+  const {
+    data: hasClaimed,
+    isLoading: isLoadingClaim,
+    refetch: refetchClaimed,
+  } = useReadContract({
+    address: faucetAddress,
+    abi: playgroundFaucetAbi,
+    functionName: "claimed",
+    args: address ? [address] : undefined,
+    chainId: daoConfig?.chain?.id,
+    query: {
+      enabled: Boolean(faucetAddress && address),
+    },
+  });
+
+  const { data: currentDelegate, refetch: refetchDelegate } = useReadContract({
+    address: daoConfig?.contracts?.governorToken?.address as `0x${string}`,
+    abi: tokenAbi,
+    functionName: "delegates",
+    args: address ? [address] : undefined,
+    chainId: daoConfig?.chain?.id,
+    query: {
+      enabled: Boolean(address && hasClaimed),
+    },
+  });
+
+  const {
+    writeContractAsync,
+    isPending: isPreparingClaim,
+    error: claimWriteError,
+    reset: resetClaim,
+  } = useWriteContract();
+  const claimReceipt = useWaitForTransactionReceipt({
+    hash: claimHash,
+    query: { enabled: Boolean(claimHash) },
+  });
+  const delegateReceipt = useWaitForTransactionReceipt({
+    hash: delegateHash,
+    query: { enabled: Boolean(delegateHash) },
+  });
+
+  useEffect(() => {
+    if (claimReceipt.isSuccess) void refetchClaimed();
+  }, [claimReceipt.isSuccess, refetchClaimed]);
+
+  useEffect(() => {
+    if (delegateReceipt.isSuccess) void refetchDelegate();
+  }, [delegateReceipt.isSuccess, refetchDelegate]);
+
+  if (daoConfig?.code !== PLAYGROUND_DAO_CODE) return <NotFound />;
+
+  const claimComplete = Boolean(hasClaimed || claimReceipt.isSuccess);
+  const isSelfDelegated =
+    Boolean(address) &&
+    (delegateReceipt.isSuccess ||
+      (typeof currentDelegate === "string" &&
+        currentDelegate.toLowerCase() === address?.toLowerCase()));
+  const claimError =
+    claimErrorState ??
+    getErrorMessage((claimWriteError ?? claimReceipt.error) as Error | null);
+  const displayedDelegateError =
+    delegateError ?? getErrorMessage(delegateReceipt.error as Error | null);
+
+  const handleClaim = async () => {
+    if (!faucetAddress || !validateBeforeExecution()) return;
+
+    resetClaim();
+    setClaimErrorState(undefined);
+    setClaimHash(undefined);
+    try {
+      const hash = await writeContractAsync({
+        address: faucetAddress,
+        abi: playgroundFaucetAbi,
+        functionName: "claim",
+        chainId: daoConfig.chain.id,
+      });
+      setClaimHash(hash);
+    } catch (error) {
+      setClaimErrorState(getErrorMessage(error as Error));
+    }
+  };
+
+  const handleSelfDelegate = async () => {
+    if (!address) return;
+
+    setDelegateError(undefined);
+    setDelegateHash(undefined);
+    try {
+      const hash = await delegate(address);
+      if (hash) setDelegateHash(hash);
+    } catch (error) {
+      setDelegateError(getErrorMessage(error as Error));
+    }
+  };
+
+  const claimButtonLabel = !isConnected
+    ? t("connectWallet")
+    : !isCorrectNetwork
+      ? t("switchNetwork", { network: daoConfig.chain.name })
+      : claimComplete
+        ? t("claimed")
+        : t("claim");
+
+  return (
+    <main className="mx-auto flex w-full max-w-[760px] flex-col gap-8 py-4 sm:py-8">
+      <header className="max-w-[65ch] space-y-3">
+        <p className="text-sm font-semibold text-muted-foreground">
+          {t("eyebrow")}
+        </p>
+        <h1 className="text-balance text-3xl font-extrabold tracking-[-0.03em] sm:text-4xl">
+          {t("title")}
+        </h1>
+        <p className="text-base leading-7 text-muted-foreground">
+          {t("description")}
+        </p>
+      </header>
+
+      <section className="rounded-[14px] bg-card p-5 shadow-card sm:p-8">
+        <div className="flex flex-col gap-6">
+          <div className="flex items-start gap-4">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-foreground text-card">
+              {claimComplete ? (
+                <Check aria-hidden="true" className="size-5" />
+              ) : (
+                <span className="font-bold">1</span>
+              )}
+            </div>
+            <div className="min-w-0 flex-1 space-y-2">
+              <h2 className="text-lg font-bold">{t("claimTitle")}</h2>
+              <p className="text-sm leading-6 text-muted-foreground">
+                {t("claimDescription")}
+              </p>
+              {!faucetAddress && (
+                <p className="flex items-start gap-2 text-sm text-destructive">
+                  <CircleAlert
+                    aria-hidden="true"
+                    className="mt-0.5 size-4 shrink-0"
+                  />
+                  {t("notConfigured")}
+                </p>
+              )}
+              {errorMessage && isConnected && (
+                <p className="text-sm text-muted-foreground">{errorMessage}</p>
+              )}
+              {claimError && (
+                <p role="alert" className="text-sm text-destructive">
+                  {claimError}
+                </p>
+              )}
+              <div className="flex flex-wrap items-center gap-4 pt-2">
+                <Button
+                  onClick={() => void handleClaim()}
+                  disabled={
+                    !faucetAddress ||
+                    claimComplete ||
+                    isLoadingClaim ||
+                    claimReceipt.isPending
+                  }
+                  isLoading={isPreparingClaim || claimReceipt.isPending}
+                  className="min-w-[160px]"
+                >
+                  {claimButtonLabel}
+                </Button>
+                {claimHash && <TransactionLink hash={claimHash} />}
+              </div>
+            </div>
+          </div>
+
+          <div className="ml-5 h-8 border-l border-dashed border-muted-foreground/40" />
+
+          <div className="flex items-start gap-4">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
+              {isSelfDelegated ? (
+                <Check aria-hidden="true" className="size-5" />
+              ) : (
+                <Vote aria-hidden="true" className="size-5" />
+              )}
+            </div>
+            <div className="min-w-0 flex-1 space-y-2">
+              <h2 className="text-lg font-bold">{t("delegateTitle")}</h2>
+              <p className="text-sm leading-6 text-muted-foreground">
+                {t("delegateDescription")}
+              </p>
+              {displayedDelegateError && (
+                <p role="alert" className="text-sm text-destructive">
+                  {displayedDelegateError}
+                </p>
+              )}
+              <div className="flex flex-wrap items-center gap-4 pt-2">
+                <Button
+                  variant="outline"
+                  onClick={() => void handleSelfDelegate()}
+                  disabled={!claimComplete || isSelfDelegated || !address}
+                  isLoading={isDelegating || delegateReceipt.isPending}
+                >
+                  {isSelfDelegated ? t("delegated") : t("delegate")}
+                </Button>
+                {delegateHash && <TransactionLink hash={delegateHash} />}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside className="flex items-start gap-3 border-t pt-5 text-sm leading-6 text-muted-foreground">
+        <CircleAlert aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+        <p>{t("gasNotice")}</p>
+      </aside>
+    </main>
+  );
+}

--- a/apps/web/src/config/abi/playground-faucet.ts
+++ b/apps/web/src/config/abi/playground-faucet.ts
@@ -1,0 +1,21 @@
+export const playgroundFaucetAbi = [
+  {
+    inputs: [],
+    name: "AlreadyClaimed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "claim",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "claimed",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -16,6 +16,7 @@ async function loadEnglishMessages(): Promise<AbstractIntlMessages> {
     notifications,
     proposalEditor,
     aiAnalysis,
+    faucet,
   ] = await Promise.all([
     import("../../messages/en/common.json"),
     import("../../messages/en/navigation.json"),
@@ -29,6 +30,7 @@ async function loadEnglishMessages(): Promise<AbstractIntlMessages> {
     import("../../messages/en/notifications.json"),
     import("../../messages/en/proposal-editor.json"),
     import("../../messages/en/ai-analysis.json"),
+    import("../../messages/en/faucet.json"),
   ]);
 
   return {
@@ -44,6 +46,7 @@ async function loadEnglishMessages(): Promise<AbstractIntlMessages> {
     notifications: notifications.default,
     proposalEditor: proposalEditor.default,
     aiAnalysis: aiAnalysis.default,
+    faucet: faucet.default,
   };
 }
 

--- a/apps/web/src/types/config.ts
+++ b/apps/web/src/types/config.ts
@@ -74,6 +74,11 @@ interface AppItem {
   description: string;
   icon: string;
   link: string;
+  params?: {
+    contract?: string;
+    faucetAddress?: string;
+    [key: string]: unknown;
+  };
 }
 
 interface FaqItem {

--- a/apps/web/src/utils/playground-faucet.ts
+++ b/apps/web/src/utils/playground-faucet.ts
@@ -1,0 +1,30 @@
+import { isAddress, type Address } from "viem";
+
+import type { AppItem, Config } from "@/types/config";
+
+export const PLAYGROUND_DAO_CODE = "playground-dao";
+
+type FaucetConfig = Pick<Config, "code" | "apps">;
+
+function isFaucetLink(app: AppItem): boolean {
+  return /(^|\/)faucet\/?(?:[?#]|$)/i.test(app.link);
+}
+
+export function getPlaygroundFaucetAddress(
+  config: FaucetConfig | null | undefined
+): Address | undefined {
+  if (config?.code !== PLAYGROUND_DAO_CODE) return undefined;
+
+  const apps = config.apps ?? [];
+  const explicitAddress = apps
+    .map((app) => app.params?.faucetAddress)
+    .find((value): value is string => Boolean(value && isAddress(value)));
+  if (explicitAddress) return explicitAddress as Address;
+
+  const contractAddress = apps
+    .filter(isFaucetLink)
+    .map((app) => app.params?.contract)
+    .find((value): value is string => Boolean(value && isAddress(value)));
+
+  return contractAddress as Address | undefined;
+}

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all fmt clean test
 .PHONY: tools foundry sync
 .PHONY: deploy dry-run deploy-playground dry-run-playground deploy-playground-skip-simulation
+.PHONY: deploy-base-playground-faucet grant-base-playground-faucet-role
 
 -include .env
 
@@ -16,6 +17,8 @@ dry-run:; @forge script script/Deploy.s.sol:Deploy --chain ${chain-id}
 deploy-playground :; @forge script script/Playground.s.sol:DeployPlayground --chain ${chain-id} --rpc-url ${rpc-url} --broadcast --verify --verifier blockscout --legacy
 dry-run-playground:; @forge script script/Playground.s.sol:DeployPlayground --chain ${chain-id} --rpc-url ${rpc-url} --skip-simulation
 deploy-playground-skip-simulation :; @forge script script/Playground.s.sol:DeployPlayground --chain ${chain-id} --rpc-url ${rpc-url} --broadcast --skip-simulation --verify --verifier blockscout --legacy
+deploy-base-playground-faucet :; @forge script script/BasePlaygroundFaucet.s.sol:DeployBasePlaygroundFaucet --chain 8453 --rpc-url base --broadcast
+grant-base-playground-faucet-role :; @forge script script/BasePlaygroundFaucet.s.sol:GrantBasePlaygroundFaucetRole --chain 8453 --rpc-url base --broadcast
 
 sync   :; @git submodule update --recursive
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -15,6 +15,7 @@ eth_rpc_url  = "https://erpc.ringdao.com/main/evm/46"
 
 [rpc_endpoints]
 darwinia = "https://rpc.darwinia.network"
+base = "https://base-rpc.publicnode.com"
 
 [etherscan]
 darwinia = { key = "xxx", url = "https://explorer.darwinia.network/api", chain = 46 }

--- a/contracts/script/BasePlaygroundFaucet.s.sol
+++ b/contracts/script/BasePlaygroundFaucet.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Script} from "forge-std/Script.sol";
+import {safeconsole} from "forge-std/safeconsole.sol";
+import {GovernanceToken} from "../src/blocknumber/GTK.sol";
+import {IMintableToken, PlaygroundFaucet} from "../src/PlaygroundFaucet.sol";
+
+contract DeployBasePlaygroundFaucet is Script {
+    uint256 internal constant BASE_CHAIN_ID = 8453;
+    address internal constant DEFAULT_DEPLOYER = 0x0f14341A7f464320319025540E8Fe48Ad0fe5aec;
+    address internal constant GTK = 0xef8ef3A1705f42e7FC1e06809940ec5942F5bB98;
+
+    function run() public returns (PlaygroundFaucet faucet) {
+        require(block.chainid == BASE_CHAIN_ID, "faucet deploy must run on Base");
+        require(GTK.code.length > 0, "Base Playground GTK has no code");
+
+        address deployer = vm.envOr("PLAYGROUND_DEPLOYER", DEFAULT_DEPLOYER);
+
+        safeconsole.log("Chain Id: ", block.chainid);
+        safeconsole.log("deployer: ", deployer);
+        safeconsole.log("gtk: ", GTK);
+
+        vm.startBroadcast(deployer);
+        faucet = new PlaygroundFaucet(IMintableToken(GTK));
+        vm.stopBroadcast();
+
+        require(address(faucet.token()) == GTK, "faucet token mismatch");
+        safeconsole.log("faucet: ", address(faucet));
+        safeconsole.log("Next: grant faucet minter role");
+    }
+}
+
+contract GrantBasePlaygroundFaucetRole is Script {
+    uint256 internal constant BASE_CHAIN_ID = 8453;
+    address internal constant DEFAULT_DEPLOYER = 0x0f14341A7f464320319025540E8Fe48Ad0fe5aec;
+    address internal constant GTK = 0xef8ef3A1705f42e7FC1e06809940ec5942F5bB98;
+
+    function run() public {
+        require(block.chainid == BASE_CHAIN_ID, "role grant must run on Base");
+        require(GTK.code.length > 0, "Base Playground GTK has no code");
+
+        address faucet = vm.envAddress("PLAYGROUND_FAUCET");
+        require(faucet.code.length > 0, "Playground faucet has no code");
+        require(address(PlaygroundFaucet(faucet).token()) == GTK, "faucet token mismatch");
+
+        address deployer = vm.envOr("PLAYGROUND_DEPLOYER", DEFAULT_DEPLOYER);
+        GovernanceToken gtk = GovernanceToken(GTK);
+        bytes32 minterRole = gtk.MINTER_ROLE();
+
+        vm.startBroadcast(deployer);
+        gtk.grantRole(minterRole, faucet);
+        vm.stopBroadcast();
+
+        require(gtk.hasRole(minterRole, faucet), "faucet missing MINTER_ROLE");
+        safeconsole.log("faucet minter role granted: ", faucet);
+    }
+}

--- a/contracts/src/PlaygroundFaucet.sol
+++ b/contracts/src/PlaygroundFaucet.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface IMintableToken {
+    function mint(address to, uint256 amount) external;
+}
+
+contract PlaygroundFaucet {
+    uint256 public constant CLAIM_AMOUNT = 10 ether;
+
+    IMintableToken public immutable token;
+    mapping(address account => bool) public claimed;
+
+    error AlreadyClaimed();
+    error InvalidToken();
+
+    event Claimed(address indexed account, uint256 amount);
+
+    constructor(IMintableToken token_) {
+        if (address(token_) == address(0)) revert InvalidToken();
+        token = token_;
+    }
+
+    function claim() external {
+        if (claimed[msg.sender]) revert AlreadyClaimed();
+
+        claimed[msg.sender] = true;
+        token.mint(msg.sender, CLAIM_AMOUNT);
+
+        emit Claimed(msg.sender, CLAIM_AMOUNT);
+    }
+}

--- a/contracts/test/PlaygroundFaucet.t.sol
+++ b/contracts/test/PlaygroundFaucet.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {IMintableToken, PlaygroundFaucet} from "../src/PlaygroundFaucet.sol";
+
+contract MintableTokenMock is IMintableToken {
+    mapping(address account => uint256) public balanceOf;
+    bool public shouldRevert;
+
+    function setShouldRevert(bool value) external {
+        shouldRevert = value;
+    }
+
+    function mint(address to, uint256 amount) external {
+        require(!shouldRevert, "mint failed");
+        balanceOf[to] += amount;
+    }
+}
+
+contract PlaygroundFaucetTest is Test {
+    address internal constant USER = address(0xBEEF);
+
+    MintableTokenMock internal token;
+    PlaygroundFaucet internal faucet;
+
+    function setUp() public {
+        token = new MintableTokenMock();
+        faucet = new PlaygroundFaucet(token);
+    }
+
+    function test_Claim_FirstClaimMintsTenTokens() public {
+        vm.expectEmit(true, false, false, true);
+        emit PlaygroundFaucet.Claimed(USER, 10 ether);
+
+        vm.prank(USER);
+        faucet.claim();
+
+        assertTrue(faucet.claimed(USER));
+        assertEq(token.balanceOf(USER), 10 ether);
+    }
+
+    function test_Claim_SecondClaimReverts() public {
+        vm.startPrank(USER);
+        faucet.claim();
+
+        vm.expectRevert(PlaygroundFaucet.AlreadyClaimed.selector);
+        faucet.claim();
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(USER), 10 ether);
+    }
+
+    function test_Claim_MintFailureDoesNotConsumeClaim() public {
+        token.setShouldRevert(true);
+
+        vm.prank(USER);
+        vm.expectRevert("mint failed");
+        faucet.claim();
+
+        assertFalse(faucet.claimed(USER));
+        assertEq(token.balanceOf(USER), 0);
+    }
+
+    function test_Constructor_ZeroTokenReverts() public {
+        vm.expectRevert(PlaygroundFaucet.InvalidToken.selector);
+        new PlaygroundFaucet(IMintableToken(address(0)));
+    }
+}


### PR DESCRIPTION
## Summary

- add a minimal onchain `PlaygroundFaucet` that mints 10 GTK once per address
- add Base-guarded deployment and separate GTK `MINTER_ROLE` grant scripts
- add a Playground-only `/faucet` page with wallet/network handling, transaction states, and self-delegation guidance
- resolve the Faucet address from Registry `apps[].params.faucetAddress` or a Faucet app `params.contract`; no deployed address is hardcoded in the web app

Part of #1010. This PR does not deploy the contract or grant roles.

## Registry contract

After deployment, the Playground app entry can provide either:

```yml
apps:
  - name: GTK Faucet
    description: Claim Playground governance tokens.
    icon: <icon-url>
    link: /faucet
    params:
      faucetAddress: <deployed-faucet-address>
```

`params.contract` is also accepted for a Faucet-linked app.

## Validation

- `forge fmt --check src/PlaygroundFaucet.sol test/PlaygroundFaucet.t.sol script/BasePlaygroundFaucet.s.sol`
- `forge test --match-path test/PlaygroundFaucet.t.sol -vvv` (4 passed)
- `pnpm --filter @degov/web exec tsc --noEmit`
- `pnpm --filter @degov/web lint`
- `pnpm run test:web-scripts` (83 passed)
- `pnpm --filter @degov/web build`
