### PR TITLE
Alias production deploy to Lisk DAO domain

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -44,6 +44,7 @@ jobs:
           vercel_group: itering
           preview_output: true
           prod_mode: true
+          alias_domain: "lisk.degov.ai"
           project_name: "degov"
           script_run: false
           dist_path: .


### PR DESCRIPTION
## Summary
- Add the Lisk DAO custom domain to the production Vercel alias list.
- Keep the existing demo production domain behavior unchanged.

## Why
- #1031 public readback shows the latest production deployment is aliased to demo.degov.ai, while lisk.degov.ai still serves an older proposal chunk without degov_proposal_read.
- The smart-vercel action supports comma/newline alias_domain values and will run vercel alias for custom domains.

## Verification
- Ruby YAML parse confirms .github/workflows/deploy-prd.yml includes alias_domain: lisk.degov.ai.
- git diff --check passed.
- GitHub commit verification for 1ee9102554303829cb17f2fdbdfba54fe66b06eb: verified=true, reason=valid.

Refs #1031
Refs #714