### PR TITLE
Prefer forwarded host for DAO metadata origin

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -14,6 +14,7 @@ import {
   SOCIAL_PREVIEW_IMAGE_WIDTH,
 } from "../src/lib/metadata.ts";
 import {
+  getPublicOriginFromHeaders,
   getPublicOriginFromHost,
   shouldUseRequestSiteUrl,
   withRequestSiteUrl,
@@ -218,6 +219,32 @@ test("request host override rejects private or invalid hosts", () => {
   assert.equal(getPublicOriginFromHost("demo.degov.ai?x=1"), null);
   assert.equal(getPublicOriginFromHost("demo.degov.ai#fragment"), null);
   assert.equal(getPublicOriginFromHost("not a host"), null);
+});
+
+test("request host override prefers forwarded public host on Vercel aliases", () => {
+  const headers = new Headers({
+    host: "degov-dev.vercel.app",
+    "x-forwarded-host": "demo.degov.ai",
+  });
+  const requestOrigin = getPublicOriginFromHeaders(headers);
+  const config = {
+    ...demoConfig,
+    siteUrl: "https://degov-dev.vercel.app",
+  };
+
+  assert.equal(requestOrigin, "https://demo.degov.ai");
+  assert.equal(
+    shouldUseRequestSiteUrl({
+      config,
+      requestOrigin,
+      requiresOrigin: false,
+    }),
+    true
+  );
+  assertSocialMetadata(
+    buildSiteMetadata(withRequestSiteUrl(config, requestOrigin)),
+    "https://demo.degov.ai"
+  );
 });
 
 test("private DAO routes keep explicit noindex metadata", () => {

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -4,7 +4,7 @@ import { headers } from "next/headers";
 import { getDaoConfigServer } from "@/lib/config";
 import { loadConfigYaml } from "@/lib/config-yaml";
 import {
-  getPublicOriginFromHost,
+  getPublicOriginFromHeaders,
   shouldUseRequestSiteUrl,
   withRequestSiteUrl,
 } from "@/lib/request-origin";
@@ -14,12 +14,12 @@ import { degovApiDaoConfigServer } from "@/utils/remote-api";
 export async function getConfigCachedByHost(): Promise<Config> {
   const hdr = await headers();
   const host = hdr.get("host");
-  const publicRequestOrigin = getPublicOriginFromHost(host);
+  const publicRequestOrigin = getPublicOriginFromHeaders(hdr);
 
   // Resolve the canonical public origin to pass to the remote config API.
   // Next.js internal revalidation requests use the pod IP as the Host header,
-  // which the backend cannot match to any DAO. Prefer Origin > Referer > Host,
-  // and skip bare pod IPs so the backend can use its database lookup correctly.
+  // which the backend cannot match to any DAO. Prefer Origin > Referer >
+  // forwarded public host so the backend can use its database lookup correctly.
   const originHeader = hdr.get("origin");
   const refererHeader = hdr.get("referer");
 
@@ -33,14 +33,13 @@ export async function getConfigCachedByHost(): Promise<Config> {
       // malformed referer
     }
   }
-  if (!resolvedOrigin && host) {
-    const isPodIp = /^\d+\.\d+\.\d+\.\d+(:\d+)?$/.test(host);
-    if (!isPodIp) {
-      resolvedOrigin = `https://${host}`;
-    }
+  if (!resolvedOrigin) {
+    resolvedOrigin = publicRequestOrigin;
   }
 
-  const hostKey = (host ?? "default").toLowerCase();
+  const hostKey = (
+    publicRequestOrigin ? new URL(publicRequestOrigin).host : host ?? "default"
+  ).toLowerCase();
 
   const get = unstable_cache(
     async () => {

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -48,6 +48,15 @@ export function getPublicOriginFromHost(
   }
 }
 
+export function getPublicOriginFromHeaders(headers: {
+  get(name: string): string | null;
+}): string | null {
+  return (
+    getPublicOriginFromHost(headers.get("x-forwarded-host")) ??
+    getPublicOriginFromHost(headers.get("host"))
+  );
+}
+
 export function shouldUseRequestSiteUrl(params: {
   config: Config;
   requestOrigin: string | null;


### PR DESCRIPTION
## Summary
- prefer `x-forwarded-host` over `host` when deriving the public DAO request origin
- reuse the forwarded public origin for the remote config cache key and API Origin fallback
- add a regression test for Vercel alias requests where `host` can remain the stale Vercel origin

## Verification
- `pnpm install --filter @degov/web... --frozen-lockfile`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-social-preview`
- `pnpm run test:seo-geo-structured-data`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- `git diff --check`

## Production context
After PR #1058 was deployed to production, cache-busted readbacks from `https://demo.degov.ai/` and a live proposal page still emitted `https://degov-dev.vercel.app` in OG and JSON-LD metadata. This follow-up fixes the remaining forwarded-host case before updating or closing the related SEO/GEO issues.