### PR TITLE
Record SEO GEO analytics inventory

### DIFF
--- a/docs/spec/seo-geo-measurement-contract.json
+++ b/docs/spec/seo-geo-measurement-contract.json
@@ -22,7 +22,7 @@
       "name": "DeGov official website",
       "repository": "ringecosystem/degov-home",
       "representativeHost": "degov.ai",
-      "analyticsTagState": "access-gap",
+      "analyticsTagState": "live-readback-no-tag",
       "ownerState": "owner-required",
       "consentState": "approval-required",
       "customDomainBoundary": "first-party-degov-domain",
@@ -38,7 +38,7 @@
       "name": "DeGov documentation",
       "repository": "ringecosystem/degov-docs",
       "representativeHost": "docs.degov.ai",
-      "analyticsTagState": "access-gap",
+      "analyticsTagState": "live-readback-empty-google-property",
       "ownerState": "owner-required",
       "consentState": "approval-required",
       "customDomainBoundary": "first-party-degov-domain",
@@ -54,7 +54,7 @@
       "name": "DeGov Square",
       "repository": "ringecosystem/degov-square",
       "representativeHost": "square.degov.ai",
-      "analyticsTagState": "known-present-unverified",
+      "analyticsTagState": "live-readback-ga4-tag-present",
       "ownerState": "owner-required",
       "consentState": "approval-required",
       "customDomainBoundary": "first-party-degov-domain",
@@ -70,7 +70,7 @@
       "name": "Individual DAO governance sites",
       "repository": "ringecosystem/degov",
       "representativeHost": "demo.degov.ai and representative registry DAO hosts",
-      "analyticsTagState": "known-present-unverified",
+      "analyticsTagState": "registry-and-lisk-live-ga4-tag-present",
       "ownerState": "dao-owner-boundary-required",
       "consentState": "approval-required",
       "customDomainBoundary": "custom DAO domains may have separate ownership and consent authority",
@@ -86,7 +86,7 @@
       "name": "DeGov Atlas",
       "repository": "ringecosystem/degov-agent-api",
       "representativeHost": "atlas.degov.ai",
-      "analyticsTagState": "access-gap",
+      "analyticsTagState": "live-readback-no-tag",
       "ownerState": "owner-required",
       "consentState": "approval-required",
       "customDomainBoundary": "first-party-degov-domain",
@@ -98,6 +98,98 @@
       ]
     }
   ],
+  "liveAnalyticsInventory": {
+    "inventoryDate": "2026-08-05",
+    "evidenceScope": "Public production HTML readback plus checked-in public repository configuration. Private GA property ownership, consent-mode debug state, retention, and report access are not inferred from tag presence.",
+    "surfaces": [
+      {
+        "surface": "home",
+        "representativeUrl": "https://degov.ai/",
+        "repository": "ringecosystem/degov-home",
+        "tagReadback": {
+          "state": "no-public-tag-found",
+          "tagIds": [],
+          "gtagLoaderPresent": false,
+          "gtmLoaderPresent": false,
+          "evidence": "Production raw HTML sampled on 2026-08-05 did not contain GA4, GTM, or UA identifiers."
+        },
+        "repositoryEvidence": "Repository text scan found no first-party analytics tag configuration outside dependency lockfile noise.",
+        "propertyOwnerState": "not-publicly-verified",
+        "consentState": "not-publicly-verified",
+        "retentionState": "not-publicly-verified",
+        "ownerBoundary": "first-party-degov-domain"
+      },
+      {
+        "surface": "docs",
+        "representativeUrl": "https://docs.degov.ai/",
+        "repository": "ringecosystem/degov-docs",
+        "tagReadback": {
+          "state": "empty-google-property-loader",
+          "tagIds": [],
+          "gtagLoaderPresent": true,
+          "gtmLoaderPresent": false,
+          "evidence": "Production raw HTML sampled on 2026-08-05 included `googletagmanager.com/gtag/js?id=` but no GA4 measurement ID."
+        },
+        "repositoryEvidence": "`mkdocs.yml` declares `analytics.provider: google` with an empty `property` value.",
+        "propertyOwnerState": "not-publicly-verified",
+        "consentState": "not-publicly-verified",
+        "retentionState": "not-publicly-verified",
+        "ownerBoundary": "first-party-degov-domain"
+      },
+      {
+        "surface": "square",
+        "representativeUrl": "https://square.degov.ai/",
+        "repository": "ringecosystem/degov-square",
+        "tagReadback": {
+          "state": "ga4-tag-present",
+          "tagIds": ["G-26505WB9XS"],
+          "gtagLoaderPresent": true,
+          "gtmLoaderPresent": false,
+          "evidence": "Production raw HTML sampled on 2026-08-05 included GA4 measurement ID `G-26505WB9XS`."
+        },
+        "repositoryEvidence": "`web/src/config/base.ts` exports `GOOGLE_ANALYTICS_TAG = 'G-26505WB9XS'`; `web/src/app/analytics.tsx` excludes private/write route prefixes from analytics rendering.",
+        "propertyOwnerState": "not-publicly-verified",
+        "consentState": "not-publicly-verified",
+        "retentionState": "not-publicly-verified",
+        "ownerBoundary": "first-party-degov-domain"
+      },
+      {
+        "surface": "dao-sites",
+        "representativeUrl": "https://lisk.degov.ai/",
+        "repository": "ringecosystem/degov",
+        "tagReadback": {
+          "state": "representative-ga4-tag-present",
+          "tagIds": ["G-0X2S8293S1"],
+          "gtagLoaderPresent": true,
+          "gtmLoaderPresent": false,
+          "evidence": "Production raw HTML sampled on 2026-08-05 included Lisk GA4 measurement ID `G-0X2S8293S1`; `https://demo.degov.ai/` did not include a public GA tag."
+        },
+        "repositoryEvidence": "`apps/web/src/app/layout.tsx` injects GA from validated DAO config `analysis.ga.tag`; degov-registry has 42 DAO YAML files with GA4 tags, including Lisk `G-0X2S8293S1`, ENS `G-30MY2D0MMM`, and Ring `G-BCRTFBKS4G`.",
+        "propertyOwnerState": "dao-owner-boundary-not-publicly-verified",
+        "consentState": "not-publicly-verified",
+        "retentionState": "not-publicly-verified",
+        "ownerBoundary": "custom DAO domains may have separate ownership and consent authority"
+      },
+      {
+        "surface": "atlas",
+        "representativeUrl": "https://atlas.degov.ai/",
+        "repository": "ringecosystem/degov-agent-api",
+        "tagReadback": {
+          "state": "no-public-tag-found",
+          "tagIds": [],
+          "gtagLoaderPresent": false,
+          "gtmLoaderPresent": false,
+          "evidence": "Production raw HTML sampled on 2026-08-05 did not contain GA4, GTM, or UA identifiers."
+        },
+        "repositoryEvidence": "Atlas app repository scan found no first-party GA/GTM tag configuration.",
+        "propertyOwnerState": "not-publicly-verified",
+        "consentState": "not-publicly-verified",
+        "retentionState": "not-publicly-verified",
+        "ownerBoundary": "first-party-degov-domain"
+      }
+    ],
+    "completionEffect": "This inventory maps public tag/no-tag evidence and owner-boundary state for the first measurement cohort. It does not approve instrumentation changes, prove GA property ownership, prove consent behavior, or save a conversion baseline."
+  },
   "channelDefinitions": [
     {
       "id": "organic-search",

--- a/docs/spec/seo-geo-measurement-contract.json
+++ b/docs/spec/seo-geo-measurement-contract.json
@@ -2,7 +2,7 @@
   "version": 1,
   "ownerIssue": "https://github.com/ringecosystem/degov/issues/1031",
   "parentIssue": "https://github.com/ringecosystem/degov/issues/714",
-  "updatedAt": "2026-08-04",
+  "updatedAt": "2026-08-05",
   "maintenance": {
     "ownerRepository": "ringecosystem/degov",
     "contractPath": "docs/spec/seo-geo-measurement-contract.json",

--- a/scripts/check-seo-geo-measurement.mjs
+++ b/scripts/check-seo-geo-measurement.mjs
@@ -125,6 +125,7 @@ const requiredTopLevelArrays = new Set([
 const requiredTopLevelObjects = new Set([
   "maintenance",
   "sourcePolicy",
+  "liveAnalyticsInventory",
   "crossDomainAttribution",
   "baselinePlan",
   "reportContract",
@@ -178,9 +179,55 @@ for (const surface of requiredSurfaces) {
 for (const surface of contract.surfaceInventory) {
   assert.ok(requiredRepositories.has(surface.repository), `${surface.id} repository`);
   assert.match(surface.representativeHost, /degov\.ai|DAO hosts/);
+  assert.doesNotMatch(surface.analyticsTagState, /access-gap|unverified/, `${surface.id} analytics tag mapped`);
   assert.ok(surface.requiredMappingEvidence.includes("consent behavior"), `${surface.id} consent`);
   assert.ok(surface.requiredMappingEvidence.includes("retention policy"), `${surface.id} retention`);
 }
+
+assert.equal(contract.liveAnalyticsInventory.inventoryDate, "2026-08-05");
+assert.match(contract.liveAnalyticsInventory.evidenceScope, /Public production HTML readback/);
+assert.match(contract.liveAnalyticsInventory.evidenceScope, /not inferred from tag presence/);
+assertArray(contract.liveAnalyticsInventory.surfaces, "live analytics inventory surfaces");
+assert.equal(contract.liveAnalyticsInventory.surfaces.length, requiredSurfaces.size);
+assertUnique(contract.liveAnalyticsInventory.surfaces, "surface", "live analytics inventory");
+const inventoryBySurface = new Map(
+  contract.liveAnalyticsInventory.surfaces.map((surface) => [surface.surface, surface])
+);
+for (const surface of requiredSurfaces) {
+  assert.ok(inventoryBySurface.has(surface), `missing live analytics inventory ${surface}`);
+}
+for (const surface of contract.liveAnalyticsInventory.surfaces) {
+  assert.ok(requiredSurfaces.has(surface.surface), `${surface.surface} known surface`);
+  assert.ok(requiredRepositories.has(surface.repository), `${surface.surface} repository`);
+  assert.match(
+    surface.representativeUrl,
+    /^https:\/\/([a-z0-9-]+\.)?degov\.ai\//,
+    `${surface.surface} representative URL`
+  );
+  assertPlainObject(surface.tagReadback, `${surface.surface} tag readback`);
+  assertArray(surface.tagReadback.tagIds, `${surface.surface} tag IDs`);
+  assert.equal(typeof surface.tagReadback.gtagLoaderPresent, "boolean", `${surface.surface} gtag loader`);
+  assert.equal(typeof surface.tagReadback.gtmLoaderPresent, "boolean", `${surface.surface} gtm loader`);
+  assert.ok(surface.tagReadback.evidence.length > 60, `${surface.surface} evidence`);
+  assert.ok(surface.repositoryEvidence.length > 50, `${surface.surface} repository evidence`);
+  assert.match(surface.propertyOwnerState, /not-publicly-verified|dao-owner-boundary/);
+  assert.match(surface.consentState, /not-publicly-verified/);
+  assert.match(surface.retentionState, /not-publicly-verified/);
+  assert.ok(surface.ownerBoundary.length > 20, `${surface.surface} owner boundary`);
+}
+assert.deepEqual(inventoryBySurface.get("home").tagReadback.tagIds, []);
+assert.equal(inventoryBySurface.get("home").tagReadback.state, "no-public-tag-found");
+assert.equal(inventoryBySurface.get("docs").tagReadback.state, "empty-google-property-loader");
+assert.deepEqual(inventoryBySurface.get("docs").tagReadback.tagIds, []);
+assert.equal(inventoryBySurface.get("docs").tagReadback.gtagLoaderPresent, true);
+assert.deepEqual(inventoryBySurface.get("square").tagReadback.tagIds, ["G-26505WB9XS"]);
+assert.match(inventoryBySurface.get("square").repositoryEvidence, /GOOGLE_ANALYTICS_TAG/);
+assert.deepEqual(inventoryBySurface.get("dao-sites").tagReadback.tagIds, ["G-0X2S8293S1"]);
+assert.match(inventoryBySurface.get("dao-sites").repositoryEvidence, /42 DAO YAML files/);
+assert.match(inventoryBySurface.get("dao-sites").repositoryEvidence, /G-30MY2D0MMM/);
+assert.equal(inventoryBySurface.get("atlas").tagReadback.state, "no-public-tag-found");
+assert.match(contract.liveAnalyticsInventory.completionEffect, /does not approve instrumentation changes/);
+assert.match(contract.liveAnalyticsInventory.completionEffect, /conversion baseline/);
 
 assertUnique(contract.channelDefinitions, "id", "channel definitions");
 const channelIds = new Set(contract.channelDefinitions.map((channel) => channel.id));

--- a/scripts/check-seo-geo-measurement.mjs
+++ b/scripts/check-seo-geo-measurement.mjs
@@ -173,6 +173,7 @@ assert.match(contract.sourcePolicy.sourceUseRule, /Missing referrer data remains
 
 assertUnique(contract.surfaceInventory, "id", "surface inventory");
 const surfaceIds = new Set(contract.surfaceInventory.map((surface) => surface.id));
+const surfaceInventoryById = new Map(contract.surfaceInventory.map((surface) => [surface.id, surface]));
 for (const surface of requiredSurfaces) {
   assert.ok(surfaceIds.has(surface), `missing surface ${surface}`);
 }
@@ -199,6 +200,11 @@ for (const surface of requiredSurfaces) {
 for (const surface of contract.liveAnalyticsInventory.surfaces) {
   assert.ok(requiredSurfaces.has(surface.surface), `${surface.surface} known surface`);
   assert.ok(requiredRepositories.has(surface.repository), `${surface.surface} repository`);
+  assert.equal(
+    surface.repository,
+    surfaceInventoryById.get(surface.surface)?.repository,
+    `${surface.surface} repository must match surface inventory`
+  );
   assert.match(
     surface.representativeUrl,
     /^https:\/\/([a-z0-9-]+\.)?degov\.ai\//,


### PR DESCRIPTION
## Summary
- add a dated live analytics inventory to the SEO/GEO measurement contract
- record public tag/no-tag evidence for home, Docs, Square, DAO sites, and Atlas
- keep property ownership, consent behavior, retention, and conversion baseline explicitly unverified
- strengthen the measurement checker so the inventory cannot silently regress

## Verification
- pnpm run test:seo-geo-measurement
- pnpm run test:seo-geo-observability
- pnpm run test:seo-geo-content-provenance
- pnpm run test:seo-geo-ai-benchmark
- pnpm run test:seo-geo-contract
- pnpm run test:seo-geo-crawler-policy
- pnpm run test:seo-geo-social-preview
- pnpm run test:seo-geo-structured-data
- git diff --check

Refs #1031
Refs #714
