### PR TITLE
fix(indexer): speed up checkpoint metrics

### DIFF
--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -323,6 +323,8 @@ fn indexer_status_query<'a>() -> QueryBuilder<'a, Postgres> {
             MAX(segment.range_end_block) AS range_end_block
           FROM degov_provisional_segment segment
           WHERE segment.status = 'available'
+            AND segment.dao_code IS NOT NULL
+            AND segment.chain_id IS NOT NULL
           GROUP BY
             segment.dao_code,
             segment.chain_id,

--- a/apps/indexer/src/graphql/query.rs
+++ b/apps/indexer/src/graphql/query.rs
@@ -312,28 +312,41 @@ pub(super) async fn count_proposals(
 fn indexer_status_query<'a>() -> QueryBuilder<'a, Postgres> {
     QueryBuilder::<Postgres>::new(
         r#"
+        WITH selector_coverage AS (
+          SELECT
+            segment.dao_code,
+            segment.chain_id,
+            segment.contract_set_id,
+            segment.dataset_key,
+            segment.source,
+            segment.selector,
+            MAX(segment.range_end_block) AS range_end_block
+          FROM degov_provisional_segment segment
+          WHERE segment.status = 'available'
+          GROUP BY
+            segment.dao_code,
+            segment.chain_id,
+            segment.contract_set_id,
+            segment.dataset_key,
+            segment.source,
+            segment.selector
+        ),
+        provisional_coverage AS (
+          SELECT
+            dao_code,
+            chain_id,
+            contract_set_id,
+            dataset_key,
+            MIN(range_end_block)::BIGINT AS provisional_height
+          FROM selector_coverage
+          GROUP BY dao_code, chain_id, contract_set_id, dataset_key
+        )
         SELECT
           checkpoint.dao_code,
           checkpoint.chain_id,
           checkpoint.contract_set_id,
           checkpoint.processed_height::BIGINT AS processed_height,
-          (
-            SELECT MIN(selector_coverage.range_end_block)::BIGINT
-            FROM (
-              SELECT MAX(segment.range_end_block) AS range_end_block
-              FROM degov_provisional_segment segment
-              WHERE segment.status = 'available'
-                AND segment.dao_code = checkpoint.dao_code
-                AND segment.chain_id IS NOT DISTINCT FROM checkpoint.chain_id
-                AND segment.contract_set_id = checkpoint.contract_set_id
-                AND segment.dataset_key = split_part(
-                  split_part(checkpoint.contract_set_id, 'dataset=', 2),
-                  '|',
-                  1
-                )
-              GROUP BY segment.source, segment.selector
-            ) selector_coverage
-          ) AS provisional_height,
+          provisional.provisional_height,
           checkpoint.target_height::BIGINT AS target_height,
           CASE
             WHEN checkpoint.target_height IS NULL THEN NULL
@@ -351,6 +364,15 @@ fn indexer_status_query<'a>() -> QueryBuilder<'a, Postgres> {
           checkpoint.updated_at::TEXT AS updated_at,
           checkpoint.last_error
         FROM degov_indexer_checkpoint checkpoint
+        LEFT JOIN provisional_coverage provisional
+          ON provisional.dao_code = checkpoint.dao_code
+         AND provisional.chain_id IS NOT DISTINCT FROM checkpoint.chain_id
+         AND provisional.contract_set_id = checkpoint.contract_set_id
+         AND provisional.dataset_key = split_part(
+           split_part(checkpoint.contract_set_id, 'dataset=', 2),
+           '|',
+           1
+         )
         "#,
     )
 }
@@ -1589,7 +1611,7 @@ mod tests {
         let query = indexer_status_query();
         let sql = query.sql();
 
-        assert!(sql.contains("segment.dataset_key = split_part"));
+        assert!(sql.contains("provisional.dataset_key = split_part"));
         assert!(sql.contains("split_part(checkpoint.contract_set_id, 'dataset=', 2)"));
     }
 

--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -1339,24 +1339,39 @@ fn collect_onchain_worker_runtime_metrics() -> Vec<OnchainRefreshWorkerMetricsRo
 async fn collect_sync_metrics(pool: &PgPool) -> Result<Vec<IndexerSyncMetricsRow>, MetricsError> {
     let rows = sqlx::query(
         r#"
+        WITH selector_coverage AS (
+          SELECT
+            segment.dao_code,
+            segment.chain_id,
+            segment.contract_set_id,
+            segment.source,
+            segment.selector,
+            MAX(segment.range_end_block) AS range_end_block
+          FROM degov_provisional_segment segment
+          WHERE segment.status = 'available'
+          GROUP BY
+            segment.dao_code,
+            segment.chain_id,
+            segment.contract_set_id,
+            segment.source,
+            segment.selector
+        ),
+        provisional_coverage AS (
+          SELECT
+            dao_code,
+            chain_id,
+            contract_set_id,
+            MIN(range_end_block)::BIGINT AS provisional_height
+          FROM selector_coverage
+          GROUP BY dao_code, chain_id, contract_set_id
+        )
         SELECT
           checkpoint.dao_code,
           checkpoint.chain_id,
           checkpoint.contract_set_id,
           checkpoint.processed_height::BIGINT AS processed_height,
           checkpoint.target_height::BIGINT AS target_height,
-          (
-            SELECT MIN(selector_coverage.range_end_block)::BIGINT
-            FROM (
-              SELECT MAX(segment.range_end_block) AS range_end_block
-              FROM degov_provisional_segment segment
-              WHERE segment.status = 'available'
-                AND segment.dao_code = checkpoint.dao_code
-                AND segment.chain_id IS NOT DISTINCT FROM checkpoint.chain_id
-                AND segment.contract_set_id = checkpoint.contract_set_id
-              GROUP BY segment.source, segment.selector
-            ) selector_coverage
-          ) AS provisional_height,
+          provisional.provisional_height,
           latest.latest_height::BIGINT AS latest_height,
           CASE
             WHEN checkpoint.target_height IS NULL THEN NULL
@@ -1370,6 +1385,10 @@ async fn collect_sync_metrics(pool: &PgPool) -> Result<Vec<IndexerSyncMetricsRow
           EXTRACT(EPOCH FROM checkpoint.updated_at)::DOUBLE PRECISION AS updated_timestamp_seconds,
           checkpoint.last_error IS NOT NULL AS last_error_present
         FROM degov_indexer_checkpoint checkpoint
+        LEFT JOIN provisional_coverage provisional
+          ON provisional.dao_code = checkpoint.dao_code
+         AND provisional.chain_id IS NOT DISTINCT FROM checkpoint.chain_id
+         AND provisional.contract_set_id = checkpoint.contract_set_id
         LEFT JOIN degov_indexer_latest_head latest
           ON latest.dao_code = checkpoint.dao_code
          AND latest.chain_id = checkpoint.chain_id

--- a/apps/indexer/src/metrics.rs
+++ b/apps/indexer/src/metrics.rs
@@ -1349,6 +1349,8 @@ async fn collect_sync_metrics(pool: &PgPool) -> Result<Vec<IndexerSyncMetricsRow
             MAX(segment.range_end_block) AS range_end_block
           FROM degov_provisional_segment segment
           WHERE segment.status = 'available'
+            AND segment.dao_code IS NOT NULL
+            AND segment.chain_id IS NOT NULL
           GROUP BY
             segment.dao_code,
             segment.chain_id,


### PR DESCRIPTION
## Summary
- rewrite checkpoint/provisional coverage metrics SQL to aggregate available provisional segments once per refresh instead of once per checkpoint row
- apply the same query shape to GraphQL indexer status while preserving dataset_key matching

## Evidence
- Production old-vs-new metrics SQL comparison returned 0 differing rows
- Production EXPLAIN for the new metrics query scans available provisional segments once (425 rows) and executed in ~18ms

## Verification
- cargo fmt --check
- cargo test -p degov-datalens-indexer --lib test_indexer_status_provisional_height_matches_contract_dataset_key -- --nocapture
- cargo test -p degov-datalens-indexer --test metrics_service -- --nocapture
- cargo check --workspace
- git diff --check