### PR TITLE
Add DAO homepage Organization JSON-LD

### DIFF
--- a/apps/web/scripts/dao-structured-data.test.ts
+++ b/apps/web/scripts/dao-structured-data.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildDaoOrganizationJsonLd } from "../src/lib/structured-data.ts";
+
+import type { Config } from "../src/types/config.ts";
+
+const config: Config = {
+  name: "Lisk DAO",
+  code: "lisk-dao",
+  logo: "https://lisk.degov.ai/logo.png",
+  siteUrl: "https://lisk.degov.ai",
+  description:
+    "Lisk DAO coordinates governance proposals, treasury decisions, and protocol upgrades.",
+  links: {
+    website: "https://lisk.com",
+    twitter: "https://x.com/LiskHQ",
+  },
+  wallet: { walletConnectProjectId: "abc" },
+  chain: {
+    id: 1135,
+    name: "Lisk",
+    logo: "https://lisk.degov.ai/chain.png",
+    rpcs: ["https://rpc.api.lisk.com"],
+    explorers: ["https://blockscout.lisk.com"],
+    nativeToken: {
+      symbol: "ETH",
+      decimals: 18,
+      priceId: "ethereum",
+    },
+  },
+  contracts: {
+    governor: "0x123",
+    governorToken: {
+      address: "0x456",
+      standard: "ERC20",
+    },
+  },
+  treasuryAssets: [],
+  indexer: {
+    endpoint: "https://indexer.degov.ai/lisk-dao/graphql",
+    startBlock: 1,
+  },
+};
+
+test("DAO Organization JSON-LD uses the validated DAO canonical origin", () => {
+  const jsonLd = buildDaoOrganizationJsonLd(config);
+  assert.ok(jsonLd);
+  const data = JSON.parse(jsonLd);
+
+  assert.deepEqual(data, {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": "https://lisk.degov.ai/#organization",
+    name: "Lisk DAO",
+    url: "https://lisk.degov.ai",
+    mainEntityOfPage: "https://lisk.degov.ai",
+    description:
+      "Lisk DAO coordinates governance proposals, treasury decisions, and protocol upgrades.",
+  });
+  assert.equal(data.sameAs, undefined, "unverified sameAs links must not be emitted");
+});
+
+test("DAO Organization JSON-LD is escaped and bounded", () => {
+  const jsonLd = buildDaoOrganizationJsonLd({
+    ...config,
+    name: "Example <DAO>",
+    description: `<b>${"Very long DAO description ".repeat(20)}</b>`,
+  });
+  assert.ok(jsonLd);
+  assert.ok(!jsonLd.includes("<"));
+
+  const data = JSON.parse(jsonLd);
+  assert.equal(data.name, "Example <DAO>");
+  assert.ok(data.description.length <= 220);
+  assert.ok(!data.description.includes("<b>"));
+});
+
+test("DAO Organization JSON-LD is omitted without a public HTTPS DAO origin", () => {
+  assert.equal(
+    buildDaoOrganizationJsonLd({ ...config, siteUrl: "http://lisk.degov.ai" }),
+    null
+  );
+  assert.equal(
+    buildDaoOrganizationJsonLd({ ...config, siteUrl: "https://localhost:3000" }),
+    null
+  );
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { buildHomeMetadata } from "@/lib/metadata";
+import { buildDaoOrganizationJsonLd } from "@/lib/structured-data";
 
 import { HomeClient } from "./_components/home-client";
 import { DaoPublicSummary } from "./_components/public-route-summary";
@@ -13,9 +14,16 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function HomePage() {
   const config = await getActiveDaoConfig();
+  const daoOrganizationJsonLd = buildDaoOrganizationJsonLd(config);
 
   return (
     <div className="flex flex-col gap-[20px] lg:gap-[30px]">
+      {daoOrganizationJsonLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: daoOrganizationJsonLd }}
+        />
+      ) : null}
       <DaoPublicSummary config={config} />
       <HomeClient />
     </div>

--- a/apps/web/src/lib/metadata-text.ts
+++ b/apps/web/src/lib/metadata-text.ts
@@ -1,0 +1,26 @@
+export function cleanMetadataText(value?: string | null): string {
+  if (!value) {
+    return "";
+  }
+
+  return value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/[`*_~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function truncateMetadataText(
+  value: string,
+  maxLength: number
+): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}

--- a/apps/web/src/lib/metadata.ts
+++ b/apps/web/src/lib/metadata.ts
@@ -1,5 +1,12 @@
 import type { Config } from "@/types/config";
 
+import { cleanMetadataText, truncateMetadataText } from "./metadata-text.ts";
+
+export {
+  cleanMetadataText,
+  truncateMetadataText,
+} from "./metadata-text.ts";
+
 import type { Metadata } from "next";
 
 const DEFAULT_SITE_URL = "https://localhost";
@@ -61,33 +68,6 @@ function shortenProposalId(proposalId: string): string {
   }
 
   return `${proposalId.slice(0, 8)}...${proposalId.slice(-6)}`;
-}
-
-export function cleanMetadataText(value?: string | null): string {
-  if (!value) {
-    return "";
-  }
-
-  return value
-    .replace(/<[^>]+>/g, " ")
-    .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/^#{1,6}\s+/gm, "")
-    .replace(/^>\s?/gm, "")
-    .replace(/[`*_~]/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-export function truncateMetadataText(
-  value: string,
-  maxLength: number
-): string {
-  if (value.length <= maxLength) {
-    return value;
-  }
-
-  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
 export function buildSiteMetadata(

--- a/apps/web/src/lib/structured-data.ts
+++ b/apps/web/src/lib/structured-data.ts
@@ -1,0 +1,46 @@
+import type { Config } from "@/types/config";
+
+import { cleanMetadataText, truncateMetadataText } from "./metadata-text.ts";
+
+const DESCRIPTION_MAX_LENGTH = 220;
+
+function getPublicSiteUrl(config: Config | null | undefined): string | null {
+  const value = config?.siteUrl?.trim();
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.hostname === "localhost") {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+export function buildDaoOrganizationJsonLd(
+  config: Config | null | undefined
+): string | null {
+  const siteUrl = getPublicSiteUrl(config);
+  if (!siteUrl || !config?.name) return null;
+
+  const description = truncateMetadataText(
+    cleanMetadataText(config.description),
+    DESCRIPTION_MAX_LENGTH
+  );
+
+  return safeJsonLd({
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": `${siteUrl}/#organization`,
+    name: config.name,
+    url: siteUrl,
+    mainEntityOfPage: siteUrl,
+    ...(description ? { description } : {}),
+  });
+}

--- a/apps/web/src/lib/structured-data.ts
+++ b/apps/web/src/lib/structured-data.ts
@@ -1,0 +1,64 @@
+import type { Config } from "@/types/config";
+
+const DESCRIPTION_MAX_LENGTH = 220;
+
+function cleanStructuredDataText(value?: string | null): string {
+  if (!value) return "";
+
+  return value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/[`*_~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncateStructuredDataText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function getPublicSiteUrl(config: Config | null | undefined): string | null {
+  const value = config?.siteUrl?.trim();
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.hostname === "localhost") {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+export function buildDaoOrganizationJsonLd(
+  config: Config | null | undefined
+): string | null {
+  const siteUrl = getPublicSiteUrl(config);
+  if (!siteUrl || !config?.name) return null;
+
+  const description = truncateStructuredDataText(
+    cleanStructuredDataText(config.description),
+    DESCRIPTION_MAX_LENGTH
+  );
+
+  return safeJsonLd({
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": `${siteUrl}/#organization`,
+    name: config.name,
+    url: siteUrl,
+    mainEntityOfPage: siteUrl,
+    ...(description ? { description } : {}),
+  });
+}


### PR DESCRIPTION
## Summary

- Add host-isolated DAO homepage `Organization` JSON-LD for public DAO sites.
- Keep the JSON-LD limited to visible, stable fields: `@id`, name, URL, mainEntityOfPage, and cleaned description.
- Omit unverified `sameAs` links and omit JSON-LD entirely when the DAO config lacks a public HTTPS `siteUrl`.
- Cover canonical origin isolation, escaping, and bounded description behavior in web-script tests.

## Issue

Part of ringecosystem/degov#1028 and umbrella ringecosystem/degov#714.

## Verification

- `pnpm install --filter @degov/web... --frozen-lockfile`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-structured-data`
- `pnpm --filter @degov/web build`
- `git diff --check`

## Notes

This implements the approved `dao.home` Organization mapping only. Proposal detail CreativeWork/WebPage markup remains deferred until a separate bounded implementation can prove visible proposal/source alignment without misclassification.
