### PR TITLE
Disable deployment Slack notifications

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -47,6 +47,6 @@ jobs:
           project_name: "degov"
           script_run: false
           dist_path: .
-          enable_notify_slack: true
+          enable_notify_slack: false
           slack_channel: public-degov
           slack_webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- disable Slack notifications for production deploys
- keep staging notifications disabled
- leave deployment behavior otherwise unchanged

## Verification
- both `deploy-prd.yml` and `deploy-stg.yml` now set `enable_notify_slack: false`
- `git diff --check` passed

This PR does not trigger a deployment or create a tag.