### PR TITLE
Document Datalens indexer deployment and startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,12 @@ DEGOV_DB_PORT=5432
 DEGOV_DB_PASSWORD=password
 DEGOV_DB_NAME=postgres
 DEGOV_INDEXER_DATABASE_URL=postgresql://postgres:password@localhost:5432/indexer
-DEGOV_INDEXER_CONFIG_FILE=apps/indexer/indexer.example.yml
-# all runs every daoCode in DEGOV_INDEXER_CONFIG_FILE. Set DEGOV_INDEXER_DAO_CODE only to filter a debug run.
+# Host file mounted by Docker Compose at /app/indexer.yml. Copy the checked-in
+# example to apps/indexer/indexer.yml and customize it for your DAO.
+DEGOV_INDEXER_CONFIG_SOURCE=./apps/indexer/indexer.yml
+# Host-native Cargo commands use the host path instead:
+# DEGOV_INDEXER_CONFIG_FILE=apps/indexer/indexer.yml
+# all runs every daoCode in the mounted config. Set DEGOV_INDEXER_DAO_CODE only to filter a debug run.
 DEGOV_INDEXER_CONTRACT_SET_MODE=all
 DEGOV_INDEXER_DAO_CODE=
 # Use latest for production durable-head tracking; numeric heights are for debug or bounded test runs.

--- a/README.md
+++ b/README.md
@@ -15,48 +15,146 @@ DeGov.AI is an open-source, on-chain governance platform built for DAOs in the E
 
 ## Setup Instructions
 
-1. **Clone the repository**
+The default Compose stack starts PostgreSQL and the web application using the
+indexer endpoint in `degov.yml`:
 
-   ```bash
-   git clone https://github.com/ringecosystem/degov.git
-   cd degov
-   ```
+```bash
+git clone https://github.com/ringecosystem/degov.git
+cd degov
+cp .env.example .env
+docker compose up -d
+```
 
-2. **Configure environment**
+Open `http://localhost:3000`. To run the DeGov indexer locally, follow the
+canonical Datalens-backed workflow below.
 
-   ```bash
-   cp .env.example .env
-   ```
+## Datalens-backed Indexer Deployment
 
-   Edit `.env` and set required variables:
+The DeGov indexer is an application of the separately deployed
+[Datalens service](https://github.com/ringecosystem/datalens). This repository
+does not start `datalens serve`. Before starting DeGov, obtain a reachable
+Datalens base URL plus an application name and bearer token authorized for the
+required chains, `evm.logs`, and the `query` and `discovery` operations. See the
+[Datalens application integration handbook](https://github.com/ringecosystem/datalens/blob/main/docs/runbook/application-integration-handbook.md)
+for the service-side boundary.
 
-   ```env
-   DEGOV_DB_PASSWORD=your-secure-password
-   DEGOV_WEB_JWT_SECRET=your-jwt-secret
-   CHAIN_RPC_1=https://eth-mainnet-rpc-url
-   ```
+### Prerequisites
 
-3. **Configure your DAO**
+- Git.
+- Docker with Compose v2 (`docker compose`).
+- Datalens application credentials described above.
+- RPC URLs only when enabling onchain refresh.
 
-   Edit `degov.yml` with your DAO settings (governor address, chain ID, etc.)
+### 1. Clone and configure the environment
 
-4. **Start all services**
+```bash
+git clone https://github.com/ringecosystem/degov.git
+cd degov
+cp .env.example .env
+cp apps/indexer/indexer.example.yml apps/indexer/indexer.yml
+```
 
-   ```bash
-   docker-compose up -d
-   ```
+Edit `.env` and replace at least these values:
 
-   This starts:
-   - PostgreSQL (port 5432)
-   - Web application (port 3000)
+```env
+DEGOV_DB_PASSWORD=replace-with-a-secure-password
+DEGOV_WEB_JWT_SECRET=replace-with-a-secure-secret
+DEGOV_INDEXER_CONFIG_SOURCE=./apps/indexer/indexer.yml
+DATALENS_ENDPOINT=https://your-datalens-service.example
+DATALENS_APPLICATION=your-authorized-application
+DATALENS_TOKEN=replace-with-an-application-token
+```
 
-   The local SQD-based indexer service has been removed while the Datalens-native
-   indexer is prepared. The web app still reads the configured indexer endpoint
-   from `degov.yml`.
+`DATALENS_ENDPOINT` must be the service base URL, not `/native/graphql`.
+Environment variables override values from the indexer config file. Keep tokens,
+database credentials, and RPC URLs in environment-backed secrets rather than
+committing them to YAML.
 
-5. **Access the application**
+### 2. Configure DAO contract sets
 
-   Open `http://localhost:3000` in your browser
+Edit the untracked `apps/indexer/indexer.yml`. Replace the example chain names,
+chain IDs, DAO codes, governor/token/timelock addresses, token standards, and
+start blocks with the contract sets to index.
+
+Normal shared deployments use:
+
+```env
+DEGOV_INDEXER_CONTRACT_SET_MODE=all
+DEGOV_INDEXER_TARGET_HEIGHT=latest
+DEGOV_INDEXER_RUN_ONCE=false
+```
+
+Leave `DEGOV_INDEXER_DAO_CODE` empty in normal `all` mode. Set it only as a
+temporary filter for a bounded debug run. If onchain refresh is enabled, each
+`rpc.chains.*.urlEnv` entry in `indexer.yml` must name a configured RPC secret,
+such as `DARWINIA_RPC_URL` or `LISK_RPC_URL`.
+
+Also edit `degov.yml` for the web application's DAO identity, chain, contracts,
+and public indexer endpoint.
+
+### 3. Initialize and start the local indexer stack
+
+Start PostgreSQL, apply the fresh schema, and verify Datalens before starting
+long-lived services:
+
+```bash
+docker compose up -d postgres
+docker compose --profile indexer run --rm indexer-migrate
+docker compose --profile indexer run --rm indexer smoke-datalens
+docker compose --profile indexer up -d indexer indexer-graphql web-local-indexer
+```
+
+The local-indexer web application is available at `http://localhost:3001`, and
+GraphQL is available at `http://localhost:4350/graphql`. The normal web service
+on port 3000 continues to use the endpoint configured in `degov.yml`.
+
+Verify GraphQL and inspect startup logs:
+
+```bash
+curl -fsS http://localhost:4350/graphql \
+  -H 'content-type: application/json' \
+  --data '{"query":"{ __typename }"}'
+docker compose logs --tail=100 indexer indexer-graphql
+```
+
+### 4. Optional onchain refresh worker
+
+The worker is disabled by default. Enable it only after configuring every RPC
+environment variable referenced by `apps/indexer/indexer.yml`:
+
+```env
+DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED=true
+DARWINIA_RPC_URL=https://your-darwinia-rpc.example
+```
+
+Then start it separately:
+
+```bash
+docker compose --profile indexer up -d onchain-worker
+```
+
+When disabled, the worker stays alive and logs that it is disabled; this is
+expected behavior.
+
+### Deployment model and lifecycle
+
+Staging and production use the same logical shape: one fresh shared indexer
+database, an explicit `migrate` job, one `run` workload in all-contract-set
+mode, one `graphql` workload, and an optional shared `worker`. Release images
+are published as `ghcr.io/ringecosystem/degov/indexer:sha-<git-sha>`.
+
+Moving from the previous SQD/v4 indexer requires a fresh database and a clean
+reindex from each configured start block. In-place migration of an old indexer
+database is not supported. See the [unified deployment contract](docs/config/contracts/datalens-indexer-unified-deployment.md),
+[staging runbook](docs/runbook/datalens-staging-deployment.md), and
+[observability runbook](docs/runbook/datalens-indexer-observability.md) for
+production routing, rollout, and diagnostic details.
+
+Stop the local stack without deleting its volumes:
+
+```bash
+docker compose --profile indexer down
+```
 
 
 We are also willing to provide hosting and maintenance services for your DAO's DeGov instance. Please contact us for more details.

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -1,7 +1,6 @@
 # DeGov Indexer
 
-`apps/indexer` is reserved for the upcoming Datalens-native governance
-indexer.
+`apps/indexer` contains the Rust Datalens-backed governance indexer.
 
 The previous SQD/Subsquid processor runtime, migrations, codegen, local startup
 scripts, and onchain-refresh worker have been removed. Do not build new work on
@@ -9,12 +8,12 @@ the old processor architecture.
 
 ## Current boundary
 
-The package now contains the initial Rust configuration and Datalens client
-boundary for the upcoming runtime. It validates the deployed Datalens service
-base endpoint, application identity, bearer token, timeout, finality mode, chain
-identity, dataset key, and query block range limit at startup. The bearer token
-is loaded from environment or secret-backed configuration and is redacted by
-config formatting.
+The package provides the indexer runner, PostgreSQL migrations and projections,
+GraphQL service, Datalens readiness smoke, and optional onchain refresh worker.
+It validates the deployed Datalens service base endpoint, application identity,
+bearer token, timeout, finality mode, chain identity, dataset key, and query
+block range limit at startup. The bearer token is loaded from environment or
+secret-backed configuration and is redacted by config formatting.
 
 The default deployment model is one shared Postgres indexer database, one
 all-mode indexer process, one GraphQL service, one onchain refresh worker, and
@@ -56,7 +55,13 @@ the replacement implementation:
 They are not runtime inputs and should not be used to revive the SQD processor
 shell.
 
+## Build and test
+
 ```bash
 just build
 just test
 ```
+
+Use the root README's [Datalens-backed indexer deployment](../../README.md#datalens-backed-indexer-deployment)
+section for the canonical environment, configuration, migration, and startup
+workflow.

--- a/apps/indexer/reference/abi/README.md
+++ b/apps/indexer/reference/abi/README.md
@@ -1,5 +1,4 @@
 # ABI folder
 
-These ABI files are retained as reference inputs for the future Datalens-native
-indexer. They are not wired to SQD typegen or any runtime command in this
-migration step.
+These ABI files are retained as reference inputs for the Datalens-backed Rust
+indexer. They are not wired to SQD typegen or used as runtime-loaded files.

--- a/apps/indexer/scripts/runtime-packaging.test.mjs
+++ b/apps/indexer/scripts/runtime-packaging.test.mjs
@@ -83,8 +83,13 @@ assert.match(
 );
 assert.match(
   composeYaml,
-  /DEGOV_INDEXER_GRAPHQL_ENDPOINT: \$\{DEGOV_INDEXER_GRAPHQL_BIND_ENDPOINT:-http:\/\/0\.0\.0\.0:4350\/graphql\}/,
-  "compose GraphQL service must bind on the GraphQL path",
+  /DEGOV_INDEXER_GRAPHQL_ENDPOINT: \$\{DEGOV_INDEXER_GRAPHQL_ENDPOINT:-http:\/\/0\.0\.0\.0:4350\/graphql\}/,
+  "compose GraphQL service must accept the public endpoint contract",
+);
+assert.match(
+  composeYaml,
+  /DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS: \$\{DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS:-0\.0\.0\.0:4350\}/,
+  "compose GraphQL service must accept the bind address contract",
 );
 assert.match(
   composeYaml,

--- a/apps/indexer/scripts/runtime-packaging.test.mjs
+++ b/apps/indexer/scripts/runtime-packaging.test.mjs
@@ -33,7 +33,7 @@ assert.match(packageConfig.scripts["indexer:worker"], /degov-datalens-indexer .*
 assert.match(packageConfig.scripts["indexer:graphql"], /degov-datalens-indexer .*graphql/);
 assert.match(packageConfig.scripts["indexer:migrate"], /degov-datalens-indexer .*migrate/);
 
-function composeConfig(args = [], { envFile = true } = {}) {
+function composeConfig(args = [], { envFile = true, env = {} } = {}) {
   const composeArgs = ["compose"];
   if (envFile) {
     composeArgs.push("--env-file", ".env.example");
@@ -46,6 +46,7 @@ function composeConfig(args = [], { envFile = true } = {}) {
     {
       cwd: repositoryRoot,
       encoding: "utf8",
+      env: { ...process.env, ...env },
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
@@ -56,6 +57,9 @@ function composeConfig(args = [], { envFile = true } = {}) {
 const defaultComposeWithoutEnvFile = composeConfig([], { envFile: false });
 const defaultCompose = composeConfig();
 const indexerCompose = composeConfig(["--profile", "indexer"]);
+const customIndexerCompose = composeConfig(["--profile", "indexer"], {
+  env: { DEGOV_INDEXER_CONFIG_SOURCE: "./apps/indexer/indexer.example.yml" },
+});
 const defaultServicesWithoutEnvFile = defaultComposeWithoutEnvFile.services ?? {};
 const defaultServices = defaultCompose.services ?? {};
 const indexerServices = indexerCompose.services ?? {};
@@ -84,8 +88,8 @@ assert.match(
 );
 assert.match(
   composeYaml,
-  /DEGOV_INDEXER_CONFIG_FILE: \$\{DEGOV_INDEXER_CONFIG_FILE:-\/app\/indexer\.yml\}/,
-  "compose must pass the config file path into indexer workloads",
+  /DEGOV_INDEXER_CONFIG_FILE: \/app\/indexer\.yml/,
+  "compose must use the mounted config path inside indexer workloads",
 );
 assert.match(
   composeYaml,
@@ -94,8 +98,18 @@ assert.match(
 );
 assert.match(
   composeYaml,
-  /\.\/apps\/indexer\/indexer\.example\.yml:\/app\/indexer\.yml:ro/,
-  "compose must mount the config-file based multi-chain contract sets",
+  /\$\{DEGOV_INDEXER_CONFIG_SOURCE:-\.\/apps\/indexer\/indexer\.example\.yml\}:\/app\/indexer\.yml:ro/,
+  "compose must mount the selected host config at the container config path",
+);
+assert.deepEqual(
+  defaultServices.postgres?.healthcheck?.test,
+  ["CMD-SHELL", "pg_isready -U postgres -d indexer"],
+  "compose must wait for the initialized indexer database",
+);
+assert.equal(
+  indexerServices["indexer-migrate"]?.depends_on?.postgres?.condition,
+  "service_healthy",
+  "the migration job must wait for the initialized indexer database",
 );
 assert.equal(
   defaultServicesWithoutEnvFile.web?.depends_on?.["indexer-graphql"],
@@ -122,6 +136,35 @@ assert.equal(
   "graphql",
   "indexer profile must include the GraphQL service entrypoint",
 );
+for (const serviceName of ["indexer", "indexer-graphql", "onchain-worker"]) {
+  assert.equal(
+    indexerServices[serviceName]?.depends_on?.["indexer-migrate"]?.condition,
+    "service_completed_successfully",
+    `${serviceName} must wait for the explicit migration job`,
+  );
+}
+for (const serviceName of ["indexer", "onchain-worker"]) {
+  assert.equal(
+    indexerServices[serviceName]?.environment?.DEGOV_INDEXER_CONFIG_FILE,
+    "/app/indexer.yml",
+    `${serviceName} must load the mounted container config path`,
+  );
+  assert.equal(
+    indexerServices[serviceName]?.volumes?.[0]?.target,
+    "/app/indexer.yml",
+    `${serviceName} must mount its config at the configured container path`,
+  );
+  assert.match(
+    indexerServices[serviceName]?.volumes?.[0]?.source ?? "",
+    /\/apps\/indexer\/indexer\.yml$/,
+    `${serviceName} must use the user config selected by .env.example`,
+  );
+  assert.match(
+    customIndexerCompose.services?.[serviceName]?.volumes?.[0]?.source ?? "",
+    /\/apps\/indexer\/indexer\.example\.yml$/,
+    `${serviceName} must honor the host config source override`,
+  );
+}
 assert.equal(
   indexerServices["web-local-indexer"]?.depends_on?.["indexer-graphql"]?.required,
   true,
@@ -170,7 +213,8 @@ assert.doesNotMatch(
 );
 
 assert.match(envExample, /DATALENS_ENDPOINT=/);
-assert.match(envExample, /DEGOV_INDEXER_CONFIG_FILE=apps\/indexer\/indexer\.example\.yml/);
+assert.match(envExample, /DEGOV_INDEXER_CONFIG_SOURCE=\.\/apps\/indexer\/indexer\.yml/);
+assert.match(envExample, /# DEGOV_INDEXER_CONFIG_FILE=apps\/indexer\/indexer\.yml/);
 assert.match(envExample, /DEGOV_INDEXER_CONTRACT_SET_MODE=all/);
 assert.match(envExample, /^DATALENS_CHAINS_JSON=$/m);
 assert.match(envExample, /DEGOV_INDEXER_DATABASE_URL=/);

--- a/degov.yml
+++ b/degov.yml
@@ -63,8 +63,8 @@ chain:
 indexer:
   endpoint: https://indexer.next.degov.ai/degov-demo-dao/graphql
   startBlock: 5873342
-  # The local SQD/Subsquid processor has been removed. Keep this endpoint pointed
-  # at an existing compatible API until the Datalens-native indexer is added.
+  # The default web stack uses this hosted endpoint. The Docker Compose indexer
+  # profile builds a separate local web image pointed at its local GraphQL service.
 
 # Core contracts related to the DAO Governance
 contracts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,8 @@ services:
       - "${DEGOV_INDEXER_PORT:-4350}:4350"
     environment:
       DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/indexer
-      DEGOV_INDEXER_GRAPHQL_ENDPOINT: ${DEGOV_INDEXER_GRAPHQL_BIND_ENDPOINT:-http://0.0.0.0:4350/graphql}
+      DEGOV_INDEXER_GRAPHQL_ENDPOINT: ${DEGOV_INDEXER_GRAPHQL_ENDPOINT:-http://0.0.0.0:4350/graphql}
+      DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS: ${DEGOV_INDEXER_GRAPHQL_BIND_ADDRESS:-0.0.0.0:4350}
 
   web:
     image: degov-web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,20 @@ services:
       - ./init-scripts/postgres:/docker-entrypoint-initdb.d
     ports:
       - "${DEGOV_DB_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d indexer"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
 
   indexer-migrate:
     image: degov-indexer
     profiles:
       - indexer
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     build:
       context: .
       dockerfile: docker/indexer.Dockerfile
@@ -29,16 +36,17 @@ services:
     profiles:
       - indexer
     depends_on:
-      - postgres
+      indexer-migrate:
+        condition: service_completed_successfully
     build:
       context: .
       dockerfile: docker/indexer.Dockerfile
     command: run
     volumes:
-      - ./apps/indexer/indexer.example.yml:/app/indexer.yml:ro
+      - ${DEGOV_INDEXER_CONFIG_SOURCE:-./apps/indexer/indexer.example.yml}:/app/indexer.yml:ro
     environment:
       DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/indexer
-      DEGOV_INDEXER_CONFIG_FILE: ${DEGOV_INDEXER_CONFIG_FILE:-/app/indexer.yml}
+      DEGOV_INDEXER_CONFIG_FILE: /app/indexer.yml
       DEGOV_INDEXER_CONTRACT_SET_MODE: ${DEGOV_INDEXER_CONTRACT_SET_MODE:-all}
       DEGOV_INDEXER_DAO_CODE: ${DEGOV_INDEXER_DAO_CODE:-}
       DEGOV_INDEXER_TARGET_HEIGHT: ${DEGOV_INDEXER_TARGET_HEIGHT:-latest}
@@ -66,16 +74,17 @@ services:
     profiles:
       - indexer
     depends_on:
-      - postgres
+      indexer-migrate:
+        condition: service_completed_successfully
     build:
       context: .
       dockerfile: docker/indexer.Dockerfile
     command: worker
     volumes:
-      - ./apps/indexer/indexer.example.yml:/app/indexer.yml:ro
+      - ${DEGOV_INDEXER_CONFIG_SOURCE:-./apps/indexer/indexer.example.yml}:/app/indexer.yml:ro
     environment:
       DEGOV_INDEXER_DATABASE_URL: postgresql://postgres:${DEGOV_DB_PASSWORD:-postgres}@postgres/indexer
-      DEGOV_INDEXER_CONFIG_FILE: ${DEGOV_INDEXER_CONFIG_FILE:-/app/indexer.yml}
+      DEGOV_INDEXER_CONFIG_FILE: /app/indexer.yml
       DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED: ${DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED:-false}
       DEGOV_ONCHAIN_REFRESH_RPC_URL: ${DEGOV_ONCHAIN_REFRESH_RPC_URL:-}
       DEGOV_ONCHAIN_REFRESH_RUN_ONCE: ${DEGOV_ONCHAIN_REFRESH_RUN_ONCE:-false}
@@ -99,7 +108,8 @@ services:
     profiles:
       - indexer
     depends_on:
-      - postgres
+      indexer-migrate:
+        condition: service_completed_successfully
     build:
       context: .
       dockerfile: docker/indexer.Dockerfile
@@ -113,7 +123,8 @@ services:
   web:
     image: degov-web
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     build:
       context: .
       dockerfile: docker/web.Dockerfile
@@ -129,8 +140,10 @@ services:
     profiles:
       - indexer
     depends_on:
-      - postgres
-      - indexer-graphql
+      postgres:
+        condition: service_healthy
+      indexer-graphql:
+        condition: service_started
     build:
       context: .
       dockerfile: docker/web.Dockerfile

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,11 @@ this repository.
 
 ## Indexer
 
-The checked-in SQD/Subsquid indexer runtime has been removed while DeGov moves
-to a Datalens-native indexer. The documents below describe historical behavior
-or API/data-model reference material unless a newer document says otherwise.
+The SQD/Subsquid runtime has been replaced by the checked-in Rust
+Datalens-backed indexer. Start with the root
+[deployment guide](../README.md#datalens-backed-indexer-deployment); the
+documents below cover development, compatibility, migration, rollout, and
+operations in more detail.
 
 - [Datalens Rust technical conventions][datalens-rust-conventions]
 - [Datalens PostgreSQL schema ownership][datalens-postgres-schema]

--- a/docs/guides/20260325__indexer_developer_guide.md
+++ b/docs/guides/20260325__indexer_developer_guide.md
@@ -2,8 +2,8 @@
 
 > Purpose: orient developers working on the Datalens-native DeGov indexer.
 >
-> Read this when: adding Rust indexer code, validating the current indexer
-> placeholder, or checking the retained schema/reference artifacts.
+> Read this when: adding Rust indexer code, validating its runtime boundaries,
+> or checking the retained schema/reference artifacts.
 >
 > This does not document how to run the removed SQD/Subsquid processor.
 
@@ -14,15 +14,16 @@ indexer. The old SQD/Subsquid processor runtime, TypeScript handlers, TypeORM
 migrations, codegen commands, local SQD startup scripts, and GraphQL server
 scripts have been removed.
 
-The current checked-in indexer is intentionally a foundation rather than a full
-runtime. It contains:
+The checked-in runtime contains:
 
-- Rust configuration and Datalens client readiness code.
+- Rust configuration, Datalens client readiness, indexing, decoding, and
+  projection code.
 - The canonical fresh PostgreSQL initialization schema in
   `apps/indexer/migrations/0001_init.sql`.
+- GraphQL and onchain refresh worker entrypoints.
 - Historical GraphQL and ABI reference artifacts in `apps/indexer/reference/`.
-- Node-based transition checks for schema ownership, Rust conventions, DAO
-  compatibility preflight policy, and Postgres initialization smoke tests.
+- Rust and Node-based checks for runtime packaging, schema ownership,
+  compatibility, projection behavior, and Postgres initialization.
 
 ## Repository Layout
 
@@ -56,8 +57,9 @@ just build
 just test
 ```
 
-`just indexer test` runs the current transition checks and Rust tests. It does
-not start a historical processor or serve an indexer GraphQL endpoint yet.
+`just indexer test` runs the indexer checks and Rust tests. For the canonical
+configuration, migration, and startup workflow, use the root
+[deployment guide](../../README.md#datalens-backed-indexer-deployment).
 
 ## Database Schema
 
@@ -91,8 +93,8 @@ old SQD processor.
 
 ## Configuration
 
-The current Rust foundation expects Datalens service configuration through
-environment variables, including:
+The Rust runtime expects Datalens service configuration through environment
+variables, including:
 
 - `DATALENS_ENDPOINT`
 - `DATALENS_APPLICATION`

--- a/docs/runbook/datalens-indexer-observability.md
+++ b/docs/runbook/datalens-indexer-observability.md
@@ -76,25 +76,24 @@ Run the checks in this order so the failing layer is clear:
 | DB/migration readiness | Available now. | Migrations apply and expected Datalens-native tables exist. | DeGov database URL, credentials, migration, or schema drift. |
 | GraphQL and web smoke | Available now. | GraphQL responds; delegates/proposals pages load; synced percentage is plausible when data exists. | API compatibility, web/API config, or stale DB view. |
 | Runtime readiness | Available now. | `run_indexer`, `run_worker`, and GraphQL packaging checks stay alive or report only config/readiness errors. | Process config, secret mounts, service readiness, or packaging. |
-| Active chunk processing | Available after projection packages are implemented. | `processed_height` advances toward `target_height`; chunk processing and commit logs appear. | DeGov query planning, decode/projection, DB transaction, or checkpoint writes. |
-| Row-family counters | Available after projection packages are implemented. | Proposal, vote, delegate, contributor, and `data_metric` totals are non-empty for an active DAO. | Decode/projection or idempotent writes. |
-| Checkpoint commits | Available after projection packages are implemented. | Checkpoint advancement occurs only with committed projection writes. | DB transaction or checkpoint contract. |
+| Active chunk processing | Available now. | `processed_height` advances toward `target_height`; chunk processing and commit logs appear. | DeGov query planning, decode/projection, DB transaction, or checkpoint writes. |
+| Row-family counters | Available now. | Proposal, vote, delegate, contributor, and `data_metric` totals are non-empty for an active DAO. | Decode/projection or idempotent writes. |
+| Checkpoint commits | Available now. | Checkpoint advancement occurs only with committed projection writes. | DB transaction or checkpoint contract. |
 | Onchain refresh queue draining | Available now when the worker is enabled with an RPC URL. | Pending work drains; failed and stale locked rows stay bounded. | ChainTool/RPC, onchain refresh worker, or lock recovery. |
-| Tally/onchain audit | Run after projection and worker packages are implemented and basic health passes. | Sampled proposal and power values agree with direct reads or have classified findings. | Business correctness after basic health passes. |
+| Tally/onchain audit | Available after basic health passes and, for power checks, worker catch-up. | Sampled proposal and power values agree with direct reads or have classified findings. | Business correctness after basic health passes. |
 
 ## Current Package Boundary
 
-HBX-264 documents observability while the checked-in DeGov indexer is still at
-the packaging/readiness boundary:
+The checked-in DeGov indexer provides the full runtime boundary:
 
 - `run_indexer` loads Datalens and database configuration, verifies Datalens
-  native GraphQL readiness, logs the configured chain/dataset/contracts, and
-  keeps the service alive.
+  native GraphQL readiness, applies migrations, and processes configured
+  contract-set ranges with transactional projection and checkpoint writes.
 - `run_worker` checks `DEGOV_INDEXER_DATABASE_URL` and
   `DEGOV_ONCHAIN_REFRESH_WORKER_ENABLED`. When enabled, it also requires
   `DEGOV_ONCHAIN_REFRESH_RPC_URL` and drains `onchain_refresh_task`; when
-  disabled, it keeps the service alive for packaging/readiness checks.
-- `graphql` checks `DEGOV_INDEXER_GRAPHQL_ENDPOINT` packaging/configuration.
+  disabled, it keeps the service alive and reports that state.
+- `graphql` applies migrations and serves the configured GraphQL paths.
 - `migrate` applies the Datalens-native Postgres schema.
 
 Do not classify queue draining as a runtime failure when the worker is disabled.
@@ -289,11 +288,10 @@ Expected signal: `indexer` verifies Datalens and processes configured ranges,
 `indexer:worker` logs disabled worker readiness and waits, and `indexer:graphql`
 logs the configured bind address, public endpoint, and served paths.
 
-## Future DeGov Indexer Health
+## DeGov Indexer Health
 
-This section is available after projection packages are implemented. With the
-current HBX-264 package, a stale checkpoint, missing chunk log, or empty row
-family can simply mean the runtime is still in placeholder readiness mode.
+A stale checkpoint, missing chunk log, or unexpectedly empty row family is a
+runtime, configuration, or data-coverage signal and should be investigated.
 
 Read checkpoint state for the workload:
 
@@ -422,9 +420,7 @@ the checkpoint has crossed blocks containing those events. Empty row families
 with advancing checkpoints usually mean query planning used the wrong address,
 topic set, chain, dataset, or start block.
 
-## Future Projection Sanity
-
-This section is available after projection packages are implemented.
+## Projection Sanity
 
 Check core projection counts:
 
@@ -697,9 +693,8 @@ business-correctness signals, not first-line service health checks.
 | Symptom | First checks | Likely domain | Action |
 | --- | --- | --- | --- |
 | Datalens auth failure | Native discovery returns 401/403 or application error. | Datalens auth. | Verify `DATALENS_APPLICATION`, token secret mount, token rotation, and application allowlist. Do not log the token. |
-| Empty Datalens rows and empty DeGov projections | Native query over a known event range returns no rows; after projection packages are implemented, checkpoint advances and row family counts stay zero. | DeGov query planning or Datalens chain/dataset config. | Confirm chain id/name, dataset `evm.logs`, governor/token/timelock addresses, topic filters, start block, and finality mode. Test a small known event range. |
-| Empty processor logs in current package | `run_indexer` verified Datalens and is waiting; no chunk logs are emitted. | Placeholder readiness boundary. | This is expected before projection packages are implemented. Do not restart as a runtime failure solely because chunk logs are absent. |
-| Empty processor logs after projection package lands | No chunk logs for the DAO and checkpoint is stale. | Runtime startup or workload config. | Check pod readiness, process args, `DEGOV_CONFIG_PATH`, DAO enabled flag, database connectivity, and whether the worker is watching the expected namespace/config. |
+| Empty Datalens rows and empty DeGov projections | Native query over a known event range returns no rows; checkpoint advances and row family counts stay zero. | DeGov query planning or Datalens chain/dataset config. | Confirm chain id/name, dataset `evm.logs`, governor/token/timelock addresses, topic filters, start block, and finality mode. Test a small known event range. |
+| Empty processor logs | No chunk logs for the DAO and checkpoint is stale. | Runtime startup or workload config. | Check pod readiness, process args, `DEGOV_INDEXER_CONFIG_FILE`, contract-set selection, database connectivity, and Datalens readiness. |
 | Decode mismatch | Logs show `DAO event decode error`; raw Datalens rows exist. | Decode/projection boundary. | Confirm ABI, event topic, token standard, timelock address, and whether the event is unsupported for the DAO compatibility policy. Unsupported events must be durable and auditable if skipped. |
 | Timestamp unit error | Proposals have implausible `vote_start_timestamp`, `vote_end_timestamp`, or page dates. | Decode/projection. | Compare raw `block_timestamp` values with expected seconds. Millisecond values are usually 1000x too large; second values interpreted as milliseconds are usually near 1970. |
 | Checkpoint stuck | `processing` chunk log repeats or `processed_height` does not advance. | Datalens query, DB transaction, decode/projection, or checkpoint. | Match the last processing log to the next error. If transaction failed, inspect DB errors and confirm checkpoint is advanced only inside the write transaction. |
@@ -718,9 +713,8 @@ business-correctness signals, not first-line service health checks.
   and refresh queue draining against the feature flags and runtime processes
   that are actually enabled for the DAO.
 - Checkpoint advancement without matching projection rows is a serious
-  correctness issue after projection packages are implemented. The batch
-  contract requires projection writes and checkpoint advancement in one
-  transaction.
+  correctness issue. The batch contract requires projection writes and
+  checkpoint advancement in one transaction.
 - A replay may be healthy with zero onchain power until the refresh worker is
   enabled, has a working RPC URL, and catches up with pending
   `onchain_refresh_task` rows. Confirm lag before restarting workers.

--- a/docs/spec/20260327__indexer_schema_reference.md
+++ b/docs/spec/20260327__indexer_schema_reference.md
@@ -1,7 +1,7 @@
 # DeGov Indexer Schema Reference
 
 > Historical reference: this schema documents the previous GraphQL-visible data
-> model and remains a compatibility target for future Datalens-native work.
+> model and remains a compatibility target for the Datalens-backed Rust indexer.
 
 This document explains what each entity in
 `apps/indexer/reference/schema.graphql` represents, how it is populated, and which

--- a/docs/spec/datalens-dao-compatibility-matrix.md
+++ b/docs/spec/datalens-dao-compatibility-matrix.md
@@ -160,5 +160,5 @@ not remain in active staging or production runs as silently skipped workloads.
 - accepting documented fallbacks as degraded with explicit selected vote-read
   methods.
 
-Future Rust implementation issues must preserve these behaviors in typed Rust
-preflight and runtime errors before replacing the placeholder script.
+Rust compatibility checks must preserve these behaviors in typed preflight and
+runtime errors.

--- a/docs/spec/datalens-rust-technical-conventions.md
+++ b/docs/spec/datalens-rust-technical-conventions.md
@@ -1,7 +1,7 @@
 # Datalens Rust Technical Conventions
 
 > Purpose: defines the required Rust conventions for the Datalens-native DeGov
-> indexer before implementation starts. Read this before adding Rust indexer
+> indexer. Read this before adding Rust indexer
 > crates, ChainTool code, projection code, Datalens client wrappers, repository
 > code, or reconcile workers. This document does not describe the historical
 > SQD/Subsquid runtime.


### PR DESCRIPTION
## Summary

- add a canonical README workflow for configuring, migrating, starting, and verifying the Datalens-backed DeGov indexer
- distinguish the external Datalens service from DeGov-owned Postgres, indexing, GraphQL, worker, and web responsibilities
- fix Docker Compose config mounting so host paths are not passed as nonexistent container paths
- gate database consumers on Postgres health and long-lived indexer services on the explicit migration job
- align indexer guides, references, and observability docs with the implemented Rust runtime

## Deployment behavior

The default Compose stack remains `postgres` plus `web` and continues to use the indexer endpoint from `degov.yml`.

The `indexer` profile now supports an untracked host config selected through `DEGOV_INDEXER_CONFIG_SOURCE`, mounts it at `/app/indexer.yml`, and keeps `DEGOV_INDEXER_CONFIG_FILE=/app/indexer.yml` inside the container. The README documents the supported sequence:

1. prepare `.env` and `apps/indexer/indexer.yml`
2. start healthy Postgres
3. run the explicit migration job
4. run the Datalens readiness smoke
5. start indexer, GraphQL, and the local-indexer web app
6. enable the onchain worker only with configured RPC secrets

## Validation

- `node apps/indexer/scripts/runtime-packaging.test.mjs`
- `node apps/indexer/scripts/staging-deployment-contract.test.mjs`
- `node apps/indexer/scripts/indexer-diagnostics.test.mjs`
- `node apps/indexer/scripts/indexer-accuracy-audit.test.mjs`
- `node apps/indexer/scripts/indexer-accuracy-diagnose.test.mjs`
- `node apps/indexer/scripts/indexer-reconcile-diagnose.test.mjs`
- `node apps/indexer/scripts/indexer-tally-onchain-e2e.test.mjs`
- `node apps/indexer/scripts/check-rust-conventions.mjs`
- `node apps/indexer/scripts/check-rust-conventions.test.mjs`
- `node apps/indexer/scripts/compatibility-preflight.test.mjs`
- `DEGOV_INDEXER_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55444/indexer cargo test -p degov-datalens-indexer --locked` with an isolated temporary Postgres 17 container
- `docker compose --env-file .env.example --profile indexer config --quiet`
- `git diff --check origin/main...HEAD`

## Known baseline issue

`pnpm run test:indexer-scripts` reaches an existing failure in `v4-parity-audit.test.mjs` because the checked-in report expects 29 matched tables while the checked-in projected output produces 26. The same failure reproduces from an isolated archive of `origin/main@45681bb`; this PR does not modify that audit or its fixtures. All script checks related to this change pass, and the pull-request indexer CI gate does not run that stale parity test.

## Cross-repository follow-up

`ringecosystem/degov-docs` must be updated after this README anchor lands so `docs/integration/deploy.md` links here instead of duplicating startup commands. This PR therefore references rather than closes the issue.

Refs #1093
