### PR TITLE
Set production DAO metadata site URL

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -29,7 +29,10 @@ jobs:
           cat > vercel.json <<'EOF'
           {
             "installCommand": "pnpm install --no-frozen-lockfile",
-            "buildCommand": "pnpm build:vercel"
+            "buildCommand": "pnpm build:vercel",
+            "env": {
+              "DEGOV_PUBLIC_SITE_URL": "https://demo.degov.ai"
+            }
           }
           EOF
 

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -316,7 +316,10 @@ test("production deploy provides the canonical public demo origin", () => {
     "utf8"
   );
 
-  assert.match(workflow, /"DEGOV_PUBLIC_SITE_URL": "https:\/\/demo\.degov\.ai"/);
+  assert.match(
+    workflow,
+    /"DEGOV_PUBLIC_SITE_URL"\s*:\s*"https:\/\/demo\.degov\.ai"/
+  );
 });
 
 test("private DAO routes keep explicit noindex metadata", () => {

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -310,6 +310,15 @@ test("production environment origin does not replace real DAO hosts", () => {
   );
 });
 
+test("production deploy provides the canonical public demo origin", () => {
+  const workflow = readFileSync(
+    path.join(rootDir, ".github/workflows/deploy-prd.yml"),
+    "utf8"
+  );
+
+  assert.match(workflow, /"DEGOV_PUBLIC_SITE_URL": "https:\/\/demo\.degov\.ai"/);
+});
+
 test("private DAO routes keep explicit noindex metadata", () => {
   const privateLayouts = [
     "apps/web/src/app/profile/layout.tsx",


### PR DESCRIPTION
## Summary
- inject `DEGOV_PUBLIC_SITE_URL=https://demo.degov.ai` into the production Vercel deployment config
- add a regression test that the production deploy workflow preserves the canonical public demo origin

## Verification
- `pnpm install --filter @degov/web... --frozen-lockfile`
- `node --test apps/web/scripts/dao-social-preview.test.ts`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-social-preview`
- `pnpm run test:seo-geo-structured-data`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- `git diff --check`

## Production context
PR #1060 added the app-level fallback, but the production readback still emitted `https://degov-dev.vercel.app` because the Vercel deployment did not provide a public production site URL to the app. This PR supplies that deployment contract explicitly.