### PR TITLE
Restore production deploy without Lisk alias

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -44,7 +44,6 @@ jobs:
           vercel_group: itering
           preview_output: true
           prod_mode: true
-          alias_domain: "lisk.degov.ai"
           project_name: "degov"
           script_run: false
           dist_path: .


### PR DESCRIPTION
## Summary
- Remove the explicit lisk.degov.ai alias from the production deploy workflow.

## Why
- PR #1075 proved the repo workflow can reach the Vercel alias step, but the production dispatch failed during certificate issuance for lisk.degov.ai.
- Leaving that alias in main would make future production deploys fail after a successful build/deployment.
- The Lisk custom-domain rollout remains an external Vercel/Cloudflare/domain-owner blocker for #1031.

## Verification
- Ruby YAML parse confirms alias_domain is absent.
- git diff --check passed.
- GitHub commit verification for 9e33344bbb05b3e84e25369dec8a70fe4d969d3f: verified=true, reason=valid.

Refs #1031
Refs #714