### PR TITLE
Normalize stale DAO site URL at config boundary

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -114,6 +114,12 @@ function assertSocialMetadata(metadata: Metadata, expectedUrl: string) {
   assert.ok(!imageUrl.includes("vercel.app"), "image URL must not use preview host");
 }
 
+function matchSourceIndex(source: string, pattern: RegExp, message: string) {
+  const match = pattern.exec(source);
+  assert.ok(match?.index !== undefined, message);
+  return match.index;
+}
+
 test("DAO social preview fallback is a public 1200x630 PNG asset", () => {
   const buffer = readFileSync(imagePath);
   const dimensions = readPngDimensions(buffer);
@@ -243,12 +249,19 @@ test("request site URL override happens after remote config cache lookup", () =>
     path.join(rootDir, "apps/web/src/app/_server/config-remote.ts"),
     "utf8"
   );
-  const cacheReturnIndex = source.indexOf("const result = await get();");
-  const overrideIndex = source.indexOf("shouldUseRequestSiteUrl", cacheReturnIndex);
+  const cacheReturnIndex = matchSourceIndex(
+    source,
+    /const\s+result\s*=\s*await\s+get\s*\(\s*\)\s*;/,
+    "config cache result must be read explicitly"
+  );
+  const overrideIndex = matchSourceIndex(
+    source.slice(cacheReturnIndex),
+    /shouldUseRequestSiteUrl/,
+    "request host override must be present after cache lookup"
+  );
 
-  assert.ok(cacheReturnIndex >= 0, "config cache result must be read explicitly");
   assert.ok(
-    overrideIndex > cacheReturnIndex,
+    overrideIndex >= 0,
     "request host override must run after cache lookup so cache hits are normalized"
   );
 });
@@ -258,12 +271,19 @@ test("local config path normalizes known stale site URL after YAML load", () => 
     path.join(rootDir, "apps/web/src/lib/config.ts"),
     "utf8"
   );
-  const yamlLoadIndex = source.indexOf("const config = loadConfigYaml(yamlText);");
-  const normalizeIndex = source.indexOf("return normalizeConfig(config);");
+  const yamlLoadIndex = matchSourceIndex(
+    source,
+    /const\s+config\s*=\s*loadConfigYaml\s*\(\s*yamlText\s*\)\s*;/,
+    "local config must load YAML explicitly"
+  );
+  const normalizeIndex = matchSourceIndex(
+    source.slice(yamlLoadIndex),
+    /return\s+normalizeConfig\s*\(\s*config\s*\)\s*;/,
+    "local config must normalize stale production siteUrl before returning config"
+  );
 
-  assert.ok(yamlLoadIndex >= 0, "local config must load YAML explicitly");
   assert.ok(
-    normalizeIndex > yamlLoadIndex,
+    normalizeIndex >= 0,
     "local config must normalize stale production siteUrl before returning config"
   );
 });

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -20,6 +20,7 @@ import {
   getPublicOriginFromHost,
   shouldUseEnvironmentSiteUrl,
   shouldUseRequestSiteUrl,
+  withKnownProductionSiteUrl,
   withRequestSiteUrl,
 } from "../src/lib/request-origin.ts";
 
@@ -213,6 +214,30 @@ test("known stale config site URL maps to the production demo alias", () => {
   assert.equal(getKnownProductionOriginFromConfig(demoConfig), null);
 });
 
+test("shared config normalization maps stale site URL before metadata builders", () => {
+  const staleVercelConfig = {
+    ...demoConfig,
+    siteUrl: "https://degov-dev.vercel.app",
+  };
+  const config = withKnownProductionSiteUrl(
+    staleVercelConfig,
+    "https://demo.degov.ai"
+  );
+
+  assertSocialMetadata(buildSiteMetadata(config), "https://demo.degov.ai");
+  assertSocialMetadata(
+    buildProposalMetadata({
+      config,
+      proposalId:
+        "0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878",
+      title: "Normalize local config site URL",
+      description:
+        "Use the production demo alias before public metadata is generated.",
+    }),
+    "https://demo.degov.ai/proposal/0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878"
+  );
+});
+
 test("request site URL override happens after remote config cache lookup", () => {
   const source = readFileSync(
     path.join(rootDir, "apps/web/src/app/_server/config-remote.ts"),
@@ -225,6 +250,21 @@ test("request site URL override happens after remote config cache lookup", () =>
   assert.ok(
     overrideIndex > cacheReturnIndex,
     "request host override must run after cache lookup so cache hits are normalized"
+  );
+});
+
+test("local config path normalizes known stale site URL after YAML load", () => {
+  const source = readFileSync(
+    path.join(rootDir, "apps/web/src/lib/config.ts"),
+    "utf8"
+  );
+  const yamlLoadIndex = source.indexOf("const config = loadConfigYaml(yamlText);");
+  const normalizeIndex = source.indexOf("return normalizeConfig(config);");
+
+  assert.ok(yamlLoadIndex >= 0, "local config must load YAML explicitly");
+  assert.ok(
+    normalizeIndex > yamlLoadIndex,
+    "local config must normalize stale production siteUrl before returning config"
   );
 });
 

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -4,11 +4,11 @@ import { headers } from "next/headers";
 import { getDaoConfigServer } from "@/lib/config";
 import { loadConfigYaml } from "@/lib/config-yaml";
 import {
-  getKnownProductionOriginFromConfig,
   getPublicOriginFromEnvironment,
   getPublicOriginFromHeaders,
   shouldUseEnvironmentSiteUrl,
   shouldUseRequestSiteUrl,
+  withKnownProductionSiteUrl,
   withRequestSiteUrl,
 } from "@/lib/request-origin";
 import type { Config } from "@/types/config";
@@ -92,10 +92,7 @@ export async function getConfigCachedByHost(): Promise<Config> {
   );
 
   const result = await get();
-  const knownProductionOrigin = getKnownProductionOriginFromConfig(result);
-  const normalizedResult = knownProductionOrigin
-    ? withRequestSiteUrl(result, knownProductionOrigin)
-    : result;
+  const normalizedResult = withKnownProductionSiteUrl(result);
 
   return shouldUseRequestSiteUrl({
     config: normalizedResult,

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -4,11 +4,25 @@ import path from "path";
 import { unstable_cache } from "next/cache";
 
 import { loadConfigYaml } from "@/lib/config-yaml";
+import {
+  getPublicOriginFromEnvironment,
+  withKnownProductionSiteUrl,
+} from "@/lib/request-origin";
 import type { Config } from "@/types/config";
 
 const defaultConfig = {
   name: "DeGov",
 };
+
+function normalizeConfig(config: Config): Config {
+  const productionOrigin = getPublicOriginFromEnvironment({
+    DEGOV_PUBLIC_SITE_URL: process.env.DEGOV_PUBLIC_SITE_URL,
+    VERCEL_ENV: process.env.VERCEL_ENV,
+    VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
+  });
+
+  return withKnownProductionSiteUrl(config, productionOrigin);
+}
 
 export const getDaoConfigServer = unstable_cache(
   async (): Promise<Config> => {
@@ -27,7 +41,7 @@ export const getDaoConfigServer = unstable_cache(
         typeof config === "object" &&
         typeof config.name === "string"
       ) {
-        return config;
+        return normalizeConfig(config);
       }
 
       return defaultConfig as Config;

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -40,6 +40,16 @@ export function getKnownProductionOriginFromConfig(
   return getKnownProductionOrigin(configuredHost);
 }
 
+export function withKnownProductionSiteUrl(
+  config: Config,
+  productionOrigin?: string | null
+): Config {
+  const knownProductionOrigin = getKnownProductionOriginFromConfig(config);
+  if (!knownProductionOrigin) return config;
+
+  return withRequestSiteUrl(config, productionOrigin ?? knownProductionOrigin);
+}
+
 export function getPublicOriginFromHost(
   host: string | null | undefined
 ): string | null {


### PR DESCRIPTION
## Summary

- Normalize known stale DAO `siteUrl` values through a shared config helper before metadata/JSON-LD builders consume config.
- Apply the normalization to the local/single-DAO config path as well as the remote config path.
- Add regression coverage for shared normalization and local config boundary ordering.

## Context

Production readback after #1063 still showed `demo.degov.ai` metadata and JSON-LD using `https://degov-dev.vercel.app`, which indicates the affected path can bypass the remote-config-only normalization.

Links: #714, #1028, #1029, #1054

## Verification

- `node --test apps/web/scripts/dao-social-preview.test.ts`
- `git diff --check`
- `pnpm run test:web-scripts`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`

Build note: Next build still reports the existing `ox/viem` dynamic dependency warning from `virtualMasterPool.js`.