### PR TITLE
Add DAO proposal read analytics event

### DIFF
--- a/apps/web/scripts/proposal-read-analytics.test.ts
+++ b/apps/web/scripts/proposal-read-analytics.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildProposalReadEventParams,
+  getChannelGroupFromReferrer,
+  PROPOSAL_READ_EVENT_NAME,
+} from "../src/lib/analytics.ts";
+
+const readSource = (relativePath: string) =>
+  readFileSync(path.join(import.meta.dirname, "..", relativePath), "utf8");
+
+test("proposal read channel groups use observable referrer categories", () => {
+  assert.equal(
+    getChannelGroupFromReferrer(undefined, "lisk.degov.ai"),
+    "direct-unknown"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://lisk.degov.ai/proposals", "lisk.degov.ai"),
+    "direct-unknown"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer(
+      "https://www.lisk.degov.ai/proposals",
+      "lisk.degov.ai"
+    ),
+    "direct-unknown"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://www.google.com/search?q=lisk+dao", "lisk.degov.ai"),
+    "organic-search"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://x.com/ringecosystem", "lisk.degov.ai"),
+    "social-organic"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://docs.degov.ai/guide", "lisk.degov.ai"),
+    "documentation-referral"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://square.degov.ai/dao/lisk", "lisk.degov.ai"),
+    "cross-product-degov-referral"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://chatgpt.com/share/example", "lisk.degov.ai"),
+    "ai-search-assistant-referral"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://example.com/post", "lisk.degov.ai"),
+    "other-external-referral"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://sex.com/post", "lisk.degov.ai"),
+    "other-external-referral"
+  );
+  assert.equal(
+    getChannelGroupFromReferrer("https://evilbing.com/post", "lisk.degov.ai"),
+    "other-external-referral"
+  );
+});
+
+test("proposal read event params match the privacy-safe contract allowlist", () => {
+  const params = buildProposalReadEventParams({
+    daoCode: "lisk-dao",
+    proposalId: "123",
+    locale: "en",
+    referrer: "https://chatgpt.com/",
+    currentHost: "lisk.degov.ai",
+  });
+
+  assert.equal(PROPOSAL_READ_EVENT_NAME, "degov_proposal_read");
+  assert.deepEqual(Object.keys(params).sort(), [
+    "channel_group",
+    "dao_slug_or_public_id",
+    "proposal_public_id",
+    "route_locale",
+    "source_surface",
+  ]);
+  assert.deepEqual(params, {
+    source_surface: "dao-sites",
+    dao_slug_or_public_id: "lisk-dao",
+    proposal_public_id: "123",
+    channel_group: "ai-search-assistant-referral",
+    route_locale: "en",
+  });
+});
+
+test("proposal read analytics source avoids sensitive payload fields", () => {
+  const analyticsSource = readSource("src/lib/analytics.ts");
+  const componentSource = readSource(
+    "src/app/proposal/[id]/proposal-read-analytics.tsx"
+  );
+  const combinedSource = `${analyticsSource}\n${componentSource}`;
+  const prohibitedPayloadFields = [
+    "wallet_address",
+    "vote_choice",
+    "token_balance",
+    "voting_power",
+    "proposal_draft",
+    "auth_state",
+    "full_query_string",
+    "unpublished_proposal_text",
+  ];
+
+  for (const field of prohibitedPayloadFields) {
+    assert.doesNotMatch(combinedSource, new RegExp(field));
+  }
+  assert.doesNotMatch(combinedSource, /window\.location\.search/);
+  assert.doesNotMatch(combinedSource, /window\.location\.href/);
+});
+
+test("proposal page only renders read analytics after a public proposal resolves", () => {
+  const pageSource = readSource("src/app/proposal/[id]/page.tsx");
+  const componentSource = readSource(
+    "src/app/proposal/[id]/proposal-read-analytics.tsx"
+  );
+
+  assert.match(pageSource, /import \{ ProposalReadAnalytics \}/);
+  assert.match(pageSource, /proposal \? \(/);
+  assert.match(pageSource, /daoCode=\{config\.code\}/);
+  assert.match(pageSource, /proposalId=\{proposal\.proposalId\}/);
+  assert.match(
+    componentSource,
+    /PROPOSAL_READ_EVENT_NAME}:\$\{params\.dao_slug_or_public_id}:\$\{params\.proposal_public_id}/
+  );
+  assert.doesNotMatch(
+    componentSource,
+    /dedupeKey = .*params\.route_locale/
+  );
+});

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -6,6 +6,7 @@ import { ProposalDetailPublicSummary } from "../../_components/public-route-summ
 import { getActiveDaoConfig, getPublicProposalDetail } from "../../_server/public-seo";
 
 import { ProposalDetailClient } from "./proposal-detail-client";
+import { ProposalReadAnalytics } from "./proposal-read-analytics";
 
 type ProposalPageProps = {
   params: Promise<{ id: string }>;
@@ -35,6 +36,12 @@ export default async function ProposalPage({ params }: ProposalPageProps) {
         proposal={proposal}
         failed={failed}
       />
+      {proposal ? (
+        <ProposalReadAnalytics
+          daoCode={config.code}
+          proposalId={proposal.proposalId}
+        />
+      ) : null}
       <ProposalDetailClient />
     </div>
   );

--- a/apps/web/src/app/proposal/[id]/proposal-read-analytics.tsx
+++ b/apps/web/src/app/proposal/[id]/proposal-read-analytics.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useLocale } from "next-intl";
+import { useEffect } from "react";
+
+import {
+  buildProposalReadEventParams,
+  PROPOSAL_READ_EVENT_NAME,
+  sendAnalyticsEvent,
+} from "@/lib/analytics";
+
+type ProposalReadAnalyticsProps = {
+  daoCode: string;
+  proposalId: string;
+};
+
+export function ProposalReadAnalytics({
+  daoCode,
+  proposalId,
+}: ProposalReadAnalyticsProps) {
+  const locale = useLocale();
+
+  useEffect(() => {
+    const params = buildProposalReadEventParams({
+      daoCode,
+      proposalId,
+      locale,
+      referrer: document.referrer,
+      currentHost: window.location.hostname,
+    });
+    const dedupeKey = `${PROPOSAL_READ_EVENT_NAME}:${params.dao_slug_or_public_id}:${params.proposal_public_id}`;
+
+    try {
+      if (window.sessionStorage.getItem(dedupeKey)) return;
+      if (sendAnalyticsEvent(PROPOSAL_READ_EVENT_NAME, params)) {
+        window.sessionStorage.setItem(dedupeKey, "1");
+      }
+    } catch {
+      sendAnalyticsEvent(PROPOSAL_READ_EVENT_NAME, params);
+    }
+  }, [daoCode, locale, proposalId]);
+
+  return null;
+}

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,155 @@
+"use client";
+
+export const PROPOSAL_READ_EVENT_NAME = "degov_proposal_read";
+
+export type ChannelGroup =
+  | "organic-search"
+  | "social-organic"
+  | "documentation-referral"
+  | "cross-product-degov-referral"
+  | "ai-search-assistant-referral"
+  | "other-external-referral"
+  | "direct-unknown";
+
+export type ProposalReadEventParams = {
+  source_surface: "dao-sites";
+  dao_slug_or_public_id: string;
+  proposal_public_id: string;
+  channel_group: ChannelGroup;
+  route_locale: string;
+};
+
+declare global {
+  interface Window {
+    gtag?: (
+      command: "event",
+      eventName: string,
+      params: ProposalReadEventParams
+    ) => void;
+  }
+}
+
+const SEARCH_HOST_SUBSTRINGS = ["google.", "yahoo."];
+const SEARCH_HOST_DOMAINS = [
+  "bing.com",
+  "duckduckgo.com",
+  "baidu.com",
+  "yandex.com",
+];
+
+const SOCIAL_HOSTS = [
+  "x.com",
+  "twitter.com",
+  "linkedin.com",
+  "facebook.com",
+  "discord.com",
+  "telegram.org",
+  "t.me",
+];
+
+const AI_REFERRER_HOSTS = [
+  "chatgpt.com",
+  "perplexity.ai",
+  "copilot.microsoft.com",
+  "gemini.google.com",
+];
+
+function normalizePublicId(value: string | null | undefined): string {
+  return String(value ?? "").trim().slice(0, 160);
+}
+
+function normalizeHost(hostname: string | null | undefined): string {
+  return String(hostname ?? "")
+    .toLowerCase()
+    .replace(/^www\./, "");
+}
+
+function hostMatchesDomain(hostname: string, candidate: string): boolean {
+  return hostname === candidate || hostname.endsWith(`.${candidate}`);
+}
+
+function hostMatchesDomains(hostname: string, candidates: string[]): boolean {
+  return candidates.some((candidate) => hostMatchesDomain(hostname, candidate));
+}
+
+export function getChannelGroupFromReferrer(
+  referrer: string | null | undefined,
+  currentHost: string | null | undefined
+): ChannelGroup {
+  if (!referrer) return "direct-unknown";
+
+  let referrerUrl: URL;
+  try {
+    referrerUrl = new URL(referrer);
+  } catch {
+    return "direct-unknown";
+  }
+
+  const referrerHost = normalizeHost(referrerUrl.hostname);
+  const current = normalizeHost(currentHost);
+
+  if (current && referrerHost === current) {
+    return "direct-unknown";
+  }
+
+  if (hostMatchesDomains(referrerHost, AI_REFERRER_HOSTS)) {
+    return "ai-search-assistant-referral";
+  }
+
+  if (
+    SEARCH_HOST_SUBSTRINGS.some((candidate) =>
+      referrerHost.includes(candidate)
+    ) ||
+    hostMatchesDomains(referrerHost, SEARCH_HOST_DOMAINS)
+  ) {
+    return "organic-search";
+  }
+
+  if (hostMatchesDomains(referrerHost, SOCIAL_HOSTS)) {
+    return "social-organic";
+  }
+
+  if (referrerHost === "docs.degov.ai") {
+    return "documentation-referral";
+  }
+
+  if (referrerHost.endsWith(".degov.ai") || referrerHost === "degov.ai") {
+    return "cross-product-degov-referral";
+  }
+
+  return "other-external-referral";
+}
+
+export function buildProposalReadEventParams({
+  daoCode,
+  proposalId,
+  locale,
+  referrer,
+  currentHost,
+}: {
+  daoCode: string | null | undefined;
+  proposalId: string | null | undefined;
+  locale: string | null | undefined;
+  referrer: string | null | undefined;
+  currentHost: string | null | undefined;
+}): ProposalReadEventParams {
+  return {
+    source_surface: "dao-sites",
+    dao_slug_or_public_id: normalizePublicId(daoCode),
+    proposal_public_id: normalizePublicId(proposalId),
+    channel_group: getChannelGroupFromReferrer(referrer, currentHost),
+    route_locale: normalizePublicId(locale) || "unknown",
+  };
+}
+
+export function sendAnalyticsEvent(
+  eventName: string,
+  params: ProposalReadEventParams
+): boolean {
+  if (typeof window === "undefined" || typeof window.gtag !== "function") {
+    return false;
+  }
+
+  window.gtag("event", eventName, params);
+  return true;
+}


### PR DESCRIPTION
## Summary

- add a privacy-safe `degov_proposal_read` analytics event for public DAO proposal detail pages
- classify only observable referrers into direct, search, social, docs, cross-product, AI assistant, or other external channel groups
- restrict event payloads to the approved DAO-site measurement contract allowlist and dedupe per proposal per session

## Verification

- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-measurement`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`

Refs #1072
Refs #1031
Refs #714