### PR TITLE
Fix proposal noscript hydration mismatch

### DIFF
--- a/apps/web/scripts/dao-content-provenance.test.ts
+++ b/apps/web/scripts/dao-content-provenance.test.ts
@@ -33,7 +33,7 @@ test("proposal detail keeps its crawler fallback out of the interactive UI", () 
 
   assert.match(
     pageSource,
-    /<noscript dangerouslySetInnerHTML=\{\{ __html: proposalSummaryHtml \}\} \/>/
+    /<noscript\s+dangerouslySetInnerHTML=\{\{\s*__html:\s*proposalSummaryHtml\s*\}\}\s*\/>/
   );
   assert.match(pageSource, /<ProposalDetailClient \/>/);
   assert.match(pageSource, /buildProposalWebPageJsonLd\(config, proposal\)/);

--- a/apps/web/scripts/dao-content-provenance.test.ts
+++ b/apps/web/scripts/dao-content-provenance.test.ts
@@ -33,7 +33,7 @@ test("proposal detail keeps its crawler fallback out of the interactive UI", () 
 
   assert.match(
     pageSource,
-    /<noscript>[\s\S]*<ProposalDetailPublicSummary[\s\S]*<\/noscript>/
+    /<noscript dangerouslySetInnerHTML=\{\{ __html: proposalSummaryHtml \}\} \/>/
   );
   assert.match(pageSource, /<ProposalDetailClient \/>/);
   assert.match(pageSource, /buildProposalWebPageJsonLd\(config, proposal\)/);

--- a/apps/web/src/app/_components/public-route-summary.tsx
+++ b/apps/web/src/app/_components/public-route-summary.tsx
@@ -49,7 +49,16 @@ export function ProposalDirectoryPublicSummary({
   );
 }
 
-export function ProposalDetailPublicSummary({
+function escapeHtml(value: string | number): string {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function proposalDetailPublicSummaryHtml({
   config,
   proposal,
   failed,
@@ -59,55 +68,25 @@ export function ProposalDetailPublicSummary({
   failed: boolean;
 }) {
   if (failed) {
-    return (
-      <section className="rounded-[14px] bg-card p-[20px] shadow-card">
-        <h1 className="text-[26px] font-extrabold">{config.name} proposal</h1>
-        <p className="mt-[10px] text-[14px] text-muted-foreground">
-          Proposal data is temporarily unavailable. This response does not classify the proposal as
-          permanently absent.
-        </p>
-      </section>
-    );
+    return `<section><h1>${escapeHtml(config.name)} proposal</h1><p>Proposal data is temporarily unavailable. This response does not classify the proposal as permanently absent.</p></section>`;
   }
 
   if (!proposal) {
-    return (
-      <section className="rounded-[14px] bg-card p-[20px] shadow-card">
-        <h1 className="text-[26px] font-extrabold">{config.name} proposal</h1>
-        <p className="mt-[10px] text-[14px] text-muted-foreground">
-          Proposal data is not indexed yet. The page will continue checking whether this proposal
-          exists on-chain.
-        </p>
-      </section>
-    );
+    return `<section><h1>${escapeHtml(config.name)} proposal</h1><p>Proposal data is not indexed yet. The page will continue checking whether this proposal exists on-chain.</p></section>`;
   }
 
   const { title, summary } = proposalTitleAndSummary(proposal);
 
-  return (
-    <section className="rounded-[14px] bg-card p-[20px] shadow-card">
-      <h1 className="text-[26px] font-extrabold">{summarize(title, 160)}</h1>
-      <p className="mt-[10px] text-[14px] text-muted-foreground">
-        {summarize(summary, 420)}
-      </p>
-      <dl className="mt-[15px] grid gap-[8px] text-[14px] sm:grid-cols-2">
-        <div>
-          <dt className="text-muted-foreground">DAO</dt>
-          <dd>{config.name}</dd>
-        </div>
-        <div>
-          <dt className="text-muted-foreground">Proposal ID</dt>
-          <dd>{proposal.proposalId}</dd>
-        </div>
-        <div>
-          <dt className="text-muted-foreground">Proposer</dt>
-          <dd>{proposal.proposer}</dd>
-        </div>
-        <div>
-          <dt className="text-muted-foreground">Votes</dt>
-          <dd>{proposal.metricsVotesCount}</dd>
-        </div>
-      </dl>
-    </section>
-  );
+  return [
+    "<section>",
+    `<h1>${escapeHtml(summarize(title, 160))}</h1>`,
+    `<p>${escapeHtml(summarize(summary, 420))}</p>`,
+    "<dl>",
+    `<div><dt>DAO</dt><dd>${escapeHtml(config.name)}</dd></div>`,
+    `<div><dt>Proposal ID</dt><dd>${escapeHtml(proposal.proposalId)}</dd></div>`,
+    `<div><dt>Proposer</dt><dd>${escapeHtml(proposal.proposer)}</dd></div>`,
+    `<div><dt>Votes</dt><dd>${escapeHtml(proposal.metricsVotesCount)}</dd></div>`,
+    "</dl>",
+    "</section>",
+  ].join("");
 }

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 
 import { buildProposalWebPageJsonLd } from "@/lib/structured-data";
 
-import { ProposalDetailPublicSummary } from "../../_components/public-route-summary";
+import { proposalDetailPublicSummaryHtml } from "../../_components/public-route-summary";
 import { getActiveDaoConfig, getPublicProposalDetail } from "../../_server/public-seo";
 
 import { ProposalDetailClient } from "./proposal-detail-client";
@@ -21,6 +21,7 @@ export default async function ProposalPage({ params }: ProposalPageProps) {
   }
 
   const proposalJsonLd = buildProposalWebPageJsonLd(config, proposal);
+  const proposalSummaryHtml = proposalDetailPublicSummaryHtml({ config, proposal, failed });
 
   return (
     <div className="flex flex-col gap-[20px]">
@@ -30,13 +31,7 @@ export default async function ProposalPage({ params }: ProposalPageProps) {
           dangerouslySetInnerHTML={{ __html: proposalJsonLd }}
         />
       ) : null}
-      <noscript>
-        <ProposalDetailPublicSummary
-          config={config}
-          proposal={proposal}
-          failed={failed}
-        />
-      </noscript>
+      <noscript dangerouslySetInnerHTML={{ __html: proposalSummaryHtml }} />
       <ProposalDetailClient />
     </div>
   );


### PR DESCRIPTION
## Summary
- serialize the proposal no-JS fallback as escaped server HTML
- keep crawler-accessible proposal facts without rendering a duplicate interactive card
- avoid React hydrating parsed `noscript` child nodes
- update the crawler/UI boundary regression check

## Validation
- focused DAO content provenance test passed
- targeted ESLint passed
- 8 SEO/GEO contract suites passed
- full `@degov/web` production build passed
- local production browser reproduction has no React hydration error
- raw HTML retains `noscript` proposal facts and JSON-LD

Deployment scope remains test environments only. No tag and no production Kubernetes rollout.