### PR TITLE
Add DAO homepage canonical metadata

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -136,6 +136,7 @@ test("DAO public metadata uses host-correct large-image social previews", () => 
   const siteMetadata = buildSiteMetadata(demoConfig);
   const homeMetadata = buildHomeMetadata(demoConfig);
 
+  assert.equal(siteMetadata.alternates?.canonical, "https://demo.degov.ai");
   assert.equal(homeMetadata.alternates?.canonical, "https://demo.degov.ai");
   assertSocialMetadata(siteMetadata, "https://demo.degov.ai");
   assertSocialMetadata(
@@ -480,16 +481,6 @@ test("private DAO routes keep explicit noindex metadata", () => {
   }
 });
 
-test("DAO homepage renders a canonical link from the validated DAO origin", () => {
-  const source = readFileSync(
-    path.join(rootDir, "apps/web/src/app/page.tsx"),
-    "utf8"
-  );
-
-  assert.match(source, /canonicalUrl\(config,\s*"\/"\)/);
-  assert.match(source, /<link rel="canonical" href={homeCanonicalUrl}/);
-});
-
 test("localized DAO homepage keeps the shared metadata generator", () => {
   const source = readFileSync(
     path.join(rootDir, "apps/web/src/app/[locale]/page.tsx"),
@@ -497,6 +488,25 @@ test("localized DAO homepage keeps the shared metadata generator", () => {
   );
 
   assert.match(source, /export \{ default, generateMetadata \} from "\.\.\/page";/);
+});
+
+test("non-home DAO routes suppress inherited homepage canonical and cards", () => {
+  const routeLayouts = [
+    "apps/web/src/app/apps/layout.tsx",
+    "apps/web/src/app/delegates/layout.tsx",
+    "apps/web/src/app/treasury/layout.tsx",
+    "apps/web/src/app/delegate/layout.tsx",
+    "apps/web/src/app/[locale]/apps/layout.tsx",
+    "apps/web/src/app/[locale]/delegates/layout.tsx",
+    "apps/web/src/app/[locale]/treasury/layout.tsx",
+    "apps/web/src/app/[locale]/delegate/layout.tsx",
+  ];
+
+  for (const layout of routeLayouts) {
+    const source = readFileSync(path.join(rootDir, layout), "utf8");
+    assert.match(source, /buildNoPublicPreviewMetadata|metadata/);
+    assert.doesNotMatch(source, /buildSiteMetadata/);
+  }
 });
 
 test("no-public-preview metadata suppresses inherited canonical and social cards", () => {

--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -480,6 +480,25 @@ test("private DAO routes keep explicit noindex metadata", () => {
   }
 });
 
+test("DAO homepage renders a canonical link from the validated DAO origin", () => {
+  const source = readFileSync(
+    path.join(rootDir, "apps/web/src/app/page.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /canonicalUrl\(config,\s*"\/"\)/);
+  assert.match(source, /<link rel="canonical" href={homeCanonicalUrl}/);
+});
+
+test("localized DAO homepage keeps the shared metadata generator", () => {
+  const source = readFileSync(
+    path.join(rootDir, "apps/web/src/app/[locale]/page.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /export \{ default, generateMetadata \} from "\.\.\/page";/);
+});
+
 test("no-public-preview metadata suppresses inherited canonical and social cards", () => {
   const metadata = buildNoPublicPreviewMetadata("Private route");
 

--- a/apps/web/src/app/[locale]/apps/layout.tsx
+++ b/apps/web/src/app/[locale]/apps/layout.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from "../../apps/layout";

--- a/apps/web/src/app/[locale]/delegate/layout.tsx
+++ b/apps/web/src/app/[locale]/delegate/layout.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from "../../delegate/layout";

--- a/apps/web/src/app/[locale]/delegates/layout.tsx
+++ b/apps/web/src/app/[locale]/delegates/layout.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from "../../delegates/layout";

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,1 +1,1 @@
-export { default } from "../page";
+export { default, generateMetadata } from "../page";

--- a/apps/web/src/app/[locale]/treasury/layout.tsx
+++ b/apps/web/src/app/[locale]/treasury/layout.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from "../../treasury/layout";

--- a/apps/web/src/app/apps/layout.tsx
+++ b/apps/web/src/app/apps/layout.tsx
@@ -1,0 +1,9 @@
+import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = buildNoPublicPreviewMetadata("Apps");
+
+export default function AppsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/delegate/layout.tsx
+++ b/apps/web/src/app/delegate/layout.tsx
@@ -1,0 +1,13 @@
+import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = buildNoPublicPreviewMetadata("Delegate");
+
+export default function DelegateLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/src/app/delegates/layout.tsx
+++ b/apps/web/src/app/delegates/layout.tsx
@@ -1,0 +1,13 @@
+import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = buildNoPublicPreviewMetadata("Delegates");
+
+export default function DelegatesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,7 +3,7 @@ import { buildDaoOrganizationJsonLd } from "@/lib/structured-data";
 
 import { HomeClient } from "./_components/home-client";
 import { DaoPublicSummary } from "./_components/public-route-summary";
-import { canonicalUrl, getActiveDaoConfig } from "./_server/public-seo";
+import { getActiveDaoConfig } from "./_server/public-seo";
 
 import type { Metadata } from "next";
 
@@ -15,11 +15,9 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function HomePage() {
   const config = await getActiveDaoConfig();
   const daoOrganizationJsonLd = buildDaoOrganizationJsonLd(config);
-  const homeCanonicalUrl = canonicalUrl(config, "/");
 
   return (
     <div className="flex flex-col gap-[20px] lg:gap-[30px]">
-      {homeCanonicalUrl ? <link rel="canonical" href={homeCanonicalUrl} /> : null}
       {daoOrganizationJsonLd ? (
         <script
           type="application/ld+json"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,7 +3,7 @@ import { buildDaoOrganizationJsonLd } from "@/lib/structured-data";
 
 import { HomeClient } from "./_components/home-client";
 import { DaoPublicSummary } from "./_components/public-route-summary";
-import { getActiveDaoConfig } from "./_server/public-seo";
+import { canonicalUrl, getActiveDaoConfig } from "./_server/public-seo";
 
 import type { Metadata } from "next";
 
@@ -15,9 +15,11 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function HomePage() {
   const config = await getActiveDaoConfig();
   const daoOrganizationJsonLd = buildDaoOrganizationJsonLd(config);
+  const homeCanonicalUrl = canonicalUrl(config, "/");
 
   return (
     <div className="flex flex-col gap-[20px] lg:gap-[30px]">
+      {homeCanonicalUrl ? <link rel="canonical" href={homeCanonicalUrl} /> : null}
       {daoOrganizationJsonLd ? (
         <script
           type="application/ld+json"

--- a/apps/web/src/app/treasury/layout.tsx
+++ b/apps/web/src/app/treasury/layout.tsx
@@ -1,0 +1,13 @@
+import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = buildNoPublicPreviewMetadata("Treasury");
+
+export default function TreasuryLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/src/lib/metadata.ts
+++ b/apps/web/src/lib/metadata.ts
@@ -89,6 +89,11 @@ export function buildSiteMetadata(
       default: `${daoName}`,
     },
     description,
+    alternates: publicSiteUrl
+      ? {
+          canonical: publicSiteUrl,
+        }
+      : undefined,
     icons: config?.logo
       ? {
           icon: [{ url: config.logo }],


### PR DESCRIPTION
## Summary

- Render a canonical link on DAO homepages from the validated DAO `siteUrl`.
- Re-export the shared homepage metadata generator for localized DAO homepage routes.
- Add regression coverage for the canonical link and localized metadata export.

## Verification

- `pnpm install --filter @degov/web... --frozen-lockfile`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-social-preview`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- `git diff --check`

Part of #1029 and #714.
