### PR TITLE
Hide duplicate proposal SEO summary from the UI

### DIFF
--- a/apps/web/scripts/dao-content-provenance.test.ts
+++ b/apps/web/scripts/dao-content-provenance.test.ts
@@ -27,3 +27,15 @@ test("DAO homepage uses the established product UI without a duplicate summary",
   assert.match(headerSource, /\{config\?\.name\}/);
   assert.doesNotMatch(summarySource, /DaoPublicSummary|Registry source/);
 });
+
+test("proposal detail keeps its crawler fallback out of the interactive UI", () => {
+  const pageSource = readSource("src/app/proposal/[id]/page.tsx");
+
+  assert.match(
+    pageSource,
+    /<noscript>[\s\S]*<ProposalDetailPublicSummary[\s\S]*<\/noscript>/
+  );
+  assert.match(pageSource, /<ProposalDetailClient \/>/);
+  assert.match(pageSource, /buildProposalWebPageJsonLd\(config, proposal\)/);
+  assert.match(pageSource, /type="application\/ld\+json"/);
+});

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -30,11 +30,13 @@ export default async function ProposalPage({ params }: ProposalPageProps) {
           dangerouslySetInnerHTML={{ __html: proposalJsonLd }}
         />
       ) : null}
-      <ProposalDetailPublicSummary
-        config={config}
-        proposal={proposal}
-        failed={failed}
-      />
+      <noscript>
+        <ProposalDetailPublicSummary
+          config={config}
+          proposal={proposal}
+          failed={failed}
+        />
+      </noscript>
       <ProposalDetailClient />
     </div>
   );


### PR DESCRIPTION
## Summary

- keep the server-rendered proposal summary as a `noscript` crawler fallback
- remove the duplicate summary card from the normal interactive proposal UI
- preserve proposal metadata and JSON-LD
- add a regression check for the crawler/UI boundary

## Validation

- 16 focused SEO/GEO, structured-data, metadata, and analytics tests passed
- targeted ESLint passed
- Impeccable detector returned no findings
- full `@degov/web` production build passed
- `git diff --check` passed

## Deployment scope

- deploy to all published test environments after merge
- no image tag
- no production Kubernetes rollout