### PR TITLE
Map stale Vercel production origin to demo alias

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -274,6 +274,31 @@ test("production environment origin overrides stale Vercel request hosts", () =>
   );
 });
 
+test("production environment maps the known stale project host to the demo alias", () => {
+  const requestOrigin = getPublicOriginFromHeaders(
+    new Headers({ host: "degov-dev.vercel.app" })
+  );
+  const environmentOrigin = getPublicOriginFromEnvironment({
+    VERCEL_ENV: "production",
+    VERCEL_PROJECT_PRODUCTION_URL: "degov-dev.vercel.app",
+  });
+  const config = {
+    ...demoConfig,
+    siteUrl: "https://degov-dev.vercel.app",
+  };
+
+  assert.equal(requestOrigin, "https://degov-dev.vercel.app");
+  assert.equal(environmentOrigin, "https://demo.degov.ai");
+  assert.equal(
+    shouldUseEnvironmentSiteUrl({ requestOrigin, environmentOrigin }),
+    true
+  );
+  assertSocialMetadata(
+    buildSiteMetadata(withRequestSiteUrl(config, environmentOrigin)),
+    "https://demo.degov.ai"
+  );
+});
+
 test("explicit public site URL environment accepts full HTTPS origins", () => {
   assert.equal(
     getPublicOriginFromEnvironment({

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -20,6 +20,14 @@ function isVercelHost(hostname: string): boolean {
   return hostname === "vercel.app" || hostname.endsWith(".vercel.app");
 }
 
+function getKnownProductionOrigin(hostname: string): string | null {
+  if (hostname === "degov-dev.vercel.app") {
+    return "https://demo.degov.ai";
+  }
+
+  return null;
+}
+
 export function getPublicOriginFromHost(
   host: string | null | undefined
 ): string | null {
@@ -89,7 +97,15 @@ export function getPublicOriginFromEnvironment(env: {
 
   if (env.VERCEL_ENV !== "production") return null;
 
-  return getPublicOriginFromUrlOrHost(env.VERCEL_PROJECT_PRODUCTION_URL);
+  const productionOrigin = getPublicOriginFromUrlOrHost(
+    env.VERCEL_PROJECT_PRODUCTION_URL
+  );
+  if (!productionOrigin) return null;
+
+  const productionHost = getHostname(productionOrigin);
+  if (!productionHost) return productionOrigin;
+
+  return getKnownProductionOrigin(productionHost) ?? productionOrigin;
 }
 
 export function shouldUseEnvironmentSiteUrl(params: {


### PR DESCRIPTION
## Summary\n- Map the known stale Vercel production project host to the public demo DAO alias before metadata config normalization.\n- Add a regression test for production runtime env exposing `degov-dev.vercel.app` while public metadata must use `demo.degov.ai`.\n\n## Verification\n- `node --test apps/web/scripts/dao-social-preview.test.ts`\n- `pnpm run test:seo-geo-social-preview`\n- `pnpm install --filter @degov/web... --frozen-lockfile`\n- `pnpm run test:web-scripts`\n- `pnpm --filter @degov/web lint`\n- `pnpm --filter @degov/web build`\n- `git diff --check`\n\nRefs #714, #1028, #1029, #1054