### PR TITLE
Suppress intentional proposal noscript hydration mismatch

### DIFF
--- a/apps/web/scripts/dao-content-provenance.test.ts
+++ b/apps/web/scripts/dao-content-provenance.test.ts
@@ -33,7 +33,7 @@ test("proposal detail keeps its crawler fallback out of the interactive UI", () 
 
   assert.match(
     pageSource,
-    /<noscript\s+dangerouslySetInnerHTML=\{\{\s*__html:\s*proposalSummaryHtml\s*\}\}\s*\/>/
+    /<noscript\s+suppressHydrationWarning\s+dangerouslySetInnerHTML=\{\{\s*__html:\s*proposalSummaryHtml\s*\}\}\s*\/>/
   );
   assert.match(pageSource, /<ProposalDetailClient \/>/);
   assert.match(pageSource, /buildProposalWebPageJsonLd\(config, proposal\)/);

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -31,7 +31,10 @@ export default async function ProposalPage({ params }: ProposalPageProps) {
           dangerouslySetInnerHTML={{ __html: proposalJsonLd }}
         />
       ) : null}
-      <noscript dangerouslySetInnerHTML={{ __html: proposalSummaryHtml }} />
+      <noscript
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: proposalSummaryHtml }}
+      />
       <ProposalDetailClient />
     </div>
   );


### PR DESCRIPTION
## Summary
- suppress hydration comparison only on the serialized proposal `noscript` fallback
- retain escaped crawler-visible proposal facts
- extend the regression assertion to require the suppression boundary

## Root cause
With scripting enabled, browsers parse `noscript` as raw text. React otherwise compares that intentional parser result with the serialized fallback HTML, reports hydration error #418, and triggers a Next streaming recovery error.

## Validation
- focused DAO content provenance tests passed
- targeted ESLint passed
- full `@degov/web` production build passed
- `git diff --check` passed

Test environments only; no tag and no production Kubernetes rollout.