### PR TITLE
Add DAO proposal WebPage structured data

### DIFF
--- a/apps/web/scripts/dao-structured-data.test.ts
+++ b/apps/web/scripts/dao-structured-data.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildDaoOrganizationJsonLd } from "../src/lib/structured-data.ts";
+import {
+  buildDaoOrganizationJsonLd,
+  buildProposalWebPageJsonLd,
+} from "../src/lib/structured-data.ts";
 
+import type { ProposalItem } from "../src/services/graphql/types.ts";
 import type { Config } from "../src/types/config.ts";
 
 const config: Config = {
@@ -41,6 +45,34 @@ const config: Config = {
     endpoint: "https://indexer.degov.ai/lisk-dao/graphql",
     startBlock: 1,
   },
+};
+
+const proposal: ProposalItem = {
+  blockNumber: "123",
+  blockTimestamp: "2026-08-05T00:00:00Z",
+  calldatas: [],
+  description:
+    "Fund the next grants season with a staged treasury budget and public reporting.",
+  id: "lisk-dao:1",
+  proposalId: "1",
+  proposer: "0x0000000000000000000000000000000000000001",
+  signatures: [],
+  targets: [],
+  transactionHash: "0xabc",
+  values: [],
+  voteEnd: "20",
+  voteStart: "10",
+  voteStartTimestamp: "2026-08-06T00:00:00Z",
+  voteEndTimestamp: "2026-08-07T00:00:00Z",
+  clockMode: "blocknumber",
+  quorum: "100",
+  decimals: "18",
+  title: "Treasury allocation for grants season 2",
+  metricsVotesWeightAbstainSum: "0",
+  metricsVotesWeightAgainstSum: "0",
+  metricsVotesWeightForSum: "0",
+  metricsVotesCount: "0",
+  voters: [],
 };
 
 test("DAO Organization JSON-LD uses the validated DAO canonical origin", () => {
@@ -83,6 +115,69 @@ test("DAO Organization JSON-LD is omitted without a public HTTPS DAO origin", ()
   );
   assert.equal(
     buildDaoOrganizationJsonLd({ ...config, siteUrl: "https://localhost:3000" }),
+    null
+  );
+});
+
+test("proposal WebPage JSON-LD describes the visible proposal page", () => {
+  const jsonLd = buildProposalWebPageJsonLd(config, proposal);
+  assert.ok(jsonLd);
+  const data = JSON.parse(jsonLd);
+
+  assert.deepEqual(data, {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://lisk.degov.ai/proposal/1#webpage",
+    url: "https://lisk.degov.ai/proposal/1",
+    name: "Treasury allocation for grants season 2",
+    mainEntityOfPage: "https://lisk.degov.ai/proposal/1",
+    isPartOf: {
+      "@id": "https://lisk.degov.ai/#website",
+      name: "Lisk DAO governance site",
+      url: "https://lisk.degov.ai",
+    },
+    about: {
+      "@type": "Organization",
+      "@id": "https://lisk.degov.ai/#organization",
+      name: "Lisk DAO",
+      url: "https://lisk.degov.ai",
+    },
+    identifier: "1",
+    description:
+      "Fund the next grants season with a staged treasury budget and public reporting.",
+  });
+  assert.equal(data.author, undefined, "proposal JSON-LD must not invent authorship");
+  assert.equal(data.aggregateRating, undefined, "proposal JSON-LD must not emit ratings");
+});
+
+test("proposal WebPage JSON-LD is escaped, bounded, and not misclassified", () => {
+  const jsonLd = buildProposalWebPageJsonLd(config, {
+    ...proposal,
+    title: "Proposal <script>alert(1)</script>",
+    description: `<b>${"Very long proposal description ".repeat(20)}</b>`,
+  });
+  assert.ok(jsonLd);
+  assert.ok(!jsonLd.includes("<"));
+
+  const data = JSON.parse(jsonLd);
+  assert.equal(data["@type"], "WebPage");
+  assert.notEqual(data["@type"], "Article");
+  assert.notEqual(data["@type"], "NewsArticle");
+  assert.notEqual(data["@type"], "Legislation");
+  assert.notEqual(data["@type"], "DiscussionForumPosting");
+  assert.equal(data.name, "Proposal alert(1)");
+  assert.ok(data.description.length <= 220);
+  assert.ok(!data.description.includes("<b>"));
+});
+
+test("proposal WebPage JSON-LD is omitted without a valid public page", () => {
+  assert.equal(buildProposalWebPageJsonLd(config, null), null);
+  assert.equal(
+    buildProposalWebPageJsonLd({ ...config, siteUrl: "http://lisk.degov.ai" }, proposal),
+    null
+  );
+  assert.equal(
+    buildProposalWebPageJsonLd({ ...config, siteUrl: "https://localhost:3000" }, proposal),
     null
   );
 });

--- a/apps/web/scripts/dao-structured-data.test.ts
+++ b/apps/web/scripts/dao-structured-data.test.ts
@@ -6,7 +6,7 @@ import {
   buildProposalWebPageJsonLd,
 } from "../src/lib/structured-data.ts";
 
-import type { ProposalItem } from "../src/services/graphql/types.ts";
+import type { ProposalItem } from "../src/services/graphql/types/index.ts";
 import type { Config } from "../src/types/config.ts";
 
 const config: Config = {
@@ -154,7 +154,7 @@ test("proposal WebPage JSON-LD is escaped, bounded, and not misclassified", () =
   const jsonLd = buildProposalWebPageJsonLd(config, {
     ...proposal,
     title: "Proposal <script>alert(1)</script>",
-    description: `<b>${"Very long proposal description ".repeat(20)}</b>`,
+    description: `<b>${"Very long proposal description ".repeat(20)}</b><discussion>private forum thread</discussion><signature>["transfer(address,uint256)"]</signature>`,
   });
   assert.ok(jsonLd);
   assert.ok(!jsonLd.includes("<"));
@@ -168,6 +168,8 @@ test("proposal WebPage JSON-LD is escaped, bounded, and not misclassified", () =
   assert.equal(data.name, "Proposal alert(1)");
   assert.ok(data.description.length <= 220);
   assert.ok(!data.description.includes("<b>"));
+  assert.ok(!data.description.includes("private forum thread"));
+  assert.ok(!data.description.includes("transfer(address,uint256)"));
 });
 
 test("proposal WebPage JSON-LD is omitted without a valid public page", () => {

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 
+import { buildProposalWebPageJsonLd } from "@/lib/structured-data";
+
 import { ProposalDetailPublicSummary } from "../../_components/public-route-summary";
 import { getActiveDaoConfig, getPublicProposalDetail } from "../../_server/public-seo";
 
@@ -18,8 +20,16 @@ export default async function ProposalPage({ params }: ProposalPageProps) {
     notFound();
   }
 
+  const proposalJsonLd = buildProposalWebPageJsonLd(config, proposal);
+
   return (
     <div className="flex flex-col gap-[20px]">
+      {proposalJsonLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: proposalJsonLd }}
+        />
+      ) : null}
       <ProposalDetailPublicSummary
         config={config}
         proposal={proposal}

--- a/apps/web/src/lib/structured-data.ts
+++ b/apps/web/src/lib/structured-data.ts
@@ -1,8 +1,10 @@
+import type { ProposalItem } from "@/services/graphql/types";
 import type { Config } from "@/types/config";
 
 import { cleanMetadataText, truncateMetadataText } from "./metadata-text.ts";
 
 const DESCRIPTION_MAX_LENGTH = 220;
+const TITLE_MAX_LENGTH = 120;
 
 function getPublicSiteUrl(config: Config | null | undefined): string | null {
   const value = config?.siteUrl?.trim();
@@ -41,6 +43,46 @@ export function buildDaoOrganizationJsonLd(
     name: config.name,
     url: siteUrl,
     mainEntityOfPage: siteUrl,
+    ...(description ? { description } : {}),
+  });
+}
+
+export function buildProposalWebPageJsonLd(
+  config: Config | null | undefined,
+  proposal: ProposalItem | null | undefined
+): string | null {
+  const siteUrl = getPublicSiteUrl(config);
+  if (!siteUrl || !config?.name || !proposal?.proposalId) return null;
+
+  const proposalUrl = new URL(`/proposal/${proposal.proposalId}`, siteUrl).toString();
+  const name = truncateMetadataText(
+    cleanMetadataText(proposal.title) || `Proposal ${proposal.proposalId}`,
+    TITLE_MAX_LENGTH
+  );
+  const description = truncateMetadataText(
+    cleanMetadataText(proposal.description),
+    DESCRIPTION_MAX_LENGTH
+  );
+
+  return safeJsonLd({
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": `${proposalUrl}#webpage`,
+    url: proposalUrl,
+    name,
+    mainEntityOfPage: proposalUrl,
+    isPartOf: {
+      "@id": `${siteUrl}/#website`,
+      name: `${config.name} governance site`,
+      url: siteUrl,
+    },
+    about: {
+      "@type": "Organization",
+      "@id": `${siteUrl}/#organization`,
+      name: config.name,
+      url: siteUrl,
+    },
+    identifier: proposal.proposalId,
     ...(description ? { description } : {}),
   });
 }

--- a/apps/web/src/lib/structured-data.ts
+++ b/apps/web/src/lib/structured-data.ts
@@ -1,6 +1,8 @@
 import type { ProposalItem } from "@/services/graphql/types";
 import type { Config } from "@/types/config";
 
+import { extractTitleAndDescription, parseDescription } from "../utils/helpers.ts";
+
 import { cleanMetadataText, truncateMetadataText } from "./metadata-text.ts";
 
 const DESCRIPTION_MAX_LENGTH = 220;
@@ -55,12 +57,19 @@ export function buildProposalWebPageJsonLd(
   if (!siteUrl || !config?.name || !proposal?.proposalId) return null;
 
   const proposalUrl = new URL(`/proposal/${proposal.proposalId}`, siteUrl).toString();
+  const parsedDescription = parseDescription(proposal.description);
+  const titleAndDescription = extractTitleAndDescription(
+    parsedDescription.mainText
+  );
   const name = truncateMetadataText(
-    cleanMetadataText(proposal.title) || `Proposal ${proposal.proposalId}`,
+    cleanMetadataText(proposal.title || titleAndDescription.title) ||
+      `Proposal ${proposal.proposalId}`,
     TITLE_MAX_LENGTH
   );
   const description = truncateMetadataText(
-    cleanMetadataText(proposal.description),
+    cleanMetadataText(
+      titleAndDescription.description || parsedDescription.mainText
+    ),
     DESCRIPTION_MAX_LENGTH
   );
 


### PR DESCRIPTION
## Summary
- Emit conservative schema.org `WebPage` JSON-LD for valid public DAO proposal detail pages.
- Reuse visible proposal title/description, canonical proposal URL, proposal identifier, and DAO Organization identity.
- Keep missing/invalid/non-public pages from emitting proposal JSON-LD and avoid Article/Legislation/DiscussionForumPosting classification.

## Verification
- pnpm install --filter @degov/web... --frozen-lockfile
- pnpm run test:web-scripts
- pnpm run test:seo-geo-structured-data
- pnpm --filter @degov/web lint
- pnpm --filter @degov/web build
- git diff --check

Refs #1054
Refs #1028
Refs #714