### PR TITLE
Normalize stale DAO config origin

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -14,6 +14,7 @@ import {
   SOCIAL_PREVIEW_IMAGE_WIDTH,
 } from "../src/lib/metadata.ts";
 import {
+  getKnownProductionOriginFromConfig,
   getPublicOriginFromEnvironment,
   getPublicOriginFromHeaders,
   getPublicOriginFromHost,
@@ -194,6 +195,22 @@ test("single DAO mode only overrides known stale Vercel config origins", () => {
     }),
     false
   );
+});
+
+test("known stale config site URL maps to the production demo alias", () => {
+  const staleVercelConfig = {
+    ...demoConfig,
+    siteUrl: "https://degov-dev.vercel.app",
+  };
+
+  const productionOrigin = getKnownProductionOriginFromConfig(staleVercelConfig);
+
+  assert.equal(productionOrigin, "https://demo.degov.ai");
+  assertSocialMetadata(
+    buildSiteMetadata(withRequestSiteUrl(staleVercelConfig, productionOrigin)),
+    "https://demo.degov.ai"
+  );
+  assert.equal(getKnownProductionOriginFromConfig(demoConfig), null);
 });
 
 test("request site URL override happens after remote config cache lookup", () => {

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { getDaoConfigServer } from "@/lib/config";
 import { loadConfigYaml } from "@/lib/config-yaml";
 import {
+  getKnownProductionOriginFromConfig,
   getPublicOriginFromEnvironment,
   getPublicOriginFromHeaders,
   shouldUseEnvironmentSiteUrl,
@@ -91,6 +92,11 @@ export async function getConfigCachedByHost(): Promise<Config> {
   );
 
   const result = await get();
+  const knownProductionOrigin = getKnownProductionOriginFromConfig(result);
+  if (knownProductionOrigin) {
+    return withRequestSiteUrl(result, knownProductionOrigin);
+  }
+
   return shouldUseRequestSiteUrl({
     config: result,
     requestOrigin: publicRequestOrigin,

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -93,15 +93,15 @@ export async function getConfigCachedByHost(): Promise<Config> {
 
   const result = await get();
   const knownProductionOrigin = getKnownProductionOriginFromConfig(result);
-  if (knownProductionOrigin) {
-    return withRequestSiteUrl(result, knownProductionOrigin);
-  }
+  const normalizedResult = knownProductionOrigin
+    ? withRequestSiteUrl(result, knownProductionOrigin)
+    : result;
 
   return shouldUseRequestSiteUrl({
-    config: result,
+    config: normalizedResult,
     requestOrigin: publicRequestOrigin,
     requiresOrigin: !process.env.NEXT_PUBLIC_DEGOV_DAO,
   })
-    ? withRequestSiteUrl(result, publicRequestOrigin)
-    : result;
+    ? withRequestSiteUrl(normalizedResult, publicRequestOrigin)
+    : normalizedResult;
 }

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -28,6 +28,18 @@ function getKnownProductionOrigin(hostname: string): string | null {
   return null;
 }
 
+export function getKnownProductionOriginFromConfig(
+  config: Config
+): string | null {
+  const configuredSiteUrl = config.siteUrl?.trim();
+  if (!configuredSiteUrl) return null;
+
+  const configuredHost = getHostname(configuredSiteUrl);
+  if (!configuredHost) return null;
+
+  return getKnownProductionOrigin(configuredHost);
+}
+
 export function getPublicOriginFromHost(
   host: string | null | undefined
 ): string | null {


### PR DESCRIPTION
## Summary\n- Normalize the known stale remote DAO config site URL before returning cached config to public metadata builders.\n- Keep the existing request/env host normalization, but no longer depend on Vercel runtime env being visible for the demo DAO production alias.\n- Add regression coverage for stale config siteUrl mapping to the public demo alias.\n\n## Verification\n- `node --test apps/web/scripts/dao-social-preview.test.ts`\n- `pnpm install --filter @degov/web... --frozen-lockfile`\n- `pnpm run test:web-scripts`\n- `pnpm run test:seo-geo-social-preview`\n- `pnpm --filter @degov/web lint`\n- `pnpm --filter @degov/web build`\n- `git diff --check`\n\nRefs #714, #1028, #1029, #1054