### PR TITLE
Expose DAO homepage provenance facts

### DIFF
--- a/apps/web/scripts/dao-content-provenance.test.ts
+++ b/apps/web/scripts/dao-content-provenance.test.ts
@@ -81,7 +81,7 @@ test("DAO homepage provenance facts expose canonical registry and contract sourc
 test("DAO homepage provenance facts reject non-http external links", () => {
   const facts = buildDaoPublicSummaryFacts({
     ...liskConfig,
-    siteUrl: "javascript:alert(1)",
+    siteUrl: " https://user:password@lisk.degov.ai ",
     links: { website: "data:text/html,phish" },
     offChainDiscussionUrl: "mailto:security@example.com",
     editLink: "/relative",
@@ -99,4 +99,13 @@ test("DAO homepage provenance facts reject non-http external links", () => {
   assert.equal(facts.contracts.governor.url, null);
   assert.equal(facts.contracts.governanceToken.url, null);
   assert.equal(facts.contracts.timelock?.url, null);
+});
+
+test("DAO homepage provenance facts trim safe URLs", () => {
+  const facts = buildDaoPublicSummaryFacts({
+    ...liskConfig,
+    links: { website: " https://lisk.com/docs " },
+  });
+
+  assert.equal(facts.officialWebsiteUrl, "https://lisk.com/docs");
 });

--- a/apps/web/scripts/dao-content-provenance.test.ts
+++ b/apps/web/scripts/dao-content-provenance.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildDaoPublicSummaryFacts } from "../src/lib/dao-public-summary.ts";
+
+import type { Config } from "../src/types/config.ts";
+
+const liskConfig: Config = {
+  name: "Lisk",
+  code: "lisk-dao",
+  logo: "https://lisk.degov.ai/logo.png",
+  siteUrl: "https://lisk.degov.ai",
+  offChainDiscussionUrl: "https://forum.lisk.com",
+  editLink: "https://github.com/ringecosystem/degov-registry/blob/main/daos/lisk-dao.yml",
+  description: "A purpose built L2 for builders in high-growth markets.",
+  links: {
+    website: "https://lisk.com",
+  },
+  wallet: { walletConnectProjectId: "abc" },
+  chain: {
+    id: 1135,
+    name: "Lisk",
+    logo: "https://lisk.degov.ai/chain.png",
+    rpcs: ["https://rpc.api.lisk.com"],
+    explorers: ["https://blockscout.lisk.com"],
+    nativeToken: {
+      symbol: "ETH",
+      decimals: 18,
+      priceId: "ethereum",
+    },
+  },
+  contracts: {
+    governor: "0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568",
+    governorToken: {
+      address: "0x2eE6Eca46d2406454708a1C80356a6E63b57D404",
+      standard: "ERC20",
+    },
+    timeLock: "0x2294A7f24187B84995A2A28112f82f07BE1BceAD",
+  },
+  treasuryAssets: [],
+  indexer: {
+    endpoint: "https://indexer.degov.ai/lisk-dao/graphql",
+    startBlock: 568752,
+  },
+};
+
+test("DAO homepage provenance facts expose canonical registry and contract sources", () => {
+  const facts = buildDaoPublicSummaryFacts(liskConfig);
+
+  assert.equal(facts.canonicalSiteUrl, "https://lisk.degov.ai/");
+  assert.equal(facts.officialWebsiteUrl, "https://lisk.com/");
+  assert.equal(facts.discussionUrl, "https://forum.lisk.com/");
+  assert.equal(
+    facts.registrySourceUrl,
+    "https://github.com/ringecosystem/degov-registry/blob/main/daos/lisk-dao.yml"
+  );
+  assert.deepEqual(facts.chain, {
+    id: 1135,
+    name: "Lisk",
+    explorerUrl: "https://blockscout.lisk.com/",
+  });
+  assert.deepEqual(facts.contracts.governor, {
+    address: "0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568",
+    url: "https://blockscout.lisk.com/address/0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568",
+  });
+  assert.deepEqual(facts.contracts.governanceToken, {
+    address: "0x2eE6Eca46d2406454708a1C80356a6E63b57D404",
+    standard: "ERC20",
+    url: "https://blockscout.lisk.com/address/0x2eE6Eca46d2406454708a1C80356a6E63b57D404",
+  });
+  assert.deepEqual(facts.contracts.timelock, {
+    address: "0x2294A7f24187B84995A2A28112f82f07BE1BceAD",
+    url: "https://blockscout.lisk.com/address/0x2294A7f24187B84995A2A28112f82f07BE1BceAD",
+  });
+  assert.deepEqual(facts.indexer, {
+    endpoint: "https://indexer.degov.ai/lisk-dao/graphql",
+    startBlock: 568752,
+  });
+});
+
+test("DAO homepage provenance facts reject non-http external links", () => {
+  const facts = buildDaoPublicSummaryFacts({
+    ...liskConfig,
+    siteUrl: "javascript:alert(1)",
+    links: { website: "data:text/html,phish" },
+    offChainDiscussionUrl: "mailto:security@example.com",
+    editLink: "/relative",
+    chain: {
+      ...liskConfig.chain,
+      explorers: ["javascript:alert(1)"],
+    },
+  });
+
+  assert.equal(facts.canonicalSiteUrl, null);
+  assert.equal(facts.officialWebsiteUrl, null);
+  assert.equal(facts.discussionUrl, null);
+  assert.equal(facts.registrySourceUrl, null);
+  assert.equal(facts.chain.explorerUrl, null);
+  assert.equal(facts.contracts.governor.url, null);
+  assert.equal(facts.contracts.governanceToken.url, null);
+  assert.equal(facts.contracts.timelock?.url, null);
+});

--- a/apps/web/src/app/_components/public-route-summary.tsx
+++ b/apps/web/src/app/_components/public-route-summary.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { buildDaoPublicSummaryFacts } from "@/lib/dao-public-summary";
 import { cleanMetadataText, truncateMetadataText } from "@/lib/metadata";
 import type { ProposalItem, ProposalListItem } from "@/services/graphql/types";
 import type { Config } from "@/types/config";
@@ -10,22 +11,8 @@ function summarize(value?: string | null, maxLength = 220): string {
   return truncateMetadataText(cleanMetadataText(value), maxLength);
 }
 
-function safeExternalUrl(value?: string | null): string | null {
-  if (!value) return null;
-
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:"
-      ? url.toString()
-      : null;
-  } catch {
-    return null;
-  }
-}
-
 export function DaoPublicSummary({ config }: { config: Config }) {
-  const websiteUrl = safeExternalUrl(config.links?.website);
-  const discussionUrl = safeExternalUrl(config.offChainDiscussionUrl);
+  const facts = buildDaoPublicSummaryFacts(config);
 
   return (
     <section className="rounded-[14px] bg-card p-[20px] shadow-card">
@@ -39,17 +26,82 @@ export function DaoPublicSummary({ config }: { config: Config }) {
         <Link className="underline" href="/proposals">
           View proposals
         </Link>
-        {websiteUrl ? (
-          <a className="underline" href={websiteUrl}>
+        {facts.officialWebsiteUrl ? (
+          <a className="underline" href={facts.officialWebsiteUrl}>
             Official website
           </a>
         ) : null}
-        {discussionUrl ? (
-          <a className="underline" href={discussionUrl}>
+        {facts.discussionUrl ? (
+          <a className="underline" href={facts.discussionUrl}>
             Discussion
           </a>
         ) : null}
+        {facts.registrySourceUrl ? (
+          <a className="underline" href={facts.registrySourceUrl}>
+            Registry source
+          </a>
+        ) : null}
       </nav>
+      <dl className="mt-[18px] grid gap-[10px] text-[14px] sm:grid-cols-2">
+        <div>
+          <dt className="text-muted-foreground">Canonical DAO site</dt>
+          <dd>{facts.canonicalSiteUrl ?? "Unavailable"}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Chain</dt>
+          <dd>
+            {facts.chain.name} ({facts.chain.id})
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Governor contract</dt>
+          <dd>
+            {facts.contracts.governor.url ? (
+              <a className="underline" href={facts.contracts.governor.url}>
+                {facts.contracts.governor.address}
+              </a>
+            ) : (
+              facts.contracts.governor.address
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Governance token</dt>
+          <dd>
+            {facts.contracts.governanceToken.url ? (
+              <a className="underline" href={facts.contracts.governanceToken.url}>
+                {facts.contracts.governanceToken.address}
+              </a>
+            ) : (
+              facts.contracts.governanceToken.address
+            )}{" "}
+            ({facts.contracts.governanceToken.standard})
+          </dd>
+        </div>
+        {facts.contracts.timelock ? (
+          <div>
+            <dt className="text-muted-foreground">Timelock contract</dt>
+            <dd>
+              {facts.contracts.timelock.url ? (
+                <a className="underline" href={facts.contracts.timelock.url}>
+                  {facts.contracts.timelock.address}
+                </a>
+              ) : (
+                facts.contracts.timelock.address
+              )}
+            </dd>
+          </div>
+        ) : null}
+        <div>
+          <dt className="text-muted-foreground">Registry start block</dt>
+          <dd>{facts.indexer.startBlock}</dd>
+        </div>
+      </dl>
+      <p className="mt-[15px] text-[13px] text-muted-foreground">
+        Registry configuration is the source for DAO identity, chain, and contract links. This
+        static summary does not claim live indexed governance freshness; proposal views show live
+        indexer state when supported by the source.
+      </p>
     </section>
   );
 }

--- a/apps/web/src/app/_components/public-route-summary.tsx
+++ b/apps/web/src/app/_components/public-route-summary.tsx
@@ -27,17 +27,32 @@ export function DaoPublicSummary({ config }: { config: Config }) {
           View proposals
         </Link>
         {facts.officialWebsiteUrl ? (
-          <a className="underline" href={facts.officialWebsiteUrl}>
+          <a
+            className="underline"
+            href={facts.officialWebsiteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Official website
           </a>
         ) : null}
         {facts.discussionUrl ? (
-          <a className="underline" href={facts.discussionUrl}>
+          <a
+            className="underline"
+            href={facts.discussionUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Discussion
           </a>
         ) : null}
         {facts.registrySourceUrl ? (
-          <a className="underline" href={facts.registrySourceUrl}>
+          <a
+            className="underline"
+            href={facts.registrySourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Registry source
           </a>
         ) : null}
@@ -57,7 +72,12 @@ export function DaoPublicSummary({ config }: { config: Config }) {
           <dt className="text-muted-foreground">Governor contract</dt>
           <dd>
             {facts.contracts.governor.url ? (
-              <a className="underline" href={facts.contracts.governor.url}>
+              <a
+                className="underline"
+                href={facts.contracts.governor.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 {facts.contracts.governor.address}
               </a>
             ) : (
@@ -69,7 +89,12 @@ export function DaoPublicSummary({ config }: { config: Config }) {
           <dt className="text-muted-foreground">Governance token</dt>
           <dd>
             {facts.contracts.governanceToken.url ? (
-              <a className="underline" href={facts.contracts.governanceToken.url}>
+              <a
+                className="underline"
+                href={facts.contracts.governanceToken.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 {facts.contracts.governanceToken.address}
               </a>
             ) : (
@@ -83,7 +108,12 @@ export function DaoPublicSummary({ config }: { config: Config }) {
             <dt className="text-muted-foreground">Timelock contract</dt>
             <dd>
               {facts.contracts.timelock.url ? (
-                <a className="underline" href={facts.contracts.timelock.url}>
+                <a
+                  className="underline"
+                  href={facts.contracts.timelock.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   {facts.contracts.timelock.address}
                 </a>
               ) : (
@@ -93,7 +123,7 @@ export function DaoPublicSummary({ config }: { config: Config }) {
           </div>
         ) : null}
         <div>
-          <dt className="text-muted-foreground">Registry start block</dt>
+          <dt className="text-muted-foreground">Indexer start block</dt>
           <dd>{facts.indexer.startBlock}</dd>
         </div>
       </dl>

--- a/apps/web/src/lib/dao-public-summary.ts
+++ b/apps/web/src/lib/dao-public-summary.ts
@@ -1,0 +1,55 @@
+import type { Config } from "@/types/config";
+
+function safeExternalUrl(value?: string | null): string | null {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function explorerAddressUrl(config: Config, address?: string | null): string | null {
+  const explorerUrl = safeExternalUrl(config.chain.explorers[0]);
+  if (!explorerUrl || !address) return null;
+
+  return new URL(`/address/${address}`, explorerUrl.endsWith("/") ? explorerUrl : `${explorerUrl}/`)
+    .toString();
+}
+
+export function buildDaoPublicSummaryFacts(config: Config) {
+  return {
+    canonicalSiteUrl: safeExternalUrl(config.siteUrl),
+    officialWebsiteUrl: safeExternalUrl(config.links?.website),
+    discussionUrl: safeExternalUrl(config.offChainDiscussionUrl),
+    registrySourceUrl: safeExternalUrl(config.editLink),
+    chain: {
+      id: config.chain.id,
+      name: config.chain.name,
+      explorerUrl: safeExternalUrl(config.chain.explorers[0]),
+    },
+    contracts: {
+      governor: {
+        address: config.contracts.governor,
+        url: explorerAddressUrl(config, config.contracts.governor),
+      },
+      governanceToken: {
+        address: config.contracts.governorToken.address,
+        standard: config.contracts.governorToken.standard,
+        url: explorerAddressUrl(config, config.contracts.governorToken.address),
+      },
+      timelock: config.contracts.timeLock
+        ? {
+            address: config.contracts.timeLock,
+            url: explorerAddressUrl(config, config.contracts.timeLock),
+          }
+        : null,
+    },
+    indexer: {
+      endpoint: safeExternalUrl(config.indexer.endpoint),
+      startBlock: config.indexer.startBlock,
+    },
+  };
+}

--- a/apps/web/src/lib/dao-public-summary.ts
+++ b/apps/web/src/lib/dao-public-summary.ts
@@ -1,10 +1,12 @@
 import type { Config } from "@/types/config";
 
 function safeExternalUrl(value?: string | null): string | null {
-  if (!value) return null;
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
 
   try {
-    const url = new URL(value);
+    const url = new URL(trimmed);
+    if (url.username || url.password) return null;
     return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null;
   } catch {
     return null;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "indexer:worker": "cargo run -p degov-datalens-indexer --locked -- worker",
     "test:indexer": "cargo test -p degov-datalens-indexer --locked",
     "test:indexer-scripts": "node apps/indexer/scripts/indexer-diagnostics.test.mjs && node apps/indexer/scripts/runtime-packaging.test.mjs && node apps/indexer/scripts/staging-deployment-contract.test.mjs && node apps/indexer/scripts/indexer-accuracy-audit.test.mjs && node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs && node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs && node apps/indexer/scripts/v4-parity-audit.test.mjs && node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs",
+    "test:dao-content-provenance": "node --test apps/web/scripts/dao-content-provenance.test.ts",
     "test:seo-geo-ai-benchmark": "node scripts/check-seo-geo-ai-benchmark.mjs",
     "test:seo-geo-content-provenance": "node scripts/check-seo-geo-content-provenance.mjs",
     "test:seo-geo-crawler-policy": "node scripts/check-seo-geo-crawler-policy.mjs",


### PR DESCRIPTION
## Summary
- expand the server-rendered DAO homepage summary with canonical site, chain, registry source, and contract facts
- normalize external source/explorer links to http(s) URLs before rendering
- add a DAO content provenance verifier for Lisk-style config facts and unsafe URL rejection

## Verification
- pnpm install --frozen-lockfile
- pnpm run test:dao-content-provenance
- pnpm run test:web-scripts
- pnpm run test:seo-geo-content-provenance
- pnpm run test:seo-geo-structured-data
- pnpm --filter @degov/web lint
- pnpm --filter @degov/web build
- git diff --check
- local raw HTML readback confirmed the server-rendered summary block appears before client hydration using the local demo config

Refs #1050
Refs #1027
Refs #714