### PR TITLE
Keep AI analysis index noindexed

### DIFF
--- a/apps/web/scripts/dao-social-preview.test.ts
+++ b/apps/web/scripts/dao-social-preview.test.ts
@@ -489,7 +489,7 @@ test("AI analysis index route cannot fall through to localized home metadata", (
   );
 
   assert.match(source, /buildNoPublicPreviewMetadata\("AI analysis"\)/);
-  assert.match(source, /notFound\(\)/);
+  assert.doesNotMatch(source, /notFound/);
   assert.doesNotMatch(source, /buildHomeMetadata|buildSiteMetadata/);
 });
 

--- a/apps/web/src/app/ai-analysis/page.tsx
+++ b/apps/web/src/app/ai-analysis/page.tsx
@@ -1,5 +1,3 @@
-import { notFound } from "next/navigation";
-
 import { buildNoPublicPreviewMetadata } from "@/lib/metadata";
 
 import type { Metadata } from "next";
@@ -7,5 +5,5 @@ import type { Metadata } from "next";
 export const metadata: Metadata = buildNoPublicPreviewMetadata("AI analysis");
 
 export default function AiAnalysisIndexPage() {
-  notFound();
+  return null;
 }


### PR DESCRIPTION
## Summary

- Keep the explicit `/ai-analysis` index route as a noindex/no-public-preview page instead of invoking the shared 404 fallback.
- Preserve the guard that prevents `/ai-analysis` from falling through to localized homepage metadata.

## Verification

- `pnpm install --filter @degov/web... --frozen-lockfile`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-social-preview`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- `git diff --check`

Part of #1029 and #714.
