### PR TITLE
Render proposal directory from server data

### DIFF
--- a/apps/web/messages/en/proposals.json
+++ b/apps/web/messages/en/proposals.json
@@ -12,6 +12,7 @@
   "viewMore": "View more",
   "loading": "Loading...",
   "noProposals": "No proposals",
+  "temporarilyUnavailable": "Proposal data is temporarily unavailable. The page will retry automatically.",
   "noVotes": "No votes",
   "columns": {
     "proposal": "Proposal",

--- a/apps/web/scripts/proposal-directory-server-rendering.test.ts
+++ b/apps/web/scripts/proposal-directory-server-rendering.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { InfiniteQueryObserver, QueryClient } from "@tanstack/react-query";
+
+import {
+  buildProposalInfiniteInitialData,
+  buildProposalListQueryKey,
+  getProposalNextPageParam,
+  shouldUseProposalInitialPage,
+  type ProposalPageParam,
+} from "../src/lib/proposal-directory-query-contract.ts";
+import { hasProposalDirectoryLoadError } from "../src/lib/proposal-directory-state.ts";
+
+const readSource = (relativePath: string) =>
+  readFileSync(path.join(import.meta.dirname, "..", relativePath), "utf8");
+
+test("proposal directory renders the existing proposal UI from server first-page data", () => {
+  const pageSource = readSource("src/app/proposals/page.tsx");
+  const clientSource = readSource("src/app/proposals/proposals-client.tsx");
+  const tableSource = readSource("src/components/proposals-table/index.tsx");
+  const listSource = readSource("src/components/proposals-list/index.tsx");
+  const hookSource = readSource(
+    "src/components/proposals-table/hooks/useProposalData.ts"
+  );
+  const localePageSource = readSource("src/app/[locale]/proposals/page.tsx");
+
+  assert.match(
+    pageSource,
+    /const initialPage = await getPublicProposalList\(config\)/
+  );
+  assert.match(pageSource, /<ProposalsClient initialPage=\{initialPage\} \/>/);
+  assert.doesNotMatch(pageSource, /ProposalDirectoryPublicSummary/);
+
+  assert.match(
+    localePageSource,
+    /export\s+\{\s*default,\s*generateMetadata\s*\}\s+from\s+"..\/..\/proposals\/page"/
+  );
+
+  assert.match(clientSource, /loadingFallback=\{\s*<ProposalsTable/);
+  assert.match(clientSource, /<h1 className="text-\[18px\] font-extrabold">/);
+  assert.match(clientSource, /desktop=\{\s*<ProposalsTable/);
+  assert.match(clientSource, /mobile=\{\s*<ProposalsList/);
+  assert.match(clientSource, /initialPage=\{initialPage\}/);
+
+  assert.match(tableSource, /href=\{`\/proposal\/\$\{record\.proposalId\}`\}/);
+  assert.match(tableSource, /\{record\.title\}/);
+  assert.match(tableSource, /initialPage\?: InitialProposalPage/);
+  assert.match(listSource, /href=\{`\/proposal\/\$\{record\.proposalId\}`\}/);
+  assert.match(listSource, /\{record\.title\}/);
+
+  assert.match(hookSource, /initialData:\s*shouldUseInitialPage/);
+  assert.match(tableSource, /state\.directoryLoadFailed/);
+  assert.match(listSource, /state\.directoryLoadFailed/);
+});
+
+test("proposal directory initial data distinguishes empty and temporary failure states", () => {
+  const publicSeoSource = readSource("src/app/_server/public-seo.ts");
+  const querySource = readSource(
+    "src/lib/proposal-directory-query-contract.ts"
+  );
+
+  assert.match(publicSeoSource, /failed:\s*false/);
+  assert.match(publicSeoSource, /failed:\s*true/);
+  assert.match(publicSeoSource, /PROPOSAL_DIRECTORY_INITIAL_PAGE_SIZE/);
+
+  assert.match(querySource, /if \(!initialPage\) return undefined/);
+  assert.match(querySource, /pages:\s*\[initialPage\.proposals\]/);
+  assert.match(querySource, /pageParams:/);
+  assert.match(publicSeoSource, /failed:\s*true,[\s\S]*updatedAt:\s*0/);
+});
+
+test("proposal directory failure state follows the current query result", () => {
+  assert.equal(
+    hasProposalDirectoryLoadError({
+      isError: false,
+      usesInitialPage: true,
+      initialPageFailed: true,
+      dataUpdatedAt: 0,
+    }),
+    true,
+    "a failed server read remains unavailable while its retry is pending"
+  );
+
+  assert.equal(
+    hasProposalDirectoryLoadError({
+      isError: false,
+      usesInitialPage: true,
+      initialPageFailed: true,
+      dataUpdatedAt: Date.now(),
+    }),
+    false,
+    "a successful empty retry clears the initial server failure"
+  );
+
+  assert.equal(
+    hasProposalDirectoryLoadError({
+      isError: false,
+      usesInitialPage: false,
+      initialPageFailed: true,
+      dataUpdatedAt: Date.now(),
+    }),
+    false,
+    "an empty wallet or support filter does not inherit the server failure"
+  );
+
+  assert.equal(
+    hasProposalDirectoryLoadError({
+      isError: true,
+      usesInitialPage: false,
+      initialPageFailed: false,
+      dataUpdatedAt: 0,
+    }),
+    true,
+    "a failed filtered request reports the current error"
+  );
+});
+
+test("proposal directory hydrates and paginates through the production query contract", async () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const initialProposals = Array.from({ length: 30 }, (_, index) => index);
+  const calls: ProposalPageParam[] = [];
+  const queryKey = buildProposalListQueryKey({
+    config: {
+      code: "fixture",
+      indexer: { endpoint: "https://indexer.example/graphql" },
+      chain: { id: 1 },
+      contracts: { governor: "0xABC" },
+    },
+    pageSize: 10,
+    initialPageSize: 30,
+  });
+  const observer = new InfiniteQueryObserver<number[]>(queryClient, {
+    queryKey,
+    queryFn: async ({ pageParam }) => {
+      calls.push(pageParam as ProposalPageParam);
+      return [30, 31];
+    },
+    initialPageParam: { offset: 0, limit: 30 },
+    initialData: buildProposalInfiniteInitialData({
+      proposals: initialProposals,
+      pageSize: 30,
+    }),
+    staleTime: Infinity,
+    getNextPageParam: (lastPage, _pages, lastPageParam) =>
+      getProposalNextPageParam(
+        lastPage,
+        lastPageParam as ProposalPageParam,
+        30,
+        10
+      ),
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  assert.equal(calls.length, 0, "fresh server data must not refetch on hydration");
+  await observer.fetchNextPage();
+  assert.deepEqual(calls, [{ offset: 30, limit: 10 }]);
+  assert.deepEqual(observer.getCurrentResult().data?.pages.flat(), [
+    ...initialProposals,
+    30,
+    31,
+  ]);
+
+  unsubscribe();
+  queryClient.clear();
+});
+
+test("proposal directory only reuses anonymous initial data for the matching query", () => {
+  const base = {
+    initialPageSize: 30,
+    normalizedInitialPageSize: 30,
+  };
+
+  assert.equal(shouldUseProposalInitialPage(base), true);
+  assert.equal(
+    shouldUseProposalInitialPage({ ...base, address: "0x123" }),
+    false
+  );
+  assert.equal(
+    shouldUseProposalInitialPage({ ...base, address: "0x123", support: "1" }),
+    false
+  );
+  assert.equal(
+    shouldUseProposalInitialPage({ ...base, connectedAddress: "0x456" }),
+    false
+  );
+
+  const anonymousKey = buildProposalListQueryKey({
+    pageSize: 10,
+    initialPageSize: 30,
+  });
+  const walletKey = buildProposalListQueryKey({
+    address: "0x123",
+    pageSize: 10,
+    initialPageSize: 30,
+  });
+  const supportKey = buildProposalListQueryKey({
+    address: "0x123",
+    support: "1",
+    pageSize: 10,
+    initialPageSize: 30,
+  });
+  const connectedWalletKey = buildProposalListQueryKey({
+    connectedAddress: "0x456",
+    pageSize: 10,
+    initialPageSize: 30,
+  });
+  assert.notDeepEqual(walletKey, anonymousKey);
+  assert.notDeepEqual(supportKey, walletKey);
+  assert.notDeepEqual(connectedWalletKey, anonymousKey);
+});

--- a/apps/web/src/app/_server/public-seo.ts
+++ b/apps/web/src/app/_server/public-seo.ts
@@ -1,16 +1,21 @@
 import { getConfigCachedByHost } from "@/app/_server/config-remote";
 import { getDaoConfigServer } from "@/lib/config";
 import {
+  fetchProposalListPage,
+  PROPOSAL_DIRECTORY_INITIAL_PAGE_SIZE,
+  PROPOSAL_LIST_ORDER_BY,
+  type InitialProposalPage,
+} from "@/lib/proposal-directory-query";
+import {
   buildGovernanceScope,
   proposalService,
   type GovernanceScope,
 } from "@/services/graphql";
-import type { ProposalItem, ProposalListItem } from "@/services/graphql/types";
+import type { ProposalItem } from "@/services/graphql/types";
 import type { Config } from "@/types/config";
 import { extractTitleAndDescription, parseDescription } from "@/utils/helpers";
 import { isDegovApiConfiguredServer } from "@/utils/remote-api";
 
-const PROPOSAL_LIST_LIMIT = 12;
 const SITEMAP_PROPOSAL_LIMIT = 500;
 
 export async function getActiveDaoConfig(): Promise<Config> {
@@ -46,25 +51,38 @@ export function publicGovernanceScope(config: Config | null | undefined): Govern
   return buildGovernanceScope(config);
 }
 
-export async function getPublicProposalList(config: Config): Promise<{
-  proposals: ProposalListItem[];
-  failed: boolean;
-}> {
+export async function getPublicProposalList(
+  config: Config
+): Promise<InitialProposalPage> {
   if (!config.indexer?.endpoint) {
-    return { proposals: [], failed: false };
+    return {
+      proposals: [],
+      failed: false,
+      pageSize: PROPOSAL_DIRECTORY_INITIAL_PAGE_SIZE,
+      updatedAt: Date.now(),
+    };
   }
 
   try {
-    const proposals = await proposalService.getProposalsList(config.indexer.endpoint, {
-      limit: PROPOSAL_LIST_LIMIT,
-      orderBy: "blockTimestamp_DESC_NULLS_LAST",
-      where: publicGovernanceScope(config),
+    const proposals = await fetchProposalListPage({
+      config,
+      limit: PROPOSAL_DIRECTORY_INITIAL_PAGE_SIZE,
     });
 
-    return { proposals, failed: false };
+    return {
+      proposals,
+      failed: false,
+      pageSize: PROPOSAL_DIRECTORY_INITIAL_PAGE_SIZE,
+      updatedAt: Date.now(),
+    };
   } catch (error) {
     console.error("Failed to load public proposal list:", error);
-    return { proposals: [], failed: true };
+    return {
+      proposals: [],
+      failed: true,
+      pageSize: PROPOSAL_DIRECTORY_INITIAL_PAGE_SIZE,
+      updatedAt: 0,
+    };
   }
 }
 
@@ -107,7 +125,7 @@ export async function getSitemapProposalIds(config: Config): Promise<string[]> {
   try {
     const proposals = await proposalService.getProposalsList(config.indexer.endpoint, {
       limit: SITEMAP_PROPOSAL_LIMIT,
-      orderBy: "blockTimestamp_DESC_NULLS_LAST",
+      orderBy: PROPOSAL_LIST_ORDER_BY,
       where: publicGovernanceScope(config),
     });
 

--- a/apps/web/src/app/proposals/page.tsx
+++ b/apps/web/src/app/proposals/page.tsx
@@ -1,6 +1,5 @@
 import { buildProposalDirectoryMetadata } from "@/lib/metadata";
 
-import { ProposalDirectoryPublicSummary } from "../_components/public-route-summary";
 import { getActiveDaoConfig, getPublicProposalList } from "../_server/public-seo";
 
 import { ProposalsClient } from "./proposals-client";
@@ -14,12 +13,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function ProposalsPage() {
   const config = await getActiveDaoConfig();
-  const { proposals, failed } = await getPublicProposalList(config);
+  const initialPage = await getPublicProposalList(config);
 
   return (
     <div className="flex flex-col gap-[20px]">
-      <ProposalDirectoryPublicSummary config={config} proposals={proposals} failed={failed} />
-      <ProposalsClient />
+      <ProposalsClient initialPage={initialPage} />
     </div>
   );
 }

--- a/apps/web/src/app/proposals/proposals-client.tsx
+++ b/apps/web/src/app/proposals/proposals-client.tsx
@@ -25,6 +25,7 @@ import {
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { useMyVotes } from "@/hooks/useMyVotes";
 import { useRouter } from "@/i18n/navigation";
+import type { InitialProposalPage } from "@/lib/proposal-directory-query";
 import { proposalService } from "@/services/graphql";
 
 import type { CheckedState } from "@radix-ui/react-checkbox";
@@ -57,7 +58,11 @@ const normalizeSupportParam = (value: string | null): SupportSelection => {
   return "all";
 };
 
-function ProposalsContent() {
+function ProposalsContent({
+  initialPage,
+}: {
+  initialPage?: InitialProposalPage;
+}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const t = useTranslations("proposals");
@@ -147,12 +152,17 @@ function ProposalsContent() {
     router.push("/proposals/new");
   }, [isConnected, hasEnoughVotes, router]);
 
+  const proposalAddress = isMyProposals
+    ? address
+    : (addressParam as `0x${string}` | undefined);
+  const proposalSupport = support === "all" ? undefined : support;
+
   return (
     <div className="flex flex-col gap-[20px]">
       <div className="flex flex-col @min-[900px]:flex-row @min-[900px]:items-start gap-[20px]">
         <div className="flex-1 min-w-0 flex flex-col gap-[20px]">
           <div className="flex items-start lg:items-center flex-col lg:flex-row justify-between gap-[20px]">
-            <h3 className="text-[18px] font-extrabold">{getDisplayTitle()}</h3>
+            <h1 className="text-[18px] font-extrabold">{getDisplayTitle()}</h1>
 
             <div className="flex items-center gap-[20px] w-full lg:w-auto">
               {isConnected && (
@@ -209,23 +219,25 @@ function ProposalsContent() {
             desktop={
               <ProposalsTable
                 type="all"
-                address={
-                  isMyProposals
-                    ? address
-                    : (addressParam as `0x${string}` | undefined)
-                }
-                support={support === "all" ? undefined : support}
+                initialPage={initialPage}
+                address={proposalAddress}
+                support={proposalSupport}
               />
             }
             mobile={
               <ProposalsList
                 type="all"
-                address={
-                  isMyProposals
-                    ? address
-                    : (addressParam as `0x${string}` | undefined)
-                }
-                support={support === "all" ? undefined : support}
+                initialPage={initialPage}
+                address={proposalAddress}
+                support={proposalSupport}
+              />
+            }
+            loadingFallback={
+              <ProposalsTable
+                type="all"
+                initialPage={initialPage}
+                address={proposalAddress}
+                support={proposalSupport}
               />
             }
           />
@@ -247,7 +259,11 @@ function ProposalsContent() {
   );
 }
 
-export function ProposalsClient() {
+export function ProposalsClient({
+  initialPage,
+}: {
+  initialPage?: InitialProposalPage;
+}) {
   const t = useTranslations("proposals");
 
   return (
@@ -255,14 +271,14 @@ export function ProposalsClient() {
       fallback={
         <div className="flex flex-col gap-[30px]">
           <div className="flex items-center justify-between gap-[20px]">
-            <h3 className="text-[18px] font-extrabold">{t("title")}</h3>
+            <h1 className="text-[18px] font-extrabold">{t("title")}</h1>
             <div className="w-[300px] h-[40px] animate-pulse bg-gray-700 rounded-[100px]"></div>
           </div>
           <div className="w-full h-[400px] animate-pulse bg-gray-800 rounded-md"></div>
         </div>
       }
     >
-      <ProposalsContent />
+      <ProposalsContent initialPage={initialPage} />
     </Suspense>
   );
 }

--- a/apps/web/src/components/proposals-list/index.tsx
+++ b/apps/web/src/components/proposals-list/index.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from "next-intl";
 
 import { DEFAULT_PAGE_SIZE, INITIAL_LIST_PAGE_SIZE } from "@/config/base";
 import { Link } from "@/i18n/navigation";
+import type { InitialProposalPage } from "@/lib/proposal-directory-query";
 import type { ProposalListItem } from "@/services/graphql/types";
 import { formatTimeAgo } from "@/utils/date";
 
@@ -54,10 +55,12 @@ export function ProposalsList({
   type,
   address,
   support,
+  initialPage,
 }: {
   type: "active" | "all";
   address?: Address;
   support?: SupportFilter;
+  initialPage?: InitialProposalPage;
 }) {
   const t = useTranslations("proposals");
   const pageSize = type === "active" ? 8 : DEFAULT_PAGE_SIZE;
@@ -67,7 +70,8 @@ export function ProposalsList({
     address,
     support,
     pageSize,
-    initialPageSize
+    initialPageSize,
+    initialPage
   );
 
   if (state.isPending) {
@@ -86,7 +90,9 @@ export function ProposalsList({
   if (state.data.length === 0) {
     return (
       <div className="rounded-[14px] bg-card p-[20px] text-center text-foreground/60">
-        {t("noProposals")}
+        {state.directoryLoadFailed
+          ? t("temporarilyUnavailable")
+          : t("noProposals")}
       </div>
     );
   }

--- a/apps/web/src/components/proposals-table/hooks/useProposalData.ts
+++ b/apps/web/src/components/proposals-table/hooks/useProposalData.ts
@@ -6,119 +6,100 @@ import { abi as GovernorAbi } from "@/config/abi/governor";
 import { DEFAULT_MULTICALL_BATCH_SIZE, DEFAULT_PAGE_SIZE } from "@/config/base";
 import { useDaoConfig } from "@/hooks/useDaoConfig";
 import {
-  buildGovernanceScope,
-  proposalService,
-  type ProposalWhere,
-} from "@/services/graphql";
+  buildProposalInfiniteInitialData,
+  buildProposalListQueryKey,
+  fetchProposalListPage,
+  getProposalNextPageParam,
+  normalizeProposalInitialPageSize,
+  shouldUseProposalInitialPage,
+  type InitialProposalPage,
+  type ProposalPageParam,
+  type SupportFilter,
+} from "@/lib/proposal-directory-query";
+import { hasProposalDirectoryLoadError } from "@/lib/proposal-directory-state";
 import type { ProposalListItem } from "@/services/graphql/types";
 import type { ProposalState as ProposalStatus } from "@/types/proposal";
 
 import type { Address } from "viem";
+export type { SupportFilter } from "@/lib/proposal-directory-query";
 export type ProposalVotes = {
   againstVotes: bigint;
   forVotes: bigint;
   abstainVotes: bigint;
 };
 
-export type SupportFilter = "0" | "1" | "2";
-
-type PageParam = {
-  offset: number;
-  limit: number;
-};
-
 export function useProposalData(
   address?: Address,
   support?: SupportFilter,
   pageSize: number = DEFAULT_PAGE_SIZE,
-  initialPageSize: number = pageSize
+  initialPageSize: number = pageSize,
+  initialPage?: InitialProposalPage
 ) {
   const daoConfig = useDaoConfig();
   const { address: connectedAddress } = useAccount();
-  const normalizedInitialPageSize = Math.max(pageSize, initialPageSize);
+  const normalizedInitialPageSize = normalizeProposalInitialPageSize(
+    pageSize,
+    initialPageSize
+  );
+  const shouldUseInitialPage = shouldUseProposalInitialPage({
+    address,
+    support,
+    connectedAddress,
+    initialPageSize: initialPage?.pageSize,
+    normalizedInitialPageSize,
+  });
 
   const {
     data,
     hasNextPage,
     isPending,
+    isError,
     isFetchingNextPage,
+    dataUpdatedAt,
     error,
     fetchNextPage,
     refetch,
   } = useInfiniteQuery<ProposalListItem[]>({
-    queryKey: [
-      "proposals",
-      daoConfig?.code,
-      daoConfig?.indexer?.endpoint,
-      daoConfig,
+    queryKey: buildProposalListQueryKey({
+      config: daoConfig,
       address,
       support,
       pageSize,
-      normalizedInitialPageSize,
+      initialPageSize: normalizedInitialPageSize,
       connectedAddress,
-    ],
+    }),
     queryFn: async ({ pageParam }) => {
-      const { offset, limit } = (pageParam as PageParam) ?? {
+      const { offset, limit } = (pageParam as ProposalPageParam) ?? {
         offset: 0,
         limit: normalizedInitialPageSize,
       };
-      let whereCondition: ProposalWhere = {
-        ...buildGovernanceScope(daoConfig),
-      };
 
-      if (address && !support) {
-        whereCondition = {
-          ...buildGovernanceScope(daoConfig),
-          proposer_eq: address?.toLowerCase(),
-          OR: {
-            voters_some: {
-              voter_eq: address?.toLowerCase(),
-            },
-          },
-        };
-      } else if (address && support) {
-        whereCondition = {
-          ...buildGovernanceScope(daoConfig),
-          voters_some: {
-            voter_eq: address?.toLowerCase(),
-            support_eq: support ? parseInt(support) : undefined,
-          },
-        };
-      }
-
-      const result = await proposalService.getProposalsList(
-        daoConfig?.indexer?.endpoint as string,
-        {
-          limit,
-          offset,
-          orderBy: "blockTimestamp_DESC_NULLS_LAST",
-          where: whereCondition,
-          voter: connectedAddress?.toLowerCase(),
-        }
-      );
-
-      return result;
+      return fetchProposalListPage({
+        config: daoConfig!,
+        limit,
+        offset,
+        address,
+        support,
+        connectedAddress,
+      });
     },
     initialPageParam: {
       offset: 0,
       limit: normalizedInitialPageSize,
-    } as PageParam,
+    } as ProposalPageParam,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
-      const lastParam = (lastPageParam as PageParam) ?? {
-        offset: 0,
-        limit: normalizedInitialPageSize,
-      };
-
-      if (!lastPage || lastPage.length < lastParam.limit) {
-        return undefined;
-      }
-
-      return {
-        offset: lastParam.offset + lastPage.length,
-        limit: pageSize,
-      } satisfies PageParam;
+      return getProposalNextPageParam(
+        lastPage,
+        lastPageParam as ProposalPageParam,
+        normalizedInitialPageSize,
+        pageSize
+      );
     },
     enabled: !!daoConfig?.indexer?.endpoint,
+    initialData: shouldUseInitialPage
+      ? buildProposalInfiniteInitialData(initialPage)
+      : undefined,
+    initialDataUpdatedAt: shouldUseInitialPage ? initialPage?.updatedAt : undefined,
     retryDelay: 10_000,
     retry: 3,
   });
@@ -126,6 +107,13 @@ export function useProposalData(
   const flattenedData = useMemo<ProposalListItem[]>(() => {
     return data?.pages.flat() || [];
   }, [data]);
+
+  const directoryLoadFailed = hasProposalDirectoryLoadError({
+    isError,
+    usesInitialPage: shouldUseInitialPage,
+    initialPageFailed: initialPage?.failed ?? false,
+    dataUpdatedAt,
+  });
 
   const statusContracts = useMemo(() => {
     const proposalStatusContract = {
@@ -182,6 +170,7 @@ export function useProposalData(
       data: flattenedData,
       hasNextPage,
       isPending,
+      directoryLoadFailed,
       isFetchingNextPage,
       error,
     },

--- a/apps/web/src/components/proposals-table/index.tsx
+++ b/apps/web/src/components/proposals-table/index.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_PAGE_SIZE, INITIAL_LIST_PAGE_SIZE } from "@/config/base";
 import { VoteType } from "@/config/vote";
 import { useBatchProfiles } from "@/hooks/useBatchProfiles";
 import { Link } from "@/i18n/navigation";
+import type { InitialProposalPage } from "@/lib/proposal-directory-query";
 import type { ProposalListItem } from "@/services/graphql/types";
 import { formatTimeAgo } from "@/utils/date";
 
@@ -61,10 +62,12 @@ export function ProposalsTable({
   type,
   address,
   support,
+  initialPage,
 }: {
   type: "active" | "all";
   address?: Address;
   support?: SupportFilter;
+  initialPage?: InitialProposalPage;
 }) {
   const t = useTranslations("proposals");
   const { address: connectedAddress } = useAccount();
@@ -74,7 +77,8 @@ export function ProposalsTable({
     address,
     support,
     pageSize,
-    initialPageSize
+    initialPageSize,
+    initialPage
   );
 
   const proposerAddresses = useMemo(() => {
@@ -249,7 +253,11 @@ export function ProposalsTable({
         dataSource={state.data}
         columns={columns as ColumnType<ProposalListItem>[]}
         isLoading={state.isPending}
-        emptyText={t("noProposals")}
+        emptyText={
+          state.directoryLoadFailed
+            ? t("temporarilyUnavailable")
+            : t("noProposals")
+        }
         rowKey="id"
         caption={
           state.hasNextPage && (

--- a/apps/web/src/lib/proposal-directory-query-contract.ts
+++ b/apps/web/src/lib/proposal-directory-query-contract.ts
@@ -1,0 +1,104 @@
+export type ProposalPageParam = {
+  offset: number;
+  limit: number;
+};
+
+type ProposalQueryConfig = {
+  code?: string;
+  indexer?: { endpoint?: string };
+  chain?: { id?: number };
+  contracts?: { governor?: string };
+};
+
+export function normalizeProposalInitialPageSize(
+  pageSize: number,
+  initialPageSize: number
+) {
+  return Math.max(pageSize, initialPageSize);
+}
+
+export function shouldUseProposalInitialPage({
+  address,
+  support,
+  connectedAddress,
+  initialPageSize,
+  normalizedInitialPageSize,
+}: {
+  address?: string;
+  support?: string;
+  connectedAddress?: string;
+  initialPageSize?: number;
+  normalizedInitialPageSize: number;
+}) {
+  return (
+    !address &&
+    !support &&
+    !connectedAddress &&
+    initialPageSize === normalizedInitialPageSize
+  );
+}
+
+export function buildProposalListQueryKey({
+  config,
+  address,
+  support,
+  pageSize,
+  initialPageSize,
+  connectedAddress,
+}: {
+  config?: ProposalQueryConfig | null;
+  address?: string;
+  support?: string;
+  pageSize: number;
+  initialPageSize: number;
+  connectedAddress?: string;
+}) {
+  return [
+    "proposals",
+    config?.code,
+    config?.indexer?.endpoint,
+    config?.chain?.id,
+    config?.contracts?.governor?.toLowerCase(),
+    address?.toLowerCase(),
+    support,
+    pageSize,
+    initialPageSize,
+    connectedAddress?.toLowerCase(),
+  ] as const;
+}
+
+export function buildProposalInfiniteInitialData<T>(initialPage?: {
+  proposals: T[];
+  pageSize: number;
+}) {
+  if (!initialPage) return undefined;
+
+  return {
+    pages: [initialPage.proposals],
+    pageParams: [
+      {
+        offset: 0,
+        limit: initialPage.pageSize,
+      } satisfies ProposalPageParam,
+    ],
+  };
+}
+
+export function getProposalNextPageParam<T>(
+  lastPage: T[] | undefined,
+  lastPageParam: ProposalPageParam | undefined,
+  initialPageSize: number,
+  pageSize: number
+) {
+  const lastParam = lastPageParam ?? {
+    offset: 0,
+    limit: initialPageSize,
+  };
+
+  if (!lastPage || lastPage.length < lastParam.limit) return undefined;
+
+  return {
+    offset: lastParam.offset + lastPage.length,
+    limit: pageSize,
+  } satisfies ProposalPageParam;
+}

--- a/apps/web/src/lib/proposal-directory-query.ts
+++ b/apps/web/src/lib/proposal-directory-query.ts
@@ -1,0 +1,90 @@
+import { DEFAULT_PAGE_SIZE, INITIAL_LIST_PAGE_SIZE } from "@/config/base";
+import {
+  buildGovernanceScope,
+  proposalService,
+  type ProposalWhere,
+} from "@/services/graphql";
+import type { ProposalListItem } from "@/services/graphql/types";
+import type { Config } from "@/types/config";
+
+export {
+  buildProposalInfiniteInitialData,
+  buildProposalListQueryKey,
+  getProposalNextPageParam,
+  normalizeProposalInitialPageSize,
+  shouldUseProposalInitialPage,
+  type ProposalPageParam,
+} from "./proposal-directory-query-contract";
+
+export type SupportFilter = "0" | "1" | "2";
+
+export type InitialProposalPage = {
+  proposals: ProposalListItem[];
+  failed: boolean;
+  pageSize: number;
+  updatedAt: number;
+};
+
+export const PROPOSAL_LIST_ORDER_BY = "blockTimestamp_DESC_NULLS_LAST";
+export const PROPOSAL_DIRECTORY_PAGE_SIZE = DEFAULT_PAGE_SIZE;
+export const PROPOSAL_DIRECTORY_INITIAL_PAGE_SIZE = INITIAL_LIST_PAGE_SIZE;
+
+export function buildProposalListWhere({
+  config,
+  address,
+  support,
+}: {
+  config?: Config | null;
+  address?: string;
+  support?: SupportFilter;
+}): ProposalWhere {
+  if (address && !support) {
+    return {
+      ...buildGovernanceScope(config),
+      proposer_eq: address.toLowerCase(),
+      OR: {
+        voters_some: {
+          voter_eq: address.toLowerCase(),
+        },
+      },
+    };
+  }
+
+  if (address && support) {
+    return {
+      ...buildGovernanceScope(config),
+      voters_some: {
+        voter_eq: address.toLowerCase(),
+        support_eq: parseInt(support),
+      },
+    };
+  }
+
+  return {
+    ...buildGovernanceScope(config),
+  };
+}
+
+export async function fetchProposalListPage({
+  config,
+  offset = 0,
+  limit,
+  address,
+  support,
+  connectedAddress,
+}: {
+  config: Config;
+  offset?: number;
+  limit: number;
+  address?: string;
+  support?: SupportFilter;
+  connectedAddress?: string;
+}) {
+  return proposalService.getProposalsList(config.indexer?.endpoint as string, {
+    limit,
+    offset,
+    orderBy: PROPOSAL_LIST_ORDER_BY,
+    where: buildProposalListWhere({ config, address, support }),
+    voter: connectedAddress?.toLowerCase(),
+  });
+}

--- a/apps/web/src/lib/proposal-directory-state.ts
+++ b/apps/web/src/lib/proposal-directory-state.ts
@@ -1,0 +1,16 @@
+export function hasProposalDirectoryLoadError({
+  isError,
+  usesInitialPage,
+  initialPageFailed,
+  dataUpdatedAt,
+}: {
+  isError: boolean;
+  usesInitialPage: boolean;
+  initialPageFailed: boolean;
+  dataUpdatedAt: number;
+}) {
+  return (
+    isError ||
+    (usesInitialPage && initialPageFailed && dataUpdatedAt === 0)
+  );
+}


### PR DESCRIPTION
## Summary

- seed the existing proposal table/list from one server-fetched anonymous first page
- render the established proposal UI in initial HTML and remove the duplicate public-summary card
- preserve filters, wallet-specific query keys, pagination, retries, localized empty/error states, and responsive behavior
- add React Query contract coverage for hydration, pagination, query transitions, and failure recovery

## UI impact

No redesign. The only intended visible change is removal of the duplicate proposal summary above the existing proposal directory.

## Verification

- `pnpm run test:web-scripts` (121 passed)
- `pnpm --filter @degov/web lint`
- `pnpm --filter @degov/web build`
- local raw HTML: normal H1 and 30 proposal links, no duplicate summary
- desktop/mobile screenshot inspection
- independent review: no remaining actionable findings
- GitHub commit verification: verified SSH signature

Closes #1081
