### PR TITLE
Fix single DAO metadata origin fallback

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/lib/metadata.ts";
 import {
   getPublicOriginFromHost,
+  shouldUseRequestSiteUrl,
   withRequestSiteUrl,
 } from "../src/lib/request-origin.ts";
 
@@ -157,6 +158,38 @@ test("request host overrides stale config site URL for public metadata", () => {
       description: "Use the current DAO host for public sharing metadata.",
     }),
     "https://demo.degov.ai/proposal/0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878"
+  );
+});
+
+test("single DAO mode only overrides known stale Vercel config origins", () => {
+  const staleVercelConfig = {
+    ...demoConfig,
+    siteUrl: "https://degov-dev.vercel.app",
+  };
+
+  assert.equal(
+    shouldUseRequestSiteUrl({
+      config: staleVercelConfig,
+      requestOrigin: "https://demo.degov.ai",
+      requiresOrigin: false,
+    }),
+    true
+  );
+  assert.equal(
+    shouldUseRequestSiteUrl({
+      config: staleVercelConfig,
+      requestOrigin: "https://evil.example",
+      requiresOrigin: false,
+    }),
+    false
+  );
+  assert.equal(
+    shouldUseRequestSiteUrl({
+      config: demoConfig,
+      requestOrigin: "https://evil.example",
+      requiresOrigin: false,
+    }),
+    false
   );
 });
 

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -3,7 +3,11 @@ import { headers } from "next/headers";
 
 import { getDaoConfigServer } from "@/lib/config";
 import { loadConfigYaml } from "@/lib/config-yaml";
-import { getPublicOriginFromHost, withRequestSiteUrl } from "@/lib/request-origin";
+import {
+  getPublicOriginFromHost,
+  shouldUseRequestSiteUrl,
+  withRequestSiteUrl,
+} from "@/lib/request-origin";
 import type { Config } from "@/types/config";
 import { degovApiDaoConfigServer } from "@/utils/remote-api";
 
@@ -61,7 +65,11 @@ export async function getConfigCachedByHost(): Promise<Config> {
         const yamlText = await res.text();
         const result = loadConfigYaml(yamlText);
 
-        return requiresOrigin
+        return shouldUseRequestSiteUrl({
+          config: result,
+          requestOrigin: publicRequestOrigin,
+          requiresOrigin,
+        })
           ? withRequestSiteUrl(result, publicRequestOrigin)
           : result;
       } catch (err) {

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -4,6 +4,22 @@ function isIpv4Host(hostname: string): boolean {
   return /^\d+\.\d+\.\d+\.\d+$/.test(hostname);
 }
 
+function getHostname(origin: string): string | null {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function isDegovOwnedHost(hostname: string): boolean {
+  return hostname === "degov.ai" || hostname.endsWith(".degov.ai");
+}
+
+function isVercelHost(hostname: string): boolean {
+  return hostname === "vercel.app" || hostname.endsWith(".vercel.app");
+}
+
 export function getPublicOriginFromHost(
   host: string | null | undefined
 ): string | null {
@@ -30,6 +46,27 @@ export function getPublicOriginFromHost(
   } catch {
     return null;
   }
+}
+
+export function shouldUseRequestSiteUrl(params: {
+  config: Config;
+  requestOrigin: string | null;
+  requiresOrigin: boolean;
+}): boolean {
+  const { config, requestOrigin, requiresOrigin } = params;
+  if (!requestOrigin) return false;
+  if (requiresOrigin) return true;
+
+  const configuredSiteUrl = config.siteUrl?.trim();
+  if (!configuredSiteUrl) return false;
+
+  const configuredHost = getHostname(configuredSiteUrl);
+  const requestHost = getHostname(requestOrigin);
+  if (!configuredHost || !requestHost || configuredHost === requestHost) {
+    return false;
+  }
+
+  return isVercelHost(configuredHost) && isDegovOwnedHost(requestHost);
 }
 
 export function withRequestSiteUrl(


### PR DESCRIPTION
## Summary\n- Allow single-DAO deployments to replace stale Vercel config origins only when serving a DeGov-owned production host.\n- Keep request-host overrides blocked for arbitrary hosts and normal non-Vercel DAO config origins.\n- Add regression coverage for the demo.degov.ai wrong-host case in single-DAO mode.\n\n## Verification\n- pnpm install --filter @degov/web... --frozen-lockfile\n- pnpm run test:web-scripts\n- pnpm run test:seo-geo-social-preview\n- pnpm run test:seo-geo-structured-data\n- pnpm --filter @degov/web lint\n- pnpm --filter @degov/web build\n- git diff --check\n\nRefs #1029\nRefs #1028\nRefs #1054\nRefs #714