### PR TITLE
Fix AI analysis public preview fallback

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -468,17 +468,29 @@ test("production deploy provides the canonical public demo origin", () => {
 });
 
 test("private DAO routes keep explicit noindex metadata", () => {
-  const privateLayouts = [
+  const privateMetadataRoutes = [
     "apps/web/src/app/profile/layout.tsx",
     "apps/web/src/app/proposals/new/layout.tsx",
     "apps/web/src/app/ai-analysis/layout.tsx",
+    "apps/web/src/app/ai-analysis/page.tsx",
   ];
 
-  for (const layout of privateLayouts) {
-    const source = readFileSync(path.join(rootDir, layout), "utf8");
+  for (const route of privateMetadataRoutes) {
+    const source = readFileSync(path.join(rootDir, route), "utf8");
     assert.match(source, /buildNoPublicPreviewMetadata/);
     assert.doesNotMatch(source, /buildSiteMetadata/);
   }
+});
+
+test("AI analysis index route cannot fall through to localized home metadata", () => {
+  const source = readFileSync(
+    path.join(rootDir, "apps/web/src/app/ai-analysis/page.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /buildNoPublicPreviewMetadata\("AI analysis"\)/);
+  assert.match(source, /notFound\(\)/);
+  assert.doesNotMatch(source, /buildHomeMetadata|buildSiteMetadata/);
 });
 
 test("localized DAO homepage keeps the shared metadata generator", () => {

--- a/apps/web/src/app/ai-analysis/page.tsx
+++ b/apps/web/src/app/ai-analysis/page.tsx
@@ -1,0 +1,11 @@
+import { notFound } from "next/navigation";
+
+import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = buildNoPublicPreviewMetadata("AI analysis");
+
+export default function AiAnalysisIndexPage() {
+  notFound();
+}


### PR DESCRIPTION
## Summary

- Add an explicit `/ai-analysis` page so the route no longer falls through to the localized DAO homepage.
- Return no-public-preview metadata and a 404 for the AI analysis index route.
- Add regression coverage that prevents the AI analysis index route from inheriting homepage canonical/social metadata.

## Verification

- `pnpm install --filter @degov/web... --frozen-lockfile`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-social-preview`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- `git diff --check`

Part of #1029 and #714.
