### PR TITLE
Enable Square features for the demo DAO

### DIFF
--- a/apps/web/scripts/proposal-comments.test.ts
+++ b/apps/web/scripts/proposal-comments.test.ts
@@ -27,6 +27,26 @@ test("proposal comments require both API configuration and DAO feature", () => {
   );
 });
 
+test("local DAO config can still use configured Square APIs", () => {
+  const remoteApi = readFileSync(
+    new URL("../src/utils/remote-api.ts", import.meta.url),
+    "utf8"
+  );
+  const clientCheck = remoteApi.match(
+    /export const isDegovApiConfiguredClient = \(\) => \{([\s\S]*?)\n\};/
+  )?.[1];
+  const restApi = remoteApi.match(
+    /export const degovRestApi = \(\): string \| undefined => \{([\s\S]*?)\n\};/
+  )?.[1];
+
+  assert.ok(clientCheck);
+  assert.ok(restApi);
+  assert.match(clientCheck, /NEXT_PUBLIC_DEGOV_API/);
+  assert.match(restApi, /NEXT_PUBLIC_DEGOV_API/);
+  assert.doesNotMatch(clientCheck, /isLocalConfigEnabledClient/);
+  assert.doesNotMatch(restApi, /isLocalConfigEnabled/);
+});
+
 test("discussion stays distinct from on-chain vote reasons", () => {
   const tabs = readFileSync(
     new URL("../src/app/proposal/[id]/tabs.tsx", import.meta.url),

--- a/apps/web/src/utils/remote-api.ts
+++ b/apps/web/src/utils/remote-api.ts
@@ -17,7 +17,6 @@ export const isDegovApiConfiguredServer = () => {
 };
 
 export const isDegovApiConfiguredClient = () => {
-  if (isLocalConfigEnabledClient()) return false;
   return Boolean(env("NEXT_PUBLIC_DEGOV_API"));
 };
 
@@ -33,14 +32,6 @@ export const degovGraphqlApi = (): string | undefined => {
 };
 
 export const degovRestApi = (): string | undefined => {
-  if (
-    typeof window !== "undefined"
-      ? isLocalConfigEnabledClient()
-      : isLocalConfigEnabledServer()
-  ) {
-    return undefined;
-  }
-
   const clientApi =
     typeof window !== "undefined" ? env("NEXT_PUBLIC_DEGOV_API") : undefined;
   const NEXT_PUBLIC_DEGOV_API = clientApi || process.env.NEXT_PUBLIC_DEGOV_API;

--- a/degov.yml
+++ b/degov.yml
@@ -1,5 +1,8 @@
 name: DeGov Demo DAO
 code: degov-demo-dao
+features:
+  - proposal-comments
+  - proposal-drafts
 logo: https://pbs.twimg.com/profile_images/1912415584257474560/GznnScP3_400x400.jpg
 siteUrl: https://degov-dev.vercel.app
 offChainDiscussionUrl: https://github.com/ringecosystem/degov/discussions


### PR DESCRIPTION
## Summary

- enable `proposal-comments` and `proposal-drafts` for the built-in `degov-demo-dao` configuration
- allow a local DAO configuration to use configured Square APIs
- keep local-vs-remote DAO config selection unchanged
- allow `demo.degov.ai` to expose the same Square-backed features as the Kubernetes demo sites

## Scope

- demo DAO feature configuration plus the local-config/API gating fix
- no production DAO configuration changes
- no image tag or Kubernetes production rollout

## Validation

- Registry DAO schema now accepts local `features` via ringecosystem/degov-registry#139
- generated `apps/web/public/degov.yml` contains both features
- proposal comments/drafts/simulation tests: 12 passed
- targeted ESLint passed
- YAML parse/value checks passed
- `git diff --check` passed