### PR TITLE
fix(indexer): cap contract set pass duration

### DIFF
--- a/apps/indexer/src/runner.rs
+++ b/apps/indexer/src/runner.rs
@@ -657,6 +657,7 @@ pub struct IndexerRunner<R, S, D = DaoEventDecoder> {
     store: S,
     decoder: D,
     shutdown_after_chunks: Option<u64>,
+    shutdown_after_duration: Option<Duration>,
     onchain_refresh_tick: Option<Box<dyn IndexerOnchainRefreshTick>>,
     chain_tool: Option<Box<dyn ChainTool + Send + Sync>>,
 }
@@ -733,6 +734,7 @@ where
             store,
             decoder,
             shutdown_after_chunks: None,
+            shutdown_after_duration: None,
             onchain_refresh_tick: None,
             chain_tool: None,
         }
@@ -748,6 +750,10 @@ where
 
     pub fn request_shutdown_after_chunks(&mut self, chunks: u64) {
         self.shutdown_after_chunks = Some(chunks);
+    }
+
+    pub fn request_shutdown_after_duration(&mut self, duration: Duration) {
+        self.shutdown_after_duration = Some(duration);
     }
 
     pub fn with_onchain_refresh_tick(mut self, tick: Box<dyn IndexerOnchainRefreshTick>) -> Self {
@@ -768,6 +774,7 @@ where
             .options
             .safe_height
             .map_or(target_height, |safe_height| safe_height.min(target_height));
+        let pass_started_at = Instant::now();
         let mut progress_rate = ProgressRateEstimator::default();
         let mut chunks_processed = 0;
         let mut provider_limit_count_since_summary = 0;
@@ -806,6 +813,9 @@ where
             if self
                 .shutdown_after_chunks
                 .is_some_and(|limit| chunks_processed >= limit)
+                || self
+                    .shutdown_after_duration
+                    .is_some_and(|limit| chunks_processed > 0 && pass_started_at.elapsed() >= limit)
             {
                 return Ok(IndexerRunnerReport {
                     chunks_processed,

--- a/apps/indexer/src/runtime/indexer.rs
+++ b/apps/indexer/src/runtime/indexer.rs
@@ -1697,6 +1697,9 @@ async fn run_contract_set_pass(
         if let Some(chunks) = max_chunks_per_run {
             runner.request_shutdown_after_chunks(chunks);
         }
+        if let Some(duration) = runtime.max_run_duration {
+            runner.request_shutdown_after_duration(duration);
+        }
 
         let report = runner
             .run_to_target(runtime.target_height)
@@ -2928,6 +2931,7 @@ mod tests {
             poll_interval: Duration::from_millis(10),
             run_once: true,
             max_chunks_per_run: None,
+            max_run_duration: None,
             database_max_connections: 1,
             checkpoint_stream_id: "datalens-native".to_owned(),
             data_source_version: "datalens-v1".to_owned(),
@@ -3219,6 +3223,7 @@ mod tests {
             progress_refresh_lag_blocks: 100,
             adaptive_chunk_sizer: Default::default(),
             max_chunks_per_run,
+            max_run_duration: None,
             onchain_refresh_tick: Default::default(),
             onchain_refresh_deferred_drain_enabled: false,
             onchain_refresh_deferred_drain_batch_size: 100,
@@ -3245,6 +3250,7 @@ mod tests {
             progress_refresh_lag_blocks: 100,
             adaptive_chunk_sizer: Default::default(),
             max_chunks_per_run: None,
+            max_run_duration: None,
             onchain_refresh_tick: Default::default(),
             onchain_refresh_deferred_drain_enabled: false,
             onchain_refresh_deferred_drain_batch_size: 100,
@@ -4067,6 +4073,7 @@ mod tests {
             poll_interval: Duration::from_millis(10),
             run_once: true,
             max_chunks_per_run: None,
+            max_run_duration: None,
             database_max_connections: 1,
             checkpoint_stream_id: "datalens-native".to_owned(),
             data_source_version: "datalens-v1".to_owned(),

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -501,6 +501,10 @@ impl IndexerRuntimeConfig {
             bail!("DEGOV_INDEXER_MAX_RUN_DURATION_MS must be greater than zero");
         }
         let max_run_duration = max_run_duration_ms.map(Duration::from_millis);
+        let max_chunks_per_run = optional_env_u64("DEGOV_INDEXER_MAX_CHUNKS_PER_RUN")?;
+        if max_chunks_per_run == Some(0) {
+            bail!("DEGOV_INDEXER_MAX_CHUNKS_PER_RUN must be greater than zero");
+        }
 
         let onchain_refresh_tick = load_onchain_refresh_tick_config()?;
         let onchain_refresh_deferred_drain_enabled = load_onchain_refresh_deferred_drain_enabled(
@@ -540,7 +544,7 @@ impl IndexerRuntimeConfig {
             realtime: RealtimeRuntimeConfig::from_env()?,
             poll_interval,
             run_once,
-            max_chunks_per_run: optional_env_u64("DEGOV_INDEXER_MAX_CHUNKS_PER_RUN")?,
+            max_chunks_per_run,
             max_run_duration,
             database_max_connections,
         })

--- a/apps/indexer/src/runtime_config.rs
+++ b/apps/indexer/src/runtime_config.rs
@@ -293,6 +293,7 @@ pub struct IndexerRuntimeConfig {
     pub poll_interval: Duration,
     pub run_once: bool,
     pub max_chunks_per_run: Option<u64>,
+    pub max_run_duration: Option<Duration>,
     pub database_max_connections: u32,
     pub checkpoint_stream_id: String,
     pub data_source_version: String,
@@ -396,6 +397,7 @@ pub struct IndexerContractSetRuntimeConfig {
     pub progress_refresh_lag_blocks: i64,
     pub adaptive_chunk_sizer: AdaptiveChunkSizerRuntimeConfig,
     pub max_chunks_per_run: Option<u64>,
+    pub max_run_duration: Option<Duration>,
     pub onchain_refresh_tick: OnchainRefreshTickConfig,
     pub onchain_refresh_deferred_drain_enabled: bool,
     pub onchain_refresh_deferred_drain_batch_size: usize,
@@ -494,6 +496,11 @@ impl IndexerRuntimeConfig {
             optional_env_u64("DEGOV_INDEXER_POLL_INTERVAL_MS")?.unwrap_or(10_000),
         );
         let run_once = optional_env_bool("DEGOV_INDEXER_RUN_ONCE")?.unwrap_or(false);
+        let max_run_duration_ms = optional_env_u64("DEGOV_INDEXER_MAX_RUN_DURATION_MS")?;
+        if max_run_duration_ms == Some(0) {
+            bail!("DEGOV_INDEXER_MAX_RUN_DURATION_MS must be greater than zero");
+        }
+        let max_run_duration = max_run_duration_ms.map(Duration::from_millis);
 
         let onchain_refresh_tick = load_onchain_refresh_tick_config()?;
         let onchain_refresh_deferred_drain_enabled = load_onchain_refresh_deferred_drain_enabled(
@@ -534,6 +541,7 @@ impl IndexerRuntimeConfig {
             poll_interval,
             run_once,
             max_chunks_per_run: optional_env_u64("DEGOV_INDEXER_MAX_CHUNKS_PER_RUN")?,
+            max_run_duration,
             database_max_connections,
         })
     }
@@ -597,6 +605,7 @@ impl IndexerRuntimeConfig {
             progress_refresh_lag_blocks: self.progress_refresh_lag_blocks,
             adaptive_chunk_sizer: self.adaptive_chunk_sizer,
             max_chunks_per_run: self.max_chunks_per_run,
+            max_run_duration: self.max_run_duration,
             onchain_refresh_tick: self.onchain_refresh_tick.clone(),
             onchain_refresh_deferred_drain_enabled: self.onchain_refresh_deferred_drain_enabled,
             onchain_refresh_deferred_drain_batch_size: self

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -1051,6 +1051,26 @@ fn test_indexer_runtime_config_rejects_zero_max_run_duration() {
 }
 
 #[test]
+fn test_indexer_runtime_config_rejects_zero_max_chunks_per_run() {
+    with_env_vars!(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_MAX_CHUNKS_PER_RUN", Some("0")),
+        ],
+        || {
+            let error = IndexerRuntimeConfig::from_env().expect_err("zero chunk budget is invalid");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("DEGOV_INDEXER_MAX_CHUNKS_PER_RUN")
+            );
+        },
+    );
+}
+
+#[test]
 fn test_datalens_retry_config_maps_query_max_attempts_to_sdk_retry_attempts() {
     let retry_config = datalens_retry_config(5);
 

--- a/apps/indexer/tests/cli_runtime_config.rs
+++ b/apps/indexer/tests/cli_runtime_config.rs
@@ -1012,6 +1012,45 @@ fn test_indexer_runtime_config_rejects_enabled_onchain_refresh_tick_zero_run_bud
 }
 
 #[test]
+fn test_indexer_runtime_config_accepts_max_run_duration() {
+    with_env_vars!(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_MAX_RUN_DURATION_MS", Some("120000")),
+        ],
+        || {
+            let config = IndexerRuntimeConfig::from_env().expect("runtime config parses");
+
+            assert_eq!(
+                config.max_run_duration,
+                Some(Duration::from_millis(120_000))
+            );
+        },
+    );
+}
+
+#[test]
+fn test_indexer_runtime_config_rejects_zero_max_run_duration() {
+    with_env_vars!(
+        [
+            ("DEGOV_INDEXER_DAO_CODE", Some("demo-dao")),
+            ("DEGOV_INDEXER_TARGET_HEIGHT", Some("123")),
+            ("DEGOV_INDEXER_MAX_RUN_DURATION_MS", Some("0")),
+        ],
+        || {
+            let error = IndexerRuntimeConfig::from_env().expect_err("zero run duration is invalid");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("DEGOV_INDEXER_MAX_RUN_DURATION_MS")
+            );
+        },
+    );
+}
+
+#[test]
 fn test_datalens_retry_config_maps_query_max_attempts_to_sdk_retry_attempts() {
     let retry_config = datalens_retry_config(5);
 
@@ -1073,6 +1112,7 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
         poll_interval: Duration::from_secs(10),
         run_once: true,
         max_chunks_per_run: None,
+        max_run_duration: Some(Duration::from_secs(120)),
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
         onchain_refresh_deferred_drain_enabled: false,
@@ -1097,6 +1137,7 @@ fn test_indexer_runtime_contract_set_plan_uses_configured_scope() {
 
     assert_eq!(planned.dao_code, "lisk-dao");
     assert_eq!(planned.start_block, 568752);
+    assert_eq!(planned.max_run_duration, Some(Duration::from_secs(120)));
     assert!(!planned.provisional.enabled);
     assert_eq!(
         planned.provisional.finality,
@@ -1162,6 +1203,7 @@ fn test_indexer_runtime_single_mode_does_not_skip_target_below_start_block() {
         poll_interval: Duration::from_secs(10),
         run_once: true,
         max_chunks_per_run: None,
+        max_run_duration: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
         onchain_refresh_deferred_drain_enabled: false,
@@ -1206,6 +1248,7 @@ fn test_indexer_runtime_latest_target_height_does_not_skip_all_mode_contract_set
         poll_interval: Duration::from_secs(10),
         run_once: true,
         max_chunks_per_run: None,
+        max_run_duration: None,
         database_max_connections: 1,
         onchain_refresh_tick: OnchainRefreshTickConfig::default(),
         onchain_refresh_deferred_drain_enabled: false,

--- a/apps/indexer/tests/indexer_runner.rs
+++ b/apps/indexer/tests/indexer_runner.rs
@@ -1056,6 +1056,25 @@ fn test_runner_stops_gracefully_between_chunks() {
 }
 
 #[test]
+fn test_runner_duration_shutdown_waits_until_after_successful_chunk() {
+    let mut runner = runner(
+        vec![vec![row(1, 0, 0)], vec![row(2, 0, 0)]],
+        ScriptedDecoder,
+    );
+    runner.request_shutdown_after_duration(Duration::ZERO);
+
+    let report = runner.run_to_target(2).expect("runner stops cleanly");
+
+    assert_eq!(report.chunks_processed, 1);
+    assert!(report.shutdown_requested);
+    assert_eq!(
+        runner.store().checkpoint().expect("checkpoint").next_block,
+        2
+    );
+    assert_eq!(runner.store().commit_count(), 1);
+}
+
+#[test]
 fn test_runner_decodes_distinct_log_addresses_with_matching_sources() {
     let attempts = Arc::new(Mutex::new(Vec::new()));
     let mut runner = runner_with_decoder(


### PR DESCRIPTION
## Summary
- add DEGOV_INDEXER_MAX_RUN_DURATION_MS to cap a single contract set pass by wall-clock time
- only stop between successful chunks so checkpoint/data writes remain safe
- pass the new runtime budget into IndexerRunner

## Verification
- cargo fmt --check
- cargo check -p degov-datalens-indexer --locked
- cargo test -p degov-datalens-indexer --locked --lib
- cargo test -p degov-datalens-indexer --locked --test indexer_runner --test cli_runtime_config

Full cargo test reaches checkpoint_repository and requires DEGOV_INDEXER_TEST_DATABASE_URL in this environment.