### PR TITLE
fix(indexer): speed up refresh backlog metrics

### DIFF
--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -828,7 +828,7 @@ pub fn render_prometheus_metrics_with_status(
     metric_header(
         &mut output,
         "degov_onchain_refresh_ready_backlog_tasks",
-        "Non-completed onchain refresh task backlog count ready to be claimed by status.",
+        "Non-completed onchain refresh task backlog count with next_run_at due by status.",
         "gauge",
     );
     metric_header(

--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -821,13 +821,13 @@ pub fn render_prometheus_metrics_with_status(
     );
     metric_header(
         &mut output,
-        "degov_onchain_refresh_tasks",
+        "degov_onchain_refresh_backlog_tasks",
         "Non-completed onchain refresh task backlog count by status.",
         "gauge",
     );
     metric_header(
         &mut output,
-        "degov_onchain_refresh_ready_tasks",
+        "degov_onchain_refresh_ready_backlog_tasks",
         "Non-completed onchain refresh task backlog count ready to be claimed by status.",
         "gauge",
     );
@@ -1068,13 +1068,13 @@ pub fn render_prometheus_metrics_with_status(
         let labels = onchain_labels(row);
         append_metric(
             &mut output,
-            "degov_onchain_refresh_tasks",
+            "degov_onchain_refresh_backlog_tasks",
             &labels,
             row.tasks,
         );
         append_metric(
             &mut output,
-            "degov_onchain_refresh_ready_tasks",
+            "degov_onchain_refresh_ready_backlog_tasks",
             &labels,
             row.ready_tasks,
         );

--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -822,13 +822,13 @@ pub fn render_prometheus_metrics_with_status(
     metric_header(
         &mut output,
         "degov_onchain_refresh_tasks",
-        "Onchain refresh task count by status.",
+        "Non-completed onchain refresh task backlog count by status.",
         "gauge",
     );
     metric_header(
         &mut output,
         "degov_onchain_refresh_ready_tasks",
-        "Onchain refresh task count ready to be claimed by status.",
+        "Non-completed onchain refresh task backlog count ready to be claimed by status.",
         "gauge",
     );
     metric_header(
@@ -1416,6 +1416,7 @@ async fn collect_onchain_refresh_backlog_metrics(
             WHERE next_run_at <= FLOOR(EXTRACT(EPOCH FROM now()) * 1000)::NUMERIC
           )::BIGINT AS ready_tasks
         FROM onchain_refresh_task
+        WHERE status <> 'completed'
         GROUP BY dao_code, chain_id, contract_set_id, status
         ORDER BY dao_code, chain_id, contract_set_id, status
         "#,

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -143,9 +143,9 @@ where
     ApplyRuntimeMaintenanceFuture: Future<Output = Result<()>>,
 {
     start_realtime()?;
-    let metrics_server = start_metrics().await?;
     ensure_warmup().await?;
     apply_runtime_maintenance().await?;
+    let metrics_server = start_metrics().await?;
 
     Ok(metrics_server)
 }
@@ -2254,11 +2254,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_post_schema_startup_starts_realtime_before_runtime_maintenance() {
+    async fn test_post_schema_startup_starts_metrics_after_runtime_maintenance() {
         let (realtime_started_tx, realtime_started_rx) = tokio::sync::oneshot::channel();
         let (maintenance_started_tx, maintenance_started_rx) = tokio::sync::oneshot::channel();
+        let (metrics_started_tx, metrics_started_rx) = tokio::sync::oneshot::channel();
         let realtime_start_count = Arc::new(AtomicUsize::new(0));
+        let metrics_start_count = Arc::new(AtomicUsize::new(0));
         let realtime_start_count_for_startup = realtime_start_count.clone();
+        let metrics_start_count_for_startup = metrics_start_count.clone();
         let release_maintenance = Arc::new(tokio::sync::Semaphore::new(0));
         let release_maintenance_for_startup = release_maintenance.clone();
 
@@ -2271,7 +2274,13 @@ mod tests {
                         .expect("realtime startup signal is received");
                     Ok(())
                 },
-                || async { Ok(()) },
+                || async move {
+                    metrics_start_count_for_startup.fetch_add(1, Ordering::SeqCst);
+                    metrics_started_tx
+                        .send(())
+                        .expect("metrics startup signal is received");
+                    Ok(())
+                },
                 || async { Ok(()) },
                 || async move {
                     maintenance_started_tx
@@ -2299,13 +2308,23 @@ mod tests {
             !startup.is_finished(),
             "runtime maintenance remains independent from already-started realtime work"
         );
+        assert_eq!(
+            metrics_start_count.load(Ordering::SeqCst),
+            0,
+            "metrics startup waits until runtime maintenance completes"
+        );
 
         release_maintenance.add_permits(1);
+        timeout(Duration::from_secs(1), metrics_started_rx)
+            .await
+            .expect("metrics startup begins after runtime maintenance")
+            .expect("metrics startup signal is sent");
         startup
             .await
             .expect("post-schema startup task joins")
             .expect("post-schema startup succeeds");
         assert_eq!(realtime_start_count.load(Ordering::SeqCst), 1);
+        assert_eq!(metrics_start_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/apps/indexer/src/runtime/migrate.rs
+++ b/apps/indexer/src/runtime/migrate.rs
@@ -298,6 +298,18 @@ async fn ensure_runtime_indexes(connection: &mut PgConnection) -> Result<()> {
 
     execute_concurrent_runtime_index(
         connection,
+        "onchain_refresh_task_backlog_metrics_idx",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_task_backlog_metrics_idx
+         ON onchain_refresh_task (
+            dao_code, chain_id, contract_set_id, status, next_run_at
+         )
+         WHERE status <> 'completed'",
+    )
+    .await
+    .context("ensure onchain refresh backlog metrics index")?;
+
+    execute_concurrent_runtime_index(
+        connection,
         "onchain_refresh_deferred_candidate_scope_drain_idx",
         "CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_deferred_candidate_scope_drain_idx
          ON onchain_refresh_deferred_candidate (
@@ -885,6 +897,7 @@ async fn drop_invalid_runtime_indexes_for_connection(connection: &mut PgConnecti
         "onchain_refresh_task_processing_scope_retry_idx",
     )
     .await?;
+    drop_invalid_runtime_index(connection, "onchain_refresh_task_backlog_metrics_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_rolling_metadata_preload_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_current_from_scope_idx").await?;
     drop_invalid_runtime_index(connection, "delegate_current_power_refresh_idx").await?;

--- a/apps/indexer/tests/metrics_service.rs
+++ b/apps/indexer/tests/metrics_service.rs
@@ -141,10 +141,10 @@ fn test_prometheus_renderer_emits_indexer_sync_and_onchain_backlog_gauges() {
         "degov_indexer_eta_seconds{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\"} 52.2"
     ));
     assert!(output.contains(
-        "degov_onchain_refresh_tasks{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",status=\"pending\"} 15"
+        "degov_onchain_refresh_backlog_tasks{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",status=\"pending\"} 15"
     ));
     assert!(output.contains(
-        "degov_onchain_refresh_ready_tasks{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",status=\"pending\"} 9"
+        "degov_onchain_refresh_ready_backlog_tasks{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",status=\"pending\"} 9"
     ));
     assert!(output.contains(
         "degov_onchain_refresh_deferred_candidates{dao_code=\"ring-dao\",chain_id=\"46\",contract_set_id=\"dao=ring-dao|chain=46|governor=0xgovernor\",status=\"deferred\"} 7"

--- a/apps/indexer/tests/migration_schema.rs
+++ b/apps/indexer/tests/migration_schema.rs
@@ -340,6 +340,22 @@ async fn test_migration_applies_required_schema_to_clean_postgres() -> Result<()
     assert_index_exists(
         &database.pool,
         &database.schema,
+        "onchain_refresh_task_backlog_metrics_idx",
+    )
+    .await?;
+    assert_index_definition_contains(
+        &database.pool,
+        &database.schema,
+        "onchain_refresh_task_backlog_metrics_idx",
+        &[
+            "USING btree (dao_code, chain_id, contract_set_id, status, next_run_at)",
+            "WHERE (status <> 'completed'::text)",
+        ],
+    )
+    .await?;
+    assert_index_exists(
+        &database.pool,
+        &database.schema,
         "delegate_current_from_scope_idx",
     )
     .await?;
@@ -1101,6 +1117,7 @@ fn test_indexer_keeps_init_migration_stable_and_appends_runtime_markers()
     assert!(runtime_migration.contains("onchain_refresh_task_pending_scope_claim_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_failed_scope_retry_idx"));
     assert!(runtime_migration.contains("onchain_refresh_task_processing_scope_retry_idx"));
+    assert!(runtime_migration.contains("onchain_refresh_task_backlog_metrics_idx"));
     assert!(runtime_migration.contains(
         "execute_concurrent_runtime_index(\n        connection,\n        \"onchain_refresh_deferred_candidate_scope_drain_idx\",\n        \"CREATE INDEX CONCURRENTLY IF NOT EXISTS onchain_refresh_deferred_candidate_scope_drain_idx"
     ));


### PR DESCRIPTION
## Summary
- publish onchain refresh backlog under explicit metric names: `degov_onchain_refresh_backlog_tasks` and `degov_onchain_refresh_ready_backlog_tasks`
- stop scanning completed historical onchain refresh tasks in the backlog metrics query
- add a partial runtime index for non-completed onchain refresh backlog metrics
- start DB-backed metrics only after runtime maintenance finishes, so rollout builds the index before the refresh loop can query it

## Production evidence
- `onchain_refresh_task` had 1,902,249 completed rows and 1,100 non-completed rows
- existing metrics aggregation scanned the table every scrape and logged ~4.7-5.2s slow SQL
- filtering non-completed rows without a partial index still used a parallel seq scan, so code and index are both required

## Safety
- does not delete or modify task data
- does not change task claiming, writes, checkpoints, or sync behavior
- runtime index is created with `CREATE INDEX CONCURRENTLY IF NOT EXISTS`
- metrics startup waits for runtime maintenance before DB-backed refresh starts

## Compatibility
- old `degov_onchain_refresh_tasks` / `degov_onchain_refresh_ready_tasks` families are replaced by explicit backlog metric families to avoid changing the old names silently
- repo/manifests search did not find Prometheus rules or dashboards referencing the old names; external dashboards should migrate if they use them

## Verification
- `cargo fmt --check`
- `cargo test -p degov-datalens-indexer --test metrics_service -- --nocapture`
- `cargo test -p degov-datalens-indexer --lib test_post_schema_startup_starts_metrics_after_runtime_maintenance -- --nocapture`
- `cargo test -p degov-datalens-indexer --test migration_schema test_indexer_keeps_init_migration_stable_and_appends_runtime_markers -- --nocapture`
- `cargo check --workspace`

## Note
Full `migration_schema` integration suite requires `DEGOV_INDEXER_TEST_DATABASE_URL`, which is not configured in this environment.