### PR TITLE
Define SEO/GEO structured data contract

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,7 @@ jobs:
           pnpm run test:seo-geo-observability
           pnpm run test:seo-geo-crawler-policy
           pnpm run test:seo-geo-social-preview
+          pnpm run test:seo-geo-structured-data
           pnpm run test:web-scripts
           pnpm --filter @degov/web build
 

--- a/docs/spec/seo-geo-structured-data-contract.json
+++ b/docs/spec/seo-geo-structured-data-contract.json
@@ -85,9 +85,21 @@
         "@type",
         "@id",
         "name",
-        "url",
-        "publisher"
+        "url"
       ],
+      "requiredEntityProperties": {
+        "Organization": [
+          "@id",
+          "name",
+          "url"
+        ],
+        "WebSite": [
+          "@id",
+          "name",
+          "url",
+          "publisher"
+        ]
+      },
       "forbiddenProperties": [
         "aggregateRating",
         "review",
@@ -370,7 +382,9 @@
         "name",
         "url",
         "mainEntityOfPage",
-        "itemListElement"
+        "itemListElement",
+        "position",
+        "item"
       ],
       "forbiddenProperties": [
         "dataset-without-license",
@@ -490,8 +504,7 @@
       "id": "ratings-reviews-fake-freshness",
       "rejectedTypes": [
         "AggregateRating",
-        "Review",
-        "fakeDateModified"
+        "Review"
       ],
       "reason": "Ratings, reviews, authors, and freshness dates must not be invented or derived from build/deploy time."
     },

--- a/docs/spec/seo-geo-structured-data-contract.json
+++ b/docs/spec/seo-geo-structured-data-contract.json
@@ -352,6 +352,7 @@
       "validation": [
         "json-ld-parse",
         "proposal-visible-content-comparison",
+        "canonical-jsonld-url-agreement",
         "metadata-jsonld-entity-agreement",
         "invalid-route-no-jsonld"
       ],

--- a/docs/spec/seo-geo-structured-data-contract.json
+++ b/docs/spec/seo-geo-structured-data-contract.json
@@ -1,0 +1,600 @@
+{
+  "version": 1,
+  "ownerIssue": "https://github.com/ringecosystem/degov/issues/1028",
+  "parentIssue": "https://github.com/ringecosystem/degov/issues/714",
+  "updatedAt": "2026-08-04",
+  "maintenance": {
+    "ownerRepository": "ringecosystem/degov",
+    "contractPath": "docs/spec/seo-geo-structured-data-contract.json",
+    "localCheck": "pnpm run test:seo-geo-structured-data",
+    "changeRule": "A structured-data mapping, entity identity rule, approval state, or completion claim may change only with an owner issue, source URL, visible-content evidence, validation plan, rollback path, and #714-linked rationale."
+  },
+  "sourcePolicy": {
+    "googleStructuredDataIntro": "https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data",
+    "googleStructuredDataGeneralGuidelines": "https://developers.google.com/search/docs/appearance/structured-data/sd-policies",
+    "googleSupportedGallery": "https://developers.google.com/search/docs/appearance/structured-data/search-gallery",
+    "googleBreadcrumb": "https://developers.google.com/search/docs/appearance/structured-data/breadcrumb",
+    "googleArticle": "https://developers.google.com/search/docs/appearance/structured-data/article",
+    "googleProfilePage": "https://developers.google.com/search/docs/appearance/structured-data/profile-page",
+    "googleFaqChange": "https://developers.google.com/search/blog/2023/08/howto-faq-changes",
+    "schemaOrganization": "https://schema.org/Organization",
+    "schemaWebSite": "https://schema.org/WebSite",
+    "schemaWebPage": "https://schema.org/WebPage",
+    "schemaCollectionPage": "https://schema.org/CollectionPage",
+    "schemaItemList": "https://schema.org/ItemList",
+    "schemaCreativeWork": "https://schema.org/CreativeWork",
+    "schemaDataset": "https://schema.org/Dataset",
+    "sourceUseRule": "Use Google Search feature documentation to decide rich-result eligibility, and schema.org semantics to decide whether a type accurately describes visible page content. Schema existence alone is not approval."
+  },
+  "entityIdentity": {
+    "publisher": {
+      "id": "degov-publisher",
+      "type": "Organization",
+      "stableAtId": "https://degov.ai/#organization",
+      "canonicalUrl": "https://degov.ai/",
+      "name": "DeGov",
+      "sameAsPolicy": "Only verified official DeGov-controlled profiles and product URLs may be included. Do not add community mirrors, unverified social profiles, or DAO-specific links to the publisher identity.",
+      "surfaces": [
+        "home",
+        "docs",
+        "square",
+        "dao-sites",
+        "atlas"
+      ]
+    },
+    "website": {
+      "id": "degov-website",
+      "type": "WebSite",
+      "stableAtId": "https://degov.ai/#website",
+      "canonicalUrl": "https://degov.ai/",
+      "publisherAtId": "https://degov.ai/#organization"
+    },
+    "daoEntityRule": {
+      "type": "Organization",
+      "stableAtIdPattern": "<dao.siteUrl>/#organization",
+      "canonicalUrlPattern": "<dao.siteUrl>/",
+      "sameAsPolicy": "Use only DAO official URLs verified from approved registry/configuration data and visible on the public DAO page. Do not include user-submitted, unverified, private, or stale links.",
+      "hostIsolationRule": "The DAO @id, url, logo, sameAs links, and JSON-LD entity facts must come from the active validated DAO configuration, never from the request Host header alone or another DAO cache entry.",
+      "visibleContentRule": "DAO name, logo/image when used, description, canonical URL, and official links must be visible on the page or directly cited by visible page content."
+    },
+    "urlAgreementRule": "For each approved public page, JSON-LD url/mainEntityOfPage, HTML canonical, og:url, and sitemap URL must agree on the validated production origin and canonical path.",
+    "localeRule": "Localized names, descriptions, and inLanguage values may be emitted only when the visible localized page content is available and uses the same canonical/alternate strategy as the route contract."
+  },
+  "pageClassDecisions": [
+    {
+      "id": "home.root",
+      "surface": "home",
+      "repository": "ringecosystem/degov-home",
+      "candidateTypes": [
+        "Organization",
+        "WebSite"
+      ],
+      "decision": "approved-existing-recheck-required",
+      "rationale": "The official homepage is the canonical product/publisher surface and already has an Organization/WebSite implementation to recheck against the shared identity contract.",
+      "googleSupportedFeature": "organization-and-site-understanding",
+      "schemaSemanticFit": "direct",
+      "requiredVisibleEvidence": [
+        "DeGov product identity",
+        "canonical homepage URL",
+        "publisher name",
+        "public logo or image when used",
+        "official product links"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "@id",
+        "name",
+        "url",
+        "publisher"
+      ],
+      "forbiddenProperties": [
+        "aggregateRating",
+        "review",
+        "fakeFoundingDate",
+        "unverifiedSameAs"
+      ],
+      "validation": [
+        "json-ld-parse",
+        "stable-at-id",
+        "canonical-jsonld-url-agreement",
+        "visible-content-comparison",
+        "deployed-raw-html-readback"
+      ],
+      "rollback": "Remove or revert the homepage JSON-LD block if identity, canonical, or visible-content agreement fails."
+    },
+    {
+      "id": "home.pricing-content",
+      "surface": "home",
+      "repository": "ringecosystem/degov-home",
+      "candidateTypes": [
+        "WebPage"
+      ],
+      "decision": "approved-conditional",
+      "rationale": "Generic WebPage markup can describe visible pricing/content pages without claiming a richer unsupported product or FAQ result.",
+      "googleSupportedFeature": "not-rich-result-specific",
+      "schemaSemanticFit": "direct",
+      "requiredVisibleEvidence": [
+        "visible page title",
+        "canonical URL",
+        "publisher identity",
+        "content description"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "@id",
+        "url",
+        "name",
+        "isPartOf",
+        "publisher"
+      ],
+      "forbiddenProperties": [
+        "Offer",
+        "Product",
+        "FAQPage-with-hidden-questions",
+        "fakeReview"
+      ],
+      "validation": [
+        "json-ld-parse",
+        "canonical-jsonld-url-agreement",
+        "visible-content-comparison"
+      ],
+      "rollback": "Fall back to no route-level JSON-LD if pricing facts, visible content, or supported-type requirements are not stable."
+    },
+    {
+      "id": "docs.breadcrumb",
+      "surface": "docs",
+      "repository": "ringecosystem/degov-docs",
+      "candidateTypes": [
+        "BreadcrumbList"
+      ],
+      "decision": "approved-conditional",
+      "rationale": "BreadcrumbList is appropriate only when the docs page exposes visible canonical breadcrumbs.",
+      "googleSupportedFeature": "breadcrumb",
+      "schemaSemanticFit": "direct",
+      "requiredVisibleEvidence": [
+        "visible breadcrumb trail",
+        "canonical docs URL",
+        "breadcrumb item names",
+        "breadcrumb item URLs"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "itemListElement",
+        "position",
+        "name",
+        "item"
+      ],
+      "forbiddenProperties": [
+        "breadcrumb-to-wrong-host",
+        "hidden-breadcrumb-only"
+      ],
+      "validation": [
+        "json-ld-parse",
+        "breadcrumb-visible-content-comparison",
+        "canonical-jsonld-url-agreement",
+        "google-rich-results-test"
+      ],
+      "rollback": "Disable BreadcrumbList for docs pages whose visible breadcrumb or canonical host cannot be proven."
+    },
+    {
+      "id": "docs.article",
+      "surface": "docs",
+      "repository": "ringecosystem/degov-docs",
+      "candidateTypes": [
+        "Article",
+        "TechArticle"
+      ],
+      "decision": "deferred",
+      "rationale": "Docs article markup needs real author, review/update dates, publisher, headline, and article body evidence; build dates must not be used as freshness.",
+      "googleSupportedFeature": "article",
+      "schemaSemanticFit": "conditional",
+      "requiredVisibleEvidence": [
+        "visible headline",
+        "visible author or accountable publisher",
+        "real datePublished or dateModified",
+        "article body",
+        "canonical docs URL"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "headline",
+        "author",
+        "publisher",
+        "datePublished-or-dateModified",
+        "mainEntityOfPage"
+      ],
+      "forbiddenProperties": [
+        "build-date-as-dateModified",
+        "fake-author",
+        "hidden-review-date"
+      ],
+      "validation": [
+        "json-ld-parse",
+        "visible-date-author-comparison",
+        "google-rich-results-test"
+      ],
+      "rollback": "Do not emit Article/TechArticle until editorial authorship and date semantics are approved."
+    },
+    {
+      "id": "square.directory",
+      "surface": "square",
+      "repository": "ringecosystem/degov-square",
+      "candidateTypes": [
+        "WebSite",
+        "CollectionPage",
+        "ItemList"
+      ],
+      "decision": "approved-conditional",
+      "rationale": "The Square directory can be a CollectionPage/ItemList only when DAO items and links are present in initial visible HTML.",
+      "googleSupportedFeature": "not-rich-result-specific",
+      "schemaSemanticFit": "conditional",
+      "requiredVisibleEvidence": [
+        "visible directory title",
+        "visible DAO item names",
+        "visible DAO canonical links",
+        "canonical Square URL"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "@id",
+        "url",
+        "name",
+        "mainEntity",
+        "itemListElement"
+      ],
+      "forbiddenProperties": [
+        "hidden-directory-items",
+        "unverified-dao-links",
+        "client-only-items-with-jsonld"
+      ],
+      "validation": [
+        "json-ld-parse",
+        "visible-itemlist-comparison",
+        "canonical-jsonld-url-agreement",
+        "deployed-raw-html-readback"
+      ],
+      "rollback": "Remove ItemList markup if directory items are not server-readable or canonical DAO links cannot be verified."
+    },
+    {
+      "id": "dao.home",
+      "surface": "dao-sites",
+      "repository": "ringecosystem/degov",
+      "candidateTypes": [
+        "Organization"
+      ],
+      "decision": "approved-conditional",
+      "rationale": "A public DAO homepage may describe the DAO as an Organization when identity facts are visible and host-isolated.",
+      "googleSupportedFeature": "organization-and-entity-understanding",
+      "schemaSemanticFit": "direct",
+      "requiredVisibleEvidence": [
+        "visible DAO name",
+        "visible DAO description or governance context",
+        "canonical DAO homepage",
+        "verified official DAO links when sameAs is emitted",
+        "visible logo or image when image is emitted"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "@id",
+        "name",
+        "url",
+        "mainEntityOfPage"
+      ],
+      "forbiddenProperties": [
+        "unverifiedSameAs",
+        "cross-dao-identity",
+        "hidden-contract-facts",
+        "wallet-or-profile-data"
+      ],
+      "validation": [
+        "json-ld-parse",
+        "host-isolation",
+        "visible-content-comparison",
+        "canonical-jsonld-url-agreement",
+        "two-dao-fixture-test"
+      ],
+      "rollback": "Disable DAO Organization markup for the affected route if configuration, canonical, sameAs, or cache isolation fails."
+    },
+    {
+      "id": "dao.proposal-detail",
+      "surface": "dao-sites",
+      "repository": "ringecosystem/degov",
+      "candidateTypes": [
+        "WebPage",
+        "CreativeWork"
+      ],
+      "decision": "approved-conditional",
+      "rationale": "Proposal detail pages may use generic page/creative-work semantics, but must not be misclassified as Article, Legislation, NewsArticle, or DiscussionForumPosting by default.",
+      "googleSupportedFeature": "not-rich-result-specific",
+      "schemaSemanticFit": "conditional",
+      "requiredVisibleEvidence": [
+        "visible proposal title",
+        "visible proposal canonical URL",
+        "visible DAO identity",
+        "visible proposal source or identifier",
+        "visible data-as-of or source freshness when emitted"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "@id",
+        "url",
+        "name",
+        "isPartOf",
+        "about"
+      ],
+      "forbiddenProperties": [
+        "Article",
+        "NewsArticle",
+        "Legislation",
+        "DiscussionForumPosting",
+        "fake-author",
+        "vote-choice-user-data"
+      ],
+      "validation": [
+        "json-ld-parse",
+        "proposal-visible-content-comparison",
+        "metadata-jsonld-entity-agreement",
+        "invalid-route-no-jsonld"
+      ],
+      "rollback": "Fall back to no proposal JSON-LD if proposal visibility, source, or entity alignment cannot be proven."
+    },
+    {
+      "id": "atlas.dao-detail",
+      "surface": "atlas",
+      "repository": "ringecosystem/degov-agent-api",
+      "candidateTypes": [
+        "Organization",
+        "BreadcrumbList"
+      ],
+      "decision": "approved-conditional",
+      "rationale": "Atlas DAO detail pages can describe the visible DAO entity and breadcrumb context when the canonical Atlas route and DAO identity are stable.",
+      "googleSupportedFeature": "breadcrumb-plus-entity-understanding",
+      "schemaSemanticFit": "direct",
+      "requiredVisibleEvidence": [
+        "visible DAO name",
+        "visible Atlas DAO canonical URL",
+        "visible breadcrumb trail",
+        "visible source/freshness context when emitted"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "@id",
+        "name",
+        "url",
+        "mainEntityOfPage",
+        "itemListElement"
+      ],
+      "forbiddenProperties": [
+        "dataset-without-license",
+        "hidden-dao-facts",
+        "unverifiedSameAs"
+      ],
+      "validation": [
+        "json-ld-parse",
+        "visible-content-comparison",
+        "breadcrumb-visible-content-comparison",
+        "canonical-jsonld-url-agreement"
+      ],
+      "rollback": "Remove Atlas DAO JSON-LD if the visible DAO entity, breadcrumb, or canonical route cannot be proven."
+    },
+    {
+      "id": "atlas.participant-profile",
+      "surface": "atlas",
+      "repository": "ringecosystem/degov-agent-api",
+      "candidateTypes": [
+        "ProfilePage"
+      ],
+      "decision": "deferred",
+      "rationale": "ProfilePage requires an approved public participant/profile indexing policy and privacy review before describing people or organizations.",
+      "googleSupportedFeature": "profile-page",
+      "schemaSemanticFit": "conditional",
+      "requiredVisibleEvidence": [
+        "approved public profile route",
+        "visible profile identity",
+        "privacy-safe public value",
+        "consent/index policy",
+        "no private wallet/governance payload"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "mainEntity",
+        "name-or-alternateName"
+      ],
+      "forbiddenProperties": [
+        "private-wallet-profile",
+        "vote-choice",
+        "token-balance-linked-to-person",
+        "unapprovedSameAs"
+      ],
+      "validation": [
+        "privacy-review-link",
+        "index-policy-link",
+        "visible-content-comparison",
+        "private-route-no-jsonld"
+      ],
+      "rollback": "Do not emit ProfilePage until profile privacy, public value, and index policy are approved."
+    },
+    {
+      "id": "atlas.dataset",
+      "surface": "atlas",
+      "repository": "ringecosystem/degov-agent-api",
+      "candidateTypes": [
+        "Dataset"
+      ],
+      "decision": "deferred",
+      "rationale": "Dataset markup requires a real dataset landing page and explicit license, creator, distribution/access, and provenance contract.",
+      "googleSupportedFeature": "dataset",
+      "schemaSemanticFit": "conditional",
+      "requiredVisibleEvidence": [
+        "dataset landing page",
+        "visible license",
+        "visible creator/publisher",
+        "distribution or access method",
+        "provenance and data freshness",
+        "methodology"
+      ],
+      "requiredProperties": [
+        "@context",
+        "@type",
+        "name",
+        "description",
+        "license",
+        "creator",
+        "distribution-or-access",
+        "isBasedOn-or-measurementTechnique"
+      ],
+      "forbiddenProperties": [
+        "dataset-without-license",
+        "dataset-without-provenance",
+        "api-response-as-dataset-without-landing-page",
+        "fake-freshness"
+      ],
+      "validation": [
+        "dataset-contract-link",
+        "visible-license-comparison",
+        "distribution-fetch-check",
+        "provenance-review"
+      ],
+      "rollback": "Do not emit Dataset until Atlas has an approved dataset product contract."
+    }
+  ],
+  "explicitRejections": [
+    {
+      "id": "proposal-as-news-article",
+      "rejectedTypes": [
+        "Article",
+        "NewsArticle",
+        "BlogPosting",
+        "DiscussionForumPosting",
+        "Legislation"
+      ],
+      "reason": "A governance proposal page is not automatically editorial journalism, a forum thread, or legislation. Use only a generic page/creative-work mapping unless visible content and product semantics justify a narrower type."
+    },
+    {
+      "id": "faq-growth-strategy",
+      "rejectedTypes": [
+        "FAQPage"
+      ],
+      "reason": "FAQ markup is not a growth KPI and must not be added unless the FAQ content is visible and appropriate; Google FAQ rich results are restricted and should not drive bulk FAQ expansion."
+    },
+    {
+      "id": "ratings-reviews-fake-freshness",
+      "rejectedTypes": [
+        "AggregateRating",
+        "Review",
+        "fakeDateModified"
+      ],
+      "reason": "Ratings, reviews, authors, and freshness dates must not be invented or derived from build/deploy time."
+    },
+    {
+      "id": "participant-profile-before-policy",
+      "rejectedTypes": [
+        "ProfilePage"
+      ],
+      "reason": "Participant or profile markup is blocked until privacy, public value, and indexability policies are approved."
+    }
+  ],
+  "validationModel": {
+    "ciChecks": [
+      "json-ld-parse",
+      "required-property-shape",
+      "stable-at-id",
+      "canonical-jsonld-url-agreement",
+      "visible-content-comparison",
+      "invalid-private-no-jsonld",
+      "host-isolation",
+      "safe-json-serialization"
+    ],
+    "manualChecks": [
+      "schema-org-validator",
+      "google-rich-results-test-for-supported-types",
+      "search-console-enhancement-report-when-available",
+      "deployed-raw-html-readback"
+    ],
+    "releaseBlockingFailures": [
+      "malformed-json-ld",
+      "wrong-host-jsonld-url",
+      "jsonld-canonical-og-url-mismatch",
+      "hidden-or-fabricated-fact",
+      "invalid-private-or-noindex-page-jsonld",
+      "cross-dao-entity-contamination",
+      "unsafe-json-serialization",
+      "misleading-rich-result-type",
+      "build-date-as-content-date",
+      "unverified-same-as",
+      "dataset-without-contract",
+      "profile-without-privacy-policy"
+    ],
+    "informationalOnly": [
+      "rich-result-not-shown",
+      "external-ranking-change",
+      "schema-count",
+      "ai-citation-frequency"
+    ],
+    "rollbackProcedure": "Remove or disable the affected JSON-LD block, preserve canonical/meta behavior, record the failure class and affected route, and link the rollback evidence to the owner issue and #714."
+  },
+  "repositoryFollowUps": [
+    {
+      "repository": "ringecosystem/degov-home",
+      "approvedScopes": [
+        "home.root",
+        "home.pricing-content"
+      ],
+      "status": "implementation-issue-required-after-contract",
+      "scope": "Recheck existing Organization/WebSite JSON-LD after home PR #31, align @id with the shared publisher identity, and add only visible-content-backed WebPage markup for approved content pages."
+    },
+    {
+      "repository": "ringecosystem/degov-docs",
+      "approvedScopes": [
+        "docs.breadcrumb"
+      ],
+      "status": "implementation-issue-required-after-contract",
+      "scope": "Add visible-breadcrumb-backed BreadcrumbList markup; defer Article/TechArticle until authorship and real date semantics exist."
+    },
+    {
+      "repository": "ringecosystem/degov-square",
+      "approvedScopes": [
+        "square.directory"
+      ],
+      "status": "implementation-issue-required-after-contract",
+      "scope": "Add CollectionPage/ItemList only when DAO directory items and canonical links are present in initial visible HTML."
+    },
+    {
+      "repository": "ringecosystem/degov",
+      "approvedScopes": [
+        "dao.home",
+        "dao.proposal-detail"
+      ],
+      "status": "implementation-issue-required-after-contract",
+      "scope": "Add host-isolated DAO Organization markup and optional generic proposal page/CreativeWork markup with invalid/private route exclusion."
+    },
+    {
+      "repository": "ringecosystem/degov-agent-api",
+      "approvedScopes": [
+        "atlas.dao-detail"
+      ],
+      "status": "implementation-issue-required-after-contract",
+      "scope": "Add Atlas DAO Organization/BreadcrumbList markup; defer ProfilePage and Dataset until privacy and dataset contracts are approved."
+    }
+  ],
+  "completionState": {
+    "contractApproved": false,
+    "contractApprovalEvidence": [],
+    "implementationIssuesLinked": false,
+    "implementationIssueLinks": [],
+    "officialSiteRecheckComplete": false,
+    "officialSiteRecheckEvidence": [],
+    "validatorEvidenceComplete": false,
+    "validatorEvidenceRecords": [],
+    "closeIssueWhen": "The shared entity contract is approved, repository-specific implementation issues are linked for approved mappings, official-site JSON-LD is rechecked after degov-home PR #31, validator/readback evidence exists for implemented mappings, and #714 has the final evidence summary."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:seo-geo-crawler-policy": "node scripts/check-seo-geo-crawler-policy.mjs",
     "test:seo-geo-observability": "node scripts/check-seo-geo-observability.mjs",
     "test:seo-geo-social-preview": "node scripts/check-seo-geo-social-preview.mjs",
+    "test:seo-geo-structured-data": "node scripts/check-seo-geo-structured-data.mjs",
     "test:seo-geo-contract": "node scripts/check-seo-geo-route-contract.mjs",
     "test:web-scripts": "node --test apps/web/scripts/*.test.ts apps/web/scripts/*.test.mjs"
   },

--- a/scripts/check-seo-geo-structured-data.mjs
+++ b/scripts/check-seo-geo-structured-data.mjs
@@ -156,7 +156,8 @@ assert.match(contract.maintenance.changeRule, /visible-content evidence/);
 assert.match(contract.maintenance.changeRule, /rollback path/);
 
 for (const sourceKey of requiredSourceKeys) {
-  assert.match(contract.sourcePolicy[sourceKey], /^https:\/\//, `missing source ${sourceKey}`);
+  assert.equal(typeof contract.sourcePolicy[sourceKey], "string", `missing source ${sourceKey}`);
+  assert.match(contract.sourcePolicy[sourceKey], /^https:\/\//, `invalid source ${sourceKey}`);
 }
 assert.match(contract.sourcePolicy.sourceUseRule, /Schema existence alone is not approval/);
 
@@ -246,6 +247,36 @@ for (const forbiddenType of [
   );
 }
 
+const homeDecision = contract.pageClassDecisions.find(
+  (decision) => decision.id === "home.root"
+);
+assert.ok(homeDecision.requiredEntityProperties, "home.root must split entity properties");
+assert.deepEqual(homeDecision.requiredEntityProperties.Organization, [
+  "@id",
+  "name",
+  "url",
+]);
+assert.deepEqual(homeDecision.requiredEntityProperties.WebSite, [
+  "@id",
+  "name",
+  "url",
+  "publisher",
+]);
+assert.ok(
+  !homeDecision.requiredProperties.includes("publisher"),
+  "publisher must not be a shared home.root Organization/WebSite requirement"
+);
+
+const atlasDaoDecision = contract.pageClassDecisions.find(
+  (decision) => decision.id === "atlas.dao-detail"
+);
+for (const breadcrumbField of ["itemListElement", "position", "name", "item"]) {
+  assert.ok(
+    atlasDaoDecision.requiredProperties.includes(breadcrumbField),
+    `Atlas DAO breadcrumb mapping must require ${breadcrumbField}`
+  );
+}
+
 const datasetDecision = contract.pageClassDecisions.find(
   (decision) => decision.id === "atlas.dataset"
 );
@@ -277,6 +308,9 @@ for (const rejectionId of requiredExplicitRejectionIds) {
 }
 for (const rejection of contract.explicitRejections) {
   assert.ok(rejection.rejectedTypes.length > 0, `${rejection.id} rejectedTypes`);
+  for (const rejectedType of rejection.rejectedTypes) {
+    assert.match(rejectedType, /^[A-Z][A-Za-z]+$/, `${rejection.id} rejected type ${rejectedType}`);
+  }
   assert.ok(rejection.reason.length > 60, `${rejection.id} reason`);
 }
 

--- a/scripts/check-seo-geo-structured-data.mjs
+++ b/scripts/check-seo-geo-structured-data.mjs
@@ -1,0 +1,381 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const contractPath = path.join(
+  rootDir,
+  "docs/spec/seo-geo-structured-data-contract.json"
+);
+const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+
+const requiredSurfaces = new Set(["home", "docs", "square", "dao-sites", "atlas"]);
+const requiredRepositories = new Set([
+  "ringecosystem/degov",
+  "ringecosystem/degov-agent-api",
+  "ringecosystem/degov-docs",
+  "ringecosystem/degov-home",
+  "ringecosystem/degov-square",
+]);
+const requiredDecisionIds = new Set([
+  "home.root",
+  "home.pricing-content",
+  "docs.breadcrumb",
+  "docs.article",
+  "square.directory",
+  "dao.home",
+  "dao.proposal-detail",
+  "atlas.dao-detail",
+  "atlas.participant-profile",
+  "atlas.dataset",
+]);
+const approvedOrConditionalIds = new Set([
+  "home.root",
+  "home.pricing-content",
+  "docs.breadcrumb",
+  "square.directory",
+  "dao.home",
+  "dao.proposal-detail",
+  "atlas.dao-detail",
+]);
+const deferredIds = new Set([
+  "docs.article",
+  "atlas.participant-profile",
+  "atlas.dataset",
+]);
+const requiredSourceKeys = new Set([
+  "googleStructuredDataIntro",
+  "googleStructuredDataGeneralGuidelines",
+  "googleSupportedGallery",
+  "googleBreadcrumb",
+  "googleArticle",
+  "googleProfilePage",
+  "googleFaqChange",
+  "schemaOrganization",
+  "schemaWebSite",
+  "schemaWebPage",
+  "schemaCollectionPage",
+  "schemaItemList",
+  "schemaCreativeWork",
+  "schemaDataset",
+]);
+const requiredPublisherFields = new Set([
+  "id",
+  "type",
+  "stableAtId",
+  "canonicalUrl",
+  "name",
+  "sameAsPolicy",
+  "surfaces",
+]);
+const requiredDaoRuleFields = new Set([
+  "type",
+  "stableAtIdPattern",
+  "canonicalUrlPattern",
+  "sameAsPolicy",
+  "hostIsolationRule",
+  "visibleContentRule",
+]);
+const requiredDecisionFields = new Set([
+  "id",
+  "surface",
+  "repository",
+  "candidateTypes",
+  "decision",
+  "rationale",
+  "googleSupportedFeature",
+  "schemaSemanticFit",
+  "requiredVisibleEvidence",
+  "requiredProperties",
+  "forbiddenProperties",
+  "validation",
+  "rollback",
+]);
+const allowedDecisions = new Set([
+  "approved-existing-recheck-required",
+  "approved-conditional",
+  "deferred",
+  "rejected",
+]);
+const allowedSemanticFits = new Set(["direct", "conditional", "none"]);
+const requiredCiChecks = new Set([
+  "json-ld-parse",
+  "required-property-shape",
+  "stable-at-id",
+  "canonical-jsonld-url-agreement",
+  "visible-content-comparison",
+  "invalid-private-no-jsonld",
+  "host-isolation",
+  "safe-json-serialization",
+]);
+const requiredManualChecks = new Set([
+  "schema-org-validator",
+  "google-rich-results-test-for-supported-types",
+  "search-console-enhancement-report-when-available",
+  "deployed-raw-html-readback",
+]);
+const requiredReleaseBlockingFailures = new Set([
+  "malformed-json-ld",
+  "wrong-host-jsonld-url",
+  "jsonld-canonical-og-url-mismatch",
+  "hidden-or-fabricated-fact",
+  "invalid-private-or-noindex-page-jsonld",
+  "cross-dao-entity-contamination",
+  "unsafe-json-serialization",
+  "misleading-rich-result-type",
+  "build-date-as-content-date",
+  "unverified-same-as",
+  "dataset-without-contract",
+  "profile-without-privacy-policy",
+]);
+const requiredExplicitRejectionIds = new Set([
+  "proposal-as-news-article",
+  "faq-growth-strategy",
+  "ratings-reviews-fake-freshness",
+  "participant-profile-before-policy",
+]);
+const evidenceUrlPattern = /^https:\/\/github\.com\/ringecosystem\/.+/;
+
+function assertFields(object, fields, label) {
+  for (const field of fields) {
+    assert.ok(Object.hasOwn(object, field), `${label} missing ${field}`);
+  }
+}
+
+assert.equal(contract.version, 1);
+assert.equal(contract.ownerIssue, "https://github.com/ringecosystem/degov/issues/1028");
+assert.equal(contract.parentIssue, "https://github.com/ringecosystem/degov/issues/714");
+assert.equal(
+  contract.maintenance.contractPath,
+  "docs/spec/seo-geo-structured-data-contract.json"
+);
+assert.equal(contract.maintenance.localCheck, "pnpm run test:seo-geo-structured-data");
+assert.match(contract.maintenance.changeRule, /owner issue/);
+assert.match(contract.maintenance.changeRule, /visible-content evidence/);
+assert.match(contract.maintenance.changeRule, /rollback path/);
+
+for (const sourceKey of requiredSourceKeys) {
+  assert.match(contract.sourcePolicy[sourceKey], /^https:\/\//, `missing source ${sourceKey}`);
+}
+assert.match(contract.sourcePolicy.sourceUseRule, /Schema existence alone is not approval/);
+
+assertFields(contract.entityIdentity.publisher, requiredPublisherFields, "publisher");
+assert.equal(contract.entityIdentity.publisher.type, "Organization");
+assert.equal(contract.entityIdentity.publisher.stableAtId, "https://degov.ai/#organization");
+assert.equal(contract.entityIdentity.publisher.canonicalUrl, "https://degov.ai/");
+for (const surface of requiredSurfaces) {
+  assert.ok(
+    contract.entityIdentity.publisher.surfaces.includes(surface),
+    `publisher missing surface ${surface}`
+  );
+}
+assert.match(contract.entityIdentity.publisher.sameAsPolicy, /Only verified/);
+assert.equal(contract.entityIdentity.website.stableAtId, "https://degov.ai/#website");
+assert.equal(contract.entityIdentity.website.publisherAtId, "https://degov.ai/#organization");
+
+assertFields(contract.entityIdentity.daoEntityRule, requiredDaoRuleFields, "daoEntityRule");
+assert.equal(contract.entityIdentity.daoEntityRule.type, "Organization");
+assert.equal(contract.entityIdentity.daoEntityRule.stableAtIdPattern, "<dao.siteUrl>/#organization");
+assert.match(contract.entityIdentity.daoEntityRule.sameAsPolicy, /verified/);
+assert.match(contract.entityIdentity.daoEntityRule.hostIsolationRule, /Host header alone/);
+assert.match(contract.entityIdentity.daoEntityRule.visibleContentRule, /visible/);
+assert.match(contract.entityIdentity.urlAgreementRule, /HTML canonical, og:url, and sitemap URL/);
+assert.match(contract.entityIdentity.localeRule, /visible localized page content/);
+
+assert.equal(
+  contract.pageClassDecisions.length,
+  new Set(contract.pageClassDecisions.map((decision) => decision.id)).size,
+  "page-class decision IDs must be unique"
+);
+const decisionIds = new Set(contract.pageClassDecisions.map((decision) => decision.id));
+for (const decisionId of requiredDecisionIds) {
+  assert.ok(decisionIds.has(decisionId), `missing page-class decision ${decisionId}`);
+}
+
+for (const decision of contract.pageClassDecisions) {
+  assertFields(decision, requiredDecisionFields, decision.id);
+  assert.ok(requiredSurfaces.has(decision.surface), `${decision.id} surface`);
+  assert.ok(requiredRepositories.has(decision.repository), `${decision.id} repository`);
+  assert.ok(Array.isArray(decision.candidateTypes), `${decision.id} candidateTypes`);
+  assert.ok(decision.candidateTypes.length > 0, `${decision.id} candidateTypes`);
+  assert.ok(allowedDecisions.has(decision.decision), `${decision.id} decision`);
+  assert.ok(allowedSemanticFits.has(decision.schemaSemanticFit), `${decision.id} semantic fit`);
+  assert.ok(decision.rationale.length > 60, `${decision.id} rationale`);
+  assert.ok(decision.requiredVisibleEvidence.length > 0, `${decision.id} visible evidence`);
+  assert.ok(decision.requiredProperties.length > 0, `${decision.id} required properties`);
+  if (decision.decision.startsWith("approved")) {
+    assert.ok(decision.validation.includes("json-ld-parse"), `${decision.id} must parse JSON-LD`);
+  }
+  assert.ok(decision.rollback.length > 40, `${decision.id} rollback`);
+}
+
+for (const decisionId of approvedOrConditionalIds) {
+  const decision = contract.pageClassDecisions.find((item) => item.id === decisionId);
+  assert.ok(
+    decision.decision.startsWith("approved"),
+    `${decisionId} should be approved or conditionally approved`
+  );
+  assert.notEqual(decision.schemaSemanticFit, "none", `${decisionId} semantic fit`);
+  assert.ok(
+    decision.validation.includes("visible-content-comparison") ||
+      decision.validation.includes("breadcrumb-visible-content-comparison") ||
+      decision.validation.includes("visible-itemlist-comparison") ||
+      decision.validation.includes("proposal-visible-content-comparison"),
+    `${decisionId} needs visible-content validation`
+  );
+}
+
+for (const decisionId of deferredIds) {
+  const decision = contract.pageClassDecisions.find((item) => item.id === decisionId);
+  assert.equal(decision.decision, "deferred", `${decisionId} must remain deferred`);
+}
+
+const proposalDecision = contract.pageClassDecisions.find(
+  (decision) => decision.id === "dao.proposal-detail"
+);
+for (const forbiddenType of [
+  "Article",
+  "NewsArticle",
+  "Legislation",
+  "DiscussionForumPosting",
+]) {
+  assert.ok(
+    proposalDecision.forbiddenProperties.includes(forbiddenType),
+    `proposal detail must forbid ${forbiddenType}`
+  );
+}
+
+const datasetDecision = contract.pageClassDecisions.find(
+  (decision) => decision.id === "atlas.dataset"
+);
+for (const evidence of [
+  "visible license",
+  "visible creator/publisher",
+  "distribution or access method",
+  "provenance and data freshness",
+]) {
+  assert.ok(datasetDecision.requiredVisibleEvidence.includes(evidence));
+}
+assert.ok(datasetDecision.forbiddenProperties.includes("dataset-without-license"));
+assert.ok(datasetDecision.validation.includes("dataset-contract-link"));
+
+const profileDecision = contract.pageClassDecisions.find(
+  (decision) => decision.id === "atlas.participant-profile"
+);
+assert.ok(profileDecision.requiredVisibleEvidence.includes("privacy-safe public value"));
+assert.ok(profileDecision.validation.includes("privacy-review-link"));
+
+assert.equal(
+  contract.explicitRejections.length,
+  new Set(contract.explicitRejections.map((rejection) => rejection.id)).size,
+  "explicit rejection IDs must be unique"
+);
+const rejectionIds = new Set(contract.explicitRejections.map((rejection) => rejection.id));
+for (const rejectionId of requiredExplicitRejectionIds) {
+  assert.ok(rejectionIds.has(rejectionId), `missing explicit rejection ${rejectionId}`);
+}
+for (const rejection of contract.explicitRejections) {
+  assert.ok(rejection.rejectedTypes.length > 0, `${rejection.id} rejectedTypes`);
+  assert.ok(rejection.reason.length > 60, `${rejection.id} reason`);
+}
+
+for (const check of requiredCiChecks) {
+  assert.ok(contract.validationModel.ciChecks.includes(check), `missing CI check ${check}`);
+}
+for (const check of requiredManualChecks) {
+  assert.ok(contract.validationModel.manualChecks.includes(check), `missing manual check ${check}`);
+}
+for (const failure of requiredReleaseBlockingFailures) {
+  assert.ok(
+    contract.validationModel.releaseBlockingFailures.includes(failure),
+    `missing release-blocking failure ${failure}`
+  );
+}
+assert.ok(contract.validationModel.informationalOnly.includes("schema-count"));
+assert.ok(contract.validationModel.informationalOnly.includes("rich-result-not-shown"));
+assert.match(contract.validationModel.rollbackProcedure, /Remove or disable/);
+
+assert.equal(
+  contract.repositoryFollowUps.length,
+  new Set(contract.repositoryFollowUps.map((followUp) => followUp.repository)).size,
+  "repository follow-up entries must be unique by repository"
+);
+const followUpRepositories = new Set(
+  contract.repositoryFollowUps.map((followUp) => followUp.repository)
+);
+for (const repository of requiredRepositories) {
+  assert.ok(followUpRepositories.has(repository), `missing follow-up for ${repository}`);
+}
+for (const followUp of contract.repositoryFollowUps) {
+  assert.equal(followUp.status, "implementation-issue-required-after-contract");
+  assert.ok(followUp.approvedScopes.length > 0, `${followUp.repository} approved scopes`);
+  for (const scope of followUp.approvedScopes) {
+    assert.ok(decisionIds.has(scope), `${followUp.repository} unknown scope ${scope}`);
+  }
+  assert.ok(followUp.scope.length > 80, `${followUp.repository} follow-up scope`);
+}
+
+assert.equal(typeof contract.completionState.contractApproved, "boolean");
+assert.ok(Array.isArray(contract.completionState.contractApprovalEvidence));
+assert.equal(typeof contract.completionState.implementationIssuesLinked, "boolean");
+assert.ok(Array.isArray(contract.completionState.implementationIssueLinks));
+assert.equal(typeof contract.completionState.officialSiteRecheckComplete, "boolean");
+assert.ok(Array.isArray(contract.completionState.officialSiteRecheckEvidence));
+assert.equal(typeof contract.completionState.validatorEvidenceComplete, "boolean");
+assert.ok(Array.isArray(contract.completionState.validatorEvidenceRecords));
+assert.match(contract.completionState.closeIssueWhen, /official-site JSON-LD is rechecked/);
+assert.match(contract.completionState.closeIssueWhen, /#714 has the final evidence summary/);
+
+if (contract.completionState.contractApproved) {
+  assert.ok(
+    contract.completionState.contractApprovalEvidence.length > 0,
+    "contract approval requires evidence links"
+  );
+  for (const evidenceUrl of contract.completionState.contractApprovalEvidence) {
+    assert.match(evidenceUrl, evidenceUrlPattern);
+  }
+}
+
+if (contract.completionState.implementationIssuesLinked) {
+  assert.ok(
+    contract.completionState.implementationIssueLinks.length >= requiredRepositories.size,
+    "linked implementation state requires one link per repository"
+  );
+  const linkedRepositories = new Set(
+    contract.completionState.implementationIssueLinks.map((link) => link.repository)
+  );
+  for (const repository of requiredRepositories) {
+    assert.ok(linkedRepositories.has(repository), `missing implementation link for ${repository}`);
+  }
+  for (const link of contract.completionState.implementationIssueLinks) {
+    assert.match(link.url, evidenceUrlPattern, `${link.repository} link`);
+  }
+}
+
+if (contract.completionState.officialSiteRecheckComplete) {
+  assert.ok(
+    contract.completionState.officialSiteRecheckEvidence.length > 0,
+    "official-site recheck completion requires evidence"
+  );
+  for (const evidenceUrl of contract.completionState.officialSiteRecheckEvidence) {
+    assert.match(evidenceUrl, evidenceUrlPattern);
+  }
+}
+
+if (contract.completionState.validatorEvidenceComplete) {
+  assert.ok(
+    contract.completionState.validatorEvidenceRecords.length > 0,
+    "validator completion requires evidence records"
+  );
+  for (const evidence of contract.completionState.validatorEvidenceRecords) {
+    assert.ok(decisionIds.has(evidence.pageClassId), `unknown page class ${evidence.pageClassId}`);
+    assert.match(evidence.url, evidenceUrlPattern, `${evidence.pageClassId} evidence URL`);
+    assert.ok(evidence.validator.length > 0, `${evidence.pageClassId} validator`);
+    assert.equal(evidence.result, "pass", `${evidence.pageClassId} validator result`);
+  }
+}
+
+console.log(
+  `SEO/GEO structured-data contract ok: ${contract.pageClassDecisions.length} page classes, ${contract.explicitRejections.length} rejections, ${contract.repositoryFollowUps.length} repository follow-ups`
+);

--- a/scripts/check-seo-geo-structured-data.mjs
+++ b/scripts/check-seo-geo-structured-data.mjs
@@ -267,6 +267,11 @@ assert.ok(
   "publisher must not be a shared home.root Organization/WebSite requirement"
 );
 
+assert.ok(
+  proposalDecision.validation.includes("canonical-jsonld-url-agreement"),
+  "proposal JSON-LD must validate canonical URL agreement"
+);
+
 const atlasDaoDecision = contract.pageClassDecisions.find(
   (decision) => decision.id === "atlas.dao-detail"
 );


### PR DESCRIPTION
## Summary

Defines the cross-product SEO/GEO structured-data and entity-identity contract for #1028.

This PR adds a versioned contract covering:

- the stable DeGov publisher and WebSite `@id` contract
- DAO entity `@id`, canonical URL, host-isolation, and verified `sameAs` rules
- approve/defer/reject decisions for 10 candidate page classes across home, docs, Square, DAO sites, and Atlas
- explicit rejections for misleading proposal Article/Legislation mappings, FAQ growth tactics, fake ratings/reviews/freshness, and participant profile markup before privacy/index approval
- Dataset prerequisites for license, creator, distribution/access, provenance, and dataset landing page
- validation, release-blocking failure classes, rollback rules, and repository follow-up scopes
- completion-state guardrails so #1028 is not closed before follow-up issues and validator/readback evidence exist

## Validation

- pnpm install --filter @degov/web... --frozen-lockfile
- pnpm run test:seo-geo-structured-data
- pnpm run test:seo-geo-contract
- pnpm run test:seo-geo-observability
- pnpm run test:seo-geo-crawler-policy
- pnpm run test:seo-geo-social-preview
- pnpm run test:web-scripts
- pnpm --filter @degov/web build
- git diff --check

## Notes

This intentionally does not close #1028. Repository-specific implementation issues, official-site JSON-LD recheck evidence, and validator/readback evidence remain required follow-up work.
