### PR TITLE
Add DeGov indexer monitoring metrics

### DIFF
--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -23,6 +23,7 @@ use crate::{OnchainRefreshRunReport, OnchainRefreshTaskScope};
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct IndexerMetricsSnapshot {
     pub sync_rows: Vec<IndexerSyncMetricsRow>,
+    pub configured_scope_rows: Vec<IndexerConfiguredScopeMetricsRow>,
     pub onchain_backlog_rows: Vec<OnchainRefreshBacklogMetricsRow>,
     pub deferred_onchain_backlog_rows: Vec<OnchainRefreshBacklogMetricsRow>,
     pub chunk_runtime_rows: Vec<IndexerChunkRuntimeMetricsRow>,
@@ -57,6 +58,14 @@ pub struct IndexerSyncMetricsRow {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct IndexerConfiguredScopeMetricsRow {
+    pub dao_code: String,
+    pub chain_id: i32,
+    pub contract_set_id: String,
+    pub start_block: i64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct OnchainRefreshBacklogMetricsRow {
     pub dao_code: String,
     pub chain_id: i32,
@@ -81,6 +90,17 @@ pub struct IndexerChunkRuntimeMetricsRow {
     pub chunk_duration_seconds_count: u64,
     pub last_chunk_size: Option<u32>,
     pub current_chunk_size: Option<u32>,
+    pub chunk_attempts_success_total: u64,
+    pub chunk_attempts_failure_total: u64,
+    pub last_chain_pass_success_timestamp_seconds: Option<f64>,
+    pub last_forward_advance_timestamp_seconds: Option<f64>,
+    pub consecutive_failures: u64,
+    pub chain_pass_success_total: u64,
+    pub chain_pass_failure_total: u64,
+    pub datalens_head_observed_timestamp_seconds: Option<f64>,
+    pub datalens_head_advanced_timestamp_seconds: Option<f64>,
+    pub last_datalens_head_height: Option<i64>,
+    pub reorg_rollbacks_total: u64,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -131,6 +151,7 @@ struct MetricsScopeKey {
 
 #[derive(Clone, Debug, Default)]
 struct RuntimeMetricsState {
+    configured_scope_rows: BTreeMap<MetricsScopeKey, IndexerConfiguredScopeMetricsRow>,
     sync_rows: BTreeMap<MetricsScopeKey, RuntimeSyncMetricsRow>,
     chunk_rows: BTreeMap<MetricsScopeKey, IndexerChunkRuntimeMetricsRow>,
     onchain_worker_rows: BTreeMap<OnchainWorkerMetricsScopeKey, OnchainRefreshWorkerMetricsRow>,
@@ -254,7 +275,10 @@ impl MetricsSnapshotCache {
         };
         drop(state);
 
-        snapshot.chunk_runtime_rows = collect_runtime_metrics(&mut snapshot.sync_rows);
+        let (configured_scope_rows, chunk_runtime_rows) =
+            collect_runtime_metrics(&mut snapshot.sync_rows);
+        snapshot.configured_scope_rows = configured_scope_rows;
+        snapshot.chunk_runtime_rows = chunk_runtime_rows;
         snapshot.onchain_worker_rows = collect_onchain_worker_runtime_metrics();
         (snapshot, status)
     }
@@ -264,6 +288,7 @@ pub async fn record_indexer_latest_head(
     pool: &PgPool,
     record: &IndexerLatestHeadRecord,
 ) -> Result<(), MetricsError> {
+    record_indexer_head_observation(record);
     sqlx::query(
         r#"
         INSERT INTO degov_indexer_latest_head (
@@ -295,6 +320,73 @@ pub async fn record_indexer_latest_head(
     .await?;
 
     Ok(())
+}
+
+pub fn record_configured_indexer_scope(identity: &IndexerCheckpointIdentity, start_block: i64) {
+    let key = MetricsScopeKey {
+        dao_code: identity.dao_code.clone(),
+        chain_id: identity.chain_id,
+        contract_set_id: identity.contract_set_id.clone(),
+    };
+    let mut state = runtime_metrics_state()
+        .lock()
+        .expect("runtime metrics mutex is not poisoned");
+    state.configured_scope_rows.insert(
+        key,
+        IndexerConfiguredScopeMetricsRow {
+            dao_code: identity.dao_code.clone(),
+            chain_id: identity.chain_id,
+            contract_set_id: identity.contract_set_id.clone(),
+            start_block,
+        },
+    );
+}
+
+pub fn record_indexer_chain_pass(
+    identity: &IndexerCheckpointIdentity,
+    success: bool,
+    consecutive_failures: u64,
+) {
+    let row = runtime_chunk_row(identity);
+    let mut state = runtime_metrics_state()
+        .lock()
+        .expect("runtime metrics mutex is not poisoned");
+    let row = state.chunk_rows.entry(row.0).or_insert(row.1);
+    row.consecutive_failures = consecutive_failures;
+    if success {
+        row.chain_pass_success_total = row.chain_pass_success_total.saturating_add(1);
+        row.last_chain_pass_success_timestamp_seconds = Some(unix_timestamp_seconds());
+    } else {
+        row.chain_pass_failure_total = row.chain_pass_failure_total.saturating_add(1);
+    }
+}
+
+pub fn record_indexer_head_observation_for_identity(
+    identity: &IndexerCheckpointIdentity,
+    latest_height: i64,
+) {
+    let record = IndexerLatestHeadRecord {
+        dao_code: identity.dao_code.clone(),
+        chain_id: identity.chain_id,
+        contract_set_id: identity.contract_set_id.clone(),
+        stream_id: identity.stream_id.clone(),
+        data_source_version: identity.data_source_version.clone(),
+        latest_height,
+    };
+    record_indexer_head_observation(&record);
+}
+
+pub fn record_indexer_chunk_attempt(identity: &IndexerCheckpointIdentity, success: bool) {
+    let row = runtime_chunk_row(identity);
+    let mut state = runtime_metrics_state()
+        .lock()
+        .expect("runtime metrics mutex is not poisoned");
+    let row = state.chunk_rows.entry(row.0).or_insert(row.1);
+    if success {
+        row.chunk_attempts_success_total = row.chunk_attempts_success_total.saturating_add(1);
+    } else {
+        row.chunk_attempts_failure_total = row.chunk_attempts_failure_total.saturating_add(1);
+    }
 }
 
 pub async fn spawn_metrics_server(
@@ -369,7 +461,10 @@ pub async fn collect_indexer_metrics_snapshot(
     pool: &PgPool,
 ) -> Result<IndexerMetricsSnapshot, MetricsError> {
     let mut snapshot = collect_db_metrics_snapshot(pool).await?;
-    snapshot.chunk_runtime_rows = collect_runtime_metrics(&mut snapshot.sync_rows);
+    let (configured_scope_rows, chunk_runtime_rows) =
+        collect_runtime_metrics(&mut snapshot.sync_rows);
+    snapshot.configured_scope_rows = configured_scope_rows;
+    snapshot.chunk_runtime_rows = chunk_runtime_rows;
     snapshot.onchain_worker_rows = collect_onchain_worker_runtime_metrics();
 
     Ok(snapshot)
@@ -385,6 +480,7 @@ async fn collect_db_metrics_snapshot(
 
     Ok(IndexerMetricsSnapshot {
         sync_rows,
+        configured_scope_rows: Vec::new(),
         onchain_backlog_rows,
         deferred_onchain_backlog_rows,
         ..Default::default()
@@ -441,6 +537,56 @@ pub fn record_indexer_chunk_metrics(
     row.chunk_duration_seconds_count = row.chunk_duration_seconds_count.saturating_add(1);
     row.last_chunk_size = Some(observation.last_chunk_size);
     row.current_chunk_size = Some(observation.current_chunk_size);
+    row.last_forward_advance_timestamp_seconds = Some(unix_timestamp_seconds());
+}
+
+fn record_indexer_head_observation(record: &IndexerLatestHeadRecord) {
+    let key = MetricsScopeKey {
+        dao_code: record.dao_code.clone(),
+        chain_id: record.chain_id,
+        contract_set_id: record.contract_set_id.clone(),
+    };
+    let mut state = runtime_metrics_state()
+        .lock()
+        .expect("runtime metrics mutex is not poisoned");
+    let row =
+        state
+            .chunk_rows
+            .entry(key.clone())
+            .or_insert_with(|| IndexerChunkRuntimeMetricsRow {
+                dao_code: key.dao_code.clone(),
+                chain_id: key.chain_id,
+                contract_set_id: key.contract_set_id.clone(),
+                ..Default::default()
+            });
+    let now = unix_timestamp_seconds();
+    row.datalens_head_observed_timestamp_seconds = Some(now);
+    if row
+        .last_datalens_head_height
+        .is_none_or(|previous| record.latest_height > previous)
+    {
+        row.datalens_head_advanced_timestamp_seconds = Some(now);
+    }
+    row.last_datalens_head_height = Some(record.latest_height);
+}
+
+fn runtime_chunk_row(
+    identity: &IndexerCheckpointIdentity,
+) -> (MetricsScopeKey, IndexerChunkRuntimeMetricsRow) {
+    let key = MetricsScopeKey {
+        dao_code: identity.dao_code.clone(),
+        chain_id: identity.chain_id,
+        contract_set_id: identity.contract_set_id.clone(),
+    };
+    (
+        key.clone(),
+        IndexerChunkRuntimeMetricsRow {
+            dao_code: key.dao_code,
+            chain_id: key.chain_id,
+            contract_set_id: key.contract_set_id,
+            ..Default::default()
+        },
+    )
 }
 
 pub fn record_onchain_refresh_worker_report(
@@ -556,6 +702,66 @@ pub fn render_prometheus_metrics_with_status(
         "degov_metrics_snapshot_stale",
         "Whether the DB-backed metrics snapshot is older than the configured freshness threshold.",
         "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_configured_scope_info",
+        "Configured DeGov indexer scope information.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_checkpoint_present",
+        "Whether a configured DeGov indexer scope has a durable checkpoint row.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_last_chain_pass_success_timestamp_seconds",
+        "Unix timestamp of the last successful DeGov indexer chain pass.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_last_forward_advance_timestamp_seconds",
+        "Unix timestamp of the last forward durable checkpoint advancement.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_consecutive_failures",
+        "Consecutive DeGov indexer contract set pass failures.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_chain_passes_total",
+        "DeGov indexer contract set passes by result.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_chunk_attempts_total",
+        "DeGov indexer chunk attempts by result.",
+        "counter",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_datalens_head_observed_timestamp_seconds",
+        "Unix timestamp of the last Datalens head observation.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_datalens_head_advanced_timestamp_seconds",
+        "Unix timestamp of the last Datalens head advancement.",
+        "gauge",
+    );
+    metric_header(
+        &mut output,
+        "degov_indexer_reorg_rollbacks_total",
+        "DeGov indexer reorg rollbacks.",
+        "counter",
     );
     metric_header(
         &mut output,
@@ -757,6 +963,27 @@ pub fn render_prometheus_metrics_with_status(
         i64::from(status.stale),
     );
 
+    for row in &snapshot.configured_scope_rows {
+        let labels = configured_scope_labels(row);
+        let checkpoint_present = snapshot.sync_rows.iter().any(|sync_row| {
+            sync_row.dao_code == row.dao_code
+                && sync_row.chain_id == row.chain_id
+                && sync_row.contract_set_id == row.contract_set_id
+        });
+        append_metric(
+            &mut output,
+            "degov_indexer_configured_scope_info",
+            &configured_scope_info_labels(row),
+            1,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_checkpoint_present",
+            &labels,
+            i64::from(checkpoint_present),
+        );
+    }
+
     for row in &snapshot.sync_rows {
         let labels = sync_labels(row);
         append_optional_metric(
@@ -929,6 +1156,66 @@ pub fn render_prometheus_metrics_with_status(
             &labels,
             row.current_chunk_size,
         );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_last_chain_pass_success_timestamp_seconds",
+            &labels,
+            row.last_chain_pass_success_timestamp_seconds,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_last_forward_advance_timestamp_seconds",
+            &labels,
+            row.last_forward_advance_timestamp_seconds,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_consecutive_failures",
+            &labels,
+            row.consecutive_failures,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_chain_passes_total",
+            &result_labels(row, "success"),
+            row.chain_pass_success_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_chain_passes_total",
+            &result_labels(row, "failure"),
+            row.chain_pass_failure_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_chunk_attempts_total",
+            &result_labels(row, "success"),
+            row.chunk_attempts_success_total,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_chunk_attempts_total",
+            &result_labels(row, "failure"),
+            row.chunk_attempts_failure_total,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_datalens_head_observed_timestamp_seconds",
+            &labels,
+            row.datalens_head_observed_timestamp_seconds,
+        );
+        append_optional_metric(
+            &mut output,
+            "degov_indexer_datalens_head_advanced_timestamp_seconds",
+            &labels,
+            row.datalens_head_advanced_timestamp_seconds,
+        );
+        append_metric(
+            &mut output,
+            "degov_indexer_reorg_rollbacks_total",
+            &labels,
+            row.reorg_rollbacks_total,
+        );
     }
 
     for row in &snapshot.onchain_worker_rows {
@@ -1014,7 +1301,10 @@ fn unix_timestamp_seconds() -> f64 {
 
 fn collect_runtime_metrics(
     sync_rows: &mut [IndexerSyncMetricsRow],
-) -> Vec<IndexerChunkRuntimeMetricsRow> {
+) -> (
+    Vec<IndexerConfiguredScopeMetricsRow>,
+    Vec<IndexerChunkRuntimeMetricsRow>,
+) {
     let state = runtime_metrics_state()
         .lock()
         .expect("runtime metrics mutex is not poisoned");
@@ -1030,7 +1320,10 @@ fn collect_runtime_metrics(
         }
     }
 
-    state.chunk_rows.values().cloned().collect()
+    (
+        state.configured_scope_rows.values().cloned().collect(),
+        state.chunk_rows.values().cloned().collect(),
+    )
 }
 
 fn runtime_metrics_state() -> &'static Mutex<RuntimeMetricsState> {
@@ -1203,6 +1496,22 @@ fn sync_labels(row: &IndexerSyncMetricsRow) -> Vec<(&'static str, String)> {
     ]
 }
 
+fn configured_scope_labels(row: &IndexerConfiguredScopeMetricsRow) -> Vec<(&'static str, String)> {
+    vec![
+        ("dao_code", row.dao_code.clone()),
+        ("chain_id", row.chain_id.to_string()),
+        ("contract_set_id", row.contract_set_id.clone()),
+    ]
+}
+
+fn configured_scope_info_labels(
+    row: &IndexerConfiguredScopeMetricsRow,
+) -> Vec<(&'static str, String)> {
+    let mut labels = configured_scope_labels(row);
+    labels.push(("start_block", row.start_block.to_string()));
+    labels
+}
+
 fn onchain_labels(row: &OnchainRefreshBacklogMetricsRow) -> Vec<(&'static str, String)> {
     vec![
         ("dao_code", row.dao_code.clone()),
@@ -1226,6 +1535,15 @@ fn cache_labels(
 ) -> Vec<(&'static str, String)> {
     let mut labels = chunk_labels(row);
     labels.push(("outcome", outcome.to_owned()));
+    labels
+}
+
+fn result_labels(
+    row: &IndexerChunkRuntimeMetricsRow,
+    result: &'static str,
+) -> Vec<(&'static str, String)> {
+    let mut labels = chunk_labels(row);
+    labels.push(("result", result.to_owned()));
     labels
 }
 

--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt::Display,
     future::Future,
     sync::{Arc, Mutex, OnceLock},
@@ -100,7 +100,6 @@ pub struct IndexerChunkRuntimeMetricsRow {
     pub datalens_head_observed_timestamp_seconds: Option<f64>,
     pub datalens_head_advanced_timestamp_seconds: Option<f64>,
     pub last_datalens_head_height: Option<i64>,
-    pub reorg_rollbacks_total: u64,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -342,21 +341,18 @@ pub fn record_configured_indexer_scope(identity: &IndexerCheckpointIdentity, sta
     );
 }
 
-pub fn record_indexer_chain_pass(
-    identity: &IndexerCheckpointIdentity,
-    success: bool,
-    consecutive_failures: u64,
-) {
+pub fn record_indexer_chain_pass(identity: &IndexerCheckpointIdentity, success: bool) {
     let row = runtime_chunk_row(identity);
     let mut state = runtime_metrics_state()
         .lock()
         .expect("runtime metrics mutex is not poisoned");
     let row = state.chunk_rows.entry(row.0).or_insert(row.1);
-    row.consecutive_failures = consecutive_failures;
     if success {
+        row.consecutive_failures = 0;
         row.chain_pass_success_total = row.chain_pass_success_total.saturating_add(1);
         row.last_chain_pass_success_timestamp_seconds = Some(unix_timestamp_seconds());
     } else {
+        row.consecutive_failures = row.consecutive_failures.saturating_add(1);
         row.chain_pass_failure_total = row.chain_pass_failure_total.saturating_add(1);
     }
 }
@@ -566,8 +562,8 @@ fn record_indexer_head_observation(record: &IndexerLatestHeadRecord) {
         .is_none_or(|previous| record.latest_height > previous)
     {
         row.datalens_head_advanced_timestamp_seconds = Some(now);
+        row.last_datalens_head_height = Some(record.latest_height);
     }
-    row.last_datalens_head_height = Some(record.latest_height);
 }
 
 fn runtime_chunk_row(
@@ -756,12 +752,6 @@ pub fn render_prometheus_metrics_with_status(
         "degov_indexer_datalens_head_advanced_timestamp_seconds",
         "Unix timestamp of the last Datalens head advancement.",
         "gauge",
-    );
-    metric_header(
-        &mut output,
-        "degov_indexer_reorg_rollbacks_total",
-        "DeGov indexer reorg rollbacks.",
-        "counter",
     );
     metric_header(
         &mut output,
@@ -963,13 +953,25 @@ pub fn render_prometheus_metrics_with_status(
         i64::from(status.stale),
     );
 
+    let checkpoint_keys = snapshot
+        .sync_rows
+        .iter()
+        .map(|row| {
+            (
+                row.dao_code.as_str(),
+                row.chain_id,
+                row.contract_set_id.as_str(),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+
     for row in &snapshot.configured_scope_rows {
         let labels = configured_scope_labels(row);
-        let checkpoint_present = snapshot.sync_rows.iter().any(|sync_row| {
-            sync_row.dao_code == row.dao_code
-                && sync_row.chain_id == row.chain_id
-                && sync_row.contract_set_id == row.contract_set_id
-        });
+        let checkpoint_present = checkpoint_keys.contains(&(
+            row.dao_code.as_str(),
+            row.chain_id,
+            row.contract_set_id.as_str(),
+        ));
         append_metric(
             &mut output,
             "degov_indexer_configured_scope_info",
@@ -1209,12 +1211,6 @@ pub fn render_prometheus_metrics_with_status(
             "degov_indexer_datalens_head_advanced_timestamp_seconds",
             &labels,
             row.datalens_head_advanced_timestamp_seconds,
-        );
-        append_metric(
-            &mut output,
-            "degov_indexer_reorg_rollbacks_total",
-            &labels,
-            row.reorg_rollbacks_total,
         );
     }
 

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -933,11 +933,21 @@ where
             let checkpoint_identity = self.options.checkpoint_identity.clone();
             let checkpoint_next_block_before = checkpoint.next_block;
             let write_started_at = Instant::now();
-            let mut transaction = self
-                .store
-                .begin_transaction()
-                .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
+            let mut transaction = match self.store.begin_transaction() {
+                Ok(transaction) => transaction,
+                Err(error) => {
+                    crate::metrics::record_indexer_chunk_attempt(
+                        &self.options.checkpoint_identity,
+                        false,
+                    );
+                    return Err(transaction_error(&checkpoint_identity, range, error));
+                }
+            };
             if let Err(error) = transaction.apply_projection_batch(&processing.batch) {
+                crate::metrics::record_indexer_chunk_attempt(
+                    &self.options.checkpoint_identity,
+                    false,
+                );
                 return Err(rollback_transaction_after_error(
                     &checkpoint_identity,
                     range,
@@ -950,6 +960,10 @@ where
                 range.to_block,
                 Some(effective_target),
             ) {
+                crate::metrics::record_indexer_chunk_attempt(
+                    &self.options.checkpoint_identity,
+                    false,
+                );
                 return Err(rollback_transaction_after_error(
                     &checkpoint_identity,
                     range,
@@ -969,6 +983,10 @@ where
             if let Err(error) = transaction
                 .update_adaptive_chunk_state(&self.options.checkpoint_identity, &sizing_decision)
             {
+                crate::metrics::record_indexer_chunk_attempt(
+                    &self.options.checkpoint_identity,
+                    false,
+                );
                 return Err(rollback_transaction_after_error(
                     &checkpoint_identity,
                     range,
@@ -976,9 +994,13 @@ where
                     error,
                 ));
             }
-            transaction
-                .commit()
-                .map_err(|error| transaction_error(&checkpoint_identity, range, error))?;
+            if let Err(error) = transaction.commit() {
+                crate::metrics::record_indexer_chunk_attempt(
+                    &self.options.checkpoint_identity,
+                    false,
+                );
+                return Err(transaction_error(&checkpoint_identity, range, error));
+            }
             let write_duration = write_started_at.elapsed();
             let (deferred_drain_count, deferred_drain_duration) =
                 self.drain_deferred_onchain_refresh_tasks(range);

--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -851,6 +851,10 @@ where
             let processing = match self.process_range(range, effective_target) {
                 Ok(processing) => processing,
                 Err(error) => {
+                    crate::metrics::record_indexer_chunk_attempt(
+                        &self.options.checkpoint_identity,
+                        false,
+                    );
                     let failed_range_block_count = range_block_count(range);
                     if is_provider_limit_error(&error) && failed_range_block_count > 1 {
                         provider_limit_count_since_summary += 1;
@@ -1011,6 +1015,7 @@ where
                     current_chunk_size: sizing_decision.current_chunk_size,
                 },
             );
+            crate::metrics::record_indexer_chunk_attempt(&self.options.checkpoint_identity, true);
             info!(
                 "Datalens indexer chunk observed dao_code={} chain_id={} contract_set_id={} stream_id={} data_source_version={} configured_start_block={} from_block={} to_block={} target_height={} chunk_size={} datalens_request_count={} returned_row_count={} decoded_count={} projection_proposal_events={} projection_vote_events={} projection_token_events={} projection_timelock_events={} read_duration_ms={} decode_duration_ms={} project_duration_ms={} write_duration_ms={} local_processing_write_duration_ms={} total_duration_ms={} checkpoint_next_block_before={} checkpoint_advanced_to={} checkpoint_next_block_after={} synced_percentage={:.2} configured_range_synced_percentage={:.2} remaining_blocks={} current_rate_blocks_per_second={} eta_seconds={} datalens_retry_attempts=unavailable adaptive_chunk_size_before={} adaptive_chunk_size_after={} adaptive_reason={} adaptive_cache_full_hit_count={} adaptive_cache_partial_hit_count={} adaptive_cache_miss_count={} adaptive_cache_provider_fill_range_count={} adaptive_query_duration_max_ms={} onchain_refresh_deferred_drain_enabled={} onchain_refresh_deferred_drain_batch_size={} onchain_refresh_deferred_drain_count={} onchain_refresh_deferred_drain_duration_ms={}",
                 self.options.checkpoint_identity.dao_code,

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -814,6 +814,18 @@ async fn run_configured_contract_set_pass_result(
     pool: sqlx::PgPool,
     datalens_query_gate: Option<DatalensQueryConcurrencyGate>,
 ) -> std::result::Result<ContractSetPassOutcome, ContractSetPassError> {
+    let checkpoint_identity = crate::IndexerCheckpointIdentity {
+        dao_code: contract_set.dao_code.clone(),
+        chain_id: contract_set.contract.chain_id,
+        contract_set_id: contract_set.contract_set_id.clone(),
+        stream_id: runtime.checkpoint_stream_id.clone(),
+        data_source_version: runtime.data_source_version.clone(),
+    };
+    crate::metrics::record_configured_indexer_scope(
+        &checkpoint_identity,
+        contract_set.contract.start_block,
+    );
+
     let target_height = resolve_contract_set_target_height(runtime, &contract_set.config)
         .await
         .map_err(ContractSetPassError::setup)?;
@@ -840,17 +852,6 @@ async fn run_configured_contract_set_pass_result(
         }
         Err(error) => return Err(ContractSetPassError::setup(error)),
     };
-    let checkpoint_identity = crate::IndexerCheckpointIdentity {
-        dao_code: contract_runtime.dao_code.clone(),
-        chain_id: contract_set.contract.chain_id,
-        contract_set_id: contract_runtime.checkpoint_contract_set_id.clone(),
-        stream_id: contract_runtime.checkpoint_stream_id.clone(),
-        data_source_version: contract_runtime.data_source_version.clone(),
-    };
-    crate::metrics::record_configured_indexer_scope(
-        &checkpoint_identity,
-        contract_runtime.start_block,
-    );
     crate::metrics::record_indexer_head_observation_for_identity(
         &checkpoint_identity,
         target_height,
@@ -867,7 +868,7 @@ async fn run_configured_contract_set_pass_result(
     {
         Ok(report) => report,
         Err(error) => {
-            crate::metrics::record_indexer_chain_pass(&checkpoint_identity, false, 1);
+            crate::metrics::record_indexer_chain_pass(&checkpoint_identity, false);
             return Err(error.with_contract_runtime(contract_runtime.clone()));
         }
     };
@@ -887,7 +888,7 @@ async fn run_configured_contract_set_pass_result(
         report.last_progress.onchain_refresh_allowed
     );
 
-    crate::metrics::record_indexer_chain_pass(&checkpoint_identity, true, 0);
+    crate::metrics::record_indexer_chain_pass(&checkpoint_identity, true);
     Ok(ContractSetPassOutcome { report })
 }
 

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -840,6 +840,21 @@ async fn run_configured_contract_set_pass_result(
         }
         Err(error) => return Err(ContractSetPassError::setup(error)),
     };
+    let checkpoint_identity = crate::IndexerCheckpointIdentity {
+        dao_code: contract_runtime.dao_code.clone(),
+        chain_id: contract_set.contract.chain_id,
+        contract_set_id: contract_runtime.checkpoint_contract_set_id.clone(),
+        stream_id: contract_runtime.checkpoint_stream_id.clone(),
+        data_source_version: contract_runtime.data_source_version.clone(),
+    };
+    crate::metrics::record_configured_indexer_scope(
+        &checkpoint_identity,
+        contract_runtime.start_block,
+    );
+    crate::metrics::record_indexer_head_observation_for_identity(
+        &checkpoint_identity,
+        target_height,
+    );
     let report = match run_contract_set_pass(
         runtime.contract_set_mode,
         contract_runtime.clone(),
@@ -851,7 +866,10 @@ async fn run_configured_contract_set_pass_result(
     .await
     {
         Ok(report) => report,
-        Err(error) => return Err(error.with_contract_runtime(contract_runtime.clone())),
+        Err(error) => {
+            crate::metrics::record_indexer_chain_pass(&checkpoint_identity, false, 1);
+            return Err(error.with_contract_runtime(contract_runtime.clone()));
+        }
     };
     cleanup_finalized_provisional_overlays(&contract_runtime, &contract_set, pool.clone())
         .await
@@ -869,6 +887,7 @@ async fn run_configured_contract_set_pass_result(
         report.last_progress.onchain_refresh_allowed
     );
 
+    crate::metrics::record_indexer_chain_pass(&checkpoint_identity, true, 0);
     Ok(ContractSetPassOutcome { report })
 }
 

--- a/apps/indexer/tests/metrics_service.rs
+++ b/apps/indexer/tests/metrics_service.rs
@@ -75,7 +75,6 @@ fn test_prometheus_renderer_emits_indexer_sync_and_onchain_backlog_gauges() {
             datalens_head_observed_timestamp_seconds: Some(1_782_437_030.0),
             datalens_head_advanced_timestamp_seconds: Some(1_782_437_030.0),
             last_datalens_head_height: Some(12_209_940),
-            reorg_rollbacks_total: 0,
         }],
         onchain_worker_rows: vec![OnchainRefreshWorkerMetricsRow {
             scope: "contract_set".to_owned(),

--- a/apps/indexer/tests/metrics_service.rs
+++ b/apps/indexer/tests/metrics_service.rs
@@ -27,6 +27,14 @@ fn test_prometheus_renderer_emits_indexer_sync_and_onchain_backlog_gauges() {
             current_rate_blocks_per_second: Some(4.5),
             eta_seconds: Some(52.2),
         }],
+        configured_scope_rows: vec![
+            degov_datalens_indexer::metrics::IndexerConfiguredScopeMetricsRow {
+                dao_code: "ring-dao".to_owned(),
+                chain_id: 46,
+                contract_set_id: "dao=ring-dao|chain=46|governor=0xgovernor".to_owned(),
+                start_block: 12_000_000,
+            },
+        ],
         onchain_backlog_rows: vec![OnchainRefreshBacklogMetricsRow {
             dao_code: "ring-dao".to_owned(),
             chain_id: 46,
@@ -57,6 +65,17 @@ fn test_prometheus_renderer_emits_indexer_sync_and_onchain_backlog_gauges() {
             chunk_duration_seconds_count: 2,
             last_chunk_size: Some(5000),
             current_chunk_size: Some(10000),
+            chunk_attempts_success_total: 2,
+            chunk_attempts_failure_total: 1,
+            last_chain_pass_success_timestamp_seconds: Some(1_782_437_010.0),
+            last_forward_advance_timestamp_seconds: Some(1_782_437_020.0),
+            consecutive_failures: 0,
+            chain_pass_success_total: 3,
+            chain_pass_failure_total: 1,
+            datalens_head_observed_timestamp_seconds: Some(1_782_437_030.0),
+            datalens_head_advanced_timestamp_seconds: Some(1_782_437_030.0),
+            last_datalens_head_height: Some(12_209_940),
+            reorg_rollbacks_total: 0,
         }],
         onchain_worker_rows: vec![OnchainRefreshWorkerMetricsRow {
             scope: "contract_set".to_owned(),
@@ -81,6 +100,12 @@ fn test_prometheus_renderer_emits_indexer_sync_and_onchain_backlog_gauges() {
         "degov_indexer_processed_height{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 12209673"
     ));
     assert!(output.contains(
+        "degov_indexer_configured_scope_info{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",start_block=\"12000000\"} 1"
+    ));
+    assert!(output.contains(
+        "degov_indexer_checkpoint_present{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 1"
+    ));
+    assert!(output.contains(
         "degov_indexer_target_height{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 12209908"
     ));
     assert!(output.contains(
@@ -97,6 +122,21 @@ fn test_prometheus_renderer_emits_indexer_sync_and_onchain_backlog_gauges() {
     ));
     assert!(output.contains(
         "degov_indexer_current_rate_blocks_per_second{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 4.5"
+    ));
+    assert!(output.contains(
+        "degov_indexer_last_chain_pass_success_timestamp_seconds{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 1782437010"
+    ));
+    assert!(output.contains(
+        "degov_indexer_last_forward_advance_timestamp_seconds{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 1782437020"
+    ));
+    assert!(output.contains(
+        "degov_indexer_chain_passes_total{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",result=\"success\"} 3"
+    ));
+    assert!(output.contains(
+        "degov_indexer_chunk_attempts_total{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",result=\"failure\"} 1"
+    ));
+    assert!(output.contains(
+        "degov_indexer_datalens_head_observed_timestamp_seconds{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 1782437030"
     ));
     assert!(output.contains(
         "degov_indexer_eta_seconds{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 52.2"


### PR DESCRIPTION
## Summary
- add DeGov indexer scope/checkpoint-presence metrics
- record pass success/failure, chunk attempts, forward-progress timestamps, and Datalens head observation timestamps
- extend metrics renderer coverage for the new series

## Validation
- cargo fmt --check
- cargo check -p degov-datalens-indexer --locked
- cargo test -p degov-datalens-indexer --locked --test metrics_service
- cargo test -p degov-datalens-indexer --locked runtime::indexer::tests
- git diff --check