### PR TITLE
Define SEO/GEO measurement contract

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,7 @@ jobs:
           pnpm run test:seo-geo-observability
           pnpm run test:seo-geo-content-provenance
           pnpm run test:seo-geo-crawler-policy
+          pnpm run test:seo-geo-measurement
           pnpm run test:seo-geo-social-preview
           pnpm run test:seo-geo-structured-data
           pnpm run test:web-scripts

--- a/docs/spec/seo-geo-measurement-contract.json
+++ b/docs/spec/seo-geo-measurement-contract.json
@@ -370,7 +370,7 @@
       ],
       "prohibitedSensitiveParameters": [
         "wallet_address",
-        "ens_name",
+        "ens_identity",
         "vote_choice",
         "token_balance",
         "voting_power",

--- a/docs/spec/seo-geo-measurement-contract.json
+++ b/docs/spec/seo-geo-measurement-contract.json
@@ -1,0 +1,564 @@
+{
+  "version": 1,
+  "ownerIssue": "https://github.com/ringecosystem/degov/issues/1031",
+  "parentIssue": "https://github.com/ringecosystem/degov/issues/714",
+  "updatedAt": "2026-08-04",
+  "maintenance": {
+    "ownerRepository": "ringecosystem/degov",
+    "contractPath": "docs/spec/seo-geo-measurement-contract.json",
+    "localCheck": "pnpm run test:seo-geo-measurement",
+    "changeRule": "A surface inventory, channel definition, attribution decision, event contract, sensitive-data boundary, baseline claim, report claim, or completion claim may change only with an owner issue, privacy review state, validation method, and #714-linked rationale.",
+    "closeIssueWhen": "The privacy-safe measurement contract is approved, current analytics tags and owners are mapped, consent/custom-domain gaps are recorded, repository-specific implementation issues are linked, test/debug evidence confirms event semantics and consent behavior, a reproducible qualified-conversion report is linked to #714, and no success claim relies only on sessions, tag presence, or event volume."
+  },
+  "sourcePolicy": {
+    "observabilityBaseline": "docs/spec/search-crawler-observability-baseline.json",
+    "contentProvenanceContract": "docs/spec/seo-geo-content-provenance-contract.json",
+    "socialPreviewContract": "docs/spec/seo-geo-social-preview-contract.json",
+    "sourceUseRule": "Measurement changes must use first-party product ownership, consent authority, and debug/readback evidence. Missing referrer data remains direct/unknown and must not be inferred as AI traffic."
+  },
+  "surfaceInventory": [
+    {
+      "id": "home",
+      "name": "DeGov official website",
+      "repository": "ringecosystem/degov-home",
+      "representativeHost": "degov.ai",
+      "analyticsTagState": "access-gap",
+      "ownerState": "owner-required",
+      "consentState": "approval-required",
+      "customDomainBoundary": "first-party-degov-domain",
+      "requiredMappingEvidence": [
+        "tag or no-tag readback",
+        "analytics property owner",
+        "consent behavior",
+        "retention policy"
+      ]
+    },
+    {
+      "id": "docs",
+      "name": "DeGov documentation",
+      "repository": "ringecosystem/degov-docs",
+      "representativeHost": "docs.degov.ai",
+      "analyticsTagState": "access-gap",
+      "ownerState": "owner-required",
+      "consentState": "approval-required",
+      "customDomainBoundary": "first-party-degov-domain",
+      "requiredMappingEvidence": [
+        "tag or no-tag readback",
+        "analytics property owner",
+        "consent behavior",
+        "retention policy"
+      ]
+    },
+    {
+      "id": "square",
+      "name": "DeGov Square",
+      "repository": "ringecosystem/degov-square",
+      "representativeHost": "square.degov.ai",
+      "analyticsTagState": "known-present-unverified",
+      "ownerState": "owner-required",
+      "consentState": "approval-required",
+      "customDomainBoundary": "first-party-degov-domain",
+      "requiredMappingEvidence": [
+        "current GA tag/property",
+        "analytics property owner",
+        "consent behavior",
+        "retention policy"
+      ]
+    },
+    {
+      "id": "dao-sites",
+      "name": "Individual DAO governance sites",
+      "repository": "ringecosystem/degov",
+      "representativeHost": "demo.degov.ai and representative registry DAO hosts",
+      "analyticsTagState": "known-present-unverified",
+      "ownerState": "dao-owner-boundary-required",
+      "consentState": "approval-required",
+      "customDomainBoundary": "custom DAO domains may have separate ownership and consent authority",
+      "requiredMappingEvidence": [
+        "representative registry GA tag configuration",
+        "custom-domain owner boundary",
+        "consent behavior",
+        "retention policy"
+      ]
+    },
+    {
+      "id": "atlas",
+      "name": "DeGov Atlas",
+      "repository": "ringecosystem/degov-agent-api",
+      "representativeHost": "atlas.degov.ai",
+      "analyticsTagState": "access-gap",
+      "ownerState": "owner-required",
+      "consentState": "approval-required",
+      "customDomainBoundary": "first-party-degov-domain",
+      "requiredMappingEvidence": [
+        "tag or no-tag readback",
+        "analytics property owner",
+        "consent behavior",
+        "retention policy"
+      ]
+    }
+  ],
+  "channelDefinitions": [
+    {
+      "id": "organic-search",
+      "name": "Organic search",
+      "classificationRule": "Referrer or analytics source is a recognized non-paid search engine and no paid campaign marker is present.",
+      "allowedExamples": [
+        "google organic",
+        "bing organic"
+      ],
+      "forbiddenInference": "Do not classify answer-engine or direct traffic as organic search without observable source evidence."
+    },
+    {
+      "id": "paid-search",
+      "name": "Paid search",
+      "classificationRule": "Paid campaign parameters or ad platform source identify paid search, if this channel is ever used.",
+      "allowedExamples": [
+        "utm_medium=cpc"
+      ],
+      "forbiddenInference": "Do not infer paid search from search-engine referrers without campaign evidence."
+    },
+    {
+      "id": "social-organic",
+      "name": "Social organic",
+      "classificationRule": "Referrer or campaign source identifies a social platform and no paid campaign marker is present.",
+      "allowedExamples": [
+        "x.com",
+        "linkedin.com",
+        "discord.com",
+        "telegram.org"
+      ],
+      "forbiddenInference": "Do not treat all chat or messenger traffic as social when the referrer is absent."
+    },
+    {
+      "id": "direct-unknown",
+      "name": "Direct or referrer unknown",
+      "classificationRule": "No reliable referrer, campaign, or source evidence is available.",
+      "allowedExamples": [
+        "typed URL",
+        "missing referrer",
+        "privacy-stripped source"
+      ],
+      "forbiddenInference": "Do not infer that direct/unknown traffic came from AI search, social, or dark social."
+    },
+    {
+      "id": "documentation-referral",
+      "name": "Documentation referral",
+      "classificationRule": "A DeGov Docs page links to another DeGov product and the referral is preserved.",
+      "allowedExamples": [
+        "docs.degov.ai to a DAO site",
+        "docs.degov.ai to Square"
+      ],
+      "forbiddenInference": "Do not overwrite the original acquisition source when cross-domain attribution preserves it."
+    },
+    {
+      "id": "cross-product-degov-referral",
+      "name": "Cross-product DeGov referral",
+      "classificationRule": "A first-party DeGov product links to another DeGov product after the original acquisition source is known or safely preserved.",
+      "allowedExamples": [
+        "degov.ai to docs.degov.ai",
+        "square.degov.ai to DAO site",
+        "atlas.degov.ai to DAO site"
+      ],
+      "forbiddenInference": "Referral exclusion must not erase the original acquisition source."
+    },
+    {
+      "id": "ai-search-assistant-referral",
+      "name": "AI/search-assistant referral",
+      "classificationRule": "A real observable referrer or campaign source identifies an AI answer, search assistant, or citation surface.",
+      "allowedExamples": [
+        "perplexity.ai",
+        "chatgpt.com when present as an observable referrer",
+        "copilot.microsoft.com when present as an observable referrer"
+      ],
+      "forbiddenInference": "Missing referrer data remains direct/unknown; do not infer AI traffic from landing page, timing, or user agent alone."
+    },
+    {
+      "id": "other-external-referral",
+      "name": "Other external referral",
+      "classificationRule": "A non-DeGov external referrer exists but does not match approved search, paid, social, docs, cross-product, or AI/search-assistant rules.",
+      "allowedExamples": [
+        "third-party article",
+        "partner website"
+      ],
+      "forbiddenInference": "Do not reclassify external referrals into campaign channels without source evidence."
+    }
+  ],
+  "candidateJourneys": [
+    {
+      "id": "home-to-product-engagement",
+      "surface": "home",
+      "decision": "approved-contract",
+      "userAction": "Official-site landing followed by Docs, Square, Atlas, pricing, or product engagement.",
+      "conversionValue": "qualified product navigation",
+      "privacyNotes": "No wallet, address, or authentication state is required."
+    },
+    {
+      "id": "docs-meaningful-navigation",
+      "surface": "docs",
+      "decision": "approved-contract",
+      "userAction": "Organic docs landing followed by meaningful documentation navigation or integration action.",
+      "conversionValue": "qualified documentation use",
+      "privacyNotes": "No private DAO, draft, wallet, or user profile data may be attached."
+    },
+    {
+      "id": "square-to-dao-discovery",
+      "surface": "square",
+      "decision": "approved-contract",
+      "userAction": "Square directory discovery followed by canonical DAO-site visit.",
+      "conversionValue": "DAO discovery click",
+      "privacyNotes": "DAO identity and target URL are allowed only when already public and canonical."
+    },
+    {
+      "id": "dao-proposal-read",
+      "surface": "dao-sites",
+      "decision": "approved-contract",
+      "userAction": "Organic, social, or AI landing on a DAO page followed by proposal directory or proposal read.",
+      "conversionValue": "proposal read",
+      "privacyNotes": "Do not include vote choice, wallet address, token balance, or proposal draft data."
+    },
+    {
+      "id": "proposal-to-governance-action",
+      "surface": "dao-sites",
+      "decision": "approved-conditional",
+      "userAction": "Proposal read followed by wallet connect or governance action intent.",
+      "conversionValue": "privacy-safe governance action intent",
+      "privacyNotes": "Measure only approved non-sensitive intent. Vote choice and wallet identity are prohibited unless separately approved and transformed for a lawful purpose."
+    },
+    {
+      "id": "atlas-to-source-navigation",
+      "surface": "atlas",
+      "decision": "approved-contract",
+      "userAction": "Atlas DAO or analysis page followed by canonical DAO site, source, proposal, or methodology click.",
+      "conversionValue": "source navigation",
+      "privacyNotes": "Do not profile private participants or include wallet/person identity."
+    },
+    {
+      "id": "ai-social-engaged-visit",
+      "surface": "cross-product",
+      "decision": "approved-contract",
+      "userAction": "AI/search-assistant or social referral followed by engaged visit or useful source navigation.",
+      "conversionValue": "qualified referred engagement",
+      "privacyNotes": "AI source classification requires observable referrer or campaign evidence."
+    }
+  ],
+  "crossDomainAttribution": {
+    "journeyDomains": [
+      "degov.ai",
+      "docs.degov.ai",
+      "square.degov.ai",
+      "atlas.degov.ai",
+      "representative DAO hosts from validated registry configuration"
+    ],
+    "propertyDecision": "Separate product properties or a shared property may be used only after owner and consent authority are recorded for each participating surface.",
+    "linkerDecision": "Cross-domain linker/session behavior is allowed only when lawful, technically appropriate, and approved by each product or DAO-domain owner.",
+    "referralExclusionDecision": "Referral exclusions may suppress self-referrals only when they preserve the original acquisition source and do not turn unknown traffic into a claimed channel.",
+    "customDaoDomainDecision": "Custom DAO domains remain separate ownership boundaries until explicit owner, consent, and retention authority are recorded.",
+    "optOutDecision": "Opt-out or consent state must not be silently propagated across products unless the ownership and consent basis are approved.",
+    "deduplicationDecision": "Conversions require deterministic event IDs or session-scoped dedupe rules before aggregation."
+  },
+  "eventContracts": [
+    {
+      "name": "degov_product_navigation",
+      "product": "home",
+      "userAction": "Click from official site to Docs, Square, Atlas, pricing, or product page.",
+      "triggeringCondition": "Rendered link activation by a user.",
+      "allowedParameters": [
+        "source_surface",
+        "target_surface",
+        "target_path_class",
+        "channel_group",
+        "locale"
+      ],
+      "prohibitedSensitiveParameters": [
+        "wallet_address",
+        "auth_state",
+        "full_query_string"
+      ],
+      "conversionStatus": "qualified-navigation",
+      "deduplication": "session plus target_surface plus target_path_class",
+      "consentRequirement": "analytics consent or approved aggregate-only mode",
+      "owner": "official-site owner",
+      "retention": "requires approved retention policy",
+      "testProcedure": "Debug event readback confirms allowed parameters only and no sensitive URL payload."
+    },
+    {
+      "name": "degov_docs_navigation",
+      "product": "docs",
+      "userAction": "Navigate from a priority docs page to another meaningful docs page, live example, or integration action.",
+      "triggeringCondition": "Rendered docs link activation or approved integration action.",
+      "allowedParameters": [
+        "source_surface",
+        "topic_id",
+        "target_path_class",
+        "channel_group",
+        "locale"
+      ],
+      "prohibitedSensitiveParameters": [
+        "private_dao_id",
+        "wallet_address",
+        "proposal_draft"
+      ],
+      "conversionStatus": "qualified-docs-use",
+      "deduplication": "session plus topic_id plus target_path_class",
+      "consentRequirement": "analytics consent or approved aggregate-only mode",
+      "owner": "docs owner",
+      "retention": "requires approved retention policy",
+      "testProcedure": "Debug event readback confirms topic mapping and no private payload."
+    },
+    {
+      "name": "degov_square_dao_click",
+      "product": "square",
+      "userAction": "Click from Square directory to a canonical DAO governance site.",
+      "triggeringCondition": "Rendered canonical DAO link activation.",
+      "allowedParameters": [
+        "source_surface",
+        "dao_slug_or_public_id",
+        "target_host_class",
+        "channel_group"
+      ],
+      "prohibitedSensitiveParameters": [
+        "wallet_address",
+        "user_profile",
+        "notification_destination"
+      ],
+      "conversionStatus": "dao-discovery",
+      "deduplication": "session plus dao_slug_or_public_id",
+      "consentRequirement": "analytics consent or approved aggregate-only mode",
+      "owner": "square owner",
+      "retention": "requires approved retention policy",
+      "testProcedure": "Debug event readback confirms canonical target and public DAO identifier only."
+    },
+    {
+      "name": "degov_proposal_read",
+      "product": "dao-sites",
+      "userAction": "View a public proposal detail page after landing or proposal-list navigation.",
+      "triggeringCondition": "Public proposal detail route renders successfully.",
+      "allowedParameters": [
+        "source_surface",
+        "dao_slug_or_public_id",
+        "proposal_public_id",
+        "channel_group",
+        "route_locale"
+      ],
+      "prohibitedSensitiveParameters": [
+        "wallet_address",
+        "vote_choice",
+        "token_balance",
+        "voting_power",
+        "proposal_draft",
+        "auth_state"
+      ],
+      "conversionStatus": "proposal-read",
+      "deduplication": "session plus dao_slug_or_public_id plus proposal_public_id",
+      "consentRequirement": "analytics consent or approved aggregate-only mode",
+      "owner": "dao-site owner",
+      "retention": "requires approved retention policy and DAO-domain owner boundary",
+      "testProcedure": "Debug event readback confirms public IDs only and no wallet/governance-sensitive payload."
+    },
+    {
+      "name": "degov_governance_action_intent",
+      "product": "dao-sites",
+      "userAction": "Privacy-safe wallet connect or governance action intent after proposal read.",
+      "triggeringCondition": "Approved intent action occurs after consent and without recording outcome details.",
+      "allowedParameters": [
+        "source_surface",
+        "dao_slug_or_public_id",
+        "proposal_public_id",
+        "action_type",
+        "channel_group"
+      ],
+      "prohibitedSensitiveParameters": [
+        "wallet_address",
+        "ens_name",
+        "vote_choice",
+        "token_balance",
+        "voting_power",
+        "signature",
+        "auth_token"
+      ],
+      "conversionStatus": "conditional-conversion",
+      "deduplication": "session plus dao_slug_or_public_id plus proposal_public_id plus action_type",
+      "consentRequirement": "explicit analytics consent and owner approval required",
+      "owner": "dao-site owner",
+      "retention": "requires approved retention policy and privacy review",
+      "testProcedure": "Debug event readback confirms no wallet identity, no vote choice, and consent gating."
+    },
+    {
+      "name": "degov_atlas_source_click",
+      "product": "atlas",
+      "userAction": "Click from Atlas to a canonical DAO site, source, proposal, or methodology page.",
+      "triggeringCondition": "Rendered source or canonical link activation.",
+      "allowedParameters": [
+        "source_surface",
+        "target_type",
+        "dao_slug_or_public_id",
+        "channel_group"
+      ],
+      "prohibitedSensitiveParameters": [
+        "wallet_address",
+        "participant_profile",
+        "private_profile_state"
+      ],
+      "conversionStatus": "source-navigation",
+      "deduplication": "session plus target_type plus dao_slug_or_public_id",
+      "consentRequirement": "analytics consent or approved aggregate-only mode",
+      "owner": "atlas owner",
+      "retention": "requires approved retention policy",
+      "testProcedure": "Debug event readback confirms target classification and no participant profiling."
+    },
+    {
+      "name": "degov_referred_engaged_visit",
+      "product": "cross-product",
+      "userAction": "AI/search-assistant, social, or organic referred visit reaches an approved engaged-state threshold.",
+      "triggeringCondition": "Observable source channel plus approved engagement threshold.",
+      "allowedParameters": [
+        "landing_surface",
+        "channel_group",
+        "referrer_class",
+        "engagement_class",
+        "locale"
+      ],
+      "prohibitedSensitiveParameters": [
+        "full_referrer_url_with_sensitive_query",
+        "wallet_address",
+        "auth_state",
+        "private_query"
+      ],
+      "conversionStatus": "qualified-engagement",
+      "deduplication": "session plus landing_surface plus channel_group",
+      "consentRequirement": "analytics consent or approved aggregate-only mode",
+      "owner": "analytics owner",
+      "retention": "requires approved retention policy",
+      "testProcedure": "Debug event readback confirms direct/unknown is not reclassified as AI and query strings are stripped."
+    }
+  ],
+  "sensitiveExclusions": [
+    "wallet_address",
+    "ens_identity",
+    "vote_choice",
+    "token_balance",
+    "voting_power_linked_to_person",
+    "proposal_draft",
+    "unpublished_proposal_text",
+    "authentication_session_token",
+    "oauth_state",
+    "oauth_code",
+    "email",
+    "notification_destination",
+    "private_profile_value",
+    "settings_value",
+    "full_query_string_with_sensitive_values"
+  ],
+  "baselinePlan": {
+    "requiredBeforeInstrumentation": true,
+    "requiredInputs": [
+      "current analytics tags and properties by surface",
+      "current consent behavior by surface",
+      "current organic social referral channel definitions",
+      "cross-domain self-referral examples",
+      "missing or duplicate event observations",
+      "dated baseline owner"
+    ],
+    "storageRule": "Save the dated baseline in an approved issue, repository artifact, or measurement workspace before instrumentation changes.",
+    "analysisRule": "Compare event semantics, consent behavior, attribution preservation, and conversion quality. Do not treat total sessions, tag presence, or event volume as the success condition."
+  },
+  "repositoryFollowUps": [
+    {
+      "repository": "ringecosystem/degov-home",
+      "surface": "home",
+      "scope": "Map current official-site analytics/consent state and implement approved product-navigation events only after owner and retention approval.",
+      "issueRequired": true,
+      "blocksClose": true
+    },
+    {
+      "repository": "ringecosystem/degov-docs",
+      "surface": "docs",
+      "scope": "Map docs analytics/consent state and implement approved meaningful-navigation events only after owner and retention approval.",
+      "issueRequired": true,
+      "blocksClose": true
+    },
+    {
+      "repository": "ringecosystem/degov-square",
+      "surface": "square",
+      "scope": "Verify current GA property ownership and implement approved Square-to-DAO discovery events without private payloads.",
+      "issueRequired": true,
+      "blocksClose": true
+    },
+    {
+      "repository": "ringecosystem/degov",
+      "surface": "dao-sites",
+      "scope": "Map registry DAO tag configuration, custom-domain ownership, consent behavior, and implement approved proposal-read or action-intent events without wallet/vote payloads.",
+      "issueRequired": true,
+      "blocksClose": true
+    },
+    {
+      "repository": "ringecosystem/degov-agent-api",
+      "surface": "atlas",
+      "scope": "Map Atlas analytics/consent state and implement approved source-navigation events without participant profiling.",
+      "issueRequired": true,
+      "blocksClose": true
+    }
+  ],
+  "reportContract": {
+    "qualifiedConversionDimensions": [
+      "landing_surface",
+      "channel_group",
+      "journey_id",
+      "conversion_status",
+      "consent_mode",
+      "owner_scope"
+    ],
+    "requiredReportEvidence": [
+      "event contract version",
+      "baseline date",
+      "rollout date",
+      "debug/readback evidence",
+      "known coverage gaps",
+      "privacy review state"
+    ],
+    "forbiddenSuccessClaims": [
+      "tag installed",
+      "total sessions increased",
+      "event volume increased",
+      "direct traffic assumed to be AI",
+      "wallet/vote data used as conversion proof"
+    ]
+  },
+  "validation": {
+    "ciChecks": [
+      "contract-json-parse",
+      "surface-inventory-coverage",
+      "channel-definition-coverage",
+      "candidate-journey-coverage",
+      "cross-domain-attribution-decisions",
+      "event-contract-completeness",
+      "sensitive-exclusion-coverage",
+      "baseline-plan-required",
+      "follow-up-blockers",
+      "report-contract-no-volume-only-success"
+    ],
+    "manualChecks": [
+      "analytics-tag-readback",
+      "consent-debug-readback",
+      "event-debug-mode-readback",
+      "cross-domain-attribution-test",
+      "sensitive-payload-inspection",
+      "qualified-conversion-report-readback"
+    ],
+    "releaseBlockingFailures": [
+      "wallet-address-in-event",
+      "vote-choice-in-event",
+      "token-balance-or-voting-power-in-event",
+      "auth-token-or-oauth-secret-in-event",
+      "private-profile-or-settings-in-event",
+      "full-sensitive-query-string-in-event",
+      "direct-unknown-inferred-as-ai",
+      "cross-domain-self-referral-erases-source",
+      "custom-dao-domain-measured-without-owner-approval",
+      "instrumentation-before-baseline",
+      "success-claim-based-only-on-sessions-tags-or-volume"
+    ],
+    "rollback": "Disable or revert the affected instrumentation if consent behavior, owner authority, event semantics, attribution preservation, or sensitive-payload exclusion cannot be proven. Keep the baseline record and #714 rationale intact."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/runtime-packaging.test.mjs && node apps/indexer/scripts/staging-deployment-contract.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs && node apps/indexer/scripts/v4-parity-audit.test.mjs && node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs",
     "test:seo-geo-content-provenance": "node scripts/check-seo-geo-content-provenance.mjs",
     "test:seo-geo-crawler-policy": "node scripts/check-seo-geo-crawler-policy.mjs",
+    "test:seo-geo-measurement": "node scripts/check-seo-geo-measurement.mjs",
     "test:seo-geo-observability": "node scripts/check-seo-geo-observability.mjs",
     "test:seo-geo-social-preview": "node scripts/check-seo-geo-social-preview.mjs",
     "test:seo-geo-structured-data": "node scripts/check-seo-geo-structured-data.mjs",

--- a/scripts/check-seo-geo-measurement.mjs
+++ b/scripts/check-seo-geo-measurement.mjs
@@ -245,9 +245,12 @@ const serializedEvents = JSON.stringify(contract.eventContracts);
 for (const sensitiveValue of ["wallet_address", "vote_choice", "auth_token"]) {
   assert.match(serializedEvents, new RegExp(sensitiveValue), `missing event exclusion ${sensitiveValue}`);
 }
+const referredEngagedVisitEvent = contract.eventContracts.find(
+  (event) => event.name === "degov_referred_engaged_visit"
+);
+assert.ok(referredEngagedVisitEvent, "missing degov_referred_engaged_visit event");
 assert.match(
-  contract.eventContracts.find((event) => event.name === "degov_referred_engaged_visit")
-    .testProcedure,
+  referredEngagedVisitEvent.testProcedure,
   /direct\/unknown is not reclassified as AI/
 );
 

--- a/scripts/check-seo-geo-measurement.mjs
+++ b/scripts/check-seo-geo-measurement.mjs
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const contractPath = path.join(rootDir, "docs/spec/seo-geo-measurement-contract.json");
+const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+
+const requiredSurfaces = new Set(["home", "docs", "square", "dao-sites", "atlas"]);
+const requiredRepositories = new Set([
+  "ringecosystem/degov",
+  "ringecosystem/degov-agent-api",
+  "ringecosystem/degov-docs",
+  "ringecosystem/degov-home",
+  "ringecosystem/degov-square",
+]);
+const requiredChannels = new Set([
+  "organic-search",
+  "paid-search",
+  "social-organic",
+  "direct-unknown",
+  "documentation-referral",
+  "cross-product-degov-referral",
+  "ai-search-assistant-referral",
+  "other-external-referral",
+]);
+const requiredJourneys = new Set([
+  "home-to-product-engagement",
+  "docs-meaningful-navigation",
+  "square-to-dao-discovery",
+  "dao-proposal-read",
+  "proposal-to-governance-action",
+  "atlas-to-source-navigation",
+  "ai-social-engaged-visit",
+]);
+const requiredEventFields = new Set([
+  "name",
+  "product",
+  "userAction",
+  "triggeringCondition",
+  "allowedParameters",
+  "prohibitedSensitiveParameters",
+  "conversionStatus",
+  "deduplication",
+  "consentRequirement",
+  "owner",
+  "retention",
+  "testProcedure",
+]);
+const requiredSensitiveExclusions = new Set([
+  "wallet_address",
+  "ens_identity",
+  "vote_choice",
+  "token_balance",
+  "voting_power_linked_to_person",
+  "proposal_draft",
+  "unpublished_proposal_text",
+  "authentication_session_token",
+  "oauth_state",
+  "oauth_code",
+  "email",
+  "notification_destination",
+  "private_profile_value",
+  "settings_value",
+  "full_query_string_with_sensitive_values",
+]);
+const requiredBaselineInputs = new Set([
+  "current analytics tags and properties by surface",
+  "current consent behavior by surface",
+  "current organic social referral channel definitions",
+  "cross-domain self-referral examples",
+  "missing or duplicate event observations",
+  "dated baseline owner",
+]);
+const requiredCiChecks = new Set([
+  "contract-json-parse",
+  "surface-inventory-coverage",
+  "channel-definition-coverage",
+  "candidate-journey-coverage",
+  "cross-domain-attribution-decisions",
+  "event-contract-completeness",
+  "sensitive-exclusion-coverage",
+  "baseline-plan-required",
+  "follow-up-blockers",
+  "report-contract-no-volume-only-success",
+]);
+const requiredManualChecks = new Set([
+  "analytics-tag-readback",
+  "consent-debug-readback",
+  "event-debug-mode-readback",
+  "cross-domain-attribution-test",
+  "sensitive-payload-inspection",
+  "qualified-conversion-report-readback",
+]);
+const requiredReleaseBlockingFailures = new Set([
+  "wallet-address-in-event",
+  "vote-choice-in-event",
+  "token-balance-or-voting-power-in-event",
+  "auth-token-or-oauth-secret-in-event",
+  "private-profile-or-settings-in-event",
+  "full-sensitive-query-string-in-event",
+  "direct-unknown-inferred-as-ai",
+  "cross-domain-self-referral-erases-source",
+  "custom-dao-domain-measured-without-owner-approval",
+  "instrumentation-before-baseline",
+  "success-claim-based-only-on-sessions-tags-or-volume",
+]);
+const requiredReportDimensions = new Set([
+  "landing_surface",
+  "channel_group",
+  "journey_id",
+  "conversion_status",
+  "consent_mode",
+  "owner_scope",
+]);
+const requiredTopLevelArrays = new Set([
+  "surfaceInventory",
+  "channelDefinitions",
+  "candidateJourneys",
+  "eventContracts",
+  "sensitiveExclusions",
+  "repositoryFollowUps",
+]);
+const requiredTopLevelObjects = new Set([
+  "maintenance",
+  "sourcePolicy",
+  "crossDomainAttribution",
+  "baselinePlan",
+  "reportContract",
+  "validation",
+]);
+
+function assertArray(value, label) {
+  assert.ok(Array.isArray(value), `${label} must be an array`);
+}
+
+function assertPlainObject(value, label) {
+  assert.equal(typeof value, "object", `${label} must be an object`);
+  assert.notEqual(value, null, `${label} must be an object`);
+  assert.ok(!Array.isArray(value), `${label} must be an object`);
+}
+
+function assertFields(object, fields, label) {
+  for (const field of fields) {
+    assert.ok(Object.hasOwn(object, field), `${label} missing ${field}`);
+  }
+}
+
+function assertUnique(items, key, label) {
+  assert.equal(
+    items.length,
+    new Set(items.map((item) => item[key])).size,
+    `${label} must have unique ${key}`
+  );
+}
+
+assert.equal(contract.version, 1);
+assert.equal(contract.ownerIssue, "https://github.com/ringecosystem/degov/issues/1031");
+assert.equal(contract.parentIssue, "https://github.com/ringecosystem/degov/issues/714");
+for (const field of requiredTopLevelArrays) {
+  assertArray(contract[field], field);
+}
+for (const field of requiredTopLevelObjects) {
+  assertPlainObject(contract[field], field);
+}
+assert.equal(contract.maintenance.contractPath, "docs/spec/seo-geo-measurement-contract.json");
+assert.equal(contract.maintenance.localCheck, "pnpm run test:seo-geo-measurement");
+assert.match(contract.maintenance.changeRule, /privacy review state/);
+assert.match(contract.maintenance.closeIssueWhen, /qualified-conversion report/);
+assert.match(contract.sourcePolicy.sourceUseRule, /Missing referrer data remains direct\/unknown/);
+
+assertUnique(contract.surfaceInventory, "id", "surface inventory");
+const surfaceIds = new Set(contract.surfaceInventory.map((surface) => surface.id));
+for (const surface of requiredSurfaces) {
+  assert.ok(surfaceIds.has(surface), `missing surface ${surface}`);
+}
+for (const surface of contract.surfaceInventory) {
+  assert.ok(requiredRepositories.has(surface.repository), `${surface.id} repository`);
+  assert.match(surface.representativeHost, /degov\.ai|DAO hosts/);
+  assert.ok(surface.requiredMappingEvidence.includes("consent behavior"), `${surface.id} consent`);
+  assert.ok(surface.requiredMappingEvidence.includes("retention policy"), `${surface.id} retention`);
+}
+
+assertUnique(contract.channelDefinitions, "id", "channel definitions");
+const channelIds = new Set(contract.channelDefinitions.map((channel) => channel.id));
+for (const channel of requiredChannels) {
+  assert.ok(channelIds.has(channel), `missing channel ${channel}`);
+}
+for (const channel of contract.channelDefinitions) {
+  assert.ok(channel.classificationRule.length > 50, `${channel.id} rule`);
+  assert.ok(channel.allowedExamples.length > 0, `${channel.id} examples`);
+  assert.ok(channel.forbiddenInference.length > 40, `${channel.id} forbidden inference`);
+}
+assert.match(
+  contract.channelDefinitions.find((channel) => channel.id === "direct-unknown").forbiddenInference,
+  /Do not infer/
+);
+assert.match(
+  contract.channelDefinitions.find((channel) => channel.id === "ai-search-assistant-referral")
+    .forbiddenInference,
+  /Missing referrer data remains direct\/unknown/
+);
+
+assertUnique(contract.candidateJourneys, "id", "candidate journeys");
+const journeyIds = new Set(contract.candidateJourneys.map((journey) => journey.id));
+for (const journey of requiredJourneys) {
+  assert.ok(journeyIds.has(journey), `missing journey ${journey}`);
+}
+for (const journey of contract.candidateJourneys) {
+  assert.ok(
+    requiredSurfaces.has(journey.surface) || journey.surface === "cross-product",
+    `${journey.id} surface`
+  );
+  assert.ok(journey.decision.startsWith("approved"), `${journey.id} decision`);
+  assert.ok(journey.userAction.length > 50, `${journey.id} action`);
+  assert.ok(journey.privacyNotes.length > 50, `${journey.id} privacy notes`);
+}
+
+for (const decision of [
+  "journeyDomains",
+  "propertyDecision",
+  "linkerDecision",
+  "referralExclusionDecision",
+  "customDaoDomainDecision",
+  "optOutDecision",
+  "deduplicationDecision",
+]) {
+  assert.ok(Object.hasOwn(contract.crossDomainAttribution, decision), `missing ${decision}`);
+}
+assert.match(contract.crossDomainAttribution.referralExclusionDecision, /preserve the original acquisition source/);
+assert.match(contract.crossDomainAttribution.customDaoDomainDecision, /separate ownership boundaries/);
+
+assertUnique(contract.eventContracts, "name", "event contracts");
+assert.ok(contract.eventContracts.length >= requiredJourneys.size, "event contract coverage");
+for (const event of contract.eventContracts) {
+  assertFields(event, requiredEventFields, event.name);
+  assert.ok(event.allowedParameters.includes("channel_group"), `${event.name} channel_group`);
+  assert.ok(event.prohibitedSensitiveParameters.length > 0, `${event.name} prohibited parameters`);
+  assert.match(event.consentRequirement, /consent|approved/);
+  assert.match(event.retention, /retention/);
+  assert.match(event.testProcedure, /Debug event readback|Debug event/);
+}
+const serializedEvents = JSON.stringify(contract.eventContracts);
+for (const sensitiveValue of ["wallet_address", "vote_choice", "auth_token"]) {
+  assert.match(serializedEvents, new RegExp(sensitiveValue), `missing event exclusion ${sensitiveValue}`);
+}
+assert.match(
+  contract.eventContracts.find((event) => event.name === "degov_referred_engaged_visit")
+    .testProcedure,
+  /direct\/unknown is not reclassified as AI/
+);
+
+for (const exclusion of requiredSensitiveExclusions) {
+  assert.ok(contract.sensitiveExclusions.includes(exclusion), `missing exclusion ${exclusion}`);
+}
+
+assert.equal(contract.baselinePlan.requiredBeforeInstrumentation, true);
+for (const input of requiredBaselineInputs) {
+  assert.ok(contract.baselinePlan.requiredInputs.includes(input), `missing baseline input ${input}`);
+}
+assert.match(contract.baselinePlan.storageRule, /before instrumentation changes/);
+assert.match(contract.baselinePlan.analysisRule, /Do not treat total sessions/);
+
+assert.equal(contract.repositoryFollowUps.length, requiredSurfaces.size);
+for (const followUp of contract.repositoryFollowUps) {
+  assert.ok(requiredRepositories.has(followUp.repository), `${followUp.surface} repository`);
+  assert.ok(requiredSurfaces.has(followUp.surface), `${followUp.surface} surface`);
+  assert.equal(followUp.issueRequired, true, `${followUp.surface} issue`);
+  assert.equal(followUp.blocksClose, true, `${followUp.surface} close blocker`);
+  assert.match(followUp.scope, /consent|owner|privacy|payload|retention/);
+}
+
+for (const dimension of requiredReportDimensions) {
+  assert.ok(
+    contract.reportContract.qualifiedConversionDimensions.includes(dimension),
+    `missing report dimension ${dimension}`
+  );
+}
+assert.ok(
+  contract.reportContract.forbiddenSuccessClaims.includes("tag installed"),
+  "tag presence cannot be success"
+);
+assert.ok(
+  contract.reportContract.forbiddenSuccessClaims.includes("event volume increased"),
+  "event volume cannot be success"
+);
+assert.ok(
+  contract.reportContract.forbiddenSuccessClaims.includes("direct traffic assumed to be AI"),
+  "direct traffic cannot be assumed AI"
+);
+
+for (const check of requiredCiChecks) {
+  assert.ok(contract.validation.ciChecks.includes(check), `missing CI check ${check}`);
+}
+for (const check of requiredManualChecks) {
+  assert.ok(contract.validation.manualChecks.includes(check), `missing manual check ${check}`);
+}
+for (const failure of requiredReleaseBlockingFailures) {
+  assert.ok(
+    contract.validation.releaseBlockingFailures.includes(failure),
+    `missing release blocking failure ${failure}`
+  );
+}
+assert.match(contract.validation.rollback, /Disable or revert/);
+assert.match(contract.validation.rollback, /#714 rationale/);
+
+console.log(
+  `SEO/GEO measurement contract ok: ${contract.surfaceInventory.length} surfaces, ${contract.channelDefinitions.length} channels, ${contract.eventContracts.length} events`
+);


### PR DESCRIPTION
## Summary

Defines the cross-product privacy-safe organic, social, and AI conversion measurement contract for #1031.

This PR adds a versioned contract covering:

- surface inventory, analytics owner state, consent state, and custom-domain boundaries
- organic, paid, social, direct/unknown, docs, cross-product, AI/search-assistant, and other referral channel definitions
- candidate user journeys and privacy-safe event contracts
- sensitive data exclusions for wallet, vote, auth, OAuth, private profile/settings, and query payloads
- cross-domain attribution decisions, baseline requirements, repository follow-up gates, report constraints, validation, and rollback rules

## Validation

- pnpm run test:seo-geo-measurement
- pnpm run test:seo-geo-content-provenance
- pnpm run test:seo-geo-contract
- pnpm run test:seo-geo-observability
- pnpm run test:seo-geo-crawler-policy
- pnpm run test:seo-geo-social-preview
- pnpm run test:seo-geo-structured-data
- pnpm install --filter @degov/web... --frozen-lockfile
- pnpm run test:web-scripts
- pnpm --filter @degov/web build
- git diff --check

## Notes

This intentionally does not close #1031 yet. Live analytics/tag ownership mapping, consent/debug evidence, repository-specific implementation issues, and reproducible qualified-conversion reporting remain required follow-up work.