### PR TITLE
Normalize stale DAO config app links

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -256,6 +256,12 @@ test("shared config normalization maps stale production origins in public app li
         icon: "https://demo.degov.ai/token-wrap.png",
         link: "https://token-wrap.degov.ai?config=https://degov-dev.vercel.app/degov.yml",
       },
+      {
+        name: "Untrusted Prefix Host",
+        description: "Must not normalize a prefixed hostname",
+        icon: "https://demo.degov.ai/untrusted.png",
+        link: "https://degov-dev.vercel.app.evil.com/degov.yml",
+      },
     ],
   };
   const config = withKnownProductionConfigOrigins(
@@ -267,6 +273,10 @@ test("shared config normalization maps stale production origins in public app li
   assert.equal(
     config.apps?.[0]?.link,
     "https://token-wrap.degov.ai?config=https://demo.degov.ai/degov.yml"
+  );
+  assert.equal(
+    config.apps?.[1]?.link,
+    "https://degov-dev.vercel.app.evil.com/degov.yml"
   );
 });
 

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -20,6 +20,7 @@ import {
   getPublicOriginFromHost,
   shouldUseEnvironmentSiteUrl,
   shouldUseRequestSiteUrl,
+  withKnownProductionConfigOrigins,
   withKnownProductionSiteUrl,
   withRequestSiteUrl,
 } from "../src/lib/request-origin.ts";
@@ -241,6 +242,31 @@ test("shared config normalization maps stale site URL before metadata builders",
         "Use the production demo alias before public metadata is generated.",
     }),
     "https://demo.degov.ai/proposal/0xb1318bd67737f2fe8a918bfd691ac5e69e174a0c9455bcc36b80a3ccc7caa878"
+  );
+});
+
+test("shared config normalization maps stale production origins in public app links", () => {
+  const staleVercelConfig = {
+    ...demoConfig,
+    siteUrl: "https://degov-dev.vercel.app",
+    apps: [
+      {
+        name: "Token Wrap",
+        description: "Wrap tokens",
+        icon: "https://demo.degov.ai/token-wrap.png",
+        link: "https://token-wrap.degov.ai?config=https://degov-dev.vercel.app/degov.yml",
+      },
+    ],
+  };
+  const config = withKnownProductionConfigOrigins(
+    staleVercelConfig,
+    "https://demo.degov.ai"
+  );
+
+  assert.equal(config.siteUrl, "https://demo.degov.ai");
+  assert.equal(
+    config.apps?.[0]?.link,
+    "https://token-wrap.degov.ai?config=https://demo.degov.ai/degov.yml"
   );
 });
 

--- a/apps/web/src/app/_server/config-remote.ts
+++ b/apps/web/src/app/_server/config-remote.ts
@@ -8,7 +8,7 @@ import {
   getPublicOriginFromHeaders,
   shouldUseEnvironmentSiteUrl,
   shouldUseRequestSiteUrl,
-  withKnownProductionSiteUrl,
+  withKnownProductionConfigOrigins,
   withRequestSiteUrl,
 } from "@/lib/request-origin";
 import type { Config } from "@/types/config";
@@ -92,7 +92,7 @@ export async function getConfigCachedByHost(): Promise<Config> {
   );
 
   const result = await get();
-  const normalizedResult = withKnownProductionSiteUrl(result);
+  const normalizedResult = withKnownProductionConfigOrigins(result);
 
   return shouldUseRequestSiteUrl({
     config: normalizedResult,

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -6,7 +6,7 @@ import { unstable_cache } from "next/cache";
 import { loadConfigYaml } from "@/lib/config-yaml";
 import {
   getPublicOriginFromEnvironment,
-  withKnownProductionSiteUrl,
+  withKnownProductionConfigOrigins,
 } from "@/lib/request-origin";
 import type { Config } from "@/types/config";
 
@@ -21,7 +21,7 @@ function normalizeConfig(config: Config): Config {
     VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
   });
 
-  return withKnownProductionSiteUrl(config, productionOrigin);
+  return withKnownProductionConfigOrigins(config, productionOrigin);
 }
 
 export const getDaoConfigServer = unstable_cache(

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -24,6 +24,10 @@ const KNOWN_PRODUCTION_ORIGINS = new Map([
   ["degov-dev.vercel.app", "https://demo.degov.ai"],
 ]);
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function getKnownProductionOrigin(hostname: string): string | null {
   return KNOWN_PRODUCTION_ORIGINS.get(hostname) ?? null;
 }
@@ -57,10 +61,11 @@ export function replaceKnownProductionOrigins(
   let result = value;
 
   for (const [hostname, knownProductionOrigin] of KNOWN_PRODUCTION_ORIGINS) {
-    result = result.replaceAll(
-      `https://${hostname}`,
-      productionOrigin ?? knownProductionOrigin
+    const staleOrigin = new RegExp(
+      `https://${escapeRegex(hostname)}(?=[/?#]|$)`,
+      "g"
     );
+    result = result.replace(staleOrigin, productionOrigin ?? knownProductionOrigin);
   }
 
   return result;

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -20,12 +20,12 @@ function isVercelHost(hostname: string): boolean {
   return hostname === "vercel.app" || hostname.endsWith(".vercel.app");
 }
 
-function getKnownProductionOrigin(hostname: string): string | null {
-  if (hostname === "degov-dev.vercel.app") {
-    return "https://demo.degov.ai";
-  }
+const KNOWN_PRODUCTION_ORIGINS = new Map([
+  ["degov-dev.vercel.app", "https://demo.degov.ai"],
+]);
 
-  return null;
+function getKnownProductionOrigin(hostname: string): string | null {
+  return KNOWN_PRODUCTION_ORIGINS.get(hostname) ?? null;
 }
 
 export function getKnownProductionOriginFromConfig(
@@ -48,6 +48,49 @@ export function withKnownProductionSiteUrl(
   if (!knownProductionOrigin) return config;
 
   return withRequestSiteUrl(config, productionOrigin ?? knownProductionOrigin);
+}
+
+export function replaceKnownProductionOrigins(
+  value: string,
+  productionOrigin?: string | null
+): string {
+  let result = value;
+
+  for (const [hostname, knownProductionOrigin] of KNOWN_PRODUCTION_ORIGINS) {
+    result = result.replaceAll(
+      `https://${hostname}`,
+      productionOrigin ?? knownProductionOrigin
+    );
+  }
+
+  return result;
+}
+
+export function withKnownProductionConfigOrigins(
+  config: Config,
+  productionOrigin?: string | null
+): Config {
+  const siteUrlConfig = withKnownProductionSiteUrl(config, productionOrigin);
+  if (!siteUrlConfig.apps?.length) return siteUrlConfig;
+
+  let changed = siteUrlConfig !== config;
+  const apps = siteUrlConfig.apps.map((app) => {
+    const link = replaceKnownProductionOrigins(app.link, productionOrigin);
+    if (link === app.link) return app;
+
+    changed = true;
+    return {
+      ...app,
+      link,
+    };
+  });
+
+  return changed
+    ? {
+        ...siteUrlConfig,
+        apps,
+      }
+    : siteUrlConfig;
 }
 
 export function getPublicOriginFromHost(


### PR DESCRIPTION
## Summary

- Normalize known stale production origins in public DAO config app links at the shared config boundary.
- Keep site URL normalization on the same helper so local and remote config paths behave consistently.
- Add regression coverage for the public Token Wrap-style `config=` app link case observed in production readback.

## Context

After #1064, production `demo.degov.ai` canonical/OG/JSON-LD URLs were corrected, but raw HTML still contained one stale `degov-dev.vercel.app` occurrence from the DAO app link `https://token-wrap.degov.ai?config=https://degov-dev.vercel.app/degov.yml`.

Links: #714, #1029

## Verification

- `node --test apps/web/scripts/dao-social-preview.test.ts`
- `pnpm run test:web-scripts`
- `pnpm --filter @degov/web lint`
- `git diff --check`
- `pnpm --filter @degov/web build`

Build note: Next build still reports the existing `ox/viem` dynamic dependency warning from `virtualMasterPool.js`.