### PR TITLE
feat(web): render nested comment replies

### DIFF
--- a/apps/web/messages/en/proposal-detail.json
+++ b/apps/web/messages/en/proposal-detail.json
@@ -27,6 +27,7 @@
     "markdownSupported": "Markdown supported",
     "comment": "Comment",
     "reply": "Reply",
+    "replyingTo": "Replying to {address}",
     "edit": "Edit",
     "delete": "Delete",
     "save": "Save",

--- a/apps/web/scripts/proposal-comments.test.ts
+++ b/apps/web/scripts/proposal-comments.test.ts
@@ -149,6 +149,16 @@ test("proposal comment trees handle large chains and cycles in linear passes", (
   const threadedCycle = threadProposalComments(cycle);
   assert.equal(threadedCycle.length, size);
   assert.ok(threadedCycle.every(({ depth }) => depth === 0));
+
+  const siblings = [
+    comment("root"),
+    ...Array.from({ length: size }, (_, index) =>
+      comment(String(index), "root")
+    ),
+  ];
+  const threadedSiblings = threadProposalComments(siblings);
+  assert.equal(threadedSiblings.length, size + 1);
+  assert.equal(threadedSiblings.at(-1)?.depth, 1);
 });
 
 test("remote GraphQL authentication is scoped to every request", () => {

--- a/apps/web/scripts/proposal-comments.test.ts
+++ b/apps/web/scripts/proposal-comments.test.ts
@@ -2,7 +2,26 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
+import { threadProposalComments } from "../src/app/proposal/[id]/comment-tree.ts";
 import { isProposalFeatureEnabled } from "../src/utils/proposal-features.ts";
+
+import type { ProposalComment } from "../src/services/graphql/types/proposal-comments.ts";
+
+const comment = (
+  id: string,
+  replyToId?: string,
+  state: ProposalComment["state"] = "ACTIVE"
+): ProposalComment => ({
+  id,
+  daoCode: "demo",
+  chainId: 1,
+  proposalId: "1",
+  authorAddress: `0x${id.padStart(40, "0")}`,
+  replyToId,
+  body: state === "ACTIVE" ? id : null,
+  state,
+  ctime: "2026-08-20T00:00:00Z",
+});
 
 const config = {
   features: ["proposal-comments"],
@@ -67,6 +86,52 @@ test("provider markdown is sanitized before rendering", () => {
   assert.match(discussion, /DOMPurify\.sanitize\(marked\.parse/);
   assert.match(discussion, /state === "DELETED"/);
   assert.doesNotMatch(discussion, /comment\.body[^\n]*__html/);
+});
+
+test("proposal comments preserve nested reply targets and depth", () => {
+  const threaded = threadProposalComments([
+    comment("1"),
+    comment("2"),
+    comment("3", "1"),
+    comment("4", "3"),
+    comment("5", "4"),
+    comment("6", "1"),
+  ]);
+
+  assert.deepEqual(
+    threaded.map(({ comment: item, depth, replyTarget }) => ({
+      id: item.id,
+      depth,
+      replyTarget: replyTarget?.id,
+    })),
+    [
+      { id: "1", depth: 0, replyTarget: undefined },
+      { id: "3", depth: 1, replyTarget: "1" },
+      { id: "4", depth: 2, replyTarget: "3" },
+      { id: "5", depth: 3, replyTarget: "4" },
+      { id: "6", depth: 1, replyTarget: "1" },
+      { id: "2", depth: 0, replyTarget: undefined },
+    ]
+  );
+});
+
+test("proposal comment trees degrade safely for missing parents and cycles", () => {
+  const threaded = threadProposalComments([
+    comment("1", "missing"),
+    comment("2", "3"),
+    comment("3", "2"),
+    comment("4", "1", "DELETED"),
+  ]);
+
+  assert.deepEqual(
+    threaded.map(({ comment: item, depth }) => [item.id, depth]),
+    [
+      ["1", 0],
+      ["4", 1],
+      ["2", 0],
+      ["3", 0],
+    ]
+  );
 });
 
 test("remote GraphQL authentication is scoped to every request", () => {

--- a/apps/web/scripts/proposal-comments.test.ts
+++ b/apps/web/scripts/proposal-comments.test.ts
@@ -134,6 +134,23 @@ test("proposal comment trees degrade safely for missing parents and cycles", () 
   );
 });
 
+test("proposal comment trees handle large chains and cycles in linear passes", () => {
+  const size = 20_000;
+  const chain = Array.from({ length: size }, (_, index) =>
+    comment(String(index), index === 0 ? undefined : String(index - 1))
+  );
+  const threadedChain = threadProposalComments(chain);
+  assert.equal(threadedChain.length, size);
+  assert.equal(threadedChain.at(-1)?.depth, size - 1);
+
+  const cycle = Array.from({ length: size }, (_, index) =>
+    comment(String(index), String((index + 1) % size))
+  );
+  const threadedCycle = threadProposalComments(cycle);
+  assert.equal(threadedCycle.length, size);
+  assert.ok(threadedCycle.every(({ depth }) => depth === 0));
+});
+
 test("remote GraphQL authentication is scoped to every request", () => {
   const client = readFileSync(
     new URL("../src/services/graphql/remote-client.ts", import.meta.url),

--- a/apps/web/src/app/proposal/[id]/comment-tree.ts
+++ b/apps/web/src/app/proposal/[id]/comment-tree.ts
@@ -6,20 +6,40 @@ export interface ThreadedProposalComment {
   replyTarget?: ProposalComment;
 }
 
-function hasInvalidParentChain(
-  comment: ProposalComment,
+function invalidParentChains(
   commentsById: Map<string, ProposalComment>
 ) {
-  const visited = new Set([comment.id]);
-  let parentId = comment.replyToId;
+  const invalidById = new Map<string, boolean>();
 
-  while (parentId) {
-    if (visited.has(parentId)) return true;
-    visited.add(parentId);
-    parentId = commentsById.get(parentId)?.replyToId;
+  for (const comment of commentsById.values()) {
+    if (invalidById.has(comment.id)) continue;
+
+    const path: ProposalComment[] = [];
+    const pathIds = new Set<string>();
+    let current: ProposalComment | undefined = comment;
+    let invalid = false;
+
+    while (current) {
+      const resolved = invalidById.get(current.id);
+      if (resolved !== undefined) {
+        invalid = resolved;
+        break;
+      }
+      if (pathIds.has(current.id)) {
+        invalid = true;
+        break;
+      }
+      path.push(current);
+      pathIds.add(current.id);
+      current = current.replyToId
+        ? commentsById.get(current.replyToId)
+        : undefined;
+    }
+
+    for (const item of path) invalidById.set(item.id, invalid);
   }
 
-  return false;
+  return invalidById;
 }
 
 export function threadProposalComments(comments: ProposalComment[]) {
@@ -27,6 +47,7 @@ export function threadProposalComments(comments: ProposalComment[]) {
   for (const comment of comments) {
     if (!commentsById.has(comment.id)) commentsById.set(comment.id, comment);
   }
+  const invalidById = invalidParentChains(commentsById);
 
   const childrenById = new Map<string, ProposalComment[]>();
   const roots: ProposalComment[] = [];
@@ -35,7 +56,7 @@ export function threadProposalComments(comments: ProposalComment[]) {
     const parent = comment.replyToId
       ? commentsById.get(comment.replyToId)
       : undefined;
-    if (!parent || hasInvalidParentChain(comment, commentsById)) {
+    if (!parent || invalidById.get(comment.id)) {
       roots.push(comment);
       continue;
     }

--- a/apps/web/src/app/proposal/[id]/comment-tree.ts
+++ b/apps/web/src/app/proposal/[id]/comment-tree.ts
@@ -60,10 +60,12 @@ export function threadProposalComments(comments: ProposalComment[]) {
       roots.push(comment);
       continue;
     }
-    childrenById.set(parent.id, [
-      ...(childrenById.get(parent.id) ?? []),
-      comment,
-    ]);
+    const children = childrenById.get(parent.id);
+    if (children) {
+      children.push(comment);
+    } else {
+      childrenById.set(parent.id, [comment]);
+    }
   }
 
   const threaded: ThreadedProposalComment[] = [];

--- a/apps/web/src/app/proposal/[id]/comment-tree.ts
+++ b/apps/web/src/app/proposal/[id]/comment-tree.ts
@@ -1,0 +1,74 @@
+import type { ProposalComment } from "@/services/graphql/types/proposal-comments";
+
+export interface ThreadedProposalComment {
+  comment: ProposalComment;
+  depth: number;
+  replyTarget?: ProposalComment;
+}
+
+function hasInvalidParentChain(
+  comment: ProposalComment,
+  commentsById: Map<string, ProposalComment>
+) {
+  const visited = new Set([comment.id]);
+  let parentId = comment.replyToId;
+
+  while (parentId) {
+    if (visited.has(parentId)) return true;
+    visited.add(parentId);
+    parentId = commentsById.get(parentId)?.replyToId;
+  }
+
+  return false;
+}
+
+export function threadProposalComments(comments: ProposalComment[]) {
+  const commentsById = new Map<string, ProposalComment>();
+  for (const comment of comments) {
+    if (!commentsById.has(comment.id)) commentsById.set(comment.id, comment);
+  }
+
+  const childrenById = new Map<string, ProposalComment[]>();
+  const roots: ProposalComment[] = [];
+
+  for (const comment of commentsById.values()) {
+    const parent = comment.replyToId
+      ? commentsById.get(comment.replyToId)
+      : undefined;
+    if (!parent || hasInvalidParentChain(comment, commentsById)) {
+      roots.push(comment);
+      continue;
+    }
+    childrenById.set(parent.id, [
+      ...(childrenById.get(parent.id) ?? []),
+      comment,
+    ]);
+  }
+
+  const threaded: ThreadedProposalComment[] = [];
+  const visited = new Set<string>();
+  const appendThread = (root: ProposalComment) => {
+    const pending = [{ comment: root, depth: 0 }];
+    while (pending.length > 0) {
+      const current = pending.pop();
+      if (!current || visited.has(current.comment.id)) continue;
+      visited.add(current.comment.id);
+      threaded.push({
+        ...current,
+        replyTarget: current.comment.replyToId
+          ? commentsById.get(current.comment.replyToId)
+          : undefined,
+      });
+
+      const children = childrenById.get(current.comment.id) ?? [];
+      for (let index = children.length - 1; index >= 0; index -= 1) {
+        pending.push({ comment: children[index], depth: current.depth + 1 });
+      }
+    }
+  };
+
+  for (const root of roots) appendThread(root);
+  for (const comment of commentsById.values()) appendThread(comment);
+
+  return threaded;
+}

--- a/apps/web/src/app/proposal/[id]/discussion.tsx
+++ b/apps/web/src/app/proposal/[id]/discussion.tsx
@@ -13,13 +13,23 @@ import { Textarea } from "@/components/ui/textarea";
 import { useEnsureAuth } from "@/hooks/useEnsureAuth";
 import { useProposalComments } from "@/hooks/useProposalComments";
 import type { ProposalComment } from "@/services/graphql/types/proposal-comments";
+import { formatShortAddress } from "@/utils/address";
 import { formatTimeAgo } from "@/utils/date";
 import {
   extractErrorMessage,
   isAuthenticationRequired,
 } from "@/utils/graphql-error-handler";
 
+import { threadProposalComments } from "./comment-tree";
+
 const MAX_COMMENT_LENGTH = 10_000;
+const MAX_VISUAL_REPLY_DEPTH = 3;
+const replyIndentClasses = [
+  "",
+  "ms-[18px] border-s border-border/40 ps-[14px] sm:ms-[30px] sm:ps-[20px]",
+  "ms-[32px] border-s border-border/40 ps-[14px] sm:ms-[50px] sm:ps-[20px]",
+  "ms-[46px] border-s border-border/40 ps-[14px] sm:ms-[70px] sm:ps-[20px]",
+];
 
 function MarkdownComment({ body }: { body: string }) {
   const html = useMemo(
@@ -37,7 +47,8 @@ function MarkdownComment({ body }: { body: string }) {
 
 interface CommentRowProps {
   comment: ProposalComment;
-  isReply?: boolean;
+  depth?: number;
+  replyTarget?: ProposalComment;
   currentAddress?: string;
   isPending: boolean;
   editingId: string | null;
@@ -57,7 +68,8 @@ interface CommentRowProps {
 
 function CommentRow({
   comment,
-  isReply = false,
+  depth = 0,
+  replyTarget,
   currentAddress,
   isPending,
   editingId,
@@ -83,14 +95,20 @@ function CommentRow({
 
   return (
     <article
-      className={
-        isReply
-          ? "ml-[22px] border-l border-border/40 pl-[18px] sm:ml-[34px] sm:pl-[22px]"
-          : ""
-      }
+      className={replyIndentClasses[Math.min(depth, MAX_VISUAL_REPLY_DEPTH)]}
     >
       <div className="flex items-start gap-[12px] py-[18px]">
         <div className="min-w-0 flex-1">
+          {depth > 1 && replyTarget && (
+            <p
+              className="mb-[7px] text-[12px] text-muted-foreground break-words"
+              title={replyTarget.authorAddress}
+            >
+              {t("replyingTo", {
+                address: formatShortAddress(replyTarget.authorAddress),
+              })}
+            </p>
+          )}
           <div className="flex flex-wrap items-center gap-x-[10px] gap-y-[4px]">
             <AddressWithAvatar
               address={comment.authorAddress}
@@ -138,17 +156,15 @@ function CommentRow({
 
           {!isDeleted && !isEditing && (
             <div className="mt-[10px] flex items-center gap-[4px]">
-              {!isReply && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 px-2 text-muted-foreground"
-                  onClick={() => onReplyStart(comment.id)}
-                >
-                  <Reply />
-                  {t("reply")}
-                </Button>
-              )}
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 px-2 text-muted-foreground"
+                onClick={() => onReplyStart(comment.id)}
+              >
+                <Reply />
+                {t("reply")}
+              </Button>
               {isAuthor && (
                 <>
                   <Button
@@ -231,23 +247,10 @@ export function Discussion({
     () => query.data?.pages.flatMap((page) => page.items) ?? [],
     [query.data]
   );
-  const roots = useMemo(() => {
-    const ids = new Set(comments.map((comment) => comment.id));
-    return comments.filter(
-      (comment) => !comment.replyToId || !ids.has(comment.replyToId)
-    );
-  }, [comments]);
-  const replies = useMemo(() => {
-    const grouped = new Map<string, ProposalComment[]>();
-    for (const comment of comments) {
-      if (!comment.replyToId) continue;
-      grouped.set(comment.replyToId, [
-        ...(grouped.get(comment.replyToId) ?? []),
-        comment,
-      ]);
-    }
-    return grouped;
-  }, [comments]);
+  const threadedComments = useMemo(
+    () => threadProposalComments(comments),
+    [comments]
+  );
 
   const isPending =
     isAuthenticating || create.isPending || update.isPending || remove.isPending;
@@ -424,7 +427,7 @@ export function Discussion({
         )}
       </div>
 
-      {roots.length === 0 ? (
+      {threadedComments.length === 0 ? (
         <div className="flex min-h-[220px] flex-col items-center justify-center text-center">
           <MessageSquare className="size-7 text-muted-foreground" />
           <p className="mt-[12px] font-semibold">{t("empty")}</p>
@@ -434,18 +437,14 @@ export function Discussion({
         </div>
       ) : (
         <div className="divide-y divide-border/30">
-          {roots.map((comment) => (
-            <div key={comment.id}>
-              <CommentRow comment={comment} {...sharedRowProps} />
-              {(replies.get(comment.id) ?? []).map((reply) => (
-                <CommentRow
-                  key={reply.id}
-                  comment={reply}
-                  isReply
-                  {...sharedRowProps}
-                />
-              ))}
-            </div>
+          {threadedComments.map(({ comment, depth, replyTarget }) => (
+            <CommentRow
+              key={comment.id}
+              comment={comment}
+              depth={depth}
+              replyTarget={replyTarget}
+              {...sharedRowProps}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary

- show Reply on every active discussion entry
- build nested threads from the existing `replyToId` relationship
- cap visual indentation at three levels while preserving direct reply context
- degrade missing parents and cyclic provider data safely

## Validation

- `cd apps/web && node --test scripts/proposal-comments.test.ts`
- targeted ESLint for touched discussion files
- `cd apps/web && pnpm exec tsc --noEmit`
- `cd apps/web && pnpm build`

Refs #1086