### PR TITLE
Ensure DAO proposal read analytics ships in the client bundle

### DIFF
--- a/apps/web/scripts/proposal-read-analytics.test.ts
+++ b/apps/web/scripts/proposal-read-analytics.test.ts
@@ -114,14 +114,18 @@ test("proposal read analytics source avoids sensitive payload fields", () => {
 
 test("proposal page only renders read analytics after a public proposal resolves", () => {
   const pageSource = readSource("src/app/proposal/[id]/page.tsx");
+  const detailClientSource = readSource(
+    "src/app/proposal/[id]/proposal-detail-client.tsx"
+  );
   const componentSource = readSource(
     "src/app/proposal/[id]/proposal-read-analytics.tsx"
   );
 
-  assert.match(pageSource, /import \{ ProposalReadAnalytics \}/);
-  assert.match(pageSource, /proposal \? \(/);
-  assert.match(pageSource, /daoCode=\{config\.code\}/);
-  assert.match(pageSource, /proposalId=\{proposal\.proposalId\}/);
+  assert.doesNotMatch(pageSource, /import \{ ProposalReadAnalytics \}/);
+  assert.match(detailClientSource, /import \{ ProposalReadAnalytics \}/);
+  assert.match(detailClientSource, /data\?\.proposalId \? \(/);
+  assert.match(detailClientSource, /daoCode=\{daoConfig\?\.code \?\? ""\}/);
+  assert.match(detailClientSource, /proposalId=\{data\.proposalId\}/);
   assert.match(
     componentSource,
     /PROPOSAL_READ_EVENT_NAME}:\$\{params\.dao_slug_or_public_id}:\$\{params\.proposal_public_id}/

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -6,7 +6,6 @@ import { ProposalDetailPublicSummary } from "../../_components/public-route-summ
 import { getActiveDaoConfig, getPublicProposalDetail } from "../../_server/public-seo";
 
 import { ProposalDetailClient } from "./proposal-detail-client";
-import { ProposalReadAnalytics } from "./proposal-read-analytics";
 
 type ProposalPageProps = {
   params: Promise<{ id: string }>;
@@ -36,12 +35,6 @@ export default async function ProposalPage({ params }: ProposalPageProps) {
         proposal={proposal}
         failed={failed}
       />
-      {proposal ? (
-        <ProposalReadAnalytics
-          daoCode={config.code}
-          proposalId={proposal.proposalId}
-        />
-      ) : null}
       <ProposalDetailClient />
     </div>
   );

--- a/apps/web/src/app/proposal/[id]/proposal-detail-client.tsx
+++ b/apps/web/src/app/proposal/[id]/proposal-detail-client.tsx
@@ -21,6 +21,7 @@ import { CACHE_TIMES } from "@/utils/query-config";
 
 import { CurrentVotes } from "./current-votes";
 import { getProposalMissingState } from "./proposal-indexing-state";
+import { ProposalReadAnalytics } from "./proposal-read-analytics";
 import Status from "./status";
 import { Summary } from "./summary";
 import { Tabs } from "./tabs";
@@ -379,6 +380,12 @@ export function ProposalDetailClient() {
   }
   return (
     <div className="flex w-full flex-col gap-[20px] h-full min-h-0">
+      {data?.proposalId ? (
+        <ProposalReadAnalytics
+          daoCode={daoConfig?.code ?? ""}
+          proposalId={data.proposalId}
+        />
+      ) : null}
       <div className="flex items-center gap-1 text-[18px] font-extrabold">
         <Link
           className="text-muted-foreground hover:underline"


### PR DESCRIPTION
## Summary

- Move the proposal-read analytics mount into the hydrated proposal detail client after proposal data resolves.
- Keep the server page focused on public metadata/summary rendering so the analytics module is included in the client proposal bundle.
- Update the proposal-read analytics source test to assert the client-side mount point.

## Context

Public production readback on `https://lisk.degov.ai/proposal/0xb86b1e1f77d4158f82e94a5da0bd472c231fdffed3f5f7253ce114f6a67e93b9` showed GA4 `G-0X2S8293S1` loading and normal `page_view`/`scroll` events, but no `degov_proposal_read` collect request. The deployed page chunk also did not contain the `degov_proposal_read` string even though the deploy head included the original server-page mount.

This change anchors the analytics component under `ProposalDetailClient`, which is already present in the production proposal page client chunk and runs after the client proposal query resolves.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run test:web-scripts`
- `pnpm run test:seo-geo-measurement`
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- Confirmed local production build output contains `degov_proposal_read` in `apps/web/.next/static/chunks/2334-01b04c8cd550d181.js`.

Refs ringecosystem/degov#1031
Refs ringecosystem/degov#714