### PR TITLE
Use hydration-safe hidden proposal crawler summary

### DIFF
--- a/apps/web/scripts/dao-content-provenance.test.ts
+++ b/apps/web/scripts/dao-content-provenance.test.ts
@@ -33,8 +33,9 @@ test("proposal detail keeps its crawler fallback out of the interactive UI", () 
 
   assert.match(
     pageSource,
-    /<noscript\s+suppressHydrationWarning\s+dangerouslySetInnerHTML=\{\{\s*__html:\s*proposalSummaryHtml\s*\}\}\s*\/>/
+    /<div\s+hidden\s+data-crawler-summary=""\s+dangerouslySetInnerHTML=\{\{\s*__html:\s*proposalSummaryHtml\s*\}\}\s*\/>/
   );
+  assert.doesNotMatch(pageSource, /<noscript/);
   assert.match(pageSource, /<ProposalDetailClient \/>/);
   assert.match(pageSource, /buildProposalWebPageJsonLd\(config, proposal\)/);
   assert.match(pageSource, /type="application\/ld\+json"/);

--- a/apps/web/src/app/proposal/[id]/page.tsx
+++ b/apps/web/src/app/proposal/[id]/page.tsx
@@ -31,8 +31,9 @@ export default async function ProposalPage({ params }: ProposalPageProps) {
           dangerouslySetInnerHTML={{ __html: proposalJsonLd }}
         />
       ) : null}
-      <noscript
-        suppressHydrationWarning
+      <div
+        hidden
+        data-crawler-summary=""
         dangerouslySetInnerHTML={{ __html: proposalSummaryHtml }}
       />
       <ProposalDetailClient />


### PR DESCRIPTION
## Summary
- replace the structurally incompatible `noscript` boundary with a normal `hidden` crawler-summary container
- preserve escaped server-rendered proposal facts plus existing JSON-LD
- keep the summary out of visual and accessibility UI
- assert that proposal pages no longer render `noscript`

## Root cause
Browsers parse body `noscript` contents as raw text when scripting is enabled. That structural DOM difference cannot be fully suppressed during React hydration. A normal hidden element preserves the same raw HTML facts without changing the parsed tree.

## Validation
- focused DAO content provenance tests passed
- targeted ESLint passed
- full `@degov/web` production build passed
- `git diff --check` passed

Test environments only; no tag and no production Kubernetes rollout.