### PR TITLE
Fix DAO public metadata origin

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -13,6 +13,10 @@ import {
   SOCIAL_PREVIEW_IMAGE_TYPE,
   SOCIAL_PREVIEW_IMAGE_WIDTH,
 } from "../src/lib/metadata.ts";
+import {
+  getPublicOriginFromHost,
+  withRequestSiteUrl,
+} from "../src/lib/request-origin.ts";
 
 import type { Config } from "../src/types/config.ts";
 import type { Metadata } from "next";
@@ -131,6 +135,35 @@ test("DAO public metadata uses host-correct large-image social previews", () => 
     }),
     "https://demo.degov.ai/proposal/0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878"
   );
+});
+
+test("request host overrides stale config site URL for public metadata", () => {
+  const configFromRemote = {
+    ...demoConfig,
+    siteUrl: "https://degov-dev.vercel.app",
+  };
+  const config = withRequestSiteUrl(
+    configFromRemote,
+    getPublicOriginFromHost("demo.degov.ai")
+  );
+
+  assertSocialMetadata(buildSiteMetadata(config), "https://demo.degov.ai");
+  assertSocialMetadata(
+    buildProposalMetadata({
+      config,
+      proposalId:
+        "0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878",
+      title: "Fix stale production origin",
+      description: "Use the current DAO host for public sharing metadata.",
+    }),
+    "https://demo.degov.ai/proposal/0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878"
+  );
+});
+
+test("request host override rejects private or invalid hosts", () => {
+  assert.equal(getPublicOriginFromHost("127.0.0.1:3000"), null);
+  assert.equal(getPublicOriginFromHost("localhost:3000"), null);
+  assert.equal(getPublicOriginFromHost("not a host"), null);
 });
 
 test("private DAO routes keep explicit noindex metadata", () => {

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -162,7 +162,13 @@ test("request host overrides stale config site URL for public metadata", () => {
 
 test("request host override rejects private or invalid hosts", () => {
   assert.equal(getPublicOriginFromHost("127.0.0.1:3000"), null);
+  assert.equal(getPublicOriginFromHost("[::1]:3000"), null);
+  assert.equal(getPublicOriginFromHost("::1"), null);
   assert.equal(getPublicOriginFromHost("localhost:3000"), null);
+  assert.equal(getPublicOriginFromHost("demo.degov.ai@evil.com"), null);
+  assert.equal(getPublicOriginFromHost("demo.degov.ai/path"), null);
+  assert.equal(getPublicOriginFromHost("demo.degov.ai?x=1"), null);
+  assert.equal(getPublicOriginFromHost("demo.degov.ai#fragment"), null);
   assert.equal(getPublicOriginFromHost("not a host"), null);
 });
 

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -3,12 +3,14 @@ import { headers } from "next/headers";
 
 import { getDaoConfigServer } from "@/lib/config";
 import { loadConfigYaml } from "@/lib/config-yaml";
+import { getPublicOriginFromHost, withRequestSiteUrl } from "@/lib/request-origin";
 import type { Config } from "@/types/config";
 import { degovApiDaoConfigServer } from "@/utils/remote-api";
 
 export async function getConfigCachedByHost(): Promise<Config> {
   const hdr = await headers();
   const host = hdr.get("host");
+  const publicRequestOrigin = getPublicOriginFromHost(host);
 
   // Resolve the canonical public origin to pass to the remote config API.
   // Next.js internal revalidation requests use the pod IP as the Host header,
@@ -59,7 +61,7 @@ export async function getConfigCachedByHost(): Promise<Config> {
         const yamlText = await res.text();
         const result = loadConfigYaml(yamlText);
 
-        return result;
+        return withRequestSiteUrl(result, publicRequestOrigin);
       } catch (err) {
         console.error("[Cache] Remote config failed:", err);
         throw err;

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -61,7 +61,9 @@ export async function getConfigCachedByHost(): Promise<Config> {
         const yamlText = await res.text();
         const result = loadConfigYaml(yamlText);
 
-        return withRequestSiteUrl(result, publicRequestOrigin);
+        return requiresOrigin
+          ? withRequestSiteUrl(result, publicRequestOrigin)
+          : result;
       } catch (err) {
         console.error("[Cache] Remote config failed:", err);
         throw err;

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -1,0 +1,35 @@
+import type { Config } from "@/types/config";
+
+function isIpv4Host(hostname: string): boolean {
+  return /^\d+\.\d+\.\d+\.\d+$/.test(hostname);
+}
+
+export function getPublicOriginFromHost(
+  host: string | null | undefined
+): string | null {
+  const value = host?.split(",")[0]?.trim();
+  if (!value) return null;
+
+  try {
+    const url = new URL(`https://${value}`);
+    if (url.hostname === "localhost" || isIpv4Host(url.hostname)) {
+      return null;
+    }
+
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function withRequestSiteUrl(
+  config: Config,
+  requestOrigin: string | null
+): Config {
+  if (!requestOrigin) return config;
+
+  return {
+    ...config,
+    siteUrl: requestOrigin,
+  };
+}

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -9,10 +9,20 @@ export function getPublicOriginFromHost(
 ): string | null {
   const value = host?.split(",")[0]?.trim();
   if (!value) return null;
+  if (/[/?#@\\[\]\s]/.test(value)) return null;
 
   try {
     const url = new URL(`https://${value}`);
-    if (url.hostname === "localhost" || isIpv4Host(url.hostname)) {
+    if (
+      url.username ||
+      url.password ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash ||
+      url.hostname === "localhost" ||
+      url.hostname.includes(":") ||
+      isIpv4Host(url.hostname)
+    ) {
       return null;
     }
 


### PR DESCRIPTION
## Summary\n- Override remote DAO config siteUrl with the current public request host for server-rendered metadata/structured data.\n- Keep private/invalid host values out of public origins.\n- Add regression coverage for the demo.degov.ai wrong-host social preview case.\n\n## Verification\n- pnpm install --filter @degov/web... --frozen-lockfile\n- pnpm run test:web-scripts\n- pnpm run test:seo-geo-social-preview\n- pnpm run test:seo-geo-structured-data\n- pnpm --filter @degov/web lint\n- pnpm --filter @degov/web build\n- git diff --check\n\nRefs #1029\nRefs #1028\nRefs #1054\nRefs #714