### PR TITLE
Define AI benchmark evidence traceability

### DIFF
--- a/docs/spec/seo-geo-ai-benchmark-contract.json
+++ b/docs/spec/seo-geo-ai-benchmark-contract.json
@@ -210,6 +210,43 @@
     },
     "rawEvidenceRule": "Preserve answer text or durable evidence references for every run before aggregating scores."
   },
+  "evidenceTraceability": {
+    "storageApprovalStatus": "pending-approval",
+    "storageApprovalRule": "Do not store provider answer text, screenshots, or exported reports in GitHub or another workspace until the storage location, access, retention, and provider-terms basis are approved.",
+    "rawRunEvidenceSchema": {
+      "idPattern": "ai-benchmark-run-YYYY-MM-DD-provider-query-repetition",
+      "requiredFields": [
+        "run_record_id",
+        "query_id",
+        "provider",
+        "executed_at",
+        "repetition_number",
+        "raw_answer_evidence_location",
+        "citation_evidence_locations",
+        "evaluator",
+        "storage_location",
+        "storage_approval_reference",
+        "redaction_notes"
+      ],
+      "traceabilityRule": "Every run record must identify the exact query, provider, repetition, raw answer evidence location, citation evidence locations, evaluator notes, storage location, and approval reference."
+    },
+    "aggregateResultSchema": {
+      "requiredFields": [
+        "result_id",
+        "covered_query_ids",
+        "covered_providers",
+        "run_record_ids",
+        "repetition_count_by_query_provider",
+        "dimension_scores",
+        "known_limitations",
+        "bing_ai_performance_report",
+        "raw_result_location",
+        "issue_714_comment"
+      ],
+      "traceabilityRule": "Every aggregate result must link to raw run record IDs and the #714 evidence comment before any baseline, trend, or experiment claim is made."
+    },
+    "completionEffect": "This schema defines how raw evidence and aggregate results must be traced. It does not approve storage, complete a baseline run, or permit closing #1030 without real preserved evidence."
+  },
   "providerCoverage": [
     {
       "id": "chatgpt-search",

--- a/docs/spec/seo-geo-ai-benchmark-contract.json
+++ b/docs/spec/seo-geo-ai-benchmark-contract.json
@@ -224,6 +224,7 @@
         "raw_answer_evidence_location",
         "citation_evidence_locations",
         "evaluator",
+        "evaluator_notes",
         "storage_location",
         "storage_approval_reference",
         "redaction_notes"

--- a/scripts/check-seo-geo-ai-benchmark.mjs
+++ b/scripts/check-seo-geo-ai-benchmark.mjs
@@ -44,6 +44,31 @@ const requiredRunFields = new Set([
   "evaluator_notes",
   "limitations",
 ]);
+const requiredRawEvidenceFields = new Set([
+  "run_record_id",
+  "query_id",
+  "provider",
+  "executed_at",
+  "repetition_number",
+  "raw_answer_evidence_location",
+  "citation_evidence_locations",
+  "evaluator",
+  "storage_location",
+  "storage_approval_reference",
+  "redaction_notes",
+]);
+const requiredAggregateResultFields = new Set([
+  "result_id",
+  "covered_query_ids",
+  "covered_providers",
+  "run_record_ids",
+  "repetition_count_by_query_provider",
+  "dimension_scores",
+  "known_limitations",
+  "bing_ai_performance_report",
+  "raw_result_location",
+  "issue_714_comment",
+]);
 const requiredProviderIds = new Set([
   "chatgpt-search",
   "perplexity",
@@ -139,6 +164,7 @@ for (const field of [
   "sourcePolicy",
   "runRecordSchema",
   "scoringConstraints",
+  "evidenceTraceability",
   "experimentTemplate",
   "privacyAndStorage",
   "baselineState",
@@ -180,6 +206,43 @@ assert.ok(
 );
 assert.match(contract.runRecordSchema.repetitionProcedure.providerTermsRule, /provider terms/);
 assert.match(contract.runRecordSchema.rawEvidenceRule, /Preserve answer text/);
+
+assert.equal(contract.evidenceTraceability.storageApprovalStatus, "pending-approval");
+assert.match(contract.evidenceTraceability.storageApprovalRule, /Do not store provider answer text/);
+assert.match(contract.evidenceTraceability.storageApprovalRule, /provider-terms basis/);
+assertPlainObject(contract.evidenceTraceability.rawRunEvidenceSchema, "raw run evidence schema");
+assertPlainObject(contract.evidenceTraceability.aggregateResultSchema, "aggregate result schema");
+assert.match(
+  contract.evidenceTraceability.rawRunEvidenceSchema.idPattern,
+  /provider-query-repetition/
+);
+for (const field of requiredRawEvidenceFields) {
+  assert.ok(
+    contract.evidenceTraceability.rawRunEvidenceSchema.requiredFields.includes(field),
+    `missing raw evidence field ${field}`
+  );
+}
+assert.match(
+  contract.evidenceTraceability.rawRunEvidenceSchema.traceabilityRule,
+  /storage location/
+);
+assert.match(
+  contract.evidenceTraceability.rawRunEvidenceSchema.traceabilityRule,
+  /approval reference/
+);
+for (const field of requiredAggregateResultFields) {
+  assert.ok(
+    contract.evidenceTraceability.aggregateResultSchema.requiredFields.includes(field),
+    `missing aggregate result field ${field}`
+  );
+}
+assert.match(
+  contract.evidenceTraceability.aggregateResultSchema.traceabilityRule,
+  /raw run record IDs/
+);
+assert.match(contract.evidenceTraceability.aggregateResultSchema.traceabilityRule, /#714/);
+assert.match(contract.evidenceTraceability.completionEffect, /does not approve storage/);
+assert.match(contract.evidenceTraceability.completionEffect, /complete a baseline run/);
 
 assertUnique(contract.providerCoverage, "id", "provider coverage");
 const providerIds = new Set(contract.providerCoverage.map((provider) => provider.id));

--- a/scripts/check-seo-geo-ai-benchmark.mjs
+++ b/scripts/check-seo-geo-ai-benchmark.mjs
@@ -53,6 +53,7 @@ const requiredRawEvidenceFields = new Set([
   "raw_answer_evidence_location",
   "citation_evidence_locations",
   "evaluator",
+  "evaluator_notes",
   "storage_location",
   "storage_approval_reference",
   "redaction_notes",


### PR DESCRIPTION
## Summary
- Add an explicit AI benchmark evidence traceability schema for raw run records and aggregate results.
- Require storage approval references, raw evidence locations, #714 linkback, Bing AI Performance separation, and run-record IDs before any baseline/trend claim.
- Keep storage approval and first repeated baseline status explicitly open.

## Verification
- pnpm run test:seo-geo-ai-benchmark
- pnpm run test:seo-geo-content-provenance
- pnpm run test:seo-geo-measurement
- pnpm run test:seo-geo-contract
- pnpm run test:seo-geo-observability
- pnpm run test:seo-geo-crawler-policy
- pnpm run test:seo-geo-social-preview
- pnpm run test:seo-geo-structured-data
- git diff --check

Refs #1030
Refs #714