### PR TITLE
feat(web): add proposal discussions

### DIFF
--- a/apps/web/messages/en/proposal-detail.json
+++ b/apps/web/messages/en/proposal-detail.json
@@ -18,7 +18,31 @@
   "tabs": {
     "content": "Content",
     "votes": "Votes",
-    "summary": "Summary"
+    "summary": "Summary",
+    "discussion": "Discussion"
+  },
+  "discussion": {
+    "placeholder": "Add to the discussion…",
+    "replyPlaceholder": "Write a reply…",
+    "markdownSupported": "Markdown supported",
+    "comment": "Comment",
+    "reply": "Reply",
+    "edit": "Edit",
+    "delete": "Delete",
+    "save": "Save",
+    "cancel": "Cancel",
+    "edited": "edited",
+    "deleted": "Comment deleted",
+    "deleteConfirm": "Delete this comment? Replies will remain visible.",
+    "empty": "No discussion yet",
+    "emptyDescription": "Start a public conversation about this proposal.",
+    "loading": "Loading discussion",
+    "loadMore": "Load more",
+    "retry": "Retry",
+    "unavailable": "Discussion is temporarily unavailable",
+    "unavailableDescription": "The proposal remains available. Try loading the discussion again.",
+    "authCancelled": "Connect and sign in to comment.",
+    "mutationFailed": "The comment could not be saved. Please try again."
   },
   "dropdown": {
     "cancelProposal": "Cancel Proposal"

--- a/apps/web/scripts/proposal-comments.test.ts
+++ b/apps/web/scripts/proposal-comments.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { isProposalFeatureEnabled } from "../src/utils/proposal-features.ts";
+
+const config = {
+  features: ["proposal-comments"],
+} as Parameters<typeof isProposalFeatureEnabled>[0];
+
+test("proposal comments require both API configuration and DAO feature", () => {
+  assert.equal(
+    isProposalFeatureEnabled(config, "proposal-comments", "https://api.example"),
+    true
+  );
+  assert.equal(
+    isProposalFeatureEnabled(config, "proposal-comments", undefined),
+    false
+  );
+  assert.equal(
+    isProposalFeatureEnabled(
+      { ...config, features: [] },
+      "proposal-comments",
+      "https://api.example"
+    ),
+    false
+  );
+});
+
+test("discussion stays distinct from on-chain vote reasons", () => {
+  const tabs = readFileSync(
+    new URL("../src/app/proposal/[id]/tabs.tsx", import.meta.url),
+    "utf8"
+  );
+  assert.match(tabs, /activeTab === "votes"/);
+  assert.match(tabs, /activeTab === "discussion"/);
+  assert.match(tabs, /proposal-comments/);
+});
+
+test("provider markdown is sanitized before rendering", () => {
+  const discussion = readFileSync(
+    new URL("../src/app/proposal/[id]/discussion.tsx", import.meta.url),
+    "utf8"
+  );
+  assert.match(discussion, /DOMPurify\.sanitize\(marked\.parse/);
+  assert.match(discussion, /state === "DELETED"/);
+  assert.doesNotMatch(discussion, /comment\.body[^\n]*__html/);
+});
+
+test("remote GraphQL authentication is scoped to every request", () => {
+  const client = readFileSync(
+    new URL("../src/services/graphql/remote-client.ts", import.meta.url),
+    "utf8"
+  );
+  const notificationClient = readFileSync(
+    new URL("../src/services/graphql/notification-client.ts", import.meta.url),
+    "utf8"
+  );
+  assert.match(client, /requestHeaders/);
+  assert.match(client, /getRemoteToken\(address\)/);
+  assert.doesNotMatch(client, /setHeaders/);
+  assert.match(notificationClient, /requestRemote/);
+});

--- a/apps/web/scripts/proposal-comments.test.ts
+++ b/apps/web/scripts/proposal-comments.test.ts
@@ -35,6 +35,8 @@ test("discussion stays distinct from on-chain vote reasons", () => {
   assert.match(tabs, /activeTab === "votes"/);
   assert.match(tabs, /activeTab === "discussion"/);
   assert.match(tabs, /proposal-comments/);
+  assert.match(tabs, /overflow-x-auto/);
+  assert.match(tabs, /min-w-max/);
 });
 
 test("provider markdown is sanitized before rendering", () => {
@@ -58,6 +60,7 @@ test("remote GraphQL authentication is scoped to every request", () => {
   );
   assert.match(client, /requestHeaders/);
   assert.match(client, /getRemoteToken\(address\)/);
+  assert.match(client, /isDegovApiConfiguredClient\(\)/);
   assert.doesNotMatch(client, /setHeaders/);
   assert.match(notificationClient, /requestRemote/);
 });

--- a/apps/web/src/app/proposal/[id]/discussion.tsx
+++ b/apps/web/src/app/proposal/[id]/discussion.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import DOMPurify from "dompurify";
+import { MessageSquare, Pencil, Reply, RotateCcw, Trash2 } from "lucide-react";
+import { marked } from "marked";
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+import { useAccount } from "wagmi";
+
+import { AddressWithAvatar } from "@/components/address-with-avatar";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useEnsureAuth } from "@/hooks/useEnsureAuth";
+import { useProposalComments } from "@/hooks/useProposalComments";
+import type { ProposalComment } from "@/services/graphql/types/proposal-comments";
+import { formatTimeAgo } from "@/utils/date";
+import {
+  extractErrorMessage,
+  isAuthenticationRequired,
+} from "@/utils/graphql-error-handler";
+
+const MAX_COMMENT_LENGTH = 10_000;
+
+function MarkdownComment({ body }: { body: string }) {
+  const html = useMemo(
+    () => DOMPurify.sanitize(marked.parse(body) as string),
+    [body]
+  );
+
+  return (
+    <div
+      className="markdown-body text-[14px] leading-relaxed break-words"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+interface CommentRowProps {
+  comment: ProposalComment;
+  isReply?: boolean;
+  currentAddress?: string;
+  isPending: boolean;
+  editingId: string | null;
+  editBody: string;
+  replyingTo: string | null;
+  replyBody: string;
+  onEditStart: (comment: ProposalComment) => void;
+  onEditBodyChange: (value: string) => void;
+  onEditCancel: () => void;
+  onEditSave: (comment: ProposalComment) => void;
+  onReplyStart: (commentId: string) => void;
+  onReplyBodyChange: (value: string) => void;
+  onReplyCancel: () => void;
+  onReplySave: (comment: ProposalComment) => void;
+  onDelete: (comment: ProposalComment) => void;
+}
+
+function CommentRow({
+  comment,
+  isReply = false,
+  currentAddress,
+  isPending,
+  editingId,
+  editBody,
+  replyingTo,
+  replyBody,
+  onEditStart,
+  onEditBodyChange,
+  onEditCancel,
+  onEditSave,
+  onReplyStart,
+  onReplyBodyChange,
+  onReplyCancel,
+  onReplySave,
+  onDelete,
+}: CommentRowProps) {
+  const t = useTranslations("proposalDetail.discussion");
+  const isAuthor =
+    currentAddress?.toLowerCase() === comment.authorAddress.toLowerCase();
+  const isDeleted = comment.state === "DELETED";
+  const isEditing = editingId === comment.id;
+  const isReplying = replyingTo === comment.id;
+
+  return (
+    <article
+      className={
+        isReply
+          ? "ml-[22px] border-l border-border/40 pl-[18px] sm:ml-[34px] sm:pl-[22px]"
+          : ""
+      }
+    >
+      <div className="flex items-start gap-[12px] py-[18px]">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-[10px] gap-y-[4px]">
+            <AddressWithAvatar
+              address={comment.authorAddress}
+              avatarSize={26}
+              className="gap-[8px]"
+              textClassName="text-[13px] font-medium"
+            />
+            <span className="text-[12px] text-muted-foreground">
+              {formatTimeAgo(String(new Date(comment.ctime).getTime()))}
+              {comment.utime ? ` · ${t("edited")}` : ""}
+            </span>
+          </div>
+
+          <div className="mt-[10px]">
+            {isDeleted ? (
+              <p className="text-[14px] italic text-muted-foreground">
+                {t("deleted")}
+              </p>
+            ) : isEditing ? (
+              <div className="space-y-[10px]">
+                <Textarea
+                  value={editBody}
+                  maxLength={MAX_COMMENT_LENGTH}
+                  disabled={isPending}
+                  onChange={(event) => onEditBodyChange(event.target.value)}
+                />
+                <div className="flex gap-[8px]">
+                  <Button
+                    size="sm"
+                    disabled={!editBody.trim()}
+                    isLoading={isPending}
+                    onClick={() => onEditSave(comment)}
+                  >
+                    {t("save")}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={onEditCancel}>
+                    {t("cancel")}
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <MarkdownComment body={comment.body ?? ""} />
+            )}
+          </div>
+
+          {!isDeleted && !isEditing && (
+            <div className="mt-[10px] flex items-center gap-[4px]">
+              {!isReply && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 px-2 text-muted-foreground"
+                  onClick={() => onReplyStart(comment.id)}
+                >
+                  <Reply />
+                  {t("reply")}
+                </Button>
+              )}
+              {isAuthor && (
+                <>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-8 px-2 text-muted-foreground"
+                    onClick={() => onEditStart(comment)}
+                  >
+                    <Pencil />
+                    {t("edit")}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-8 px-2 text-muted-foreground hover:text-destructive"
+                    disabled={isPending}
+                    onClick={() => onDelete(comment)}
+                  >
+                    <Trash2 />
+                    {t("delete")}
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
+
+          {isReplying && (
+            <div className="mt-[12px] space-y-[10px]">
+              <Textarea
+                autoFocus
+                value={replyBody}
+                maxLength={MAX_COMMENT_LENGTH}
+                placeholder={t("replyPlaceholder")}
+                disabled={isPending}
+                onChange={(event) => onReplyBodyChange(event.target.value)}
+              />
+              <div className="flex gap-[8px]">
+                <Button
+                  size="sm"
+                  disabled={!replyBody.trim()}
+                  isLoading={isPending}
+                  onClick={() => onReplySave(comment)}
+                >
+                  {t("reply")}
+                </Button>
+                <Button size="sm" variant="ghost" onClick={onReplyCancel}>
+                  {t("cancel")}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function Discussion({
+  daoCode,
+  proposalId,
+}: {
+  daoCode: string;
+  proposalId: string;
+}) {
+  const t = useTranslations("proposalDetail.discussion");
+  const { address } = useAccount();
+  const { ensureAuth, isAuthenticating } = useEnsureAuth();
+  const { query, create, update, remove } = useProposalComments(
+    daoCode,
+    proposalId
+  );
+  const [body, setBody] = useState("");
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replyBody, setReplyBody] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editBody, setEditBody] = useState("");
+  const [mutationError, setMutationError] = useState<string | null>(null);
+
+  const comments = useMemo(
+    () => query.data?.pages.flatMap((page) => page.items) ?? [],
+    [query.data]
+  );
+  const roots = useMemo(() => {
+    const ids = new Set(comments.map((comment) => comment.id));
+    return comments.filter(
+      (comment) => !comment.replyToId || !ids.has(comment.replyToId)
+    );
+  }, [comments]);
+  const replies = useMemo(() => {
+    const grouped = new Map<string, ProposalComment[]>();
+    for (const comment of comments) {
+      if (!comment.replyToId) continue;
+      grouped.set(comment.replyToId, [
+        ...(grouped.get(comment.replyToId) ?? []),
+        comment,
+      ]);
+    }
+    return grouped;
+  }, [comments]);
+
+  const isPending =
+    isAuthenticating || create.isPending || update.isPending || remove.isPending;
+
+  const runAuthenticated = async (
+    action: (walletAddress: string) => Promise<unknown>
+  ) => {
+    setMutationError(null);
+    const auth = await ensureAuth();
+    if (!auth.success || !address) {
+      setMutationError(auth.error ?? t("authCancelled"));
+      return false;
+    }
+    try {
+      await action(address);
+      return true;
+    } catch (error) {
+      if (isAuthenticationRequired(error)) {
+        const retryAuth = await ensureAuth();
+        if (retryAuth.success) {
+          try {
+            await action(address);
+            return true;
+          } catch (retryError) {
+            error = retryError;
+          }
+        }
+      }
+      setMutationError(extractErrorMessage(error) ?? t("mutationFailed"));
+      return false;
+    }
+  };
+
+  const createComment = async () => {
+    const trimmed = body.trim();
+    if (!trimmed) return;
+    if (
+      await runAuthenticated((walletAddress) =>
+        create.mutateAsync({
+          input: { daoCode, proposalId, body: trimmed },
+          address: walletAddress,
+        })
+      )
+    ) {
+      setBody("");
+    }
+  };
+
+  const sharedRowProps = {
+    currentAddress: address,
+    isPending,
+    editingId,
+    editBody,
+    replyingTo,
+    replyBody,
+    onEditStart: (comment: ProposalComment) => {
+      setEditingId(comment.id);
+      setEditBody(comment.body ?? "");
+      setReplyingTo(null);
+    },
+    onEditBodyChange: setEditBody,
+    onEditCancel: () => setEditingId(null),
+    onEditSave: async (comment: ProposalComment) => {
+      const trimmed = editBody.trim();
+      if (!trimmed) return;
+      if (
+        await runAuthenticated((walletAddress) =>
+          update.mutateAsync({
+            input: { daoCode, commentId: comment.id, body: trimmed },
+            address: walletAddress,
+          })
+        )
+      ) {
+        setEditingId(null);
+      }
+    },
+    onReplyStart: (commentId: string) => {
+      setReplyingTo(commentId);
+      setReplyBody("");
+      setEditingId(null);
+    },
+    onReplyBodyChange: setReplyBody,
+    onReplyCancel: () => setReplyingTo(null),
+    onReplySave: async (comment: ProposalComment) => {
+      const trimmed = replyBody.trim();
+      if (!trimmed) return;
+      if (
+        await runAuthenticated((walletAddress) =>
+          create.mutateAsync({
+            input: {
+              daoCode,
+              proposalId,
+              body: trimmed,
+              replyToId: comment.id,
+            },
+            address: walletAddress,
+          })
+        )
+      ) {
+        setReplyingTo(null);
+        setReplyBody("");
+      }
+    },
+    onDelete: async (comment: ProposalComment) => {
+      if (!window.confirm(t("deleteConfirm"))) return;
+      await runAuthenticated((walletAddress) =>
+        remove.mutateAsync({
+          input: { daoCode, commentId: comment.id },
+          address: walletAddress,
+        })
+      );
+    },
+  };
+
+  if (query.isLoading) {
+    return (
+      <div className="space-y-[18px] py-[8px]" aria-label={t("loading")}>
+        {[0, 1, 2].map((item) => (
+          <div key={item} className="animate-pulse space-y-[10px]">
+            <div className="h-5 w-36 rounded bg-muted" />
+            <div className="h-4 w-full rounded bg-muted/60" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="flex min-h-[220px] flex-col items-center justify-center gap-[14px] text-center">
+        <MessageSquare className="size-7 text-muted-foreground" />
+        <div>
+          <p className="font-semibold">{t("unavailable")}</p>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            {t("unavailableDescription")}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => query.refetch()}>
+          <RotateCcw />
+          {t("retry")}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <section className="max-w-[780px]">
+      <div className="border-b border-border/30 pb-[20px]">
+        <Textarea
+          value={body}
+          maxLength={MAX_COMMENT_LENGTH}
+          placeholder={t("placeholder")}
+          disabled={isPending}
+          className="min-h-[96px] resize-y"
+          onChange={(event) => setBody(event.target.value)}
+        />
+        <div className="mt-[10px] flex items-center justify-between gap-[12px]">
+          <span className="text-[12px] text-muted-foreground">
+            {t("markdownSupported")}
+          </span>
+          <Button
+            size="sm"
+            disabled={!body.trim()}
+            isLoading={isPending}
+            onClick={createComment}
+          >
+            {t("comment")}
+          </Button>
+        </div>
+        {mutationError && (
+          <p role="alert" className="mt-[10px] text-[13px] text-destructive">
+            {mutationError}
+          </p>
+        )}
+      </div>
+
+      {roots.length === 0 ? (
+        <div className="flex min-h-[220px] flex-col items-center justify-center text-center">
+          <MessageSquare className="size-7 text-muted-foreground" />
+          <p className="mt-[12px] font-semibold">{t("empty")}</p>
+          <p className="mt-1 max-w-[340px] text-[13px] text-muted-foreground">
+            {t("emptyDescription")}
+          </p>
+        </div>
+      ) : (
+        <div className="divide-y divide-border/30">
+          {roots.map((comment) => (
+            <div key={comment.id}>
+              <CommentRow comment={comment} {...sharedRowProps} />
+              {(replies.get(comment.id) ?? []).map((reply) => (
+                <CommentRow
+                  key={reply.id}
+                  comment={reply}
+                  isReply
+                  {...sharedRowProps}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {query.hasNextPage && (
+        <div className="flex justify-center border-t border-border/30 pt-[18px]">
+          <Button
+            variant="ghost"
+            isLoading={query.isFetchingNextPage}
+            onClick={() => query.fetchNextPage()}
+          >
+            {t("loadMore")}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/proposal/[id]/tabs.tsx
+++ b/apps/web/src/app/proposal/[id]/tabs.tsx
@@ -4,8 +4,14 @@ import { useTranslations } from "next-intl";
 import { useState, useMemo } from "react";
 
 import { DEFAULT_ANIMATION_DURATION } from "@/config/base";
+import { useDaoConfig } from "@/hooks/useDaoConfig";
 import { cn } from "@/lib/utils";
 import type { ProposalItem } from "@/services/graphql/types";
+import { isProposalFeatureEnabled } from "@/utils/proposal-features";
+import {
+  degovGraphqlApi,
+  isDegovApiConfiguredClient,
+} from "@/utils/remote-api";
 
 import { TabContent } from "./tab-content";
 
@@ -41,7 +47,12 @@ const AiReview = dynamic(
   }
 );
 
-type TabType = "content" | "votes" | "ai-review";
+const Discussion = dynamic(
+  () => import("./discussion").then((mod) => mod.Discussion),
+  { loading: () => <CommentsSkeleton /> }
+);
+
+type TabType = "content" | "votes" | "ai-review" | "discussion";
 
 interface TabsProps {
   data?: ProposalItem;
@@ -55,7 +66,13 @@ const contentVariants = {
 
 export const Tabs = ({ data, isFetching }: TabsProps) => {
   const t = useTranslations("proposalDetail.tabs");
+  const daoConfig = useDaoConfig();
   const [activeTab, setActiveTab] = useState<TabType>("content");
+  const showDiscussion = isProposalFeatureEnabled(
+    daoConfig,
+    "proposal-comments",
+    isDegovApiConfiguredClient() ? degovGraphqlApi() : undefined
+  );
 
   const tabConfig = useMemo(() => {
     const baseTabs = [
@@ -73,8 +90,15 @@ export const Tabs = ({ data, isFetching }: TabsProps) => {
       },
     ];
 
+    if (showDiscussion) {
+      baseTabs.push({
+        key: "discussion" as TabType,
+        label: t("discussion"),
+      });
+    }
+
     return baseTabs;
-  }, [t]);
+  }, [showDiscussion, t]);
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -132,6 +156,15 @@ export const Tabs = ({ data, isFetching }: TabsProps) => {
           {activeTab === "ai-review" && (
             <AiReview id={data?.proposalId as string} />
           )}
+
+          {activeTab === "discussion" &&
+            data?.proposalId &&
+            daoConfig?.code && (
+              <Discussion
+                daoCode={daoConfig.code}
+                proposalId={data.proposalId}
+              />
+            )}
         </motion.div>
       </AnimatePresence>
     </div>

--- a/apps/web/src/app/proposal/[id]/tabs.tsx
+++ b/apps/web/src/app/proposal/[id]/tabs.tsx
@@ -103,8 +103,8 @@ export const Tabs = ({ data, isFetching }: TabsProps) => {
   return (
     <div className="flex flex-col h-full min-h-0">
       {/* Tab Navigation */}
-      <div className="border-b border-border/20 mb-[20px]">
-        <div className="flex gap-[32px]">
+      <div className="mb-[20px] overflow-x-auto border-b border-border/20">
+        <div className="flex min-w-max gap-[20px] sm:gap-[32px]">
           {tabConfig.map((tab) => (
             <button
               key={tab.key}

--- a/apps/web/src/hooks/useEnsureAuth.ts
+++ b/apps/web/src/hooks/useEnsureAuth.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
 import { siweService } from "@/lib/auth/siwe-service";
+import { tokenManager } from "@/lib/auth/token-manager";
+import { degovGraphqlApi } from "@/utils/remote-api";
 
 import { useSiweAuth } from "./useSiweAuth";
 
@@ -43,7 +45,9 @@ export const useEnsureAuth = () => {
       }
 
       const currentSession = await siweService.getAuthStatus(address);
-      if (currentSession.authenticated) {
+      const remoteAuthReady =
+        !degovGraphqlApi() || Boolean(tokenManager.getRemoteToken(address));
+      if (currentSession.authenticated && remoteAuthReady) {
         setIsAuthenticated(true);
         return { success: true };
       }

--- a/apps/web/src/hooks/useEnsureAuth.ts
+++ b/apps/web/src/hooks/useEnsureAuth.ts
@@ -5,7 +5,7 @@ import { useAccount } from "wagmi";
 
 import { siweService } from "@/lib/auth/siwe-service";
 import { tokenManager } from "@/lib/auth/token-manager";
-import { degovGraphqlApi } from "@/utils/remote-api";
+import { isDegovApiConfiguredClient } from "@/utils/remote-api";
 
 import { useSiweAuth } from "./useSiweAuth";
 
@@ -46,7 +46,8 @@ export const useEnsureAuth = () => {
 
       const currentSession = await siweService.getAuthStatus(address);
       const remoteAuthReady =
-        !degovGraphqlApi() || Boolean(tokenManager.getRemoteToken(address));
+        !isDegovApiConfiguredClient() ||
+        Boolean(tokenManager.getRemoteToken(address));
       if (currentSession.authenticated && remoteAuthReady) {
         setIsAuthenticated(true);
         return { success: true };

--- a/apps/web/src/hooks/useProposalComments.ts
+++ b/apps/web/src/hooks/useProposalComments.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import type {
+  CreateProposalCommentInput,
+  DeleteProposalCommentInput,
+  UpdateProposalCommentInput,
+} from "@/services/graphql/types/proposal-comments";
+import { proposalCommentsService } from "@/services/proposal-comments";
+
+const proposalCommentsKey = (daoCode: string, proposalId: string) =>
+  ["proposal-comments", daoCode, proposalId] as const;
+
+export function useProposalComments(daoCode: string, proposalId: string) {
+  const queryClient = useQueryClient();
+  const queryKey = proposalCommentsKey(daoCode, proposalId);
+
+  const query = useInfiniteQuery({
+    queryKey,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      proposalCommentsService.list({
+        daoCode,
+        proposalId,
+        first: 20,
+        after: pageParam,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.pageInfo.hasNextPage
+        ? lastPage.pageInfo.endCursor ?? undefined
+        : undefined,
+    retry: 1,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey });
+
+  const create = useMutation({
+    mutationFn: ({
+      input,
+      address,
+    }: {
+      input: CreateProposalCommentInput;
+      address: string;
+    }) => proposalCommentsService.create(input, address),
+    onSuccess: invalidate,
+  });
+
+  const update = useMutation({
+    mutationFn: ({
+      input,
+      address,
+    }: {
+      input: UpdateProposalCommentInput;
+      address: string;
+    }) => proposalCommentsService.update(input, address),
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation({
+    mutationFn: ({
+      input,
+      address,
+    }: {
+      input: DeleteProposalCommentInput;
+      address: string;
+    }) => proposalCommentsService.delete(input, address),
+    onSuccess: invalidate,
+  });
+
+  return { query, create, update, remove };
+}

--- a/apps/web/src/services/graphql/mutations/proposal-comments.ts
+++ b/apps/web/src/services/graphql/mutations/proposal-comments.ts
@@ -1,0 +1,36 @@
+const COMMENT_FIELDS = `
+  id
+  daoCode
+  chainId
+  proposalId
+  authorAddress
+  replyToId
+  body
+  state
+  ctime
+  utime
+`;
+
+export const CREATE_PROPOSAL_COMMENT = `
+  mutation CreateProposalComment($input: CreateProposalCommentInput!) {
+    createProposalComment(input: $input) {
+      ${COMMENT_FIELDS}
+    }
+  }
+`;
+
+export const UPDATE_PROPOSAL_COMMENT = `
+  mutation UpdateProposalComment($input: UpdateProposalCommentInput!) {
+    updateProposalComment(input: $input) {
+      ${COMMENT_FIELDS}
+    }
+  }
+`;
+
+export const DELETE_PROPOSAL_COMMENT = `
+  mutation DeleteProposalComment($input: DeleteProposalCommentInput!) {
+    deleteProposalComment(input: $input) {
+      ${COMMENT_FIELDS}
+    }
+  }
+`;

--- a/apps/web/src/services/graphql/notification-client.ts
+++ b/apps/web/src/services/graphql/notification-client.ts
@@ -1,45 +1,16 @@
-import { GraphQLClient, type ClientError } from "graphql-request";
-import { cache } from "react";
+import { createRemoteGraphQLClient, requestRemote } from "./remote-client";
 
-// Note: re-auth is handled by callers (e.g., hooks/components) explicitly.
-import { clearRemoteToken, getRemoteToken } from "@/lib/auth/token-manager";
-import { degovGraphqlApi } from "@/utils/remote-api";
+import type { Variables } from "graphql-request";
 
-export const createNotificationGraphQLClient = cache(() => {
-  const endpoint = degovGraphqlApi();
-  if (!endpoint) {
-    throw new Error("DeGov API endpoint is not configured");
-  }
-  return new GraphQLClient(endpoint);
-});
+export const createNotificationGraphQLClient = createRemoteGraphQLClient;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function requestNotification<T = any, V extends object = object>(
+export async function requestNotification<
+  T = unknown,
+  V extends Variables = Variables,
+>(
   document: string,
   variables: V | undefined,
   address: string
 ): Promise<T> {
-  const client = createNotificationGraphQLClient();
-
-  const doRequest = async (): Promise<T> => {
-    const token = getRemoteToken(address);
-    if (token) client.setHeaders({ Authorization: `Bearer ${token}` });
-    return variables
-      ? await client.request<T>(document, variables)
-      : await client.request<T>(document);
-  };
-
-  try {
-    return await doRequest();
-  } catch (error) {
-    // Surface 401 to the caller for manual authentication
-    const err = error as ClientError;
-    const status = (err as { response?: { status?: number } })?.response?.status;
-    if (status === 401) {
-      clearRemoteToken(address);
-      throw err;
-    }
-    console.error("Notification GraphQL request error:", error);
-    throw error;
-  }
+  return requestRemote<T, V>(document, variables, address);
 }

--- a/apps/web/src/services/graphql/queries/proposal-comments.ts
+++ b/apps/web/src/services/graphql/queries/proposal-comments.ts
@@ -1,0 +1,22 @@
+export const PROPOSAL_COMMENTS = `
+  query ProposalComments($input: ProposalCommentsInput!) {
+    proposalComments(input: $input) {
+      items {
+        id
+        daoCode
+        chainId
+        proposalId
+        authorAddress
+        replyToId
+        body
+        state
+        ctime
+        utime
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;

--- a/apps/web/src/services/graphql/remote-client.ts
+++ b/apps/web/src/services/graphql/remote-client.ts
@@ -1,0 +1,45 @@
+import {
+  GraphQLClient,
+  type ClientError,
+  type RequestOptions,
+  type Variables,
+} from "graphql-request";
+import { cache } from "react";
+
+import { clearRemoteToken, getRemoteToken } from "@/lib/auth/token-manager";
+import { isAuthenticationRequired } from "@/utils/graphql-error-handler";
+import { degovGraphqlApi } from "@/utils/remote-api";
+
+export const createRemoteGraphQLClient = cache(() => {
+  const endpoint = degovGraphqlApi();
+  if (!endpoint) {
+    throw new Error("DeGov API endpoint is not configured");
+  }
+  return new GraphQLClient(endpoint);
+});
+
+export async function requestRemote<T, V extends Variables = Variables>(
+  document: string,
+  variables?: V,
+  address?: string
+): Promise<T> {
+  const client = createRemoteGraphQLClient();
+  const token = address ? getRemoteToken(address) : null;
+  const requestHeaders = token
+    ? { Authorization: `Bearer ${token}` }
+    : undefined;
+
+  try {
+    const options = {
+      document,
+      variables,
+      requestHeaders,
+    } as unknown as RequestOptions<V, T>;
+    return await client.request<T, V>(options);
+  } catch (error) {
+    if (address && isAuthenticationRequired(error)) {
+      clearRemoteToken(address);
+    }
+    throw error as ClientError;
+  }
+}

--- a/apps/web/src/services/graphql/remote-client.ts
+++ b/apps/web/src/services/graphql/remote-client.ts
@@ -8,10 +8,15 @@ import { cache } from "react";
 
 import { clearRemoteToken, getRemoteToken } from "@/lib/auth/token-manager";
 import { isAuthenticationRequired } from "@/utils/graphql-error-handler";
-import { degovGraphqlApi } from "@/utils/remote-api";
+import {
+  degovGraphqlApi,
+  isDegovApiConfiguredClient,
+} from "@/utils/remote-api";
 
 export const createRemoteGraphQLClient = cache(() => {
-  const endpoint = degovGraphqlApi();
+  const endpoint = isDegovApiConfiguredClient()
+    ? degovGraphqlApi()
+    : undefined;
   if (!endpoint) {
     throw new Error("DeGov API endpoint is not configured");
   }

--- a/apps/web/src/services/graphql/types/proposal-comments.ts
+++ b/apps/web/src/services/graphql/types/proposal-comments.ts
@@ -1,0 +1,47 @@
+export type ProposalCommentState = "ACTIVE" | "DELETED";
+
+export interface ProposalComment {
+  id: string;
+  daoCode: string;
+  chainId: number;
+  proposalId: string;
+  authorAddress: `0x${string}`;
+  replyToId?: string | null;
+  body?: string | null;
+  state: ProposalCommentState;
+  ctime: string;
+  utime?: string | null;
+}
+
+export interface ProposalCommentPage {
+  items: ProposalComment[];
+  pageInfo: {
+    endCursor?: string | null;
+    hasNextPage: boolean;
+  };
+}
+
+export interface ProposalCommentsInput {
+  daoCode: string;
+  proposalId: string;
+  first?: number;
+  after?: string;
+}
+
+export interface CreateProposalCommentInput {
+  daoCode: string;
+  proposalId: string;
+  body: string;
+  replyToId?: string;
+}
+
+export interface UpdateProposalCommentInput {
+  daoCode: string;
+  commentId: string;
+  body: string;
+}
+
+export interface DeleteProposalCommentInput {
+  daoCode: string;
+  commentId: string;
+}

--- a/apps/web/src/services/proposal-comments.ts
+++ b/apps/web/src/services/proposal-comments.ts
@@ -1,0 +1,67 @@
+import {
+  CREATE_PROPOSAL_COMMENT,
+  DELETE_PROPOSAL_COMMENT,
+  UPDATE_PROPOSAL_COMMENT,
+} from "./graphql/mutations/proposal-comments";
+import { PROPOSAL_COMMENTS } from "./graphql/queries/proposal-comments";
+import { requestRemote } from "./graphql/remote-client";
+
+import type {
+  CreateProposalCommentInput,
+  DeleteProposalCommentInput,
+  ProposalComment,
+  ProposalCommentPage,
+  ProposalCommentsInput,
+  UpdateProposalCommentInput,
+} from "./graphql/types/proposal-comments";
+
+export const proposalCommentsService = {
+  async list(input: ProposalCommentsInput): Promise<ProposalCommentPage> {
+    const response = await requestRemote<{
+      proposalComments: ProposalCommentPage;
+    }, { input: ProposalCommentsInput }>(PROPOSAL_COMMENTS, { input });
+    return response.proposalComments;
+  },
+
+  async create(
+    input: CreateProposalCommentInput,
+    address: string
+  ): Promise<ProposalComment> {
+    const response = await requestRemote<{
+      createProposalComment: ProposalComment;
+    }, { input: CreateProposalCommentInput }>(
+      CREATE_PROPOSAL_COMMENT,
+      { input },
+      address
+    );
+    return response.createProposalComment;
+  },
+
+  async update(
+    input: UpdateProposalCommentInput,
+    address: string
+  ): Promise<ProposalComment> {
+    const response = await requestRemote<{
+      updateProposalComment: ProposalComment;
+    }, { input: UpdateProposalCommentInput }>(
+      UPDATE_PROPOSAL_COMMENT,
+      { input },
+      address
+    );
+    return response.updateProposalComment;
+  },
+
+  async delete(
+    input: DeleteProposalCommentInput,
+    address: string
+  ): Promise<ProposalComment> {
+    const response = await requestRemote<{
+      deleteProposalComment: ProposalComment;
+    }, { input: DeleteProposalCommentInput }>(
+      DELETE_PROPOSAL_COMMENT,
+      { input },
+      address
+    );
+    return response.deleteProposalComment;
+  },
+};

--- a/apps/web/src/types/config.ts
+++ b/apps/web/src/types/config.ts
@@ -100,6 +100,7 @@ interface Config {
   logo: string;
   siteUrl: string;
   offChainDiscussionUrl?: string;
+  features?: string[];
   description: string;
   links: Links;
   theme?: Theme;

--- a/apps/web/src/utils/proposal-features.ts
+++ b/apps/web/src/utils/proposal-features.ts
@@ -1,0 +1,9 @@
+import type { Config } from "@/types/config";
+
+export function isProposalFeatureEnabled(
+  config: Config | null | undefined,
+  feature: string,
+  apiEndpoint: string | undefined
+): boolean {
+  return Boolean(apiEndpoint && config?.features?.includes(feature));
+}

--- a/apps/web/src/utils/remote-api.ts
+++ b/apps/web/src/utils/remote-api.ts
@@ -16,6 +16,11 @@ export const isDegovApiConfiguredServer = () => {
   return !!NEXT_PUBLIC_DEGOV_API;
 };
 
+export const isDegovApiConfiguredClient = () => {
+  if (isLocalConfigEnabledClient()) return false;
+  return Boolean(env("NEXT_PUBLIC_DEGOV_API"));
+};
+
 export const degovGraphqlApi = (): string | undefined => {
   const clientApi =
     typeof window !== "undefined" ? env("NEXT_PUBLIC_DEGOV_API") : undefined;


### PR DESCRIPTION
## Summary

- add a feature-gated Discussion tab backed by Square proposal comments
- support public pagination and authenticated create/reply/edit/delete flows
- sanitize provider markdown and isolate Square loading/error states from proposal rendering
- add a shared per-request remote GraphQL client so wallet switches cannot retain stale bearer headers
- require both configured Square API and DAO `proposal-comments` capability

## Verification

- `cd apps/web && node --test scripts/proposal-comments.test.ts`
- targeted ESLint for all touched web files
- `cd apps/web && pnpm build`

Full standalone `tsc --noEmit` still reports seven pre-existing errors in SEO test scripts; the production build type-check passes.

Closes #1086. No tag or deployment is included in this PR.