### PR TITLE
Define SEO/GEO crawler access policy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,7 @@ jobs:
           pnpm install --filter @degov/web... --frozen-lockfile
           pnpm run test:seo-geo-contract
           pnpm run test:seo-geo-observability
+          pnpm run test:seo-geo-crawler-policy
           pnpm run test:web-scripts
           pnpm --filter @degov/web build
 

--- a/docs/spec/seo-geo-crawler-access-policy.json
+++ b/docs/spec/seo-geo-crawler-access-policy.json
@@ -1012,6 +1012,7 @@
       "userAgent",
       "crawlerPurpose",
       "identityVerification",
+      "observationState",
       "wafAction",
       "cacheResult",
       "count",
@@ -1028,7 +1029,8 @@
       "blocked",
       "challenged",
       "failed",
-      "not-observed"
+      "not-observed",
+      "access-gap"
     ],
     "rule": "Do not report a policy as implemented from a User-Agent string alone. Every public claim must include host, purpose, identity state, outcome state, owner, observation window, and evidence link."
   },

--- a/docs/spec/seo-geo-crawler-access-policy.json
+++ b/docs/spec/seo-geo-crawler-access-policy.json
@@ -1,0 +1,1495 @@
+{
+  "version": 1,
+  "ownerIssue": "https://github.com/ringecosystem/degov/issues/1026",
+  "parentIssue": "https://github.com/ringecosystem/degov/issues/714",
+  "updatedAt": "2026-08-04",
+  "maintenance": {
+    "ownerRepository": "ringecosystem/degov",
+    "contractPath": "docs/spec/seo-geo-crawler-access-policy.json",
+    "localCheck": "pnpm run test:seo-geo-crawler-policy",
+    "changeRule": "A crawler, purpose class, policy decision, control layer, or rollout rule may change only with an owner, official source, verification method, rollback path, and #714-linked rationale."
+  },
+  "policyDefaults": {
+    "publicSearchIndex": "allow",
+    "publicAiSearchReference": "allow",
+    "publicUserTriggeredFetch": "allow",
+    "publicModelTraining": "block-by-default",
+    "publicSocialPreview": "allow",
+    "privateTransactionalPreviewStaging": "block-or-auth-required",
+    "trainingAccessRule": "Training access remains blocked or undecided unless product, legal, security, and infrastructure owners explicitly approve a change.",
+    "identityRule": "A claimed User-Agent alone is never verified identity; use official IP, reverse-DNS, provider verification, or platform-provided verified bot signals where available."
+  },
+  "purposeClasses": [
+    {
+      "id": "search-index",
+      "description": "General search indexing crawlers that discover, crawl, and index public web pages.",
+      "defaultPolicy": "allow",
+      "expectedPublicOutcome": "Approved public canonical pages, robots.txt, sitemaps, and share assets are reachable unless route policy says otherwise.",
+      "notObservedMeaning": "No verified request in the observation window; do not treat as blocked or allowed without crawl evidence."
+    },
+    {
+      "id": "ai-search-reference",
+      "description": "AI answer or search-reference crawlers that fetch public pages for search results, answers, citations, or grounding.",
+      "defaultPolicy": "allow",
+      "expectedPublicOutcome": "Approved public content remains reachable for citation/reference use and is measured separately from model-training crawlers.",
+      "notObservedMeaning": "No verified AI reference request in the observation window; preserve as not-observed."
+    },
+    {
+      "id": "user-triggered-fetch",
+      "description": "Fetchers that retrieve a URL because an end user requested or pasted it into a product.",
+      "defaultPolicy": "allow",
+      "expectedPublicOutcome": "Approved public pages can be fetched for user-requested previews or answers; private/auth routes remain protected.",
+      "notObservedMeaning": "No verified user-triggered fetch in the observation window."
+    },
+    {
+      "id": "model-training",
+      "description": "Crawlers or product tokens used to control model training or broad model improvement access.",
+      "defaultPolicy": "block-by-default",
+      "expectedPublicOutcome": "Existing training restrictions remain unchanged until explicit product/legal/security approval.",
+      "notObservedMeaning": "No verified training crawler or policy-token effect in the observation window; do not infer compliance from absence alone."
+    },
+    {
+      "id": "social-preview",
+      "description": "Preview crawlers that fetch public pages and media when links are shared in social or messaging products.",
+      "defaultPolicy": "allow",
+      "expectedPublicOutcome": "Approved public pages and absolute HTTPS share images are reachable for rich previews.",
+      "notObservedMeaning": "No verified preview request in the observation window."
+    }
+  ],
+  "productSurfaces": [
+    {
+      "id": "home",
+      "hostScope": [
+        "degov.ai"
+      ],
+      "repository": "ringecosystem/degov-home",
+      "ownerRole": "official-site owner",
+      "routeScope": "public official-site pages and share assets",
+      "desiredPolicyByPurpose": {
+        "search-index": "allow",
+        "ai-search-reference": "allow",
+        "user-triggered-fetch": "allow",
+        "model-training": "block-by-default",
+        "social-preview": "allow"
+      }
+    },
+    {
+      "id": "docs",
+      "hostScope": [
+        "docs.degov.ai"
+      ],
+      "repository": "ringecosystem/degov-docs",
+      "ownerRole": "docs owner",
+      "routeScope": "public documentation pages, sitemap, robots, and share assets",
+      "desiredPolicyByPurpose": {
+        "search-index": "allow",
+        "ai-search-reference": "allow",
+        "user-triggered-fetch": "allow",
+        "model-training": "block-by-default",
+        "social-preview": "allow"
+      }
+    },
+    {
+      "id": "square",
+      "hostScope": [
+        "square.degov.ai"
+      ],
+      "repository": "ringecosystem/degov-square",
+      "ownerRole": "square owner",
+      "routeScope": "public DAO directory and public share assets",
+      "desiredPolicyByPurpose": {
+        "search-index": "allow",
+        "ai-search-reference": "allow",
+        "user-triggered-fetch": "allow",
+        "model-training": "block-by-default",
+        "social-preview": "allow"
+      }
+    },
+    {
+      "id": "dao-sites",
+      "hostScope": [
+        "demo.degov.ai",
+        "lisk.degov.ai",
+        "representative custom DAO hosts"
+      ],
+      "repository": "ringecosystem/degov",
+      "ownerRole": "DAO-site owner",
+      "routeScope": "public DAO home, proposal list, proposal detail, delegate, treasury, robots, sitemap, and share assets",
+      "desiredPolicyByPurpose": {
+        "search-index": "allow",
+        "ai-search-reference": "allow",
+        "user-triggered-fetch": "allow",
+        "model-training": "block-by-default",
+        "social-preview": "allow"
+      }
+    },
+    {
+      "id": "atlas",
+      "hostScope": [
+        "atlas.degov.ai"
+      ],
+      "repository": "ringecosystem/degov-agent-api",
+      "ownerRole": "Atlas owner",
+      "routeScope": "public Atlas pages and approved public API-backed share surfaces",
+      "desiredPolicyByPurpose": {
+        "search-index": "allow",
+        "ai-search-reference": "allow",
+        "user-triggered-fetch": "allow",
+        "model-training": "block-by-default",
+        "social-preview": "allow"
+      }
+    },
+    {
+      "id": "private-transactional-preview-staging",
+      "hostScope": [
+        "authenticated routes",
+        "write routes",
+        "OAuth routes",
+        "profile edit routes",
+        "preview deployments",
+        "staging deployments"
+      ],
+      "repository": "owning application or infrastructure repository",
+      "ownerRole": "product owner plus security owner",
+      "routeScope": "private, transactional, write, preview, and staging surfaces",
+      "desiredPolicyByPurpose": {
+        "search-index": "block-or-auth-required",
+        "ai-search-reference": "block-or-auth-required",
+        "user-triggered-fetch": "block-or-auth-required",
+        "model-training": "block-or-auth-required",
+        "social-preview": "block-or-auth-required"
+      }
+    }
+  ],
+  "controlLayers": [
+    {
+      "id": "application-robots",
+      "ownerRole": "application owner",
+      "scope": "robots.txt, sitemap declarations, page robots metadata, X-Robots-Tag, status-code behavior",
+      "publicEvidence": "Fetch robots.txt, sitemap.xml, representative HTML, and headers for each host.",
+      "confidentiality": "public"
+    },
+    {
+      "id": "cdn-waf",
+      "ownerRole": "infrastructure/security owner",
+      "scope": "verified bot handling, WAF challenges, rate limits, allowlists, blocks, cache behavior",
+      "publicEvidence": "Publish aggregate outcome counts only; do not publish rules, IP lists, or raw logs.",
+      "confidentiality": "private-operational"
+    },
+    {
+      "id": "gitops-infrastructure",
+      "ownerRole": "infrastructure owner",
+      "scope": "Cloudflare, hosting, DNS, routing, and edge policy changes",
+      "publicEvidence": "Link approved change request or sanitized rollout summary.",
+      "confidentiality": "private-operational"
+    },
+    {
+      "id": "authentication",
+      "ownerRole": "application/security owner",
+      "scope": "cookies, sessions, auth gates, preview protection, write-route protection",
+      "publicEvidence": "Representative route status and noindex/auth behavior.",
+      "confidentiality": "public-or-private"
+    }
+  ],
+  "crawlerAgents": [
+    {
+      "id": "googlebot",
+      "provider": "Google",
+      "token": "Googlebot",
+      "purposeClass": "search-index",
+      "officialSource": "https://developers.google.com/crawling/docs/crawlers-fetchers/overview-google-crawlers",
+      "robotsBehavior": "Uses robots.txt and Google crawler/fetcher behavior documented by Google.",
+      "identityVerification": "Use Google's official reverse DNS and IP verification guidance before treating a request as verified Googlebot.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous robots/CDN rules and confirm Googlebot outcome in aggregate logs.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "bingbot",
+      "provider": "Microsoft Bing",
+      "token": "Bingbot",
+      "purposeClass": "search-index",
+      "officialSource": "https://www.bing.com/webmasters/help/which-crawlers-does-bing-use-8c184ec0",
+      "robotsBehavior": "Uses robots.txt and Bing Webmaster crawler behavior documented by Microsoft.",
+      "identityVerification": "Use Bing Webmaster Tools or Microsoft's documented IP/rDNS verification before treating a request as verified Bingbot.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous robots/CDN rules and confirm Bingbot outcome in aggregate logs.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "oai-searchbot",
+      "provider": "OpenAI",
+      "token": "OAI-SearchBot",
+      "purposeClass": "ai-search-reference",
+      "officialSource": "https://developers.openai.com/api/docs/bots",
+      "robotsBehavior": "OpenAI documents OAI-SearchBot as a search user agent that can be managed separately from GPTBot.",
+      "identityVerification": "Use OpenAI's documented bot source and verified crawler identification before classifying access.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous robots/CDN rules and confirm OAI-SearchBot outcome in aggregate logs.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "chatgpt-user",
+      "provider": "OpenAI",
+      "token": "ChatGPT-User",
+      "purposeClass": "user-triggered-fetch",
+      "officialSource": "https://developers.openai.com/api/docs/bots",
+      "robotsBehavior": "OpenAI documents user-triggered fetchers separately from automatic crawlers.",
+      "identityVerification": "Classify only with documented OpenAI identity signals; do not infer from User-Agent alone.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "cdn-waf",
+        "authentication"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "security",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous CDN/auth handling and confirm user-triggered fetch outcomes in aggregate logs.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "gptbot",
+      "provider": "OpenAI",
+      "token": "GPTBot",
+      "purposeClass": "model-training",
+      "officialSource": "https://developers.openai.com/api/docs/bots",
+      "robotsBehavior": "OpenAI documents GPTBot separately from OAI-SearchBot and user-triggered agents.",
+      "identityVerification": "Use OpenAI's documented bot identity before classifying access.",
+      "desiredPolicy": "block-by-default",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "legal",
+        "security",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous training-bot block and confirm no approved policy was widened.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "claude-searchbot",
+      "provider": "Anthropic",
+      "token": "Claude-SearchBot",
+      "purposeClass": "ai-search-reference",
+      "officialSource": "https://support.claude.com/en/articles/8896518-does-anthropic-crawl-data-from-the-web-and-how-can-site-owners-block-the-crawler",
+      "robotsBehavior": "Anthropic documents web access behavior and distinguishes search/reference access from model-training crawlers.",
+      "identityVerification": "Use Anthropic's documented crawler identity guidance where available; otherwise record as unverified.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous robots/CDN rules and confirm Claude-SearchBot outcome in aggregate logs.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "claude-user",
+      "provider": "Anthropic",
+      "token": "Claude-User",
+      "purposeClass": "user-triggered-fetch",
+      "officialSource": "https://support.claude.com/en/articles/8896518-does-anthropic-crawl-data-from-the-web-and-how-can-site-owners-block-the-crawler",
+      "robotsBehavior": "Anthropic documents user-requested fetching separately from broad crawling.",
+      "identityVerification": "Use documented Anthropic identity signals where available; otherwise record as unverified.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "cdn-waf",
+        "authentication"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "security",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous CDN/auth handling and confirm user-triggered fetch outcomes in aggregate logs.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "claudebot",
+      "provider": "Anthropic",
+      "token": "ClaudeBot",
+      "purposeClass": "model-training",
+      "officialSource": "https://support.claude.com/en/articles/8896518-does-anthropic-crawl-data-from-the-web-and-how-can-site-owners-block-the-crawler",
+      "robotsBehavior": "Anthropic documents ClaudeBot separately from user-triggered access.",
+      "identityVerification": "Use documented Anthropic identity signals where available; otherwise record as unverified.",
+      "desiredPolicy": "block-by-default",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "legal",
+        "security",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous training-bot block and confirm no approved policy was widened.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "perplexitybot",
+      "provider": "Perplexity",
+      "token": "PerplexityBot",
+      "purposeClass": "ai-search-reference",
+      "officialSource": "https://docs.perplexity.ai/guides/bots",
+      "robotsBehavior": "Perplexity documents crawler/user-agent controls for its bots.",
+      "identityVerification": "Use Perplexity's documented identity guidance where available; otherwise record as unverified.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous robots/CDN rules and confirm PerplexityBot outcome in aggregate logs.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "perplexity-user",
+      "provider": "Perplexity",
+      "token": "Perplexity-User",
+      "purposeClass": "user-triggered-fetch",
+      "officialSource": "https://docs.perplexity.ai/guides/bots",
+      "robotsBehavior": "Perplexity documents user-requested fetch behavior separately from crawler access.",
+      "identityVerification": "Use Perplexity's documented identity guidance where available; otherwise record as unverified.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "cdn-waf",
+        "authentication"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "security",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous CDN/auth handling and confirm user-triggered fetch outcomes in aggregate logs.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "google-extended",
+      "provider": "Google",
+      "token": "Google-Extended",
+      "purposeClass": "model-training",
+      "officialSource": "https://developers.google.com/search/docs/crawling-indexing/google-common-crawlers#google-extended",
+      "robotsBehavior": "Google-Extended is a robots.txt product token, not a distinct HTTP User-Agent to classify from access logs.",
+      "identityVerification": "Do not expect Google-Extended in request logs; verify related Google crawler identity separately and audit robots.txt policy text.",
+      "desiredPolicy": "block-by-default",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "legal",
+        "security",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous Google-Extended robots directive and confirm public robots.txt output.",
+      "tokenType": "robots-product-token",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "robots-policy-audit",
+      "maxIdentityState": "policy-token-only"
+    },
+    {
+      "id": "facebookexternalhit",
+      "provider": "Meta",
+      "token": "facebookexternalhit",
+      "purposeClass": "social-preview",
+      "officialSource": "https://developers.facebook.com/docs/sharing/webmasters/crawler",
+      "robotsBehavior": "Meta documents its sharing crawler for link previews.",
+      "identityVerification": "Use Meta's documented crawler behavior and aggregate edge evidence; preserve unverified requests separately.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous social-preview handling and confirm share preview fetches.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "linkedinbot",
+      "provider": "LinkedIn",
+      "token": "LinkedInBot",
+      "purposeClass": "social-preview",
+      "officialSource": "https://www.linkedin.com/robots.txt",
+      "robotsBehavior": "LinkedIn publishes LinkedInBot in its robots.txt; treat as social/search preview access until product-specific docs say otherwise.",
+      "identityVerification": "LinkedIn does not publish a crawler-specific verification method in the cited source; classify matching requests as unverified unless the edge platform supplies a verified-bot signal.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous social-preview handling and confirm LinkedIn preview fetches.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-published-token-list",
+      "identityVerificationMethod": "unavailable",
+      "maxIdentityState": "unverified"
+    },
+    {
+      "id": "twitterbot",
+      "provider": "X/Twitter",
+      "token": "Twitterbot",
+      "purposeClass": "social-preview",
+      "officialSource": "https://developer.x.com/en/docs/x-for-websites/cards/overview/abouts-cards",
+      "robotsBehavior": "X/Twitter Cards require public metadata and media fetchability for previews.",
+      "identityVerification": "Use platform verified-bot signals or aggregate edge evidence; preserve unverified requests separately.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "application-robots",
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous social-preview handling and confirm X/Twitter card fetches.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "slackbot",
+      "provider": "Slack",
+      "token": "Slackbot-LinkExpanding",
+      "purposeClass": "social-preview",
+      "officialSource": "https://api.slack.com/robots",
+      "robotsBehavior": "Slack documents link-expanding robots that fetch metadata and media for shared URLs.",
+      "identityVerification": "Use Slack's documented User-Agent plus aggregate edge evidence; preserve unverified requests separately.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous social-preview handling and confirm Slack unfurl fetches.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-crawler-documentation",
+      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
+      "maxIdentityState": "verified"
+    },
+    {
+      "id": "discordbot",
+      "provider": "Discord",
+      "token": "Discordbot",
+      "purposeClass": "social-preview",
+      "officialSource": "https://docs.discord.com/developers/reference",
+      "robotsBehavior": "Discord link preview behavior must be treated as social-preview fetching, not indexing or training.",
+      "identityVerification": "Discord does not publish a crawler-specific verification method in the cited source; classify matching requests as unverified unless the edge platform supplies a verified-bot signal.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous social-preview handling and confirm Discord embed fetches.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-generic-reference",
+      "identityVerificationMethod": "unavailable",
+      "maxIdentityState": "unverified"
+    },
+    {
+      "id": "telegrambot",
+      "provider": "Telegram",
+      "token": "TelegramBot",
+      "purposeClass": "social-preview",
+      "officialSource": "https://core.telegram.org/bots/api",
+      "robotsBehavior": "Telegram link preview behavior must be treated as social-preview fetching, not indexing or training.",
+      "identityVerification": "Telegram does not publish a crawler-specific verification method in the cited source; classify matching requests as unverified unless the edge platform supplies a verified-bot signal.",
+      "desiredPolicy": "allow",
+      "productScope": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ],
+      "enforcementLayers": [
+        "cdn-waf"
+      ],
+      "evidenceState": "access-gap",
+      "ownerApprovers": [
+        "product",
+        "infrastructure"
+      ],
+      "rollback": "Restore previous social-preview handling and confirm Telegram preview fetches.",
+      "tokenType": "http-user-agent",
+      "officialSourceType": "provider-generic-reference",
+      "identityVerificationMethod": "unavailable",
+      "maxIdentityState": "unverified"
+    }
+  ],
+  "currentProductionBehavior": [
+    {
+      "surface": "home",
+      "hosts": [
+        "degov.ai"
+      ],
+      "observedAt": "2026-08-04T17:42:11Z",
+      "observationWindow": "public-http-readback-2026-08-04",
+      "source": "public robots.txt fetch",
+      "publicRobots": {
+        "state": "observed",
+        "statusCode": 200,
+        "contentType": "text/plain; charset=utf-8",
+        "summary": "User-Agent * allows / and declares https://degov.ai/sitemap.xml; no training-specific disallow was observed."
+      },
+      "cdnWaf": {
+        "state": "access-gap",
+        "ownerRole": "infrastructure/security owner",
+        "requiredAction": "Export aggregate verified-bot outcomes by purpose before claiming CDN/WAF implementation."
+      },
+      "authState": "public routes expected public; private/write routes remain auth-controlled by owning apps",
+      "purposeOutcomes": [
+        {
+          "purposeClass": "search-index",
+          "publicRobotsOutcome": "allowed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-allow-all"
+        },
+        {
+          "purposeClass": "ai-search-reference",
+          "publicRobotsOutcome": "allowed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-allow-all"
+        },
+        {
+          "purposeClass": "user-triggered-fetch",
+          "publicRobotsOutcome": "allowed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-allow-all"
+        },
+        {
+          "purposeClass": "model-training",
+          "publicRobotsOutcome": "gap",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "no-training-specific-public-robots-block-observed"
+        },
+        {
+          "purposeClass": "social-preview",
+          "publicRobotsOutcome": "allowed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-allow-all"
+        }
+      ],
+      "gapOwner": "official-site owner plus infrastructure/security owner",
+      "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+    },
+    {
+      "surface": "docs",
+      "hosts": [
+        "docs.degov.ai"
+      ],
+      "observedAt": "2026-08-04T17:42:11Z",
+      "observationWindow": "public-http-readback-2026-08-04",
+      "source": "public robots.txt fetch",
+      "publicRobots": {
+        "state": "known-gap",
+        "statusCode": 404,
+        "contentType": "text/html; charset=utf-8",
+        "summary": "robots.txt returned a 404 HTML document; no parseable crawler-purpose policy was observed."
+      },
+      "cdnWaf": {
+        "state": "access-gap",
+        "ownerRole": "infrastructure/security owner",
+        "requiredAction": "Export aggregate verified-bot outcomes by purpose before claiming CDN/WAF implementation."
+      },
+      "authState": "public docs routes expected public",
+      "purposeOutcomes": [
+        {
+          "purposeClass": "search-index",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        },
+        {
+          "purposeClass": "ai-search-reference",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        },
+        {
+          "purposeClass": "user-triggered-fetch",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        },
+        {
+          "purposeClass": "model-training",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        },
+        {
+          "purposeClass": "social-preview",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        }
+      ],
+      "gapOwner": "docs owner plus infrastructure/security owner",
+      "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+    },
+    {
+      "surface": "square",
+      "hosts": [
+        "square.degov.ai"
+      ],
+      "observedAt": "2026-08-04T17:42:11Z",
+      "observationWindow": "public-http-readback-2026-08-04",
+      "source": "public robots.txt fetch",
+      "publicRobots": {
+        "state": "known-gap",
+        "statusCode": 404,
+        "contentType": "text/html; charset=utf-8",
+        "summary": "robots.txt returned a 404 Next.js HTML page; no parseable crawler-purpose policy was observed."
+      },
+      "cdnWaf": {
+        "state": "access-gap",
+        "ownerRole": "infrastructure/security owner",
+        "requiredAction": "Export aggregate verified-bot outcomes by purpose before claiming CDN/WAF implementation."
+      },
+      "authState": "public directory expected public; account/OAuth/settings/write routes should remain blocked or auth-required",
+      "purposeOutcomes": [
+        {
+          "purposeClass": "search-index",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        },
+        {
+          "purposeClass": "ai-search-reference",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        },
+        {
+          "purposeClass": "user-triggered-fetch",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        },
+        {
+          "purposeClass": "model-training",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        },
+        {
+          "purposeClass": "social-preview",
+          "publicRobotsOutcome": "not-observed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "robots-404-html"
+        }
+      ],
+      "gapOwner": "square owner plus infrastructure/security owner",
+      "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+    },
+    {
+      "surface": "dao-sites",
+      "hosts": [
+        "demo.degov.ai",
+        "lisk.degov.ai"
+      ],
+      "observedAt": "2026-08-04T17:42:13Z",
+      "observationWindow": "public-http-readback-2026-08-04",
+      "source": "public robots.txt fetch",
+      "publicRobots": {
+        "state": "mixed",
+        "statusCode": 200,
+        "contentType": "mixed text/html and text/plain",
+        "summary": "demo.degov.ai still served an HTML shell for robots.txt in prior route evidence; lisk.degov.ai served Cloudflare managed content signals with search=yes, ai-train=no, ClaudeBot disallow, and Google-Extended disallow."
+      },
+      "cdnWaf": {
+        "state": "access-gap",
+        "ownerRole": "infrastructure/security owner",
+        "requiredAction": "Export aggregate verified-bot outcomes by purpose before claiming CDN/WAF implementation."
+      },
+      "authState": "public DAO routes expected public; write/auth routes protected",
+      "purposeOutcomes": [
+        {
+          "purposeClass": "search-index",
+          "publicRobotsOutcome": "mixed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "lisk-cloudflare-search-allow-demo-html-gap"
+        },
+        {
+          "purposeClass": "ai-search-reference",
+          "publicRobotsOutcome": "mixed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "lisk-cloudflare-use-reference-demo-html-gap"
+        },
+        {
+          "purposeClass": "user-triggered-fetch",
+          "publicRobotsOutcome": "mixed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "lisk-cloudflare-use-reference-demo-html-gap"
+        },
+        {
+          "purposeClass": "model-training",
+          "publicRobotsOutcome": "mixed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "lisk-cloudflare-ai-train-no-demo-html-gap"
+        },
+        {
+          "purposeClass": "social-preview",
+          "publicRobotsOutcome": "mixed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "lisk-cloudflare-allow-demo-html-gap"
+        }
+      ],
+      "gapOwner": "DAO-site owner plus infrastructure/security owner",
+      "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+    },
+    {
+      "surface": "atlas",
+      "hosts": [
+        "atlas.degov.ai"
+      ],
+      "observedAt": "2026-08-04T17:42:13Z",
+      "observationWindow": "public-http-readback-2026-08-04",
+      "source": "public robots.txt fetch",
+      "publicRobots": {
+        "state": "observed",
+        "statusCode": 200,
+        "contentType": "text/plain; charset=utf-8",
+        "summary": "Cloudflare managed content signals observed: search=yes, ai-train=no, use=reference, plus ClaudeBot and Google-Extended disallow entries."
+      },
+      "cdnWaf": {
+        "state": "access-gap",
+        "ownerRole": "infrastructure/security owner",
+        "requiredAction": "Export aggregate verified-bot outcomes by purpose before claiming CDN/WAF implementation."
+      },
+      "authState": "public Atlas routes expected public",
+      "purposeOutcomes": [
+        {
+          "purposeClass": "search-index",
+          "publicRobotsOutcome": "allowed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "cloudflare-search-yes"
+        },
+        {
+          "purposeClass": "ai-search-reference",
+          "publicRobotsOutcome": "allowed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "cloudflare-use-reference"
+        },
+        {
+          "purposeClass": "user-triggered-fetch",
+          "publicRobotsOutcome": "allowed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "cloudflare-use-reference"
+        },
+        {
+          "purposeClass": "model-training",
+          "publicRobotsOutcome": "blocked",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "cloudflare-ai-train-no-google-extended-claudebot-disallow"
+        },
+        {
+          "purposeClass": "social-preview",
+          "publicRobotsOutcome": "allowed",
+          "edgeOutcome": "access-gap",
+          "evidenceBasis": "cloudflare-default-allow"
+        }
+      ],
+      "gapOwner": "Atlas owner plus infrastructure/security owner",
+      "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+    }
+  ],
+  "verificationRequirements": {
+    "requiredLogFields": [
+      "timestamp",
+      "host",
+      "pathGroup",
+      "statusGroup",
+      "userAgent",
+      "crawlerPurpose",
+      "identityVerification",
+      "wafAction",
+      "cacheResult",
+      "count",
+      "window"
+    ],
+    "identityStates": [
+      "verified",
+      "unverified",
+      "policy-token-only",
+      "not-observed"
+    ],
+    "accessOutcomeStates": [
+      "allowed",
+      "blocked",
+      "challenged",
+      "failed",
+      "not-observed"
+    ],
+    "rule": "Do not report a policy as implemented from a User-Agent string alone. Every public claim must include host, purpose, identity state, outcome state, owner, observation window, and evidence link."
+  },
+  "implementationFollowups": [
+    {
+      "ownerRepository": "ringecosystem/degov",
+      "when": "Open only if DAO robots/sitemap or application robots metadata needs a code change after the policy is approved.",
+      "allowedScope": "DAO-site application robots/meta/status behavior only."
+    },
+    {
+      "ownerRepository": "ringecosystem/degov-home",
+      "when": "Open only for official-site robots/share asset policy changes.",
+      "allowedScope": "degov.ai application robots/meta/status behavior only."
+    },
+    {
+      "ownerRepository": "ringecosystem/degov-docs",
+      "when": "Open only for docs robots/share asset policy changes.",
+      "allowedScope": "docs.degov.ai application robots/meta/status behavior only."
+    },
+    {
+      "ownerRepository": "ringecosystem/degov-square",
+      "when": "Open only for Square robots/share asset policy changes.",
+      "allowedScope": "square.degov.ai application robots/meta/status behavior only."
+    },
+    {
+      "ownerRepository": "ringecosystem/degov-agent-api",
+      "when": "Open only for Atlas robots/share asset policy changes.",
+      "allowedScope": "atlas.degov.ai application robots/meta/status behavior only."
+    },
+    {
+      "ownerRepository": "infrastructure policy repository",
+      "when": "Open only for CDN/WAF, Cloudflare managed robots, DNS, hosting, or GitOps rule changes after the policy is approved.",
+      "allowedScope": "Infrastructure-owned crawler allow/block/challenge policy and rollback runbook only."
+    }
+  ],
+  "rollout": {
+    "reviewRequired": [
+      "product",
+      "legal",
+      "security",
+      "infrastructure"
+    ],
+    "preflight": [
+      "confirm intended policy",
+      "confirm owning repository",
+      "fetch current robots and representative public routes",
+      "confirm private/write routes stay protected",
+      "record rollback owner"
+    ],
+    "monitoringWindowHours": 48,
+    "rollbackTriggers": [
+      "search-index crawler unexpectedly blocked",
+      "AI reference crawler unexpectedly blocked",
+      "training access widened without approval",
+      "private/write route becomes public",
+      "social preview assets become inaccessible"
+    ],
+    "rollbackProcedure": "Revert the owning application or infrastructure rule, confirm representative robots/route output, and record aggregate crawler outcome evidence without publishing raw logs.",
+    "incidentRule": "If a rule exposes private, transactional, preview, or staging content, treat it as a security incident and roll back before further SEO/GEO changes."
+  },
+  "approvalState": {
+    "status": "approved-policy-contract",
+    "linkedUmbrellaIssue": "https://github.com/ringecosystem/degov/issues/714",
+    "approvalRecords": [
+      {
+        "role": "product",
+        "decision": "approve public search, AI reference, user-triggered fetch, and social preview defaults for implementation follow-ups",
+        "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+      },
+      {
+        "role": "security",
+        "decision": "approve block-or-auth-required default for private/write/preview/staging surfaces and require incident rollback on exposure",
+        "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+      },
+      {
+        "role": "infrastructure",
+        "decision": "approve control-layer mapping and require aggregate verified-bot evidence before CDN/WAF implementation claims",
+        "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+      },
+      {
+        "role": "legal",
+        "decision": "approve preserving model-training restrictions by default; any widening requires a future explicit legal approval",
+        "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+      }
+    ],
+    "limitations": [
+      "private CDN/WAF rules and raw logs are not published",
+      "training access remains blocked by default",
+      "implementation follow-ups must be opened only in owning repositories"
+    ]
+  },
+  "authoritativeRuleMap": [
+    {
+      "surface": "home",
+      "purposeClass": "search-index",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-home",
+      "ownerRole": "official-site owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "official-site owner",
+      "followupTarget": "ringecosystem/degov-home"
+    },
+    {
+      "surface": "home",
+      "purposeClass": "ai-search-reference",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-home",
+      "ownerRole": "official-site owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "official-site owner",
+      "followupTarget": "ringecosystem/degov-home"
+    },
+    {
+      "surface": "home",
+      "purposeClass": "user-triggered-fetch",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "cdn-waf",
+        "authentication"
+      ],
+      "ownerRepository": "ringecosystem/degov-home",
+      "ownerRole": "official-site owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "official-site owner",
+      "followupTarget": "ringecosystem/degov-home"
+    },
+    {
+      "surface": "home",
+      "purposeClass": "model-training",
+      "desiredPolicy": "block-by-default",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRole": "official-site owner plus legal/security/infrastructure owners",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "ringecosystem/degov-home"
+    },
+    {
+      "surface": "home",
+      "purposeClass": "social-preview",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-home",
+      "ownerRole": "official-site owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "official-site owner",
+      "followupTarget": "ringecosystem/degov-home"
+    },
+    {
+      "surface": "docs",
+      "purposeClass": "search-index",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-docs",
+      "ownerRole": "docs owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "docs owner",
+      "followupTarget": "ringecosystem/degov-docs"
+    },
+    {
+      "surface": "docs",
+      "purposeClass": "ai-search-reference",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-docs",
+      "ownerRole": "docs owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "docs owner",
+      "followupTarget": "ringecosystem/degov-docs"
+    },
+    {
+      "surface": "docs",
+      "purposeClass": "user-triggered-fetch",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "cdn-waf",
+        "authentication"
+      ],
+      "ownerRepository": "ringecosystem/degov-docs",
+      "ownerRole": "docs owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "docs owner",
+      "followupTarget": "ringecosystem/degov-docs"
+    },
+    {
+      "surface": "docs",
+      "purposeClass": "model-training",
+      "desiredPolicy": "block-by-default",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRole": "docs owner plus legal/security/infrastructure owners",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "ringecosystem/degov-docs"
+    },
+    {
+      "surface": "docs",
+      "purposeClass": "social-preview",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-docs",
+      "ownerRole": "docs owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "docs owner",
+      "followupTarget": "ringecosystem/degov-docs"
+    },
+    {
+      "surface": "square",
+      "purposeClass": "search-index",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-square",
+      "ownerRole": "square owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "square owner",
+      "followupTarget": "ringecosystem/degov-square"
+    },
+    {
+      "surface": "square",
+      "purposeClass": "ai-search-reference",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-square",
+      "ownerRole": "square owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "square owner",
+      "followupTarget": "ringecosystem/degov-square"
+    },
+    {
+      "surface": "square",
+      "purposeClass": "user-triggered-fetch",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "cdn-waf",
+        "authentication"
+      ],
+      "ownerRepository": "ringecosystem/degov-square",
+      "ownerRole": "square owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "square owner",
+      "followupTarget": "ringecosystem/degov-square"
+    },
+    {
+      "surface": "square",
+      "purposeClass": "model-training",
+      "desiredPolicy": "block-by-default",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRole": "square owner plus legal/security/infrastructure owners",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "ringecosystem/degov-square"
+    },
+    {
+      "surface": "square",
+      "purposeClass": "social-preview",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-square",
+      "ownerRole": "square owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "square owner",
+      "followupTarget": "ringecosystem/degov-square"
+    },
+    {
+      "surface": "dao-sites",
+      "purposeClass": "search-index",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov",
+      "ownerRole": "DAO-site owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "DAO-site owner",
+      "followupTarget": "ringecosystem/degov"
+    },
+    {
+      "surface": "dao-sites",
+      "purposeClass": "ai-search-reference",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov",
+      "ownerRole": "DAO-site owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "DAO-site owner",
+      "followupTarget": "ringecosystem/degov"
+    },
+    {
+      "surface": "dao-sites",
+      "purposeClass": "user-triggered-fetch",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "cdn-waf",
+        "authentication"
+      ],
+      "ownerRepository": "ringecosystem/degov",
+      "ownerRole": "DAO-site owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "DAO-site owner",
+      "followupTarget": "ringecosystem/degov"
+    },
+    {
+      "surface": "dao-sites",
+      "purposeClass": "model-training",
+      "desiredPolicy": "block-by-default",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRole": "DAO-site owner plus legal/security/infrastructure owners",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "ringecosystem/degov"
+    },
+    {
+      "surface": "dao-sites",
+      "purposeClass": "social-preview",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov",
+      "ownerRole": "DAO-site owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "DAO-site owner",
+      "followupTarget": "ringecosystem/degov"
+    },
+    {
+      "surface": "atlas",
+      "purposeClass": "search-index",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-agent-api",
+      "ownerRole": "Atlas owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "Atlas owner",
+      "followupTarget": "ringecosystem/degov-agent-api"
+    },
+    {
+      "surface": "atlas",
+      "purposeClass": "ai-search-reference",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-agent-api",
+      "ownerRole": "Atlas owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "Atlas owner",
+      "followupTarget": "ringecosystem/degov-agent-api"
+    },
+    {
+      "surface": "atlas",
+      "purposeClass": "user-triggered-fetch",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "cdn-waf",
+        "authentication"
+      ],
+      "ownerRepository": "ringecosystem/degov-agent-api",
+      "ownerRole": "Atlas owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "Atlas owner",
+      "followupTarget": "ringecosystem/degov-agent-api"
+    },
+    {
+      "surface": "atlas",
+      "purposeClass": "model-training",
+      "desiredPolicy": "block-by-default",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRole": "Atlas owner plus legal/security/infrastructure owners",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "ringecosystem/degov-agent-api"
+    },
+    {
+      "surface": "atlas",
+      "purposeClass": "social-preview",
+      "desiredPolicy": "allow",
+      "authoritativeLayers": [
+        "application-robots",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "ringecosystem/degov-agent-api",
+      "ownerRole": "Atlas owner",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "Atlas owner",
+      "followupTarget": "ringecosystem/degov-agent-api"
+    }
+  ]
+}

--- a/docs/spec/seo-geo-crawler-access-policy.json
+++ b/docs/spec/seo-geo-crawler-access-policy.json
@@ -608,9 +608,9 @@
       "provider": "X/Twitter",
       "token": "Twitterbot",
       "purposeClass": "social-preview",
-      "officialSource": "https://developer.x.com/en/docs/x-for-websites/cards/overview/abouts-cards",
-      "robotsBehavior": "X/Twitter Cards require public metadata and media fetchability for previews.",
-      "identityVerification": "Use platform verified-bot signals or aggregate edge evidence; preserve unverified requests separately.",
+      "officialSource": "https://docs.x.com/overview",
+      "robotsBehavior": "X/Twitter card metadata must stay fetchable for previews, but this contract does not treat the current generic docs page as crawler-specific Twitterbot verification.",
+      "identityVerification": "X/Twitter crawler-specific official token and verification documentation was not confirmed in the cited source; classify matching requests as unverified unless the edge platform supplies a verified-bot signal.",
       "desiredPolicy": "allow",
       "productScope": [
         "home",
@@ -630,9 +630,9 @@
       ],
       "rollback": "Restore previous social-preview handling and confirm X/Twitter card fetches.",
       "tokenType": "http-user-agent",
-      "officialSourceType": "provider-crawler-documentation",
-      "identityVerificationMethod": "provider-ip-rdns-or-verified-bot-signal",
-      "maxIdentityState": "verified"
+      "officialSourceType": "unavailable",
+      "identityVerificationMethod": "unavailable",
+      "maxIdentityState": "unverified"
     },
     {
       "id": "slackbot",
@@ -700,8 +700,8 @@
       "token": "TelegramBot",
       "purposeClass": "social-preview",
       "officialSource": "https://core.telegram.org/bots/api",
-      "robotsBehavior": "Telegram link preview behavior must be treated as social-preview fetching, not indexing or training.",
-      "identityVerification": "Telegram does not publish a crawler-specific verification method in the cited source; classify matching requests as unverified unless the edge platform supplies a verified-bot signal.",
+      "robotsBehavior": "Telegram link previews are treated operationally as social-preview fetching, but this contract does not treat the Bot API page as crawler-specific TelegramBot verification.",
+      "identityVerification": "Telegram crawler-specific official token and verification documentation was not confirmed in the cited source; classify matching requests as unverified unless the edge platform supplies a verified-bot signal.",
       "desiredPolicy": "allow",
       "productScope": [
         "home",
@@ -720,7 +720,7 @@
       ],
       "rollback": "Restore previous social-preview handling and confirm Telegram preview fetches.",
       "tokenType": "http-user-agent",
-      "officialSourceType": "provider-generic-reference",
+      "officialSourceType": "unavailable",
       "identityVerificationMethod": "unavailable",
       "maxIdentityState": "unverified"
     }
@@ -1059,8 +1059,8 @@
       "allowedScope": "atlas.degov.ai application robots/meta/status behavior only."
     },
     {
-      "ownerRepository": "infrastructure policy repository",
-      "when": "Open only for CDN/WAF, Cloudflare managed robots, DNS, hosting, or GitOps rule changes after the policy is approved.",
+      "ownerRepository": "ringecosystem/degov-agent-api",
+      "when": "Open only for Atlas-owned or shared infrastructure policy changes when the owning deployment/GitOps path is in degov-agent-api.",
       "allowedScope": "Infrastructure-owned crawler allow/block/challenge policy and rollback runbook only."
     }
   ],
@@ -1090,34 +1090,32 @@
     "incidentRule": "If a rule exposes private, transactional, preview, or staging content, treat it as a security incident and roll back before further SEO/GEO changes."
   },
   "approvalState": {
-    "status": "approved-policy-contract",
+    "status": "pending-approval",
     "linkedUmbrellaIssue": "https://github.com/ringecosystem/degov/issues/714",
-    "approvalRecords": [
+    "requiredApprovalRecords": [
       {
         "role": "product",
-        "decision": "approve public search, AI reference, user-triggered fetch, and social preview defaults for implementation follow-ups",
-        "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+        "requiredEvidence": "A concrete issue comment or review approving the surface and purpose policy matrix version."
       },
       {
         "role": "security",
-        "decision": "approve block-or-auth-required default for private/write/preview/staging surfaces and require incident rollback on exposure",
-        "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+        "requiredEvidence": "A concrete issue comment or review approving private/write/preview/staging defaults and incident rollback."
       },
       {
         "role": "infrastructure",
-        "decision": "approve control-layer mapping and require aggregate verified-bot evidence before CDN/WAF implementation claims",
-        "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+        "requiredEvidence": "A concrete issue comment or review approving control-layer ownership, verified-bot observation, rollout, and rollback requirements."
       },
       {
         "role": "legal",
-        "decision": "approve preserving model-training restrictions by default; any widening requires a future explicit legal approval",
-        "evidenceLink": "https://github.com/ringecosystem/degov/issues/1026"
+        "requiredEvidence": "A concrete issue comment or review approving training restrictions and any future widening process."
       }
     ],
+    "approvalRecords": [],
     "limitations": [
       "private CDN/WAF rules and raw logs are not published",
       "training access remains blocked by default",
-      "implementation follow-ups must be opened only in owning repositories"
+      "implementation follow-ups must be opened only in owning repositories",
+      "policy cannot be treated as approved until required approval records link concrete comments or reviews"
     ]
   },
   "authoritativeRuleMap": [
@@ -1132,6 +1130,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-home",
       "ownerRole": "official-site owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "official-site owner",
       "followupTarget": "ringecosystem/degov-home"
@@ -1147,6 +1146,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-home",
       "ownerRole": "official-site owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "official-site owner",
       "followupTarget": "ringecosystem/degov-home"
@@ -1161,6 +1161,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-home",
       "ownerRole": "official-site owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "official-site owner",
       "followupTarget": "ringecosystem/degov-home"
@@ -1174,8 +1175,9 @@
         "cdn-waf",
         "gitops-infrastructure"
       ],
-      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRepository": "ringecosystem/degov-home",
       "ownerRole": "official-site owner plus legal/security/infrastructure owners",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "infrastructure/security owner",
       "followupTarget": "ringecosystem/degov-home"
@@ -1191,6 +1193,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-home",
       "ownerRole": "official-site owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "official-site owner",
       "followupTarget": "ringecosystem/degov-home"
@@ -1206,6 +1209,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-docs",
       "ownerRole": "docs owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "docs owner",
       "followupTarget": "ringecosystem/degov-docs"
@@ -1221,6 +1225,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-docs",
       "ownerRole": "docs owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "docs owner",
       "followupTarget": "ringecosystem/degov-docs"
@@ -1235,6 +1240,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-docs",
       "ownerRole": "docs owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "docs owner",
       "followupTarget": "ringecosystem/degov-docs"
@@ -1248,8 +1254,9 @@
         "cdn-waf",
         "gitops-infrastructure"
       ],
-      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRepository": "ringecosystem/degov-docs",
       "ownerRole": "docs owner plus legal/security/infrastructure owners",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "infrastructure/security owner",
       "followupTarget": "ringecosystem/degov-docs"
@@ -1265,6 +1272,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-docs",
       "ownerRole": "docs owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "docs owner",
       "followupTarget": "ringecosystem/degov-docs"
@@ -1280,6 +1288,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-square",
       "ownerRole": "square owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "square owner",
       "followupTarget": "ringecosystem/degov-square"
@@ -1295,6 +1304,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-square",
       "ownerRole": "square owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "square owner",
       "followupTarget": "ringecosystem/degov-square"
@@ -1309,6 +1319,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-square",
       "ownerRole": "square owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "square owner",
       "followupTarget": "ringecosystem/degov-square"
@@ -1322,8 +1333,9 @@
         "cdn-waf",
         "gitops-infrastructure"
       ],
-      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRepository": "ringecosystem/degov-square",
       "ownerRole": "square owner plus legal/security/infrastructure owners",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "infrastructure/security owner",
       "followupTarget": "ringecosystem/degov-square"
@@ -1339,6 +1351,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-square",
       "ownerRole": "square owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "square owner",
       "followupTarget": "ringecosystem/degov-square"
@@ -1354,6 +1367,7 @@
       ],
       "ownerRepository": "ringecosystem/degov",
       "ownerRole": "DAO-site owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "DAO-site owner",
       "followupTarget": "ringecosystem/degov"
@@ -1369,6 +1383,7 @@
       ],
       "ownerRepository": "ringecosystem/degov",
       "ownerRole": "DAO-site owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "DAO-site owner",
       "followupTarget": "ringecosystem/degov"
@@ -1383,6 +1398,7 @@
       ],
       "ownerRepository": "ringecosystem/degov",
       "ownerRole": "DAO-site owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "DAO-site owner",
       "followupTarget": "ringecosystem/degov"
@@ -1396,8 +1412,9 @@
         "cdn-waf",
         "gitops-infrastructure"
       ],
-      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRepository": "ringecosystem/degov",
       "ownerRole": "DAO-site owner plus legal/security/infrastructure owners",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "infrastructure/security owner",
       "followupTarget": "ringecosystem/degov"
@@ -1413,6 +1430,7 @@
       ],
       "ownerRepository": "ringecosystem/degov",
       "ownerRole": "DAO-site owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "DAO-site owner",
       "followupTarget": "ringecosystem/degov"
@@ -1428,6 +1446,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-agent-api",
       "ownerRole": "Atlas owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "Atlas owner",
       "followupTarget": "ringecosystem/degov-agent-api"
@@ -1443,6 +1462,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-agent-api",
       "ownerRole": "Atlas owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "Atlas owner",
       "followupTarget": "ringecosystem/degov-agent-api"
@@ -1457,6 +1477,7 @@
       ],
       "ownerRepository": "ringecosystem/degov-agent-api",
       "ownerRole": "Atlas owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "Atlas owner",
       "followupTarget": "ringecosystem/degov-agent-api"
@@ -1470,8 +1491,9 @@
         "cdn-waf",
         "gitops-infrastructure"
       ],
-      "ownerRepository": "owning application repository plus infrastructure policy repository",
+      "ownerRepository": "ringecosystem/degov-agent-api",
       "ownerRole": "Atlas owner plus legal/security/infrastructure owners",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "infrastructure/security owner",
       "followupTarget": "ringecosystem/degov-agent-api"
@@ -1487,9 +1509,90 @@
       ],
       "ownerRepository": "ringecosystem/degov-agent-api",
       "ownerRole": "Atlas owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
       "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
       "rollbackOwner": "Atlas owner",
       "followupTarget": "ringecosystem/degov-agent-api"
+    },
+    {
+      "surface": "private-transactional-preview-staging",
+      "purposeClass": "search-index",
+      "desiredPolicy": "block-or-auth-required",
+      "authoritativeLayers": [
+        "authentication",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application or infrastructure repository",
+      "ownerRole": "product owner plus security owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "owning application or infrastructure repository"
+    },
+    {
+      "surface": "private-transactional-preview-staging",
+      "purposeClass": "ai-search-reference",
+      "desiredPolicy": "block-or-auth-required",
+      "authoritativeLayers": [
+        "authentication",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application or infrastructure repository",
+      "ownerRole": "product owner plus security owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "owning application or infrastructure repository"
+    },
+    {
+      "surface": "private-transactional-preview-staging",
+      "purposeClass": "user-triggered-fetch",
+      "desiredPolicy": "block-or-auth-required",
+      "authoritativeLayers": [
+        "authentication",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application or infrastructure repository",
+      "ownerRole": "product owner plus security owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "owning application or infrastructure repository"
+    },
+    {
+      "surface": "private-transactional-preview-staging",
+      "purposeClass": "model-training",
+      "desiredPolicy": "block-or-auth-required",
+      "authoritativeLayers": [
+        "authentication",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application or infrastructure repository",
+      "ownerRole": "product owner plus security owner plus legal/security/infrastructure owners",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "owning application or infrastructure repository"
+    },
+    {
+      "surface": "private-transactional-preview-staging",
+      "purposeClass": "social-preview",
+      "desiredPolicy": "block-or-auth-required",
+      "authoritativeLayers": [
+        "authentication",
+        "cdn-waf",
+        "gitops-infrastructure"
+      ],
+      "ownerRepository": "owning application or infrastructure repository",
+      "ownerRole": "product owner plus security owner",
+      "infrastructureRepository": "ringecosystem/degov-agent-api",
+      "conflictRule": "The most restrictive approved layer wins for private/write/staging routes; public route crawler conflicts require owner review before rollout.",
+      "rollbackOwner": "infrastructure/security owner",
+      "followupTarget": "owning application or infrastructure repository"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "indexer:worker": "cargo run -p degov-datalens-indexer --locked -- worker",
     "test:indexer": "cargo test -p degov-datalens-indexer --locked",
     "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/runtime-packaging.test.mjs && node apps/indexer/scripts/staging-deployment-contract.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs && node apps/indexer/scripts/v4-parity-audit.test.mjs && node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs",
+    "test:seo-geo-crawler-policy": "node scripts/check-seo-geo-crawler-policy.mjs",
     "test:seo-geo-observability": "node scripts/check-seo-geo-observability.mjs",
     "test:seo-geo-contract": "node scripts/check-seo-geo-route-contract.mjs",
     "test:web-scripts": "node --test apps/web/scripts/*.test.ts apps/web/scripts/*.test.mjs"

--- a/scripts/check-seo-geo-crawler-policy.mjs
+++ b/scripts/check-seo-geo-crawler-policy.mjs
@@ -60,6 +60,7 @@ const evidenceStates = new Set([
   "known-fail",
 ]);
 const robotsStates = new Set(["observed", "known-gap", "known-fail", "mixed"]);
+const cdnWafStates = new Set(["observed", "not-observed", "access-gap", "known-gap"]);
 const robotsOutcomes = new Set(["allowed", "blocked", "mixed", "gap", "not-observed"]);
 const edgeOutcomes = new Set(["allowed", "blocked", "challenged", "failed", "not-observed", "access-gap"]);
 const sourceTypes = new Set([
@@ -439,9 +440,13 @@ for (const behavior of policy.currentProductionBehavior) {
   assert.ok(behavior.publicRobots.contentType.length > 3, `${behavior.surface} contentType`);
   assert.ok(behavior.publicRobots.summary.length > 30, `${behavior.surface} robots summary`);
   assert.ok(behavior.cdnWaf, `${behavior.surface} cdnWaf`);
-  assert.equal(behavior.cdnWaf.state, "access-gap", `${behavior.surface} cdnWaf state`);
+  assert.ok(cdnWafStates.has(behavior.cdnWaf.state), `${behavior.surface} cdnWaf state`);
   assert.ok(behavior.cdnWaf.ownerRole.length > 3, `${behavior.surface} cdnWaf ownerRole`);
-  assert.match(behavior.cdnWaf.requiredAction, /aggregate verified-bot outcomes/);
+  if (behavior.cdnWaf.state === "access-gap") {
+    assert.match(behavior.cdnWaf.requiredAction, /aggregate verified-bot outcomes/);
+  } else {
+    assert.match(behavior.cdnWaf.evidenceBasis, /verified-bot|aggregate|edge/i);
+  }
   assert.ok(behavior.authState.length > 5, `${behavior.surface} authState`);
   assert.ok(Array.isArray(behavior.purposeOutcomes), `${behavior.surface} purposeOutcomes`);
   assert.equal(

--- a/scripts/check-seo-geo-crawler-policy.mjs
+++ b/scripts/check-seo-geo-crawler-policy.mjs
@@ -198,6 +198,7 @@ const requiredLogFields = new Set([
   "userAgent",
   "crawlerPurpose",
   "identityVerification",
+  "observationState",
   "wafAction",
   "cacheResult",
   "count",
@@ -215,6 +216,7 @@ const requiredAccessOutcomeStates = new Set([
   "challenged",
   "failed",
   "not-observed",
+  "access-gap",
 ]);
 
 assert.equal(policy.version, 1);

--- a/scripts/check-seo-geo-crawler-policy.mjs
+++ b/scripts/check-seo-geo-crawler-policy.mjs
@@ -1,0 +1,537 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const policyPath = path.join(rootDir, "docs/spec/seo-geo-crawler-access-policy.json");
+const policy = JSON.parse(readFileSync(policyPath, "utf8"));
+
+const requiredPurposeClasses = new Set([
+  "search-index",
+  "ai-search-reference",
+  "user-triggered-fetch",
+  "model-training",
+  "social-preview",
+]);
+const requiredPublicSurfaces = new Set(["home", "docs", "square", "dao-sites", "atlas"]);
+const requiredSurfaceIds = new Set([
+  ...requiredPublicSurfaces,
+  "private-transactional-preview-staging",
+]);
+const requiredControlLayers = new Set([
+  "application-robots",
+  "cdn-waf",
+  "gitops-infrastructure",
+  "authentication",
+]);
+const requiredAgentIds = new Set([
+  "googlebot",
+  "bingbot",
+  "oai-searchbot",
+  "chatgpt-user",
+  "gptbot",
+  "claude-searchbot",
+  "claude-user",
+  "claudebot",
+  "perplexitybot",
+  "perplexity-user",
+  "google-extended",
+  "facebookexternalhit",
+  "linkedinbot",
+  "twitterbot",
+  "slackbot",
+  "discordbot",
+  "telegrambot",
+]);
+const requiredOwners = new Set(["product", "legal", "security", "infrastructure"]);
+const policyValues = new Set([
+  "allow",
+  "block",
+  "conditional",
+  "undecided",
+  "block-by-default",
+  "block-or-auth-required",
+]);
+const evidenceStates = new Set([
+  "observed",
+  "not-observed",
+  "access-gap",
+  "known-fail",
+]);
+const robotsStates = new Set(["observed", "known-gap", "known-fail", "mixed"]);
+const robotsOutcomes = new Set(["allowed", "blocked", "mixed", "gap", "not-observed"]);
+const edgeOutcomes = new Set(["allowed", "blocked", "challenged", "failed", "not-observed", "access-gap"]);
+const sourceTypes = new Set([
+  "provider-crawler-documentation",
+  "provider-published-token-list",
+  "provider-generic-reference",
+]);
+const verificationMethods = new Set([
+  "provider-ip-rdns-or-verified-bot-signal",
+  "robots-policy-audit",
+  "unavailable",
+]);
+const maxIdentityStates = new Set([
+  "verified",
+  "unverified",
+  "policy-token-only",
+]);
+const tokenTypes = new Set(["http-user-agent", "robots-product-token"]);
+const expectedAgents = {
+  googlebot: {
+    token: "Googlebot",
+    tokenType: "http-user-agent",
+    purposeClass: "search-index",
+    desiredPolicy: "allow",
+  },
+  bingbot: {
+    token: "Bingbot",
+    tokenType: "http-user-agent",
+    purposeClass: "search-index",
+    desiredPolicy: "allow",
+  },
+  "oai-searchbot": {
+    token: "OAI-SearchBot",
+    tokenType: "http-user-agent",
+    purposeClass: "ai-search-reference",
+    desiredPolicy: "allow",
+  },
+  "chatgpt-user": {
+    token: "ChatGPT-User",
+    tokenType: "http-user-agent",
+    purposeClass: "user-triggered-fetch",
+    desiredPolicy: "allow",
+  },
+  gptbot: {
+    token: "GPTBot",
+    tokenType: "http-user-agent",
+    purposeClass: "model-training",
+    desiredPolicy: "block-by-default",
+  },
+  "claude-searchbot": {
+    token: "Claude-SearchBot",
+    tokenType: "http-user-agent",
+    purposeClass: "ai-search-reference",
+    desiredPolicy: "allow",
+  },
+  "claude-user": {
+    token: "Claude-User",
+    tokenType: "http-user-agent",
+    purposeClass: "user-triggered-fetch",
+    desiredPolicy: "allow",
+  },
+  claudebot: {
+    token: "ClaudeBot",
+    tokenType: "http-user-agent",
+    purposeClass: "model-training",
+    desiredPolicy: "block-by-default",
+  },
+  perplexitybot: {
+    token: "PerplexityBot",
+    tokenType: "http-user-agent",
+    purposeClass: "ai-search-reference",
+    desiredPolicy: "allow",
+  },
+  "perplexity-user": {
+    token: "Perplexity-User",
+    tokenType: "http-user-agent",
+    purposeClass: "user-triggered-fetch",
+    desiredPolicy: "allow",
+  },
+  "google-extended": {
+    token: "Google-Extended",
+    tokenType: "robots-product-token",
+    purposeClass: "model-training",
+    desiredPolicy: "block-by-default",
+  },
+  facebookexternalhit: {
+    token: "facebookexternalhit",
+    tokenType: "http-user-agent",
+    purposeClass: "social-preview",
+    desiredPolicy: "allow",
+  },
+  linkedinbot: {
+    token: "LinkedInBot",
+    tokenType: "http-user-agent",
+    purposeClass: "social-preview",
+    desiredPolicy: "allow",
+  },
+  twitterbot: {
+    token: "Twitterbot",
+    tokenType: "http-user-agent",
+    purposeClass: "social-preview",
+    desiredPolicy: "allow",
+  },
+  slackbot: {
+    token: "Slackbot-LinkExpanding",
+    tokenType: "http-user-agent",
+    purposeClass: "social-preview",
+    desiredPolicy: "allow",
+  },
+  discordbot: {
+    token: "Discordbot",
+    tokenType: "http-user-agent",
+    purposeClass: "social-preview",
+    desiredPolicy: "allow",
+  },
+  telegrambot: {
+    token: "TelegramBot",
+    tokenType: "http-user-agent",
+    purposeClass: "social-preview",
+    desiredPolicy: "allow",
+  },
+};
+const requiredLogFields = new Set([
+  "timestamp",
+  "host",
+  "pathGroup",
+  "statusGroup",
+  "userAgent",
+  "crawlerPurpose",
+  "identityVerification",
+  "wafAction",
+  "cacheResult",
+  "count",
+  "window",
+]);
+const requiredIdentityStates = new Set([
+  "verified",
+  "unverified",
+  "policy-token-only",
+  "not-observed",
+]);
+const requiredAccessOutcomeStates = new Set([
+  "allowed",
+  "blocked",
+  "challenged",
+  "failed",
+  "not-observed",
+]);
+
+assert.equal(policy.version, 1);
+assert.equal(policy.ownerIssue, "https://github.com/ringecosystem/degov/issues/1026");
+assert.equal(policy.parentIssue, "https://github.com/ringecosystem/degov/issues/714");
+assert.equal(policy.maintenance.contractPath, "docs/spec/seo-geo-crawler-access-policy.json");
+assert.equal(policy.maintenance.localCheck, "pnpm run test:seo-geo-crawler-policy");
+assert.match(policy.maintenance.changeRule, /owner/);
+assert.match(policy.maintenance.changeRule, /official source/);
+assert.match(policy.maintenance.changeRule, /rollback/);
+
+assert.equal(policy.policyDefaults.publicSearchIndex, "allow");
+assert.equal(policy.policyDefaults.publicAiSearchReference, "allow");
+assert.equal(policy.policyDefaults.publicUserTriggeredFetch, "allow");
+assert.equal(policy.policyDefaults.publicModelTraining, "block-by-default");
+assert.equal(policy.policyDefaults.publicSocialPreview, "allow");
+assert.equal(
+  policy.policyDefaults.privateTransactionalPreviewStaging,
+  "block-or-auth-required"
+);
+assert.match(policy.policyDefaults.trainingAccessRule, /legal/);
+assert.match(policy.policyDefaults.trainingAccessRule, /security/);
+assert.match(policy.policyDefaults.identityRule, /User-Agent alone is never verified identity/);
+
+assert.equal(
+  policy.purposeClasses.length,
+  new Set(policy.purposeClasses.map((purpose) => purpose.id)).size,
+  "purpose class IDs must be unique"
+);
+const purposeIds = new Set(policy.purposeClasses.map((purpose) => purpose.id));
+for (const purposeId of requiredPurposeClasses) {
+  assert.ok(purposeIds.has(purposeId), `missing purpose class ${purposeId}`);
+}
+for (const purpose of policy.purposeClasses) {
+  assert.ok(requiredPurposeClasses.has(purpose.id), `unexpected purpose class ${purpose.id}`);
+  assert.ok(policyValues.has(purpose.defaultPolicy), `${purpose.id} defaultPolicy`);
+  assert.ok(purpose.description.length > 20, `${purpose.id} description`);
+  assert.ok(purpose.expectedPublicOutcome.length > 20, `${purpose.id} expectedPublicOutcome`);
+  assert.match(
+    purpose.notObservedMeaning,
+    /No verified|absence/,
+    `${purpose.id} must preserve not-observed semantics`
+  );
+}
+
+assert.equal(
+  policy.productSurfaces.length,
+  new Set(policy.productSurfaces.map((surface) => surface.id)).size,
+  "product surface IDs must be unique"
+);
+const surfaceIds = new Set(policy.productSurfaces.map((surface) => surface.id));
+for (const surfaceId of requiredSurfaceIds) {
+  assert.ok(surfaceIds.has(surfaceId), `missing surface ${surfaceId}`);
+}
+for (const surface of policy.productSurfaces) {
+  assert.ok(requiredSurfaceIds.has(surface.id), `unexpected surface ${surface.id}`);
+  assert.ok(Array.isArray(surface.hostScope));
+  assert.ok(surface.hostScope.length > 0, `${surface.id} hostScope`);
+  assert.match(surface.repository, /^ringecosystem\/|^owning application/);
+  assert.ok(surface.ownerRole.length > 3, `${surface.id} ownerRole`);
+  assert.ok(surface.routeScope.length > 20, `${surface.id} routeScope`);
+  for (const purposeId of requiredPurposeClasses) {
+    assert.ok(
+      Object.hasOwn(surface.desiredPolicyByPurpose, purposeId),
+      `${surface.id} missing policy for ${purposeId}`
+    );
+    assert.ok(
+      policyValues.has(surface.desiredPolicyByPurpose[purposeId]),
+      `${surface.id}/${purposeId} policy`
+    );
+  }
+  if (requiredPublicSurfaces.has(surface.id)) {
+    assert.equal(surface.desiredPolicyByPurpose["search-index"], "allow");
+    assert.equal(surface.desiredPolicyByPurpose["ai-search-reference"], "allow");
+    assert.equal(surface.desiredPolicyByPurpose["user-triggered-fetch"], "allow");
+    assert.equal(surface.desiredPolicyByPurpose["model-training"], "block-by-default");
+    assert.equal(surface.desiredPolicyByPurpose["social-preview"], "allow");
+  }
+  if (surface.id === "private-transactional-preview-staging") {
+    for (const purposeId of requiredPurposeClasses) {
+      assert.equal(surface.desiredPolicyByPurpose[purposeId], "block-or-auth-required");
+    }
+  }
+}
+
+assert.equal(
+  policy.controlLayers.length,
+  new Set(policy.controlLayers.map((layer) => layer.id)).size,
+  "control layer IDs must be unique"
+);
+const controlLayerIds = new Set(policy.controlLayers.map((layer) => layer.id));
+for (const layerId of requiredControlLayers) {
+  assert.ok(controlLayerIds.has(layerId), `missing control layer ${layerId}`);
+}
+for (const layer of policy.controlLayers) {
+  assert.ok(requiredControlLayers.has(layer.id), `unexpected control layer ${layer.id}`);
+  assert.ok(layer.ownerRole.length > 3, `${layer.id} ownerRole`);
+  assert.ok(layer.scope.length > 20, `${layer.id} scope`);
+  assert.ok(layer.publicEvidence.length > 20, `${layer.id} publicEvidence`);
+  assert.ok(layer.confidentiality.length > 3, `${layer.id} confidentiality`);
+}
+
+assert.equal(
+  policy.crawlerAgents.length,
+  new Set(policy.crawlerAgents.map((agent) => agent.id)).size,
+  "crawler agent IDs must be unique"
+);
+const agentIds = new Set(policy.crawlerAgents.map((agent) => agent.id));
+for (const agentId of requiredAgentIds) {
+  assert.ok(agentIds.has(agentId), `missing crawler agent ${agentId}`);
+}
+const agentPurposeCoverage = new Set(policy.crawlerAgents.map((agent) => agent.purposeClass));
+for (const purposeId of requiredPurposeClasses) {
+  assert.ok(agentPurposeCoverage.has(purposeId), `missing agent coverage for ${purposeId}`);
+}
+for (const agent of policy.crawlerAgents) {
+  assert.ok(requiredAgentIds.has(agent.id), `unexpected crawler agent ${agent.id}`);
+  assert.ok(expectedAgents[agent.id], `${agent.id} must have fixed expectations`);
+  assert.equal(agent.token, expectedAgents[agent.id].token, `${agent.id} token`);
+  assert.equal(agent.tokenType, expectedAgents[agent.id].tokenType, `${agent.id} tokenType`);
+  assert.equal(
+    agent.purposeClass,
+    expectedAgents[agent.id].purposeClass,
+    `${agent.id} purposeClass is fixed by provider purpose`
+  );
+  assert.equal(
+    agent.desiredPolicy,
+    expectedAgents[agent.id].desiredPolicy,
+    `${agent.id} desiredPolicy is fixed by policy`
+  );
+  assert.ok(agent.provider.length > 1, `${agent.id} provider`);
+  assert.ok(tokenTypes.has(agent.tokenType), `${agent.id} tokenType`);
+  assert.ok(requiredPurposeClasses.has(agent.purposeClass), `${agent.id} purposeClass`);
+  assert.match(agent.officialSource, /^https:\/\//, `${agent.id} officialSource`);
+  assert.ok(sourceTypes.has(agent.officialSourceType), `${agent.id} officialSourceType`);
+  assert.ok(
+    verificationMethods.has(agent.identityVerificationMethod),
+    `${agent.id} identityVerificationMethod`
+  );
+  assert.ok(maxIdentityStates.has(agent.maxIdentityState), `${agent.id} maxIdentityState`);
+  assert.ok(agent.robotsBehavior.length > 20, `${agent.id} robotsBehavior`);
+  assert.ok(agent.identityVerification.length > 20, `${agent.id} identityVerification`);
+  assert.ok(Array.isArray(agent.productScope));
+  for (const surfaceId of agent.productScope) {
+    assert.ok(requiredPublicSurfaces.has(surfaceId), `${agent.id} productScope ${surfaceId}`);
+  }
+  assert.ok(Array.isArray(agent.enforcementLayers));
+  assert.ok(agent.enforcementLayers.length > 0, `${agent.id} enforcementLayers`);
+  for (const layerId of agent.enforcementLayers) {
+    assert.ok(controlLayerIds.has(layerId), `${agent.id} enforcement layer ${layerId}`);
+  }
+  assert.ok(evidenceStates.has(agent.evidenceState), `${agent.id} evidenceState`);
+  assert.ok(Array.isArray(agent.ownerApprovers));
+  assert.ok(agent.ownerApprovers.length > 0, `${agent.id} ownerApprovers`);
+  for (const owner of agent.ownerApprovers) {
+    assert.ok(requiredOwners.has(owner), `${agent.id} ownerApprover ${owner}`);
+  }
+  assert.ok(agent.rollback.length > 20, `${agent.id} rollback`);
+  if (agent.purposeClass === "model-training") {
+    assert.equal(agent.desiredPolicy, "block-by-default", `${agent.id} training policy`);
+    assert.ok(agent.ownerApprovers.includes("legal"), `${agent.id} legal owner`);
+    assert.ok(agent.ownerApprovers.includes("security"), `${agent.id} security owner`);
+  }
+  if (agent.identityVerificationMethod === "unavailable") {
+    assert.equal(agent.maxIdentityState, "unverified", `${agent.id} unavailable verification`);
+    assert.match(agent.identityVerification, /unverified/);
+  }
+  if (agent.id === "google-extended") {
+    assert.equal(agent.purposeClass, "model-training");
+    assert.equal(agent.desiredPolicy, "block-by-default");
+    assert.equal(agent.maxIdentityState, "policy-token-only");
+    assert.match(agent.robotsBehavior, /not a distinct HTTP User-Agent/);
+    assert.match(agent.identityVerification, /Do not expect Google-Extended in request logs/);
+    assert.deepEqual(agent.enforcementLayers, ["application-robots"]);
+  }
+}
+
+assert.equal(
+  policy.currentProductionBehavior.length,
+  requiredPublicSurfaces.size,
+  "current behavior must cover every public surface"
+);
+const behaviorSurfaces = new Set(
+  policy.currentProductionBehavior.map((behavior) => behavior.surface)
+);
+for (const surfaceId of requiredPublicSurfaces) {
+  assert.ok(behaviorSurfaces.has(surfaceId), `missing current behavior for ${surfaceId}`);
+}
+for (const behavior of policy.currentProductionBehavior) {
+  assert.ok(requiredPublicSurfaces.has(behavior.surface));
+  assert.ok(Array.isArray(behavior.hosts));
+  assert.ok(behavior.hosts.length > 0, `${behavior.surface} hosts`);
+  assert.ok(
+    Number.isFinite(Date.parse(behavior.observedAt)),
+    `${behavior.surface} observedAt`
+  );
+  assert.match(behavior.observationWindow, /^public-http-readback-\d{4}-\d{2}-\d{2}$/);
+  assert.ok(behavior.source.length > 5, `${behavior.surface} source`);
+  assert.ok(behavior.publicRobots, `${behavior.surface} publicRobots`);
+  assert.ok(robotsStates.has(behavior.publicRobots.state), `${behavior.surface} robots state`);
+  assert.ok(Number.isInteger(behavior.publicRobots.statusCode), `${behavior.surface} statusCode`);
+  assert.ok(behavior.publicRobots.contentType.length > 3, `${behavior.surface} contentType`);
+  assert.ok(behavior.publicRobots.summary.length > 30, `${behavior.surface} robots summary`);
+  assert.ok(behavior.cdnWaf, `${behavior.surface} cdnWaf`);
+  assert.equal(behavior.cdnWaf.state, "access-gap", `${behavior.surface} cdnWaf state`);
+  assert.ok(behavior.cdnWaf.ownerRole.length > 3, `${behavior.surface} cdnWaf ownerRole`);
+  assert.match(behavior.cdnWaf.requiredAction, /aggregate verified-bot outcomes/);
+  assert.ok(behavior.authState.length > 5, `${behavior.surface} authState`);
+  assert.ok(Array.isArray(behavior.purposeOutcomes), `${behavior.surface} purposeOutcomes`);
+  assert.equal(
+    behavior.purposeOutcomes.length,
+    requiredPurposeClasses.size,
+    `${behavior.surface} purpose outcome count`
+  );
+  const purposeOutcomeIds = new Set(
+    behavior.purposeOutcomes.map((outcome) => outcome.purposeClass)
+  );
+  for (const purposeId of requiredPurposeClasses) {
+    assert.ok(
+      purposeOutcomeIds.has(purposeId),
+      `${behavior.surface} missing purpose outcome ${purposeId}`
+    );
+  }
+  for (const outcome of behavior.purposeOutcomes) {
+    assert.ok(requiredPurposeClasses.has(outcome.purposeClass));
+    assert.ok(robotsOutcomes.has(outcome.publicRobotsOutcome));
+    assert.ok(edgeOutcomes.has(outcome.edgeOutcome));
+    assert.ok(outcome.evidenceBasis.length > 5, `${behavior.surface}/${outcome.purposeClass} evidenceBasis`);
+  }
+  assert.ok(behavior.gapOwner.length > 3, `${behavior.surface} gapOwner`);
+  assert.match(behavior.evidenceLink, /^https:\/\/github\.com\/ringecosystem\//);
+}
+
+assert.ok(Array.isArray(policy.authoritativeRuleMap));
+assert.equal(
+  policy.authoritativeRuleMap.length,
+  requiredPublicSurfaces.size * requiredPurposeClasses.size,
+  "authoritative map must cover every public surface x purpose"
+);
+const authoritativeKeys = new Set();
+for (const rule of policy.authoritativeRuleMap) {
+  assert.ok(requiredPublicSurfaces.has(rule.surface), `rule surface ${rule.surface}`);
+  assert.ok(requiredPurposeClasses.has(rule.purposeClass), `rule purpose ${rule.purposeClass}`);
+  const key = `${rule.surface}/${rule.purposeClass}`;
+  assert.ok(!authoritativeKeys.has(key), `duplicate authoritative rule ${key}`);
+  authoritativeKeys.add(key);
+  assert.ok(policyValues.has(rule.desiredPolicy), `${key} desiredPolicy`);
+  assert.ok(Array.isArray(rule.authoritativeLayers), `${key} authoritativeLayers`);
+  assert.ok(rule.authoritativeLayers.length > 0, `${key} authoritativeLayers`);
+  for (const layerId of rule.authoritativeLayers) {
+    assert.ok(controlLayerIds.has(layerId), `${key} layer ${layerId}`);
+  }
+  if (rule.purposeClass === "model-training") {
+    assert.ok(rule.authoritativeLayers.includes("gitops-infrastructure"), `${key} gitops layer`);
+    assert.match(rule.ownerRole, /legal\/security\/infrastructure/);
+  }
+  assert.ok(rule.ownerRepository.length > 3, `${key} ownerRepository`);
+  assert.ok(rule.ownerRole.length > 3, `${key} ownerRole`);
+  assert.match(rule.conflictRule, /most restrictive approved layer wins/);
+  assert.ok(rule.rollbackOwner.length > 3, `${key} rollbackOwner`);
+  assert.ok(rule.followupTarget.length > 3, `${key} followupTarget`);
+}
+
+const verificationLogFields = new Set(policy.verificationRequirements.requiredLogFields);
+for (const field of requiredLogFields) {
+  assert.ok(verificationLogFields.has(field), `missing verification log field ${field}`);
+}
+const identityStates = new Set(policy.verificationRequirements.identityStates);
+for (const state of requiredIdentityStates) {
+  assert.ok(identityStates.has(state), `missing identity state ${state}`);
+}
+const accessOutcomeStates = new Set(policy.verificationRequirements.accessOutcomeStates);
+for (const state of requiredAccessOutcomeStates) {
+  assert.ok(accessOutcomeStates.has(state), `missing access outcome state ${state}`);
+}
+assert.match(policy.verificationRequirements.rule, /User-Agent string alone/);
+assert.match(policy.verificationRequirements.rule, /not report a policy as implemented/);
+
+assert.ok(Array.isArray(policy.implementationFollowups));
+assert.ok(policy.implementationFollowups.length >= 6);
+assert.ok(
+  policy.implementationFollowups.some(
+    (followup) => followup.ownerRepository === "infrastructure policy repository"
+  ),
+  "missing infrastructure follow-up boundary"
+);
+for (const followup of policy.implementationFollowups) {
+  assert.match(followup.ownerRepository, /^ringecosystem\/|^infrastructure policy repository$/);
+  assert.match(followup.when, /Open only/);
+  assert.ok(followup.allowedScope.length > 20);
+}
+
+for (const owner of requiredOwners) {
+  assert.ok(policy.rollout.reviewRequired.includes(owner), `missing rollout owner ${owner}`);
+}
+assert.ok(policy.rollout.preflight.includes("confirm intended policy"));
+assert.ok(policy.rollout.preflight.includes("confirm owning repository"));
+assert.ok(policy.rollout.monitoringWindowHours >= 24);
+assert.ok(policy.rollout.rollbackTriggers.includes("training access widened without approval"));
+assert.match(policy.rollout.rollbackProcedure, /Revert/);
+assert.match(policy.rollout.incidentRule, /security incident/);
+
+assert.equal(policy.approvalState.status, "approved-policy-contract");
+assert.equal(
+  policy.approvalState.linkedUmbrellaIssue,
+  "https://github.com/ringecosystem/degov/issues/714"
+);
+assert.ok(Array.isArray(policy.approvalState.approvalRecords));
+const approvalRoles = new Set(
+  policy.approvalState.approvalRecords.map((record) => record.role)
+);
+for (const owner of requiredOwners) {
+  assert.ok(approvalRoles.has(owner), `missing approval record ${owner}`);
+}
+for (const record of policy.approvalState.approvalRecords) {
+  assert.ok(requiredOwners.has(record.role), `approval role ${record.role}`);
+  assert.ok(record.decision.length > 30, `${record.role} decision`);
+  assert.match(record.evidenceLink, /^https:\/\/github\.com\/ringecosystem\/degov\/issues\/1026/);
+  if (record.role === "legal") {
+    assert.match(record.decision, /preserving model-training restrictions/);
+    assert.match(record.decision, /future explicit legal approval/);
+  }
+}
+assert.ok(policy.approvalState.limitations.includes("training access remains blocked by default"));
+
+console.log(
+  `SEO/GEO crawler policy ok: ${policy.crawlerAgents.length} agents, ${policy.productSurfaces.length} surfaces, ${policy.controlLayers.length} control layers`
+);

--- a/scripts/check-seo-geo-crawler-policy.mjs
+++ b/scripts/check-seo-geo-crawler-policy.mjs
@@ -66,6 +66,7 @@ const sourceTypes = new Set([
   "provider-crawler-documentation",
   "provider-published-token-list",
   "provider-generic-reference",
+  "unavailable",
 ]);
 const verificationMethods = new Set([
   "provider-ip-rdns-or-verified-bot-signal",
@@ -162,6 +163,9 @@ const expectedAgents = {
     tokenType: "http-user-agent",
     purposeClass: "social-preview",
     desiredPolicy: "allow",
+    officialSourceType: "unavailable",
+    identityVerificationMethod: "unavailable",
+    maxIdentityState: "unverified",
   },
   slackbot: {
     token: "Slackbot-LinkExpanding",
@@ -180,6 +184,9 @@ const expectedAgents = {
     tokenType: "http-user-agent",
     purposeClass: "social-preview",
     desiredPolicy: "allow",
+    officialSourceType: "unavailable",
+    identityVerificationMethod: "unavailable",
+    maxIdentityState: "unverified",
   },
 };
 const requiredLogFields = new Set([
@@ -337,6 +344,27 @@ for (const agent of policy.crawlerAgents) {
     expectedAgents[agent.id].desiredPolicy,
     `${agent.id} desiredPolicy is fixed by policy`
   );
+  if (expectedAgents[agent.id].officialSourceType) {
+    assert.equal(
+      agent.officialSourceType,
+      expectedAgents[agent.id].officialSourceType,
+      `${agent.id} officialSourceType`
+    );
+  }
+  if (expectedAgents[agent.id].identityVerificationMethod) {
+    assert.equal(
+      agent.identityVerificationMethod,
+      expectedAgents[agent.id].identityVerificationMethod,
+      `${agent.id} identityVerificationMethod`
+    );
+  }
+  if (expectedAgents[agent.id].maxIdentityState) {
+    assert.equal(
+      agent.maxIdentityState,
+      expectedAgents[agent.id].maxIdentityState,
+      `${agent.id} maxIdentityState`
+    );
+  }
   assert.ok(agent.provider.length > 1, `${agent.id} provider`);
   assert.ok(tokenTypes.has(agent.tokenType), `${agent.id} tokenType`);
   assert.ok(requiredPurposeClasses.has(agent.purposeClass), `${agent.id} purposeClass`);
@@ -443,12 +471,12 @@ for (const behavior of policy.currentProductionBehavior) {
 assert.ok(Array.isArray(policy.authoritativeRuleMap));
 assert.equal(
   policy.authoritativeRuleMap.length,
-  requiredPublicSurfaces.size * requiredPurposeClasses.size,
-  "authoritative map must cover every public surface x purpose"
+  requiredSurfaceIds.size * requiredPurposeClasses.size,
+  "authoritative map must cover every surface x purpose"
 );
 const authoritativeKeys = new Set();
 for (const rule of policy.authoritativeRuleMap) {
-  assert.ok(requiredPublicSurfaces.has(rule.surface), `rule surface ${rule.surface}`);
+  assert.ok(requiredSurfaceIds.has(rule.surface), `rule surface ${rule.surface}`);
   assert.ok(requiredPurposeClasses.has(rule.purposeClass), `rule purpose ${rule.purposeClass}`);
   const key = `${rule.surface}/${rule.purposeClass}`;
   assert.ok(!authoritativeKeys.has(key), `duplicate authoritative rule ${key}`);
@@ -463,7 +491,9 @@ for (const rule of policy.authoritativeRuleMap) {
     assert.ok(rule.authoritativeLayers.includes("gitops-infrastructure"), `${key} gitops layer`);
     assert.match(rule.ownerRole, /legal\/security\/infrastructure/);
   }
-  assert.ok(rule.ownerRepository.length > 3, `${key} ownerRepository`);
+  assert.match(rule.ownerRepository, /^ringecosystem\/|^owning application or infrastructure repository$/);
+  assert.notEqual(rule.ownerRepository, "infrastructure policy repository");
+  assert.match(rule.infrastructureRepository, /^ringecosystem\//, `${key} infrastructureRepository`);
   assert.ok(rule.ownerRole.length > 3, `${key} ownerRole`);
   assert.match(rule.conflictRule, /most restrictive approved layer wins/);
   assert.ok(rule.rollbackOwner.length > 3, `${key} rollbackOwner`);
@@ -489,12 +519,15 @@ assert.ok(Array.isArray(policy.implementationFollowups));
 assert.ok(policy.implementationFollowups.length >= 6);
 assert.ok(
   policy.implementationFollowups.some(
-    (followup) => followup.ownerRepository === "infrastructure policy repository"
+    (followup) =>
+      followup.ownerRepository === "ringecosystem/degov-agent-api" &&
+      followup.allowedScope.includes("Infrastructure-owned")
   ),
   "missing infrastructure follow-up boundary"
 );
 for (const followup of policy.implementationFollowups) {
-  assert.match(followup.ownerRepository, /^ringecosystem\/|^infrastructure policy repository$/);
+  assert.match(followup.ownerRepository, /^ringecosystem\//);
+  assert.notEqual(followup.ownerRepository, "infrastructure policy repository");
   assert.match(followup.when, /Open only/);
   assert.ok(followup.allowedScope.length > 20);
 }
@@ -509,28 +542,32 @@ assert.ok(policy.rollout.rollbackTriggers.includes("training access widened with
 assert.match(policy.rollout.rollbackProcedure, /Revert/);
 assert.match(policy.rollout.incidentRule, /security incident/);
 
-assert.equal(policy.approvalState.status, "approved-policy-contract");
+assert.equal(policy.approvalState.status, "pending-approval");
 assert.equal(
   policy.approvalState.linkedUmbrellaIssue,
   "https://github.com/ringecosystem/degov/issues/714"
 );
-assert.ok(Array.isArray(policy.approvalState.approvalRecords));
-const approvalRoles = new Set(
-  policy.approvalState.approvalRecords.map((record) => record.role)
+assert.deepEqual(policy.approvalState.approvalRecords, []);
+assert.ok(Array.isArray(policy.approvalState.requiredApprovalRecords));
+const requiredApprovalRoles = new Set(
+  policy.approvalState.requiredApprovalRecords.map((record) => record.role)
 );
 for (const owner of requiredOwners) {
-  assert.ok(approvalRoles.has(owner), `missing approval record ${owner}`);
+  assert.ok(requiredApprovalRoles.has(owner), `missing required approval record ${owner}`);
 }
-for (const record of policy.approvalState.approvalRecords) {
+for (const record of policy.approvalState.requiredApprovalRecords) {
   assert.ok(requiredOwners.has(record.role), `approval role ${record.role}`);
-  assert.ok(record.decision.length > 30, `${record.role} decision`);
-  assert.match(record.evidenceLink, /^https:\/\/github\.com\/ringecosystem\/degov\/issues\/1026/);
+  assert.match(record.requiredEvidence, /concrete issue comment or review/);
   if (record.role === "legal") {
-    assert.match(record.decision, /preserving model-training restrictions/);
-    assert.match(record.decision, /future explicit legal approval/);
+    assert.match(record.requiredEvidence, /training restrictions/);
   }
 }
 assert.ok(policy.approvalState.limitations.includes("training access remains blocked by default"));
+assert.ok(
+  policy.approvalState.limitations.includes(
+    "policy cannot be treated as approved until required approval records link concrete comments or reviews"
+  )
+);
 
 console.log(
   `SEO/GEO crawler policy ok: ${policy.crawlerAgents.length} agents, ${policy.productSurfaces.length} surfaces, ${policy.controlLayers.length} control layers`


### PR DESCRIPTION
## Summary
- add a versioned crawler-access policy matrix for #1026 and #714
- separate search indexing, AI reference, user-triggered fetch, model-training, and social-preview purposes
- preserve training crawler restrictions by default and model Google-Extended as a robots product token, not an HTTP crawler UA
- record current public robots readback, CDN/WAF access gaps, authoritative control layers, rollout, rollback, and implementation follow-up boundaries
- add CI coverage via pnpm run test:seo-geo-crawler-policy

## Verification
- pnpm install --filter @degov/web... --frozen-lockfile
- pnpm run test:seo-geo-crawler-policy
- pnpm run test:seo-geo-observability
- pnpm run test:seo-geo-contract
- pnpm run test:web-scripts
- pnpm --filter @degov/web build
- git diff --check

Closes #1026