### PR TITLE
Normalize DAO metadata origin after cache

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -201,7 +201,7 @@ test("request site URL override happens after remote config cache lookup", () =>
   const cacheReturnIndex = source.indexOf("const result = await get();");
   const overrideIndex = source.indexOf("shouldUseRequestSiteUrl", cacheReturnIndex);
 
-  assert.ok(cacheReturnIndex > 0, "config cache result must be read explicitly");
+  assert.ok(cacheReturnIndex >= 0, "config cache result must be read explicitly");
   assert.ok(
     overrideIndex > cacheReturnIndex,
     "request host override must run after cache lookup so cache hits are normalized"

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -193,6 +193,21 @@ test("single DAO mode only overrides known stale Vercel config origins", () => {
   );
 });
 
+test("request site URL override happens after remote config cache lookup", () => {
+  const source = readFileSync(
+    path.join(rootDir, "apps/web/src/app/_server/config-remote.ts"),
+    "utf8"
+  );
+  const cacheReturnIndex = source.indexOf("const result = await get();");
+  const overrideIndex = source.indexOf("shouldUseRequestSiteUrl", cacheReturnIndex);
+
+  assert.ok(cacheReturnIndex > 0, "config cache result must be read explicitly");
+  assert.ok(
+    overrideIndex > cacheReturnIndex,
+    "request host override must run after cache lookup so cache hits are normalized"
+  );
+});
+
 test("request host override rejects private or invalid hosts", () => {
   assert.equal(getPublicOriginFromHost("127.0.0.1:3000"), null);
   assert.equal(getPublicOriginFromHost("[::1]:3000"), null);

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -65,13 +65,7 @@ export async function getConfigCachedByHost(): Promise<Config> {
         const yamlText = await res.text();
         const result = loadConfigYaml(yamlText);
 
-        return shouldUseRequestSiteUrl({
-          config: result,
-          requestOrigin: publicRequestOrigin,
-          requiresOrigin,
-        })
-          ? withRequestSiteUrl(result, publicRequestOrigin)
-          : result;
+        return result;
       } catch (err) {
         console.error("[Cache] Remote config failed:", err);
         throw err;
@@ -85,5 +79,11 @@ export async function getConfigCachedByHost(): Promise<Config> {
   );
 
   const result = await get();
-  return result;
+  return shouldUseRequestSiteUrl({
+    config: result,
+    requestOrigin: publicRequestOrigin,
+    requiresOrigin: !process.env.NEXT_PUBLIC_DEGOV_DAO,
+  })
+    ? withRequestSiteUrl(result, publicRequestOrigin)
+    : result;
 }


### PR DESCRIPTION
## Summary\n- Apply request-host metadata origin normalization after the remote config cache lookup, so cache hits cannot return stale Vercel siteUrl values.\n- Add regression coverage that guards the post-cache placement.\n\n## Verification\n- pnpm install --filter @degov/web... --frozen-lockfile\n- pnpm run test:web-scripts\n- pnpm run test:seo-geo-social-preview\n- pnpm run test:seo-geo-structured-data\n- pnpm --filter @degov/web lint\n- pnpm --filter @degov/web build\n- git diff --check\n\nRefs #1029\nRefs #1028\nRefs #1054\nRefs #714