### PR TITLE
Tighten DAO social preview metadata

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  buildNoPublicPreviewMetadata,
   buildProposalDirectoryMetadata,
   buildProposalMetadata,
   buildSiteMetadata,
@@ -131,7 +132,10 @@ test("DAO social preview fallback is a public 1200x630 PNG asset", () => {
 });
 
 test("DAO public metadata uses host-correct large-image social previews", () => {
-  assertSocialMetadata(buildSiteMetadata(demoConfig), "https://demo.degov.ai");
+  const siteMetadata = buildSiteMetadata(demoConfig);
+
+  assert.equal(siteMetadata.alternates?.canonical, "https://demo.degov.ai");
+  assertSocialMetadata(siteMetadata, "https://demo.degov.ai");
   assertSocialMetadata(
     buildProposalDirectoryMetadata(demoConfig),
     "https://demo.degov.ai/proposals"
@@ -469,10 +473,32 @@ test("private DAO routes keep explicit noindex metadata", () => {
 
   for (const layout of privateLayouts) {
     const source = readFileSync(path.join(rootDir, layout), "utf8");
-    assert.match(source, /robots:\s*{/);
-    assert.match(source, /index:\s*false/);
-    assert.match(source, /follow:\s*false/);
-    assert.doesNotMatch(source, /openGraph:/);
-    assert.doesNotMatch(source, /twitter:/);
+    assert.match(source, /buildNoPublicPreviewMetadata/);
+    assert.doesNotMatch(source, /buildSiteMetadata/);
   }
+});
+
+test("no-public-preview metadata suppresses inherited canonical and social cards", () => {
+  const metadata = buildNoPublicPreviewMetadata("Private route");
+
+  assert.deepEqual(metadata.robots, {
+    index: false,
+    follow: false,
+  });
+  assert.equal(metadata.alternates, null);
+  assert.equal(metadata.openGraph, null);
+  assert.equal(metadata.twitter, null);
+});
+
+test("invalid proposal metadata path suppresses public share cards", () => {
+  const source = readFileSync(
+    path.join(rootDir, "apps/web/src/app/proposal/[id]/layout.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /buildNoPublicPreviewMetadata\("Proposal not found"\)/);
+  assert.match(
+    source,
+    /if\s*\(!proposal\)\s*{\s*return buildNoPublicPreviewMetadata\("Proposal not found"\);\s*}/
+  );
 });

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  buildHomeMetadata,
   buildNoPublicPreviewMetadata,
   buildProposalDirectoryMetadata,
   buildProposalMetadata,
@@ -133,8 +134,9 @@ test("DAO social preview fallback is a public 1200x630 PNG asset", () => {
 
 test("DAO public metadata uses host-correct large-image social previews", () => {
   const siteMetadata = buildSiteMetadata(demoConfig);
+  const homeMetadata = buildHomeMetadata(demoConfig);
 
-  assert.equal(siteMetadata.alternates?.canonical, "https://demo.degov.ai");
+  assert.equal(homeMetadata.alternates?.canonical, "https://demo.degov.ai");
   assertSocialMetadata(siteMetadata, "https://demo.degov.ai");
   assertSocialMetadata(
     buildProposalDirectoryMetadata(demoConfig),

--- a/apps/web/scripts/proposal-metadata.test.ts
+++ b/apps/web/scripts/proposal-metadata.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildNoPublicPreviewMetadata,
   buildProposalMetadata,
   buildSiteMetadata,
   cleanMetadataText,
@@ -87,6 +88,7 @@ test("proposal metadata keeps a proposal-specific title and canonical url", () =
 test("site metadata uses a host-correct large social preview image", () => {
   const metadata = buildSiteMetadata(liskConfig);
 
+  assert.equal(metadata.alternates?.canonical, "https://lisk.degov.ai");
   assert.equal(metadata.openGraph?.url, "https://lisk.degov.ai");
   assert.equal(metadata.twitter?.card, "summary_large_image");
   assert.deepEqual(metadata.openGraph?.images, [
@@ -112,4 +114,17 @@ test("proposal metadata text cleaning removes markdown, html, and collapses whit
   );
 
   assert.equal(cleaned, "Hello world See forum ignored");
+});
+
+test("no-public-preview metadata removes canonical and social cards", () => {
+  const metadata = buildNoPublicPreviewMetadata("Proposal not found");
+
+  assert.equal(metadata.title, "Proposal not found");
+  assert.deepEqual(metadata.robots, {
+    index: false,
+    follow: false,
+  });
+  assert.equal(metadata.alternates, null);
+  assert.equal(metadata.openGraph, null);
+  assert.equal(metadata.twitter, null);
 });

--- a/apps/web/scripts/proposal-metadata.test.ts
+++ b/apps/web/scripts/proposal-metadata.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildHomeMetadata,
   buildNoPublicPreviewMetadata,
   buildProposalMetadata,
   buildSiteMetadata,
@@ -87,8 +88,9 @@ test("proposal metadata keeps a proposal-specific title and canonical url", () =
 
 test("site metadata uses a host-correct large social preview image", () => {
   const metadata = buildSiteMetadata(liskConfig);
+  const homeMetadata = buildHomeMetadata(liskConfig);
 
-  assert.equal(metadata.alternates?.canonical, "https://lisk.degov.ai");
+  assert.equal(homeMetadata.alternates?.canonical, "https://lisk.degov.ai");
   assert.equal(metadata.openGraph?.url, "https://lisk.degov.ai");
   assert.equal(metadata.twitter?.card, "summary_large_image");
   assert.deepEqual(metadata.openGraph?.images, [

--- a/apps/web/src/app/ai-analysis/layout.tsx
+++ b/apps/web/src/app/ai-analysis/layout.tsx
@@ -1,13 +1,10 @@
 import "../markdown-body.css";
 
+import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
+
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export const metadata: Metadata = buildNoPublicPreviewMetadata("AI analysis");
 
 export default function AiAnalysisLayout({
   children,

--- a/apps/web/src/app/profile/layout.tsx
+++ b/apps/web/src/app/profile/layout.tsx
@@ -1,11 +1,8 @@
+import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
+
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export const metadata: Metadata = buildNoPublicPreviewMetadata("Profile");
 
 export default function ProfileLayout({ children }: { children: React.ReactNode }) {
   return children;

--- a/apps/web/src/app/proposal/[id]/layout.tsx
+++ b/apps/web/src/app/proposal/[id]/layout.tsx
@@ -1,6 +1,9 @@
 import { getConfigCachedByHost } from "@/app/_server/config-remote";
 import { getDaoConfigServer } from "@/lib/config";
-import { buildProposalMetadata } from "@/lib/metadata";
+import {
+  buildNoPublicPreviewMetadata,
+  buildProposalMetadata,
+} from "@/lib/metadata";
 import { buildGovernanceScope, proposalService } from "@/services/graphql";
 import { extractTitleAndDescription, parseDescription } from "@/utils/helpers";
 import { isDegovApiConfiguredServer } from "@/utils/remote-api";
@@ -31,13 +34,7 @@ export async function generateMetadata({
   try {
     BigInt(id);
   } catch {
-    return {
-      title: "Proposal not found",
-      robots: {
-        index: false,
-        follow: false,
-      },
-    };
+    return buildNoPublicPreviewMetadata("Proposal not found");
   }
 
   if (!config?.indexer?.endpoint) {
@@ -60,10 +57,7 @@ export async function generateMetadata({
     const proposal = proposals[0];
 
     if (!proposal) {
-      return buildProposalMetadata({
-        config,
-        proposalId: id,
-      });
+      return buildNoPublicPreviewMetadata("Proposal not found");
     }
 
     const parsedDescription = parseDescription(proposal.description);

--- a/apps/web/src/app/proposals/new/layout.tsx
+++ b/apps/web/src/app/proposals/new/layout.tsx
@@ -1,11 +1,8 @@
+import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
+
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export const metadata: Metadata = buildNoPublicPreviewMetadata("New proposal");
 
 export default function NewProposalLayout({ children }: { children: React.ReactNode }) {
   return children;

--- a/apps/web/src/lib/metadata.ts
+++ b/apps/web/src/lib/metadata.ts
@@ -89,6 +89,11 @@ export function buildSiteMetadata(
       default: `${daoName}`,
     },
     description,
+    alternates: publicSiteUrl
+      ? {
+          canonical: publicSiteUrl,
+        }
+      : undefined,
     icons: config?.logo
       ? {
           icon: [{ url: config.logo }],
@@ -128,6 +133,19 @@ export function buildSiteMetadata(
     other: {
       configName: daoName,
     },
+  };
+}
+
+export function buildNoPublicPreviewMetadata(title: string): Metadata {
+  return {
+    title,
+    robots: {
+      index: false,
+      follow: false,
+    },
+    alternates: null,
+    openGraph: null,
+    twitter: null,
   };
 }
 

--- a/apps/web/src/lib/metadata.ts
+++ b/apps/web/src/lib/metadata.ts
@@ -89,11 +89,6 @@ export function buildSiteMetadata(
       default: `${daoName}`,
     },
     description,
-    alternates: publicSiteUrl
-      ? {
-          canonical: publicSiteUrl,
-        }
-      : undefined,
     icons: config?.logo
       ? {
           icon: [{ url: config.logo }],


### PR DESCRIPTION
## Summary

- Add canonical metadata to DAO site-level metadata so homepage canonical, og:url, and social page URL share the validated production origin.
- Add a no-public-preview metadata helper that keeps noindex routes from inheriting public canonical, Open Graph, or Twitter cards.
- Apply the helper to private DAO routes and invalid proposal metadata paths.

## Verification

- `pnpm install --filter @degov/web... --frozen-lockfile`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-social-preview`
- `pnpm run test:seo-geo-contract`
- `pnpm run test:seo-geo-structured-data`
- `pnpm --filter @degov/web build`
- `pnpm --filter @degov/web lint`
- `git diff --check`

Part of #1029 and #714.
