### PR TITLE
Use production origin for DAO metadata fallback

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -285,6 +285,21 @@ test("explicit public site URL environment accepts full HTTPS origins", () => {
   );
 });
 
+test("explicit public site URL environment rejects non-origin URLs", () => {
+  for (const value of [
+    "http://demo.degov.ai",
+    "https://demo.degov.ai/path",
+    "https://demo.degov.ai?x=1",
+    "https://demo.degov.ai#hash",
+    "https://demo.degov.ai@evil.com",
+  ]) {
+    assert.equal(
+      getPublicOriginFromEnvironment({ DEGOV_PUBLIC_SITE_URL: value }),
+      null
+    );
+  }
+});
+
 test("production environment origin does not replace real DAO hosts", () => {
   assert.equal(
     shouldUseEnvironmentSiteUrl({

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -14,8 +14,10 @@ import {
   SOCIAL_PREVIEW_IMAGE_WIDTH,
 } from "../src/lib/metadata.ts";
 import {
+  getPublicOriginFromEnvironment,
   getPublicOriginFromHeaders,
   getPublicOriginFromHost,
+  shouldUseEnvironmentSiteUrl,
   shouldUseRequestSiteUrl,
   withRequestSiteUrl,
 } from "../src/lib/request-origin.ts";
@@ -244,6 +246,52 @@ test("request host override prefers forwarded public host on Vercel aliases", ()
   assertSocialMetadata(
     buildSiteMetadata(withRequestSiteUrl(config, requestOrigin)),
     "https://demo.degov.ai"
+  );
+});
+
+test("production environment origin overrides stale Vercel request hosts", () => {
+  const requestOrigin = getPublicOriginFromHeaders(
+    new Headers({ host: "degov-dev.vercel.app" })
+  );
+  const environmentOrigin = getPublicOriginFromEnvironment({
+    VERCEL_ENV: "production",
+    VERCEL_PROJECT_PRODUCTION_URL: "demo.degov.ai",
+  });
+  const config = {
+    ...demoConfig,
+    siteUrl: "https://degov-dev.vercel.app",
+  };
+
+  assert.equal(requestOrigin, "https://degov-dev.vercel.app");
+  assert.equal(environmentOrigin, "https://demo.degov.ai");
+  assert.equal(
+    shouldUseEnvironmentSiteUrl({ requestOrigin, environmentOrigin }),
+    true
+  );
+  assertSocialMetadata(
+    buildSiteMetadata(withRequestSiteUrl(config, environmentOrigin)),
+    "https://demo.degov.ai"
+  );
+});
+
+test("explicit public site URL environment accepts full HTTPS origins", () => {
+  assert.equal(
+    getPublicOriginFromEnvironment({
+      DEGOV_PUBLIC_SITE_URL: "https://demo.degov.ai",
+      VERCEL_ENV: "preview",
+      VERCEL_PROJECT_PRODUCTION_URL: "degov-dev.vercel.app",
+    }),
+    "https://demo.degov.ai"
+  );
+});
+
+test("production environment origin does not replace real DAO hosts", () => {
+  assert.equal(
+    shouldUseEnvironmentSiteUrl({
+      requestOrigin: "https://lisk.degov.ai",
+      environmentOrigin: "https://demo.degov.ai",
+    }),
+    false
   );
 });
 

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -4,7 +4,9 @@ import { headers } from "next/headers";
 import { getDaoConfigServer } from "@/lib/config";
 import { loadConfigYaml } from "@/lib/config-yaml";
 import {
+  getPublicOriginFromEnvironment,
   getPublicOriginFromHeaders,
+  shouldUseEnvironmentSiteUrl,
   shouldUseRequestSiteUrl,
   withRequestSiteUrl,
 } from "@/lib/request-origin";
@@ -14,7 +16,18 @@ import { degovApiDaoConfigServer } from "@/utils/remote-api";
 export async function getConfigCachedByHost(): Promise<Config> {
   const hdr = await headers();
   const host = hdr.get("host");
-  const publicRequestOrigin = getPublicOriginFromHeaders(hdr);
+  const headerRequestOrigin = getPublicOriginFromHeaders(hdr);
+  const environmentOrigin = getPublicOriginFromEnvironment({
+    DEGOV_PUBLIC_SITE_URL: process.env.DEGOV_PUBLIC_SITE_URL,
+    VERCEL_ENV: process.env.VERCEL_ENV,
+    VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
+  });
+  const publicRequestOrigin = shouldUseEnvironmentSiteUrl({
+    requestOrigin: headerRequestOrigin,
+    environmentOrigin,
+  })
+    ? environmentOrigin
+    : headerRequestOrigin;
 
   // Resolve the canonical public origin to pass to the remote config API.
   // Next.js internal revalidation requests use the pod IP as the Host header,

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -61,7 +61,19 @@ function getPublicOriginFromUrlOrHost(value: string | undefined): string | null 
   if (!value) return null;
 
   try {
-    return getPublicOriginFromHost(new URL(value).host);
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" ||
+      url.username ||
+      url.password ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+
+    return getPublicOriginFromHost(url.host);
   } catch {
     return getPublicOriginFromHost(value);
   }

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -57,6 +57,46 @@ export function getPublicOriginFromHeaders(headers: {
   );
 }
 
+function getPublicOriginFromUrlOrHost(value: string | undefined): string | null {
+  if (!value) return null;
+
+  try {
+    return getPublicOriginFromHost(new URL(value).host);
+  } catch {
+    return getPublicOriginFromHost(value);
+  }
+}
+
+export function getPublicOriginFromEnvironment(env: {
+  DEGOV_PUBLIC_SITE_URL?: string;
+  VERCEL_ENV?: string;
+  VERCEL_PROJECT_PRODUCTION_URL?: string;
+}): string | null {
+  const explicitOrigin = getPublicOriginFromUrlOrHost(env.DEGOV_PUBLIC_SITE_URL);
+  if (explicitOrigin) return explicitOrigin;
+
+  if (env.VERCEL_ENV !== "production") return null;
+
+  return getPublicOriginFromUrlOrHost(env.VERCEL_PROJECT_PRODUCTION_URL);
+}
+
+export function shouldUseEnvironmentSiteUrl(params: {
+  requestOrigin: string | null;
+  environmentOrigin: string | null;
+}): boolean {
+  const { requestOrigin, environmentOrigin } = params;
+  if (!environmentOrigin) return false;
+  if (!requestOrigin) return true;
+
+  const requestHost = getHostname(requestOrigin);
+  const environmentHost = getHostname(environmentOrigin);
+  if (!requestHost || !environmentHost || requestHost === environmentHost) {
+    return false;
+  }
+
+  return isVercelHost(requestHost) && isDegovOwnedHost(environmentHost);
+}
+
 export function shouldUseRequestSiteUrl(params: {
   config: Config;
   requestOrigin: string | null;


### PR DESCRIPTION
## Summary
- use an explicit `DEGOV_PUBLIC_SITE_URL` or Vercel production URL as a public DAO origin fallback in production
- only replace request-derived origins when the request host is a stale Vercel host, preserving real DAO hosts such as `lisk.degov.ai`
- add regression coverage for stale Vercel host fallback, explicit full URL env parsing, and real-host preservation

## Verification
- `pnpm install --filter @degov/web... --frozen-lockfile`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-social-preview`
- `pnpm run test:seo-geo-structured-data`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- `git diff --check`

## Production context
After PR #1059 was deployed, cache-busted readbacks from `https://demo.degov.ai/` still emitted `https://degov-dev.vercel.app`, which means the runtime request host available to metadata remained the stale Vercel host. This follow-up adds a production-environment origin fallback before updating or closing related SEO/GEO issues.